### PR TITLE
Run GitHub JavaScript actions on Node 24

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 concurrency:
   group: release-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false


### PR DESCRIPTION
## What changed
- opted the `release-please` workflow into Node 24 for GitHub JavaScript actions

## Why this changed
GitHub warned that `googleapis/release-please-action` is still running on Node 20, which is deprecated on GitHub-hosted runners in 2026. The workflow itself is otherwise healthy, so this is a targeted compatibility cleanup.

## Impact
- removes the remaining Node 20 deprecation warning from the release workflow
- keeps the repo aligned with current GitHub Actions runtime guidance
- no product behavior changes

## Validation
- workflow change only
- will be verified by CI on this PR
- will be verified again on the next `main` push after merge

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kontext-dev/kontext-cli/pull/41" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
