### PR TITLE
Fix provider reauthorization URL in CLI

### DIFF
--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -90,7 +91,7 @@ func Start(ctx context.Context, opts Options) error {
 			return fmt.Errorf("parse template: %w", err)
 		}
 		if len(entries) > 0 {
-			resolved, err = resolveCredentials(ctx, session, entries, opts.IssuerURL, opts.ClientID)
+			resolved, err = resolveCredentials(ctx, session, entries, opts.ClientID)
 			if err != nil {
 				return err
 			}
@@ -169,7 +170,7 @@ func ensureSession(ctx context.Context, issuerURL, clientID string) (*auth.Sessi
 }
 
 // resolveCredentials exchanges each template entry for a live credential.
-func resolveCredentials(ctx context.Context, session *auth.Session, entries []credential.Entry, issuerURL, clientID string) ([]credential.Resolved, error) {
+func resolveCredentials(ctx context.Context, session *auth.Session, entries []credential.Entry, clientID string) ([]credential.Resolved, error) {
 	fmt.Fprintln(os.Stderr, "\nResolving credentials...")
 	var resolved []credential.Resolved
 
@@ -180,12 +181,17 @@ func resolveCredentials(ctx context.Context, session *auth.Session, entries []cr
 		if err != nil {
 			if isNotConnectedError(err) {
 				fmt.Fprintln(os.Stderr, "not connected")
-				fmt.Fprintf(os.Stderr, "  Opening browser to connect %s...\n", entry.Provider)
-				connectURL := fmt.Sprintf("%s/connect/%s", strings.TrimRight(issuerURL, "/"), entry.Provider)
-				_ = browser.OpenURL(connectURL)
-				fmt.Fprint(os.Stderr, "  Press Enter after connecting...")
-				bufio.NewReader(os.Stdin).ReadString('\n')
-				value, err = exchangeCredential(ctx, session, entry, clientID)
+				connectURL, connectErr := fetchConnectURL(ctx, session)
+				if connectErr != nil {
+					err = fmt.Errorf("create connect session: %w", connectErr)
+				} else {
+					fmt.Fprintf(os.Stderr, "  Opening browser to connect %s...\n", entry.Provider)
+					fmt.Fprintf(os.Stderr, "  If the browser doesn't open, visit:\n    %s\n", connectURL)
+					_ = browser.OpenURL(connectURL)
+					fmt.Fprint(os.Stderr, "  Press Enter after connecting...")
+					bufio.NewReader(os.Stdin).ReadString('\n')
+					value, err = exchangeCredential(ctx, session, entry, clientID)
+				}
 			}
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "⚠ skipped (%v)\n", err)
@@ -198,6 +204,48 @@ func resolveCredentials(ctx context.Context, session *auth.Session, entries []cr
 	}
 
 	return resolved, nil
+}
+
+func fetchConnectURL(ctx context.Context, session *auth.Session) (string, error) {
+	connectSessionURL := strings.TrimRight(session.IssuerURL, "/") + "/mcp/connect-session"
+
+	req, err := http.NewRequestWithContext(ctx, "POST", connectSessionURL, strings.NewReader("{}"))
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+session.AccessToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("connect session request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		if readErr != nil {
+			return "", fmt.Errorf("connect session request failed: %s", resp.Status)
+		}
+
+		msg := strings.TrimSpace(string(body))
+		if msg == "" {
+			return "", fmt.Errorf("connect session request failed: %s", resp.Status)
+		}
+		return "", fmt.Errorf("connect session request failed: %s: %s", resp.Status, msg)
+	}
+
+	var result struct {
+		ConnectURL string `json:"connectUrl"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("decode connect session response: %w", err)
+	}
+	if result.ConnectURL == "" {
+		return "", fmt.Errorf("connect session response missing connectUrl")
+	}
+
+	return result.ConnectURL, nil
 }
 
 // exchangeCredential calls POST /oauth2/token with RFC 8693 token exchange

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -1,8 +1,15 @@
 package run
 
 import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/kontext-dev/kontext-cli/internal/auth"
 )
 
 func TestFilterArgs(t *testing.T) {
@@ -22,5 +29,96 @@ func TestFilterArgs(t *testing.T) {
 	want := []string{"--allowed", "value", "prompt"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("filterArgs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestFetchConnectURL(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %q, want %q", r.Method, http.MethodPost)
+		}
+		if r.URL.Path != "/mcp/connect-session" {
+			t.Fatalf("path = %q, want %q", r.URL.Path, "/mcp/connect-session")
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-access-token" {
+			t.Fatalf("authorization = %q, want %q", got, "Bearer test-access-token")
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Fatalf("content-type = %q, want %q", got, "application/json")
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if got := string(body); got != "{}" {
+			t.Fatalf("body = %q, want %q", got, "{}")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"connectUrl":"https://app.kontext.security/providers/connect#handshake=session-123"}`))
+	}))
+	defer server.Close()
+
+	session := &auth.Session{
+		IssuerURL:   server.URL,
+		AccessToken: "test-access-token",
+	}
+
+	got, err := fetchConnectURL(context.Background(), session)
+	if err != nil {
+		t.Fatalf("fetchConnectURL() error = %v", err)
+	}
+
+	want := "https://app.kontext.security/providers/connect#handshake=session-123"
+	if got != want {
+		t.Fatalf("fetchConnectURL() = %q, want %q", got, want)
+	}
+}
+
+func TestFetchConnectURLReturnsErrorOnNon200(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	session := &auth.Session{
+		IssuerURL:   server.URL,
+		AccessToken: "test-access-token",
+	}
+
+	_, err := fetchConnectURL(context.Background(), session)
+	if err == nil {
+		t.Fatal("fetchConnectURL() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "502 Bad Gateway") {
+		t.Fatalf("fetchConnectURL() error = %q, want status in message", err)
+	}
+}
+
+func TestFetchConnectURLReturnsErrorOnEmptyConnectURL(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"connectUrl":""}`))
+	}))
+	defer server.Close()
+
+	session := &auth.Session{
+		IssuerURL:   server.URL,
+		AccessToken: "test-access-token",
+	}
+
+	_, err := fetchConnectURL(context.Background(), session)
+	if err == nil {
+		t.Fatal("fetchConnectURL() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "missing connectUrl") {
+		t.Fatalf("fetchConnectURL() error = %q, want missing connectUrl message", err)
 	}
 }

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -35,26 +36,46 @@ func TestFilterArgs(t *testing.T) {
 func TestFetchConnectURL(t *testing.T) {
 	t.Parallel()
 
+	handlerErrs := make(chan error, 1)
+	recordHandlerErr := func(format string, args ...any) {
+		select {
+		case handlerErrs <- fmt.Errorf(format, args...):
+		default:
+		}
+	}
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
-			t.Fatalf("method = %q, want %q", r.Method, http.MethodPost)
+			recordHandlerErr("method = %q, want %q", r.Method, http.MethodPost)
+			http.Error(w, "bad method", http.StatusBadRequest)
+			return
 		}
 		if r.URL.Path != "/mcp/connect-session" {
-			t.Fatalf("path = %q, want %q", r.URL.Path, "/mcp/connect-session")
+			recordHandlerErr("path = %q, want %q", r.URL.Path, "/mcp/connect-session")
+			http.Error(w, "bad path", http.StatusBadRequest)
+			return
 		}
 		if got := r.Header.Get("Authorization"); got != "Bearer test-access-token" {
-			t.Fatalf("authorization = %q, want %q", got, "Bearer test-access-token")
+			recordHandlerErr("authorization = %q, want %q", got, "Bearer test-access-token")
+			http.Error(w, "bad auth", http.StatusUnauthorized)
+			return
 		}
 		if got := r.Header.Get("Content-Type"); got != "application/json" {
-			t.Fatalf("content-type = %q, want %q", got, "application/json")
+			recordHandlerErr("content-type = %q, want %q", got, "application/json")
+			http.Error(w, "bad content-type", http.StatusBadRequest)
+			return
 		}
 
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
-			t.Fatalf("read body: %v", err)
+			recordHandlerErr("read body: %v", err)
+			http.Error(w, "read error", http.StatusInternalServerError)
+			return
 		}
 		if got := string(body); got != "{}" {
-			t.Fatalf("body = %q, want %q", got, "{}")
+			recordHandlerErr("body = %q, want %q", got, "{}")
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -70,6 +91,11 @@ func TestFetchConnectURL(t *testing.T) {
 	got, err := fetchConnectURL(context.Background(), session)
 	if err != nil {
 		t.Fatalf("fetchConnectURL() error = %v", err)
+	}
+	select {
+	case err := <-handlerErrs:
+		t.Fatal(err)
+	default:
 	}
 
 	want := "https://app.kontext.security/providers/connect#handshake=session-123"


### PR DESCRIPTION
## Summary
- replace the CLI's hand-built provider connect URL with the hosted `connectUrl` returned by `POST /mcp/connect-session`
- open that server-provided URL before retrying token exchange when provider connection or reauthorization is required
- add focused tests for the connect-session helper, including auth header, non-200 responses, and empty `connectUrl`

## Root cause
The CLI was building a browser URL from the API issuer origin, which sent users to a non-existent endpoint and produced a 404. The backend already owns the correct hosted connect URL for the dashboard flow.

## Validation
- `go test ./...`
- `go vet ./...`

Fixes #29
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kontext-dev/kontext-cli/pull/40" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
