### PR TITLE
fix: use buf managed mode for go_package override

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,4 +1,9 @@
 version: v2
+managed:
+  enabled: true
+  override:
+    - file_option: go_package_prefix
+      value: github.com/kontext-dev/kontext-cli/gen
 inputs:
   - git_repo: https://github.com/kontext-dev/proto.git
     branch: main


### PR DESCRIPTION
The shared proto repo (`kontext-dev/proto`) now uses a neutral `go_package` (`github.com/kontext-dev/proto/gen/...`). The CLI overrides it via buf managed mode to generate into its own module path.

Depends on: kontext-dev/proto#1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kontext-dev/kontext-cli/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
