### PR TITLE
feat: wire up credential exchange via RFC 8693 token exchange

### DIFF
--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -30,16 +30,16 @@ type LoginResult struct {
 	Session *Session
 }
 
-// oauthMetadata is the response from /.well-known/oauth-authorization-server.
-type oauthMetadata struct {
+// OAuthMetadata is the response from /.well-known/oauth-authorization-server.
+type OAuthMetadata struct {
 	Issuer                string `json:"issuer"`
 	AuthorizationEndpoint string `json:"authorization_endpoint"`
 	TokenEndpoint         string `json:"token_endpoint"`
 	JwksURI               string `json:"jwks_uri"`
 }
 
-// discoverEndpoints fetches OAuth authorization server metadata.
-func discoverEndpoints(ctx context.Context, baseURL string) (*oauthMetadata, error) {
+// DiscoverEndpoints fetches OAuth authorization server metadata.
+func DiscoverEndpoints(ctx context.Context, baseURL string) (*OAuthMetadata, error) {
 	url := strings.TrimRight(baseURL, "/") + "/.well-known/oauth-authorization-server"
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
@@ -57,7 +57,7 @@ func discoverEndpoints(ctx context.Context, baseURL string) (*oauthMetadata, err
 		return nil, fmt.Errorf("discovery failed: %s", resp.Status)
 	}
 
-	var meta oauthMetadata
+	var meta OAuthMetadata
 	if err := json.NewDecoder(resp.Body).Decode(&meta); err != nil {
 		return nil, fmt.Errorf("decode discovery: %w", err)
 	}
@@ -68,7 +68,7 @@ func discoverEndpoints(ctx context.Context, baseURL string) (*oauthMetadata, err
 // Login performs the browser-based OAuth PKCE login flow.
 func Login(ctx context.Context, issuerURL, clientID string) (*LoginResult, error) {
 	// 1. Discover endpoints
-	meta, err := discoverEndpoints(ctx, issuerURL)
+	meta, err := DiscoverEndpoints(ctx, issuerURL)
 	if err != nil {
 		return nil, fmt.Errorf("oauth discovery failed for %s: %w", issuerURL, err)
 	}
@@ -181,7 +181,7 @@ func RefreshSession(ctx context.Context, session *Session) (*Session, error) {
 		return nil, fmt.Errorf("no refresh token available")
 	}
 
-	meta, err := discoverEndpoints(ctx, session.IssuerURL)
+	meta, err := DiscoverEndpoints(ctx, session.IssuerURL)
 	if err != nil {
 		return nil, fmt.Errorf("oauth discovery: %w", err)
 	}

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -16,21 +16,30 @@ import (
 	"github.com/kontext-dev/kontext-cli/gen/kontext/agent/v1/agentv1connect"
 )
 
+// TokenSource returns a valid access token, refreshing if necessary.
+type TokenSource func() (string, error)
+
 // Client wraps the ConnectRPC AgentService client.
 type Client struct {
 	rpc agentv1connect.AgentServiceClient
 }
 
-// NewClient creates a ConnectRPC client authenticated with the user's bearer token.
-func NewClient(baseURL, accessToken string) *Client {
+// NewClient creates a ConnectRPC client that fetches a fresh token per request.
+func NewClient(baseURL string, ts TokenSource) *Client {
 	httpClient := &http.Client{
 		Timeout:   30 * time.Second,
-		Transport: &bearerTransport{token: accessToken, base: http.DefaultTransport},
+		Transport: &bearerTransport{tokenSource: ts, base: http.DefaultTransport},
 	}
 
 	return &Client{
 		rpc: agentv1connect.NewAgentServiceClient(httpClient, baseURL),
 	}
+}
+
+// StaticToken returns a TokenSource that always returns the same token.
+// Useful for tests or short-lived commands.
+func StaticToken(token string) TokenSource {
+	return func() (string, error) { return token, nil }
 }
 
 // BaseURL returns the API base URL from env or default.
@@ -81,13 +90,18 @@ func (c *Client) IngestEvent(ctx context.Context, req *agentv1.ProcessHookEventR
 	return stream.CloseResponse()
 }
 
-// bearerTransport injects the user's OIDC token into every request.
+// bearerTransport fetches a fresh token for every outgoing request.
 type bearerTransport struct {
-	token string
-	base  http.RoundTripper
+	tokenSource TokenSource
+	base        http.RoundTripper
 }
 
 func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Set("Authorization", "Bearer "+t.token)
-	return t.base.RoundTrip(req)
+	token, err := t.tokenSource()
+	if err != nil {
+		return nil, fmt.Errorf("token refresh: %w", err)
+	}
+	r := req.Clone(req.Context())
+	r.Header.Set("Authorization", "Bearer "+token)
+	return t.base.RoundTrip(r)
 }

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -4,12 +4,16 @@ package run
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"strings"
 	"syscall"
 	"time"
@@ -48,8 +52,8 @@ func Start(ctx context.Context, opts Options) error {
 	}
 	fmt.Fprintf(os.Stderr, "✓ Authenticated as %s\n", identity)
 
-	// 2. Backend client — authenticated with the user's OIDC token
-	client := backend.NewClient(backend.BaseURL(), session.AccessToken)
+	// 2. Backend client — token source refreshes automatically on expiry
+	client := backend.NewClient(backend.BaseURL(), newSessionTokenSource(ctx, session))
 
 	// 3. Create session via ConnectRPC
 	hostname, _ := os.Hostname()
@@ -71,29 +75,10 @@ func Start(ctx context.Context, opts Options) error {
 	}
 
 	sessionID := createResp.SessionId
-	fmt.Fprintf(os.Stderr, "✓ Session: %s (%s)\n", createResp.SessionName, sessionID[:8])
+	fmt.Fprintf(os.Stderr, "✓ Session: %s (%s)\n", createResp.SessionName, truncateID(sessionID))
 
-	// 4. Start sidecar
-	sessionDir := filepath.Join(os.TempDir(), "kontext", sessionID)
-	os.MkdirAll(sessionDir, 0700)
-
-	sc, err := sidecar.New(sessionDir, client, sessionID, opts.Agent)
-	if err != nil {
-		return fmt.Errorf("sidecar: %w", err)
-	}
-	if err := sc.Start(ctx); err != nil {
-		return fmt.Errorf("sidecar start: %w", err)
-	}
-	defer sc.Stop()
-
-	// 5. Generate hook settings
-	kontextBin, _ := os.Executable()
-	settingsPath, err := GenerateSettings(sessionDir, kontextBin, opts.Agent)
-	if err != nil {
-		return fmt.Errorf("generate settings: %w", err)
-	}
-
-	// 6. Env template + credentials (optional)
+	// 4. Resolve credentials (before sidecar starts — no background goroutines yet,
+	//    so reading session fields is safe without synchronization)
 	var resolved []credential.Resolved
 	if _, err := os.Stat(opts.TemplateFile); err == nil {
 		entries, err := credential.ParseTemplate(opts.TemplateFile)
@@ -106,6 +91,26 @@ func Start(ctx context.Context, opts Options) error {
 				return err
 			}
 		}
+	}
+
+	// 5. Start sidecar
+	sessionDir := filepath.Join(os.TempDir(), "kontext", sessionID)
+	os.MkdirAll(sessionDir, 0700)
+
+	sc, err := sidecar.New(sessionDir, client, sessionID, opts.Agent)
+	if err != nil {
+		return fmt.Errorf("sidecar: %w", err)
+	}
+	if err := sc.Start(ctx); err != nil {
+		return fmt.Errorf("sidecar start: %w", err)
+	}
+	defer sc.Stop()
+
+	// 6. Generate hook settings
+	kontextBin, _ := os.Executable()
+	settingsPath, err := GenerateSettings(sessionDir, kontextBin, opts.Agent)
+	if err != nil {
+		return fmt.Errorf("generate settings: %w", err)
 	}
 
 	// 7. Build env
@@ -122,7 +127,7 @@ func Start(ctx context.Context, opts Options) error {
 	defer cancel()
 
 	_ = client.EndSession(endCtx, sessionID)
-	fmt.Fprintf(os.Stderr, "\n✓ Session ended (%s)\n", sessionID[:8])
+	fmt.Fprintf(os.Stderr, "\n✓ Session ended (%s)\n", truncateID(sessionID))
 
 	os.RemoveAll(sessionDir)
 
@@ -187,8 +192,59 @@ func resolveCredentials(ctx context.Context, session *auth.Session, entries []cr
 	return resolved, nil
 }
 
-func exchangeCredential(_ context.Context, _ *auth.Session, _ credential.Entry) (string, error) {
-	return "", fmt.Errorf("credential exchange not yet connected to backend")
+// exchangeCredential calls POST /oauth2/token with RFC 8693 token exchange
+// to resolve a provider credential. The user's access token serves as both
+// the subject_token and the Bearer auth — no client secret needed.
+func exchangeCredential(ctx context.Context, session *auth.Session, entry credential.Entry) (string, error) {
+	meta, err := auth.DiscoverEndpoints(ctx, session.IssuerURL)
+	if err != nil {
+		return "", fmt.Errorf("oauth discovery: %w", err)
+	}
+
+	form := url.Values{
+		"grant_type":         {"urn:ietf:params:oauth:grant-type:token-exchange"},
+		"client_id":          {auth.DefaultClientID},
+		"subject_token":      {session.AccessToken},
+		"subject_token_type": {"urn:ietf:params:oauth:token-type:access_token"},
+		"resource":           {entry.Provider},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", meta.TokenEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "Bearer "+session.AccessToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("token exchange request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		AccessToken  string `json:"access_token"`
+		TokenType    string `json:"token_type"`
+		ProviderKind string `json:"provider_kind"`
+		Error        string `json:"error"`
+		ErrorDesc    string `json:"error_description"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("decode token exchange response: %w", err)
+	}
+
+	if result.Error != "" {
+		if result.Error == "invalid_target" && strings.Contains(result.ErrorDesc, "not allowed") {
+			return "", fmt.Errorf("provider not connected: %s", entry.Provider)
+		}
+		return "", fmt.Errorf("token exchange failed: %s: %s", result.Error, result.ErrorDesc)
+	}
+
+	if result.AccessToken == "" {
+		return "", fmt.Errorf("token exchange returned empty access_token")
+	}
+
+	return result.AccessToken, nil
 }
 
 func isNotConnectedError(err error) bool {
@@ -199,6 +255,34 @@ func isNotConnectedError(err error) bool {
 func buildEnv(resolved []credential.Resolved) []string {
 	env := append(os.Environ(), "KONTEXT_RUN=1")
 	return credential.BuildEnv(resolved, env)
+}
+
+// newSessionTokenSource returns a TokenSource that transparently refreshes
+// the OIDC access token when it expires, so long-running sessions keep working.
+func newSessionTokenSource(ctx context.Context, session *auth.Session) backend.TokenSource {
+	mu := &sync.Mutex{}
+	return func() (string, error) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		if !session.IsExpired() {
+			return session.AccessToken, nil
+		}
+
+		refreshed, err := auth.RefreshSession(ctx, session)
+		if err != nil {
+			return "", fmt.Errorf("token expired and refresh failed: %w", err)
+		}
+
+		// Persist so other processes (and the next `kontext start`) see the new token
+		if saveErr := auth.SaveSession(refreshed); saveErr != nil {
+			fmt.Fprintf(os.Stderr, "⚠ Could not persist refreshed session: %v\n", saveErr)
+		}
+
+		// Update the shared session pointer for subsequent calls
+		*session = *refreshed
+		return session.AccessToken, nil
+	}
 }
 
 func launchAgentDirect(ctx context.Context, opts Options) error {
@@ -243,19 +327,52 @@ func launchAgentWithSettings(_ context.Context, agentName string, env, extraArgs
 	return err
 }
 
+// flagName extracts the flag name from an arg, handling --flag=value syntax.
+func flagName(arg string) string {
+	if i := strings.Index(arg, "="); i != -1 {
+		return arg[:i]
+	}
+	return arg
+}
+
 func filterArgs(args []string) []string {
 	blocked := map[string]bool{
 		"--bare":                         true,
 		"--dangerously-skip-permissions": true,
 	}
+	// Flags that take a value argument — strip the flag AND the next arg.
+	blockedWithValue := map[string]bool{
+		"--settings":        true,
+		"--setting-sources": true,
+	}
 
 	var filtered []string
+	skip := false
 	for _, arg := range args {
-		if blocked[arg] {
+		if skip {
+			skip = false
+			continue
+		}
+		name := flagName(arg)
+		if blocked[name] {
 			fmt.Fprintf(os.Stderr, "⚠ Stripped blocked flag: %s\n", arg)
+			continue
+		}
+		if blockedWithValue[name] {
+			fmt.Fprintf(os.Stderr, "⚠ Stripped blocked flag: %s\n", arg)
+			if !strings.Contains(arg, "=") {
+				skip = true // skip the next arg (the value)
+			}
 			continue
 		}
 		filtered = append(filtered, arg)
 	}
 	return filtered
+}
+
+func truncateID(id string) string {
+	if len(id) >= 8 {
+		return id[:8]
+	}
+	return id
 }


### PR DESCRIPTION
## Summary

- Export `DiscoverEndpoints` and `OAuthMetadata` from the auth package so `run.go` can call OAuth discovery
- Replace the `exchangeCredential` stub with a real implementation that calls `POST /oauth2/token` using RFC 8693 token exchange
- The user's access token is the `subject_token` — no client secret needed (public client)
- Works for both OAuth tokens and API keys (both returned via `access_token` field)

## Note

Based on `feat/governance-telemetry-pipeline` — the credential exchange imports `backend`, `sidecar`, and proto types introduced there. Should be merged after that branch lands on main.

## Test plan

- [ ] `kontext start` with a `.env.kontext` containing `GITHUB_TOKEN={{kontext:github}}` resolves credentials after backend gate is relaxed (kontext-dev/kontext#410)
- [ ] Provider not connected → opens browser to connect flow, retries on Enter
- [ ] Expired/invalid session → triggers re-login before exchange

## Depends on

- kontext-dev/kontext#413 — backend gate relaxation (allows public clients with verified user tokens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)