### PR TITLE
Harden CLI repo for public release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,10 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Set up Buf
-        uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Buf
+        run: |
+          go install github.com/bufbuild/buf/cmd/buf@v1.58.0
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Install protoc plugins
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,44 +6,75 @@ on:
   pull_request:
     branches: [main]
 
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+permissions:
+  contents: read
 
-      - uses: actions/setup-go@v5
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          cache: true
+
+      - name: Download modules
+        run: go mod download
+
+      - name: Verify modules
+        run: go mod verify
+
+      - name: Check formatting
+        run: test -z "$(gofmt -l $(find cmd internal -name '*.go' -type f))"
 
       - name: Build
-        run: go build ./cmd/kontext
+        run: go build ./...
 
       - name: Vet
         run: go vet ./...
 
       - name: Test
-        run: go test ./...
+        run: go test -race ./...
+
+      - name: Check vulnerabilities
+        run: |
+          go build -o ./bin/kontext ./cmd/kontext
+          go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+          govulncheck -mode=binary ./bin/kontext
 
   proto:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@v5
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          cache: true
 
-      - uses: bufbuild/buf-setup-action@v1
+      - name: Set up Buf
+        uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install protoc plugins
         run: |
-          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-          go install connectrpc.com/connect/cmd/protoc-gen-connect-go@latest
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11
+          go install connectrpc.com/connect/cmd/protoc-gen-connect-go@v1.19.1
 
