### PR TITLE
cd: add goreleaser and Homebrew tap release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,50 @@
+version: 2
+
+project_name: kontext
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - main: ./cmd/kontext
+    binary: kontext
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^ci:"
+      - "^chore:"
+
+brews:
+  - repository:
+      owner: kontext-dev
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    homepage: "https://kontext.security"
+    description: "Identity, credentials, and governance for AI agents"
+    license: "MIT"
+    install: |
+      bin.install "kontext"
+    test: |
+      system "#{bin}/kontext", "--version"


### PR DESCRIPTION
## Summary
- Add `.goreleaser.yaml` — builds `kontext` for macOS/Linux (amd64 + arm64), publishes GitHub releases
- Add `.github/workflows/release.yml` — triggers goreleaser on `v*` tag push
- goreleaser auto-publishes the Homebrew formula to `kontext-dev/homebrew-tap`

## Setup required
- Add a `HOMEBREW_TAP_TOKEN` repo secret: a GitHub PAT with write access to `kontext-dev/homebrew-tap`

## To release
```bash
git tag v0.1.0
git push origin v0.1.0
```

Users can then install with:
```bash
brew install kontext-dev/tap/kontext
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kontext-dev/kontext-cli/pull/20" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
