### PR TITLE
refactor: change ProcessHookEvent from bidi streaming to unary RPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ kontext start --agent claude
 ```
 
 On first run, the CLI handles everything interactively:
+
 - No session? Opens browser for OIDC login, stores refresh token in system keyring
 - No `.env.kontext`? Prompts for which providers the project needs, writes the file
 - Provider not connected? Opens browser to the Kontext hosted connect flow
@@ -56,11 +57,11 @@ Commit this to your repo — the team shares it.
 
 ### Supported agents
 
-| Agent | Flag | Status |
-|---|---|---|
-| Claude Code | `--agent claude` | Active |
-| Cursor | `--agent cursor` | Planned |
-| Codex | `--agent codex` | Planned |
+| Agent       | Flag             | Status  |
+| ----------- | ---------------- | ------- |
+| Claude Code | `--agent claude` | Active  |
+| Cursor      | `--agent cursor` | Planned |
+| Codex       | `--agent codex`  | Planned |
 
 ## Architecture
 
@@ -103,17 +104,18 @@ The CLI separates **governance telemetry** from **developer observability**. The
 
 Session lifecycle and tool call events flow to the Kontext backend. This powers the dashboard — sessions, traces, audit trail.
 
-| Event | Source | When |
-|---|---|---|
-| `session.begin` | CLI lifecycle | Agent launched |
-| `session.end` | CLI lifecycle | Agent exited |
-| `hook.pre_tool_call` | PreToolUse hook | Before every tool execution |
-| `hook.post_tool_call` | PostToolUse hook | After every tool execution |
-| `hook.user_prompt` | UserPromptSubmit hook | User submits a prompt |
+| Event                 | Source                | When                        |
+| --------------------- | --------------------- | --------------------------- |
+| `session.begin`       | CLI lifecycle         | Agent launched              |
+| `session.end`         | CLI lifecycle         | Agent exited                |
+| `hook.pre_tool_call`  | PreToolUse hook       | Before every tool execution |
+| `hook.post_tool_call` | PostToolUse hook      | After every tool execution  |
+| `hook.user_prompt`    | UserPromptSubmit hook | User submits a prompt       |
 
-Events are streamed to the backend via the ConnectRPC `ProcessHookEvent` bidirectional stream and stored in the `mcp_events` table.
+Events are sent to the backend via the ConnectRPC `ProcessHookEvent` unary RPC and stored in the `mcp_events` table.
 
 **What governance telemetry captures:**
+
 - What the agent tried to do (tool name + input)
 - What happened (tool response)
 - Whether it was allowed (policy decision)
@@ -121,6 +123,7 @@ Events are streamed to the backend via the ConnectRPC `ProcessHookEvent` bidirec
 - When (timestamps, duration)
 
 **What governance telemetry does NOT capture:**
+
 - LLM reasoning or thinking
 - Token usage or cost
 - Model parameters
@@ -132,6 +135,7 @@ Events are streamed to the backend via the ConnectRPC `ProcessHookEvent` bidirec
 LLM-level observability — generation details, token costs, reasoning traces, conversation history — is a separate concern. It is not part of the governance pipeline.
 
 For this, the CLI will optionally export OpenTelemetry spans to an external backend:
+
 - **Langfuse** — open-source, has a native Claude Code integration, self-hostable
 - **Dash0** — OTEL-native SaaS, cheap ($0.60/M spans), AI/agent-aware
 

--- a/gen/kontext/agent/v1/agent.pb.go
+++ b/gen/kontext/agent/v1/agent.pb.go
@@ -586,9 +586,9 @@ const file_kontext_agent_v1_agent_proto_rawDesc = "" +
 	"\x14DECISION_UNSPECIFIED\x10\x00\x12\x12\n" +
 	"\x0eDECISION_ALLOW\x10\x01\x12\x11\n" +
 	"\rDECISION_DENY\x10\x02\x12\x10\n" +
-	"\fDECISION_ASK\x10\x032\x8e\x03\n" +
-	"\fAgentService\x12m\n" +
-	"\x10ProcessHookEvent\x12).kontext.agent.v1.ProcessHookEventRequest\x1a*.kontext.agent.v1.ProcessHookEventResponse(\x010\x01\x12`\n" +
+	"\fDECISION_ASK\x10\x032\x8a\x03\n" +
+	"\fAgentService\x12i\n" +
+	"\x10ProcessHookEvent\x12).kontext.agent.v1.ProcessHookEventRequest\x1a*.kontext.agent.v1.ProcessHookEventResponse\x12`\n" +
 	"\rCreateSession\x12&.kontext.agent.v1.CreateSessionRequest\x1a'.kontext.agent.v1.CreateSessionResponse\x12T\n" +
 	"\tHeartbeat\x12\".kontext.agent.v1.HeartbeatRequest\x1a#.kontext.agent.v1.HeartbeatResponse\x12W\n" +
 	"\n" +