-      - name: Generate from kontext-dev/proto
+      - name: Generate protobuf code
         run: buf generate
 
       - name: Check generated code is up to date

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   dependency-review:
+    if: ${{ github.event.repository.private == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,16 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Dependency review
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,18 +5,22 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         id: release
         with:
           config-file: release-please-config.json
@@ -26,20 +30,22 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          cache: true
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
-          version: "~> v2"
+          version: "~> v2.13"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 *.exe
 .env.kontext
 kontext
+.DS_Store

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,10 +2,6 @@ version: 2
 
 project_name: kontext
 
-before:
-  hooks:
-    - go mod tidy
-
 builds:
   - main: ./cmd/kontext
     binary: kontext

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,22 @@
+# Code of Conduct
+
+## Our standard
+
+We want Kontext CLI to be a respectful, low-ego project. Be direct, kind, and professional. Harassment, discrimination, intimidation, or personal attacks are not acceptable.
+
+## Expected behavior
+
+- Assume good intent and communicate clearly.
+- Give actionable technical feedback without hostility.
+- Keep discussions focused on the work.
+
+## Unacceptable behavior
+
+- Harassment or abusive language
+- Discriminatory remarks
+- Doxxing, threats, or sustained disruption
+- Bad-faith interactions meant to derail the project
+
+## Reporting
+
+If someone crosses the line, contact a maintainer directly. Maintainers may remove comments, close threads, or ban contributors when needed to protect the project and its contributors.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing
+
+Thanks for helping improve Kontext CLI.
+
+## Ground rules
+
+- Keep changes small, direct, and production-ready.
+- Use conventional commits. Release automation depends on them.
+- Do not add compatibility shims unless they are required for a safe production migration.
+- Prefer the standard library and existing dependencies over new packages.
+
+## Local setup
+
+```bash
+go mod download
+go test ./...
+go test -race ./...
+go vet ./...
+gofmt -w ./cmd ./internal
+```
+
+If you touch generated protobuf code, also run:
+
+```bash
+buf generate
+```
+
+## Pull requests
+
+- Include tests for behavior changes.
+- Update the README when user-facing behavior changes.
+- Keep generated code, docs, and release notes in sync with the code.
+
+## Release flow
+
+- `release-please` opens release PRs and calculates semver bumps from conventional commits.
+- GitHub Releases are built with GoReleaser.
+- Homebrew publishing is handled from the release workflow.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Kontext contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="https://raw.githubusercontent.com/kontext-dev/kontext-cli/main/assets/banner-cli.png" alt="Kontext" width="auto" height="auto" style="margin-bottom: 20px;" />
+<img src="assets/banner-cli.png" alt="Kontext CLI banner" width="auto" height="auto" style="margin-bottom: 20px;" />
 
 # Kontext CLI
 
@@ -12,7 +12,7 @@ Identity, credentials, and governance for AI agents.
 
 ## What is Kontext CLI?
 
-Kontext CLI is an open-source command-line tool that wraps your AI coding agents (Claude Code, Cursor, Codex) with enterprise-grade identity, credential management, and governance — without changing how you use them.
+Kontext CLI is an open-source command-line tool that wraps AI coding agents with enterprise-grade identity, credential management, and governance — without changing how developers work.
 
 **Why we built it:** AI coding agents need access to GitHub, Stripe, databases, and dozens of other services. Today, teams copy-paste long-lived API keys into `.env` files and hope for the best. Kontext replaces that with short-lived, scoped credentials that are injected at session start and gone when the session ends. Every tool call is logged. Every secret is accounted for.
 
@@ -20,11 +20,21 @@ Kontext CLI is an open-source command-line tool that wraps your AI coding agents
 
 ## Quick Start
 
+If the tap is public:
+
 ```bash
 brew install kontext-dev/tap/kontext
 ```
 
-Then, from any project directory:
+If you're on the private preview, install from GitHub Releases instead:
+
+```bash
+gh release download v0.1.0 --repo kontext-dev/kontext-cli --pattern '*darwin_arm64*' --dir /tmp \
+  && tar -xzf /tmp/kontext_0.1.0_darwin_arm64.tar.gz -C /tmp \
+  && sudo mv /tmp/kontext /usr/local/bin/kontext
+```
+
+Then, from any project directory with Claude Code installed:
 
 ```bash
 kontext start --agent claude
@@ -42,18 +52,17 @@ kontext start --agent claude
 2. **Creates a session** — registers with the Kontext backend, visible in the dashboard
 3. **Resolves credentials** — reads `.env.kontext`, exchanges placeholders for short-lived tokens
 4. **Launches the agent** — spawns Claude Code with credentials injected as env vars + governance hooks
-5. **Captures every action** — PreToolUse, PostToolUse, and UserPromptSubmit events streamed to the backend
+5. **Captures hook events** — PreToolUse, PostToolUse, and UserPromptSubmit events streamed to the backend
 6. **Tears down cleanly** — session ended, credentials expired, temp files removed
 
 ## Features
 
-- **One command to launch any agent:** `kontext start --agent claude` — no config files, no Docker, no setup scripts
+- **One command to launch Claude Code:** `kontext start --agent claude` — no config files, no Docker, no setup scripts
 - **Ephemeral credentials:** short-lived tokens scoped to the session, automatically expired on exit. No more long-lived API keys in `.env` files
 - **Declarative credential templates:** commit `.env.kontext` to your repo, and every developer on the team gets the same credential setup without sharing secrets
-- **Full audit trail:** every tool call, every file edit, every command — streamed to the dashboard with user, session, and org attribution
-- **Policy enforcement:** PreToolUse hooks evaluate allow/deny before the agent acts, with ~5ms overhead (native Go binary, no runtime startup)
+- **Governance telemetry:** Claude hook events are streamed to the backend with user, session, and org attribution
 - **Secure by default:** OIDC authentication, system keyring storage, RFC 8693 token exchange, AES-256-GCM encryption at rest
-- **Agent-agnostic:** works with Claude Code today, with Cursor and Codex support coming
+- **Lean runtime:** native Go binary, no local daemon install, no Node/Python runtime required
 
 ## Declare Credentials
 
@@ -72,8 +81,8 @@ Commit this to your repo — the whole team shares the same template. Secrets st
 | Agent       | Flag             | Status  |
 | ----------- | ---------------- | ------- |
 | Claude Code | `--agent claude` | Active  |
-| Cursor      | `--agent cursor` | Planned |
-| Codex       | `--agent codex`  | Planned |
+
+Cursor and Codex support are planned, but they are not shipped in this repo yet.
 
 ## Architecture
 
@@ -83,21 +92,20 @@ kontext start --agent claude
   ├── Auth: OIDC refresh token from keyring
   ├── ConnectRPC: CreateSession → session in dashboard
   ├── Sidecar: Unix socket server (kontext.sock)
-  │     ├── Heartbeat loop (30s)
-  │     └── Async event ingestion via ConnectRPC
+  │     └── Heartbeat loop (30s)
   ├── Hooks: settings.json → Claude Code --settings
   ├── Agent: spawn claude with injected env
   │     │
-  │     ├── [PreToolUse]        → kontext hook → sidecar → ingest
-  │     ├── [PostToolUse]       → kontext hook → sidecar → ingest
-  │     └── [UserPromptSubmit]  → kontext hook → sidecar → ingest
+  │     ├── [PreToolUse]        → kontext hook → sidecar → backend
+  │     ├── [PostToolUse]       → kontext hook → sidecar → backend
+  │     └── [UserPromptSubmit]  → kontext hook → sidecar → backend
   │
   └── On exit: EndSession → cleanup
 ```
 
-**Go sidecar:** A lightweight sidecar process runs alongside the agent, communicating over a Unix socket. Hook handlers evaluate policy decisions in ~5ms and stream events asynchronously to the backend — zero impact on agent performance.
+**Go sidecar:** A lightweight sidecar process runs alongside the agent and communicates over a Unix socket. Hook handlers send normalized events through the sidecar so the CLI can keep agent-specific logic out of the backend contract.
 
-**Governance telemetry:** Session lifecycle and tool call events flow to the Kontext backend, powering the dashboard with sessions, traces, and full audit trail. The CLI captures what the agent tried to do, what happened, and whether it was allowed — but never captures LLM reasoning, token usage, or conversation history.
+**Governance telemetry:** Session lifecycle and hook events flow to the Kontext backend, powering the dashboard with sessions, traces, and audit history. The CLI captures what the agent tried to do and what happened, but never captures LLM reasoning, token usage, or conversation history.
 
 ## Development
 
@@ -110,6 +118,9 @@ buf generate
 
 # Test
 go test ./...
+go test -race ./...
+go vet ./...
+gofmt -w ./cmd ./internal
 
 # Link for local use
 ln -sf $(pwd)/bin/kontext ~/.local/bin/kontext
@@ -117,7 +128,7 @@ ln -sf $(pwd)/bin/kontext ~/.local/bin/kontext
 
 ## Protocol
 
-Service definitions: [`proto/kontext/agent/v1/agent.proto`](proto/kontext/agent/v1/agent.proto)
+Service definitions: [kontext-dev/proto `agent.proto`](https://github.com/kontext-dev/proto/blob/main/proto/kontext/agent/v1/agent.proto)
 
 The CLI communicates with the Kontext backend exclusively via ConnectRPC. Hook handlers communicate with the sidecar over a Unix socket using length-prefixed JSON.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Supported versions
+
+- `main`
+- The latest released version
+
+Older releases may not receive fixes.
+
+## Reporting a vulnerability
+
+- Use GitHub private vulnerability reporting for this repository when it is available.
+- If private reporting is not available yet, contact a maintainer directly.
+- Do not open public issues for security reports.
+
+Please include:
+
+- A clear description of the issue
+- Steps to reproduce it
+- The affected version or commit
+- Any proof-of-concept or logs that help confirm impact
+
+We will triage reports as quickly as we can and coordinate a fix before public disclosure.

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -7,6 +7,7 @@ managed:
 inputs:
   - git_repo: https://github.com/kontext-dev/proto.git
     branch: main
+    ref: eb148cfee8e1d390a3f1e29116d210f2459f4670
 plugins:
   - local: protoc-gen-go
     out: gen

--- a/cmd/kontext/main.go
+++ b/cmd/kontext/main.go
@@ -60,7 +60,7 @@ func startCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&agentName, "agent", "claude", "Agent to launch (claude, cursor, codex)")
+	cmd.Flags().StringVar(&agentName, "agent", "claude", "Agent to launch (currently: claude)")
 	cmd.Flags().StringVar(&templateFile, "env-template", ".env.kontext", "Path to env template file")
 
 	return cmd

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kontext-dev/kontext-cli
 
-go 1.25.0
+go 1.25.9
 
 require (
 	connectrpc.com/connect v1.19.1

--- a/internal/agent/claude/claude.go
+++ b/internal/agent/claude/claude.go
@@ -51,17 +51,17 @@ type hookOutput struct {
 }
 
 type hookSpecificOutput struct {
-	HookEventName          string `json:"hookEventName"`
-	PermissionDecision     string `json:"permissionDecision,omitempty"`
+	HookEventName            string `json:"hookEventName"`
+	PermissionDecision       string `json:"permissionDecision,omitempty"`
 	PermissionDecisionReason string `json:"permissionDecisionReason,omitempty"`
-	AdditionalContext      string `json:"additionalContext,omitempty"`
+	AdditionalContext        string `json:"additionalContext,omitempty"`
 }
 
 func (c *Claude) EncodeAllow(event *agent.HookEvent, reason string) ([]byte, error) {
 	out := hookOutput{
 		HookSpecificOutput: &hookSpecificOutput{
-			HookEventName:      event.HookEventName,
-			PermissionDecision: "allow",
+			HookEventName:            event.HookEventName,
+			PermissionDecision:       "allow",
 			PermissionDecisionReason: reason,
 		},
 	}
@@ -71,8 +71,8 @@ func (c *Claude) EncodeAllow(event *agent.HookEvent, reason string) ([]byte, err
 func (c *Claude) EncodeDeny(event *agent.HookEvent, reason string) ([]byte, error) {
 	out := hookOutput{
 		HookSpecificOutput: &hookSpecificOutput{
-			HookEventName:      event.HookEventName,
-			PermissionDecision: "deny",
+			HookEventName:            event.HookEventName,
+			PermissionDecision:       "deny",
 			PermissionDecisionReason: reason,
 		},
 	}

--- a/internal/credential/credential.go
+++ b/internal/credential/credential.go
@@ -20,6 +20,14 @@ type Entry struct {
 	Raw      string // e.g., "{{kontext:github}}"
 }
 
+// Target returns the full provider target used for token exchange.
+func (e Entry) Target() string {
+	if e.Resource == "" {
+		return e.Provider
+	}
+	return e.Provider + "/" + e.Resource
+}
+
 // Resolved is a credential entry with its resolved value.
 type Resolved struct {
 	Entry

--- a/internal/credential/credential_test.go
+++ b/internal/credential/credential_test.go
@@ -1,0 +1,56 @@
+package credential
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseTemplate(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env.kontext")
+
+	content := `
+# comment
+GITHUB_TOKEN={{kontext:github}}
+DATABASE_URL={{kontext:postgres/prod-readonly}}
+PLAIN=value
+EMPTY=
+STRIPE_KEY={{kontext:stripe}}
+`
+
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+
+	entries, err := ParseTemplate(path)
+	if err != nil {
+		t.Fatalf("ParseTemplate() error = %v", err)
+	}
+
+	if got, want := len(entries), 3; got != want {
+		t.Fatalf("ParseTemplate() len = %d, want %d", got, want)
+	}
+
+	if got, want := entries[0].EnvVar, "GITHUB_TOKEN"; got != want {
+		t.Fatalf("entries[0].EnvVar = %q, want %q", got, want)
+	}
+	if got, want := entries[0].Target(), "github"; got != want {
+		t.Fatalf("entries[0].Target() = %q, want %q", got, want)
+	}
+
+	if got, want := entries[1].EnvVar, "DATABASE_URL"; got != want {
+		t.Fatalf("entries[1].EnvVar = %q, want %q", got, want)
+	}
+	if got, want := entries[1].Provider, "postgres"; got != want {
+		t.Fatalf("entries[1].Provider = %q, want %q", got, want)
+	}
+	if got, want := entries[1].Resource, "prod-readonly"; got != want {
+		t.Fatalf("entries[1].Resource = %q, want %q", got, want)
+	}
+	if got, want := entries[1].Target(), "postgres/prod-readonly"; got != want {
+		t.Fatalf("entries[1].Target() = %q, want %q", got, want)
+	}
+}

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -1,6 +1,6 @@
 // Package hook handles the hook event lifecycle.
-// It reads hook events from stdin, evaluates them against the sidecar
-// (or directly against the backend), and writes decisions to stdout.
+// It reads hook events from stdin, hands them to the local evaluator,
+// and writes the resulting decision to stdout.
 package hook
 
 import (

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -13,14 +13,16 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
-	"sync"
+	"slices"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
 	"github.com/cli/browser"
 
 	agentv1 "github.com/kontext-dev/kontext-cli/gen/kontext/agent/v1"
+	"github.com/kontext-dev/kontext-cli/internal/agent"
 	"github.com/kontext-dev/kontext-cli/internal/auth"
 	"github.com/kontext-dev/kontext-cli/internal/backend"
 	"github.com/kontext-dev/kontext-cli/internal/credential"
@@ -38,6 +40,10 @@ type Options struct {
 
 // Start is the main entry point for `kontext start`.
 func Start(ctx context.Context, opts Options) error {
+	if _, ok := agent.Get(opts.Agent); !ok {
+		return fmt.Errorf("unsupported agent %q (supported: %s)", opts.Agent, strings.Join(supportedAgents(), ", "))
+	}
+
 	// 1. Auth
 	session, err := ensureSession(ctx, opts.IssuerURL, opts.ClientID)
 	if err != nil {
@@ -69,9 +75,7 @@ func Start(ctx context.Context, opts Options) error {
 		},
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "⚠ Session creation failed: %v\n", err)
-		fmt.Fprintln(os.Stderr, "  Launching without telemetry (backend may not support ConnectRPC yet)")
-		return launchAgentDirect(ctx, opts)
+		return fmt.Errorf("create managed session: %w", err)
 	}
 
 	sessionID := createResp.SessionId
@@ -86,7 +90,7 @@ func Start(ctx context.Context, opts Options) error {
 			return fmt.Errorf("parse template: %w", err)
 		}
 		if len(entries) > 0 {
-			resolved, err = resolveCredentials(ctx, session, entries)
+			resolved, err = resolveCredentials(ctx, session, entries, opts.IssuerURL, opts.ClientID)
 			if err != nil {
 				return err
 			}
@@ -97,7 +101,9 @@ func Start(ctx context.Context, opts Options) error {
 	// Use /tmp (not $TMPDIR) with a short ID to keep the Unix socket path
 	// under macOS's 104-byte sun_path limit.
 	sessionDir := filepath.Join("/tmp", "kontext", truncateID(sessionID))
-	os.MkdirAll(sessionDir, 0700)
+	if err := os.MkdirAll(sessionDir, 0o700); err != nil {
+		return fmt.Errorf("create session dir: %w", err)
+	}
 
 	sc, err := sidecar.New(sessionDir, client, sessionID, opts.Agent)
 	if err != nil {
@@ -163,23 +169,23 @@ func ensureSession(ctx context.Context, issuerURL, clientID string) (*auth.Sessi
 }
 
 // resolveCredentials exchanges each template entry for a live credential.
-func resolveCredentials(ctx context.Context, session *auth.Session, entries []credential.Entry) ([]credential.Resolved, error) {
+func resolveCredentials(ctx context.Context, session *auth.Session, entries []credential.Entry, issuerURL, clientID string) ([]credential.Resolved, error) {
 	fmt.Fprintln(os.Stderr, "\nResolving credentials...")
 	var resolved []credential.Resolved
 
 	for _, entry := range entries {
-		fmt.Fprintf(os.Stderr, "  %s (%s)... ", entry.EnvVar, entry.Provider)
+		fmt.Fprintf(os.Stderr, "  %s (%s)... ", entry.EnvVar, entry.Target())
 
-		value, err := exchangeCredential(ctx, session, entry)
+		value, err := exchangeCredential(ctx, session, entry, clientID)
 		if err != nil {
 			if isNotConnectedError(err) {
 				fmt.Fprintln(os.Stderr, "not connected")
 				fmt.Fprintf(os.Stderr, "  Opening browser to connect %s...\n", entry.Provider)
-				connectURL := fmt.Sprintf("%s/connect/%s", auth.DefaultIssuerURL, entry.Provider)
+				connectURL := fmt.Sprintf("%s/connect/%s", strings.TrimRight(issuerURL, "/"), entry.Provider)
 				_ = browser.OpenURL(connectURL)
 				fmt.Fprint(os.Stderr, "  Press Enter after connecting...")
 				bufio.NewReader(os.Stdin).ReadString('\n')
-				value, err = exchangeCredential(ctx, session, entry)
+				value, err = exchangeCredential(ctx, session, entry, clientID)
 			}
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "⚠ skipped (%v)\n", err)
@@ -197,7 +203,7 @@ func resolveCredentials(ctx context.Context, session *auth.Session, entries []cr
 // exchangeCredential calls POST /oauth2/token with RFC 8693 token exchange
 // to resolve a provider credential. The user's access token serves as both
 // the subject_token and the Bearer auth — no client secret needed.
-func exchangeCredential(ctx context.Context, session *auth.Session, entry credential.Entry) (string, error) {
+func exchangeCredential(ctx context.Context, session *auth.Session, entry credential.Entry, clientID string) (string, error) {
 	meta, err := auth.DiscoverEndpoints(ctx, session.IssuerURL)
 	if err != nil {
 		return "", fmt.Errorf("oauth discovery: %w", err)
@@ -205,10 +211,10 @@ func exchangeCredential(ctx context.Context, session *auth.Session, entry creden
 
 	form := url.Values{
 		"grant_type":         {"urn:ietf:params:oauth:grant-type:token-exchange"},
-		"client_id":          {auth.DefaultClientID},
+		"client_id":          {clientID},
 		"subject_token":      {session.AccessToken},
 		"subject_token_type": {"urn:ietf:params:oauth:token-type:access_token"},
-		"resource":           {entry.Provider},
+		"resource":           {entry.Target()},
 	}
 
 	req, err := http.NewRequestWithContext(ctx, "POST", meta.TokenEndpoint, strings.NewReader(form.Encode()))
@@ -261,6 +267,12 @@ func buildEnv(resolved []credential.Resolved) []string {
 	return credential.BuildEnv(resolved, env)
 }
 
+func supportedAgents() []string {
+	names := agent.Names()
+	slices.Sort(names)
+	return names
+}
+
 // newSessionTokenSource returns a TokenSource that transparently refreshes
 // the OIDC access token when it expires, so long-running sessions keep working.
 func newSessionTokenSource(ctx context.Context, session *auth.Session) backend.TokenSource {
@@ -287,11 +299,6 @@ func newSessionTokenSource(ctx context.Context, session *auth.Session) backend.T
 		*session = *refreshed
 		return session.AccessToken, nil
 	}
-}
-
-func launchAgentDirect(ctx context.Context, opts Options) error {
-	fmt.Fprintf(os.Stderr, "\nLaunching %s...\n\n", opts.Agent)
-	return launchAgentWithSettings(ctx, opts.Agent, os.Environ(), opts.Args, "")
 }
 
 func launchAgentWithSettings(_ context.Context, agentName string, env, extraArgs []string, settingsPath string) error {

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -1,0 +1,26 @@
+package run
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFilterArgs(t *testing.T) {
+	t.Parallel()
+
+	args := []string{
+		"--settings", "user-settings.json",
+		"--dangerously-skip-permissions",
+		"--setting-sources=local",
+		"--allowed",
+		"value",
+		"--bare",
+		"prompt",
+	}
+
+	got := filterArgs(args)
+	want := []string{"--allowed", "value", "prompt"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("filterArgs() = %#v, want %#v", got, want)
+	}
+}

--- a/internal/sidecar/sidecar.go
+++ b/internal/sidecar/sidecar.go
@@ -1,6 +1,6 @@
 // Package sidecar implements the local session server.
 // Hook handlers connect over a Unix socket. The sidecar relays events
-// to the Kontext backend via ConnectRPC and returns policy decisions.
+// to the Kontext backend via ConnectRPC and keeps the session alive.
 package sidecar
 
 import (


### PR DESCRIPTION
## What changed
- hardened CI and release workflows with pinned GitHub Actions SHAs, tighter permissions, timeouts, dependency review, module verification, race tests, and binary vulnerability scanning
- upgraded the repo toolchain target to Go 1.25.9 and removed release-time `go mod tidy` mutation from GoReleaser
- pinned the external proto generation source ref and added contributor-facing open source files: `LICENSE`, `SECURITY.md`, `CONTRIBUTING.md`, and `CODE_OF_CONDUCT.md`
- fixed CLI correctness gaps around unsupported agents, managed-session startup, and credential target resolution for `.env.kontext` entries with resource suffixes
- tightened the README so it matches the actual shipped behavior and install paths
- added focused tests for credential template parsing and blocked flag filtering

## Why this changed
The repo was close, but not quite ready to be opened up confidently. The release pipeline needed stronger reproducibility and security defaults, and the code/docs still had a few mismatches that would be rough in a public repo.

## Impact
- safer and more reproducible CI/release automation
- a cleaner public-repo trust surface for contributors and security reporting
- more accurate documentation for what the CLI actually supports today
- correct credential exchange behavior for provider/resource targets like `postgres/prod-readonly`
- no new runtime dependencies

## Root cause
The first release pipeline was in place, but it still relied on a few permissive defaults and some “good enough for private alpha” assumptions in docs and startup behavior.

## Validation
- `buf generate`
- `git diff --exit-code gen/`
- `go mod verify`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go build ./...`
- `govulncheck -mode=binary ./bin/kontext`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kontext-dev/kontext-cli/pull/39" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
