### PR TITLE
ci: add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build ./cmd/kontext
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test ./...
+
+  proto:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: bufbuild/buf-setup-action@v1
+
+      - name: Lint proto
+        run: buf lint proto
+
+      - name: Check generated code is up to date
+        run: |
+          buf generate
+          git diff --exit-code gen/ || (echo "Generated code is out of date. Run 'buf generate' and commit." && exit 1)
+
+  proto-compat:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: bufbuild/buf-setup-action@v1
+
+      - name: Check proto compatibility with kontext-dev/proto
+        run: |
+          git clone --depth 1 https://github.com/kontext-dev/proto.git /tmp/kontext-proto
+          diff <(sort proto/kontext/agent/v1/agent.proto) <(sort /tmp/kontext-proto/kontext/agent/v1/agent.proto) || (echo "Proto definitions diverged from kontext-dev/proto. Sync them." && exit 1)


### PR DESCRIPTION
## Summary

Adds CI with three jobs:

**build** — `go build`, `go vet`, `go test`

**proto** — `buf lint` on proto definitions + verify generated code in `gen/` is up to date

**proto-compat** — checks that `proto/kontext/agent/v1/agent.proto` matches `kontext-dev/proto` (the shared source of truth). Fails if they diverge.

## Related

- https://github.com/kontext-dev/proto — shared proto repo with its own CI (`buf lint` + `buf breaking`)
- The proto-compat check ensures the CLI always stays in sync with the canonical definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kontext-dev/kontext-cli/pull/4" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
