### PR TITLE
docs: mention dependency review in public PR flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,7 @@ buf generate
 - Include tests for behavior changes.
 - Update the README when user-facing behavior changes.
 - Keep generated code, docs, and release notes in sync with the code.
+- Public PRs also run `dependency-review`, so dependency changes must pass both CI and GitHub advisory checks.
 
 ## Release flow
 


### PR DESCRIPTION
## Summary
- document that public pull requests now run dependency review
- create a minimal public PR to validate the dependency-review workflow before making it required

## Verification
- git diff --check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kontext-dev/kontext-cli/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
