### PR TITLE
fix: handle provider_reauthorization_required as reconnect-needed

### DIFF
--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -250,8 +250,10 @@ func exchangeCredential(ctx context.Context, session *auth.Session, entry creden
 }
 
 func isNotConnectedError(err error) bool {
-	return strings.Contains(err.Error(), "not connected") ||
-		strings.Contains(err.Error(), "provider not found")
+	msg := err.Error()
+	return strings.Contains(msg, "not connected") ||
+		strings.Contains(msg, "provider not found") ||
+		strings.Contains(msg, "provider_reauthorization_required")
 }
 
 func buildEnv(resolved []credential.Resolved) []string {


### PR DESCRIPTION
The token exchange returns provider_reauthorization_required when a
provider needs re-authorization. Treat it the same as not-connected
so the CLI opens the browser for the connect flow.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kontext-dev/kontext-cli/pull/27" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
