### PR TITLE
feat(cli): add logout command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ bin/
 dist/
 *.exe
 .env.kontext
-kontext
+/kontext
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ kontext start --agent claude
 ```
 
 That's it. On first run, the CLI handles everything interactively — login, provider connections, credential resolution.
+Run `kontext logout` any time to clear the stored OIDC session from your system keyring.
 
 ## How it Works
 
@@ -48,7 +49,7 @@ That's it. On first run, the CLI handles everything interactively — login, pro
 kontext start --agent claude
 ```
 
-1. **Authenticates** — opens browser for OIDC login, stores refresh token in system keyring
+1. **Authenticates** — opens browser for OIDC login, stores refresh token in system keyring, and lets you clear it later with `kontext logout`
 2. **Creates a session** — registers with the Kontext backend, visible in the dashboard
 3. **Resolves credentials** — reads `.env.kontext`, exchanges placeholders for short-lived tokens
 4. **Launches the agent** — spawns Claude Code with credentials injected as env vars + governance hooks

--- a/cmd/kontext/main.go
+++ b/cmd/kontext/main.go
@@ -3,12 +3,14 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/zalando/go-keyring"
 
 	"github.com/kontext-dev/kontext-cli/internal/agent"
 	"github.com/kontext-dev/kontext-cli/internal/auth"
@@ -97,14 +99,21 @@ func loginCmd() *cobra.Command {
 }
 
 func logoutCmd() *cobra.Command {
+	return newLogoutCmd(auth.ClearSession)
+}
+
+func newLogoutCmd(clearSession func() error) *cobra.Command {
 	return &cobra.Command{
 		Use:   "logout",
 		Short: "Log out and clear stored credentials",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := auth.ClearSession(); err != nil {
+			if err := clearSession(); err != nil {
+				if errors.Is(err, keyring.ErrNotFound) {
+					return errors.New("already logged out")
+				}
 				return fmt.Errorf("logout failed: %w", err)
 			}
-			fmt.Fprintln(os.Stderr, "Logged out successfully.")
+			fmt.Fprintln(cmd.ErrOrStderr(), "Logged out successfully.")
 			return nil
 		},
 	}

--- a/cmd/kontext/main.go
+++ b/cmd/kontext/main.go
@@ -31,6 +31,7 @@ func main() {
 
 	root.AddCommand(startCmd())
 	root.AddCommand(loginCmd())
+	root.AddCommand(logoutCmd())
 	root.AddCommand(hookCmd())
 
 	if err := root.Execute(); err != nil {
@@ -93,6 +94,20 @@ func loginCmd() *cobra.Command {
 	cmd.Flags().StringVar(&clientID, "client-id", auth.DefaultClientID, "OAuth client ID")
 
 	return cmd
+}
+
+func logoutCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "logout",
+		Short: "Log out and clear stored credentials",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := auth.ClearSession(); err != nil {
+				return fmt.Errorf("logout failed: %w", err)
+			}
+			fmt.Fprintln(os.Stderr, "Logged out successfully.")
+			return nil
+		},
+	}
 }
 
 func hookCmd() *cobra.Command {

--- a/cmd/kontext/main_test.go
+++ b/cmd/kontext/main_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/zalando/go-keyring"
+)
+
+func TestLogoutCmdSuccess(t *testing.T) {
+	cmd := newLogoutCmd(func() error { return nil })
+
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("RunE() error = %v", err)
+	}
+
+	if got, want := stderr.String(), "Logged out successfully.\n"; got != want {
+		t.Fatalf("stderr = %q, want %q", got, want)
+	}
+}
+
+func TestLogoutCmdAlreadyLoggedOut(t *testing.T) {
+	cmd := newLogoutCmd(func() error { return keyring.ErrNotFound })
+
+	err := cmd.RunE(cmd, nil)
+	if err == nil {
+		t.Fatal("RunE() error = nil, want non-nil")
+	}
+	if got, want := err.Error(), "already logged out"; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
+}
+
+func TestLogoutCmdWrapsUnexpectedErrors(t *testing.T) {
+	boom := errors.New("boom")
+	cmd := newLogoutCmd(func() error { return boom })
+
+	err := cmd.RunE(cmd, nil)
+	if err == nil {
+		t.Fatal("RunE() error = nil, want non-nil")
+	}
+	if !errors.Is(err, boom) {
+		t.Fatalf("errors.Is(err, boom) = false, err = %v", err)
+	}
+	if !strings.Contains(err.Error(), "logout failed: boom") {
+		t.Fatalf("error = %q, want wrapped logout failure", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `kontext logout` command that clears stored OIDC credentials from the system keyring
- Wires up the existing `auth.ClearSession()` function as a user-facing cobra command

## Test plan
- [ ] Run `kontext logout` after being logged in — should print "Logged out successfully."
- [ ] Run `kontext start` after logout — should prompt to re-authenticate
- [ ] Run `kontext logout` when already logged out — should return a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kontext-dev/kontext-cli/pull/46" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
