### PR TITLE
fix: surface ConnectRPC errors instead of silently swallowing them

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -82,10 +82,10 @@ func (c *Client) IngestEvent(ctx context.Context, req *agentv1.ProcessHookEventR
 		return fmt.Errorf("send hook event: %w", err)
 	}
 	if err := stream.CloseRequest(); err != nil {
-		return err
+		return fmt.Errorf("close request: %w", err)
 	}
-	if resp, err := stream.Receive(); err == nil {
-		_ = resp
+	if _, err := stream.Receive(); err != nil {
+		return fmt.Errorf("receive response: %w", err)
 	}
 	return stream.CloseResponse()
 }

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -94,7 +94,10 @@ func Start(ctx context.Context, opts Options) error {
 	}
 
 	// 5. Start sidecar
-	sessionDir := filepath.Join(os.TempDir(), "kontext", sessionID)
+	// Use /tmp (not $TMPDIR) with a short ID to keep the Unix socket path
+	// under macOS's 104-byte sun_path limit. $TMPDIR on macOS is a long
+	// path like /var/folders/.../T/ which pushes the socket path over.
+	sessionDir := filepath.Join("/tmp", "kontext", truncateID(sessionID))
 	os.MkdirAll(sessionDir, 0700)
 
 	sc, err := sidecar.New(sessionDir, client, sessionID, opts.Agent)
@@ -126,8 +129,11 @@ func Start(ctx context.Context, opts Options) error {
 	endCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	_ = client.EndSession(endCtx, sessionID)
-	fmt.Fprintf(os.Stderr, "\n✓ Session ended (%s)\n", truncateID(sessionID))
+	if err := client.EndSession(endCtx, sessionID); err != nil {
+		fmt.Fprintf(os.Stderr, "\n⚠ Could not end session on backend: %v\n", err)
+	} else {
+		fmt.Fprintf(os.Stderr, "\n✓ Session ended (%s)\n", truncateID(sessionID))
+	}
 
 	os.RemoveAll(sessionDir)
 

--- a/internal/sidecar/sidecar.go
+++ b/internal/sidecar/sidecar.go
@@ -5,10 +5,13 @@ package sidecar
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	agentv1 "github.com/kontext-dev/kontext-cli/gen/kontext/agent/v1"
@@ -23,6 +26,9 @@ type Server struct {
 	agentName  string
 	client     *backend.Client
 	cancel     context.CancelFunc
+
+	ingestFails   atomic.Int64
+	ingestWarnOnce sync.Once
 }
 
 // New creates a new sidecar server.
@@ -120,20 +126,32 @@ func (s *Server) ingestEvent(ctx context.Context, req *EvaluateRequest) {
 	}
 
 	if err := s.client.IngestEvent(ctx, hookEvent); err != nil {
-		log.Printf("sidecar: ingest: %v", err)
+		n := s.ingestFails.Add(1)
+		s.ingestWarnOnce.Do(func() {
+			fmt.Fprintf(os.Stderr, "sidecar: event ingestion failed: %v\n", err)
+		})
+		if n > 1 && n%10 == 0 {
+			fmt.Fprintf(os.Stderr, "sidecar: %d event ingestion failures (latest: %v)\n", n, err)
+		}
 	}
 }
 
 func (s *Server) heartbeatLoop(ctx context.Context) {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
+	consecutiveFails := 0
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
 			if err := s.client.Heartbeat(ctx, s.sessionID); err != nil {
-				log.Printf("sidecar: heartbeat: %v", err)
+				consecutiveFails++
+				if consecutiveFails == 1 || consecutiveFails == 3 {
+					fmt.Fprintf(os.Stderr, "sidecar: heartbeat failed (attempt %d): %v\n", consecutiveFails, err)
+				}
+			} else {
+				consecutiveFails = 0
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- **backend.IngestEvent**: propagate `Receive()` errors instead of discarding the response
- **sidecar.ingestEvent**: surface first failure + periodic reminders to stderr so the user sees when telemetry is broken
- **sidecar.heartbeatLoop**: surface persistent heartbeat failures with escalating severity
- **run.Start teardown**: report `EndSession` failure instead of printing "session ended" unconditionally

## Context
Sessions show up in the dashboard but events/traces don't appear. The entire hook → sidecar → ConnectRPC → API pipeline was silently swallowing all errors, making it impossible to diagnose where events were being lost.

## Test plan
- [ ] Run `kontext start --agent claude`, trigger tool calls, verify events appear in traces
- [ ] Kill the API server mid-session, verify stderr shows the ingestion failure message
- [ ] Let a session idle past 30s, verify heartbeat errors surface if backend is unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kontext-dev/kontext-cli/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