--- a/gen/kontext/agent/v1/agentv1connect/agent.connect.go
+++ b/gen/kontext/agent/v1/agentv1connect/agent.connect.go
@@ -47,10 +47,9 @@ const (
 
 // AgentServiceClient is a client for the kontext.agent.v1.AgentService service.
 type AgentServiceClient interface {
-	// ProcessHookEvent streams tool call events from the CLI to the backend
-	// and receives policy decisions in return. Bidirectional streaming keeps
-	// the connection open for the session lifetime.
-	ProcessHookEvent(context.Context) *connect.BidiStreamForClient[v1.ProcessHookEventRequest, v1.ProcessHookEventResponse]
+	// ProcessHookEvent sends a single tool call event from the CLI to the
+	// backend and receives a policy decision in return.
+	ProcessHookEvent(context.Context, *connect.Request[v1.ProcessHookEventRequest]) (*connect.Response[v1.ProcessHookEventResponse], error)
 	// CreateSession establishes a governed agent session. Called once at the
 	// start of `kontext start`.
 	CreateSession(context.Context, *connect.Request[v1.CreateSessionRequest]) (*connect.Response[v1.CreateSessionResponse], error)
@@ -108,8 +107,8 @@ type agentServiceClient struct {
 }
 
 // ProcessHookEvent calls kontext.agent.v1.AgentService.ProcessHookEvent.
-func (c *agentServiceClient) ProcessHookEvent(ctx context.Context) *connect.BidiStreamForClient[v1.ProcessHookEventRequest, v1.ProcessHookEventResponse] {
-	return c.processHookEvent.CallBidiStream(ctx)
+func (c *agentServiceClient) ProcessHookEvent(ctx context.Context, req *connect.Request[v1.ProcessHookEventRequest]) (*connect.Response[v1.ProcessHookEventResponse], error) {
+	return c.processHookEvent.CallUnary(ctx, req)
 }
 
 // CreateSession calls kontext.agent.v1.AgentService.CreateSession.
@@ -129,10 +128,9 @@ func (c *agentServiceClient) EndSession(ctx context.Context, req *connect.Reques
 
 // AgentServiceHandler is an implementation of the kontext.agent.v1.AgentService service.
 type AgentServiceHandler interface {
-	// ProcessHookEvent streams tool call events from the CLI to the backend
-	// and receives policy decisions in return. Bidirectional streaming keeps
-	// the connection open for the session lifetime.
-	ProcessHookEvent(context.Context, *connect.BidiStream[v1.ProcessHookEventRequest, v1.ProcessHookEventResponse]) error
+	// ProcessHookEvent sends a single tool call event from the CLI to the
+	// backend and receives a policy decision in return.
+	ProcessHookEvent(context.Context, *connect.Request[v1.ProcessHookEventRequest]) (*connect.Response[v1.ProcessHookEventResponse], error)
 	// CreateSession establishes a governed agent session. Called once at the
 	// start of `kontext start`.
 	CreateSession(context.Context, *connect.Request[v1.CreateSessionRequest]) (*connect.Response[v1.CreateSessionResponse], error)
@@ -150,7 +148,7 @@ type AgentServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewAgentServiceHandler(svc AgentServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	agentServiceMethods := v1.File_kontext_agent_v1_agent_proto.Services().ByName("AgentService").Methods()
-	agentServiceProcessHookEventHandler := connect.NewBidiStreamHandler(
+	agentServiceProcessHookEventHandler := connect.NewUnaryHandler(
 		AgentServiceProcessHookEventProcedure,
 		svc.ProcessHookEvent,
 		connect.WithSchema(agentServiceMethods.ByName("ProcessHookEvent")),
@@ -193,8 +191,8 @@ func NewAgentServiceHandler(svc AgentServiceHandler, opts ...connect.HandlerOpti
 // UnimplementedAgentServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedAgentServiceHandler struct{}
 
-func (UnimplementedAgentServiceHandler) ProcessHookEvent(context.Context, *connect.BidiStream[v1.ProcessHookEventRequest, v1.ProcessHookEventResponse]) error {
-	return connect.NewError(connect.CodeUnimplemented, errors.New("kontext.agent.v1.AgentService.ProcessHookEvent is not implemented"))
+func (UnimplementedAgentServiceHandler) ProcessHookEvent(context.Context, *connect.Request[v1.ProcessHookEventRequest]) (*connect.Response[v1.ProcessHookEventResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("kontext.agent.v1.AgentService.ProcessHookEvent is not implemented"))
 }
 
 func (UnimplementedAgentServiceHandler) CreateSession(context.Context, *connect.Request[v1.CreateSessionRequest]) (*connect.Response[v1.CreateSessionResponse], error) {

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -75,19 +75,11 @@ func (c *Client) EndSession(ctx context.Context, sessionID string) error {
 	return err
 }
 
-// IngestEvent sends a single hook event via the ProcessHookEvent bidi stream.
-// Requires HTTP/2 (HTTPS in dev via mkcert, HTTPS in production via edge TLS).
+// IngestEvent sends a single hook event via the ProcessHookEvent unary RPC.
 func (c *Client) IngestEvent(ctx context.Context, req *agentv1.ProcessHookEventRequest) error {
-	stream := c.rpc.ProcessHookEvent(ctx)
-	defer stream.CloseResponse()
-	if err := stream.Send(req); err != nil {
-		return fmt.Errorf("send hook event: %w", err)
-	}
-	if err := stream.CloseRequest(); err != nil {
-		return fmt.Errorf("close request: %w", err)
-	}
-	if _, err := stream.Receive(); err != nil {
-		return fmt.Errorf("receive response: %w", err)
+	_, err := c.rpc.ProcessHookEvent(ctx, connect.NewRequest(req))
+	if err != nil {
+		return fmt.Errorf("ProcessHookEvent: %w", err)
 	}
 	return nil
 }

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -79,6 +79,7 @@ func (c *Client) EndSession(ctx context.Context, sessionID string) error {
 // Requires HTTP/2 (HTTPS in dev via mkcert, HTTPS in production via edge TLS).
 func (c *Client) IngestEvent(ctx context.Context, req *agentv1.ProcessHookEventRequest) error {
 	stream := c.rpc.ProcessHookEvent(ctx)
+	defer stream.CloseResponse()
 	if err := stream.Send(req); err != nil {
 		return fmt.Errorf("send hook event: %w", err)
 	}
@@ -88,7 +89,7 @@ func (c *Client) IngestEvent(ctx context.Context, req *agentv1.ProcessHookEventR
 	if _, err := stream.Receive(); err != nil {
 		return fmt.Errorf("receive response: %w", err)
 	}
-	return stream.CloseResponse()
+	return nil
 }
 
 // bearerTransport fetches a fresh token for every outgoing request.

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -75,17 +75,18 @@ func (c *Client) EndSession(ctx context.Context, sessionID string) error {
 	return err
 }
 
-// IngestEvent sends a single hook event via the ProcessHookEvent stream.
+// IngestEvent sends a single hook event via the ProcessHookEvent bidi stream.
+// Requires HTTP/2 (HTTPS in dev via mkcert, HTTPS in production via edge TLS).
 func (c *Client) IngestEvent(ctx context.Context, req *agentv1.ProcessHookEventRequest) error {
 	stream := c.rpc.ProcessHookEvent(ctx)
 	if err := stream.Send(req); err != nil {
 		return fmt.Errorf("send hook event: %w", err)
 	}
 	if err := stream.CloseRequest(); err != nil {
-		return err
+		return fmt.Errorf("close request: %w", err)
 	}
-	if resp, err := stream.Receive(); err == nil {
-		_ = resp
+	if _, err := stream.Receive(); err != nil {
+		return fmt.Errorf("receive response: %w", err)
 	}
 	return stream.CloseResponse()
 }

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -94,7 +94,9 @@ func Start(ctx context.Context, opts Options) error {
 	}
 
 	// 5. Start sidecar
-	sessionDir := filepath.Join(os.TempDir(), "kontext", sessionID)
+	// Use /tmp (not $TMPDIR) with a short ID to keep the Unix socket path
+	// under macOS's 104-byte sun_path limit.
+	sessionDir := filepath.Join("/tmp", "kontext", truncateID(sessionID))
 	os.MkdirAll(sessionDir, 0700)
 
 	sc, err := sidecar.New(sessionDir, client, sessionID, opts.Agent)


### PR DESCRIPTION
## Summary

- Change ProcessHookEvent from bidi streaming to unary RPC
- Bidi streaming required HTTP/2 end-to-end, which Cloud Run doesn't support without `--use-http2` (breaks HTTP/1.1 REST endpoints)
- The RPC was already effectively unary — one event in, one ack out
- Regenerate proto stubs from kontext-dev/proto (unary definition)
- Simplify `IngestEvent` to match `CreateSession`/`Heartbeat`/`EndSession` pattern
- Update README

## Test plan
- [x] `go build ./...` passes
- [ ] E2E: `kontext start --agent claude` → events ingested successfully over HTTP/1.1

Depends on: kontext-dev/proto@eb148cf (already merged to main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kontext-dev/kontext-cli/pull/16" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
