### PR TITLE
fix: propagate IngestEvent errors and document HTTP/2 requirement

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -79,6 +79,7 @@ func (c *Client) EndSession(ctx context.Context, sessionID string) error {
 // Requires HTTP/2 (HTTPS in dev via mkcert, HTTPS in production via edge TLS).
 func (c *Client) IngestEvent(ctx context.Context, req *agentv1.ProcessHookEventRequest) error {
 	stream := c.rpc.ProcessHookEvent(ctx)
+	defer stream.CloseResponse()
 	if err := stream.Send(req); err != nil {
 		return fmt.Errorf("send hook event: %w", err)
 	}
@@ -88,7 +89,7 @@ func (c *Client) IngestEvent(ctx context.Context, req *agentv1.ProcessHookEventR
 	if _, err := stream.Receive(); err != nil {
 		return fmt.Errorf("receive response: %w", err)
 	}
-	return stream.CloseResponse()
+	return nil
 }
 
 // bearerTransport fetches a fresh token for every outgoing request.

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -75,17 +75,18 @@ func (c *Client) EndSession(ctx context.Context, sessionID string) error {
 	return err
 }
 
-// IngestEvent sends a single hook event via the ProcessHookEvent stream.
+// IngestEvent sends a single hook event via the ProcessHookEvent bidi stream.
+// Requires HTTP/2 (HTTPS in dev via mkcert, HTTPS in production via edge TLS).
 func (c *Client) IngestEvent(ctx context.Context, req *agentv1.ProcessHookEventRequest) error {
 	stream := c.rpc.ProcessHookEvent(ctx)
 	if err := stream.Send(req); err != nil {
 		return fmt.Errorf("send hook event: %w", err)
 	}
 	if err := stream.CloseRequest(); err != nil {
-		return err
+		return fmt.Errorf("close request: %w", err)
 	}
-	if resp, err := stream.Receive(); err == nil {
-		_ = resp
+	if _, err := stream.Receive(); err != nil {
+		return fmt.Errorf("receive response: %w", err)
 	}
 	return stream.CloseResponse()
 }


### PR DESCRIPTION
IngestEvent uses bidi streaming which requires HTTP/2. Previously the
Receive() error and response were silently discarded. Now all errors
are properly propagated so the sidecar can surface ingestion failures.

The dev server needs HTTPS (via mkcert) for HTTP/2 ALPN negotiation.
Production already has HTTP/2 via edge TLS at api.kontext.security.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kontext-dev/kontext-cli/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
