### PR TITLE
cd: set initial-version to 0.1.0 in release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,8 @@
 {
   "packages": {
     ".": {
-      "release-type": "go"
+      "release-type": "go",
+      "initial-version": "0.1.0"
     }
   }
 }


### PR DESCRIPTION
The manifest alone wasn't enough — release-please needs explicit
initial-version to avoid defaulting to 1.0.0.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kontext-dev/kontext-cli/pull/25" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
