### PR TITLE
fix(cli): scope exchanges to the session agent

### DIFF
--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -80,7 +80,7 @@ func Start(ctx context.Context, opts Options) error {
 	}
 
 	sessionID := createResp.SessionId
-	credentialClientID := agentOAuthClientID(createResp.AgentId)
+	credentialClientID := resolveCredentialClientID(createResp.AgentId, opts.ClientID)
 	fmt.Fprintf(os.Stderr, "✓ Session: %s (%s)\n", createResp.SessionName, truncateID(sessionID))
 
 	// 4. Resolve credentials (before sidecar starts — no background goroutines yet,
@@ -250,6 +250,13 @@ func fetchConnectURL(ctx context.Context, session *auth.Session, clientID string
 
 func agentOAuthClientID(agentID string) string {
 	return "app_" + agentID
+}
+
+func resolveCredentialClientID(agentID, fallback string) string {
+	if strings.TrimSpace(agentID) == "" {
+		return fallback
+	}
+	return agentOAuthClientID(agentID)
 }
 
 type tokenExchangeResponse struct {

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -80,6 +80,7 @@ func Start(ctx context.Context, opts Options) error {
 	}
 
 	sessionID := createResp.SessionId
+	credentialClientID := agentOAuthClientID(createResp.AgentId)
 	fmt.Fprintf(os.Stderr, "✓ Session: %s (%s)\n", createResp.SessionName, truncateID(sessionID))
 
 	// 4. Resolve credentials (before sidecar starts — no background goroutines yet,
@@ -91,7 +92,7 @@ func Start(ctx context.Context, opts Options) error {
 			return fmt.Errorf("parse template: %w", err)
 		}
 		if len(entries) > 0 {
-			resolved, err = resolveCredentials(ctx, session, entries, opts.ClientID)
+			resolved, err = resolveCredentials(ctx, session, entries, credentialClientID)
 			if err != nil {
 				return err
 			}
@@ -175,7 +176,7 @@ func resolveCredentials(ctx context.Context, session *auth.Session, entries []cr
 		if err != nil {
 			if isNotConnectedError(err) {
 				fmt.Fprintln(os.Stderr, "not connected")
-				connectURL, connectErr := fetchConnectURL(ctx, session)
+				connectURL, connectErr := fetchConnectURL(ctx, session, clientID)
 				if connectErr != nil {
 					err = fmt.Errorf("create connect session: %w", connectErr)
 				} else {
@@ -200,7 +201,12 @@ func resolveCredentials(ctx context.Context, session *auth.Session, entries []cr
 	return resolved, nil
 }
 
-func fetchConnectURL(ctx context.Context, session *auth.Session) (string, error) {
+func fetchConnectURL(ctx context.Context, session *auth.Session, clientID string) (string, error) {
+	gatewayToken, err := exchangeGatewayToken(ctx, session, clientID)
+	if err != nil {
+		return "", err
+	}
+
 	connectSessionURL := strings.TrimRight(session.IssuerURL, "/") + "/mcp/connect-session"
 
 	req, err := http.NewRequestWithContext(ctx, "POST", connectSessionURL, strings.NewReader("{}"))
@@ -208,7 +214,7 @@ func fetchConnectURL(ctx context.Context, session *auth.Session) (string, error)
 		return "", fmt.Errorf("build request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+session.AccessToken)
+	req.Header.Set("Authorization", "Bearer "+gatewayToken)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -242,13 +248,22 @@ func fetchConnectURL(ctx context.Context, session *auth.Session) (string, error)
 	return result.ConnectURL, nil
 }
 
-// exchangeCredential calls POST /oauth2/token with RFC 8693 token exchange
-// to resolve a provider credential. The user's access token serves as both
-// the subject_token and the Bearer auth — no client secret needed.
-func exchangeCredential(ctx context.Context, session *auth.Session, entry credential.Entry, clientID string) (string, error) {
+func agentOAuthClientID(agentID string) string {
+	return "app_" + agentID
+}
+
+type tokenExchangeResponse struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	ProviderKind string `json:"provider_kind"`
+	Error        string `json:"error"`
+	ErrorDesc    string `json:"error_description"`
+}
+
+func exchangeToken(ctx context.Context, session *auth.Session, clientID, resource string, scopes ...string) (*tokenExchangeResponse, error) {
 	meta, err := auth.DiscoverEndpoints(ctx, session.IssuerURL)
 	if err != nil {
-		return "", fmt.Errorf("oauth discovery: %w", err)
+		return nil, fmt.Errorf("oauth discovery: %w", err)
 	}
 
 	form := url.Values{
@@ -256,33 +271,56 @@ func exchangeCredential(ctx context.Context, session *auth.Session, entry creden
 		"client_id":          {clientID},
 		"subject_token":      {session.AccessToken},
 		"subject_token_type": {"urn:ietf:params:oauth:token-type:access_token"},
-		"resource":           {entry.Target()},
+		"resource":           {resource},
+	}
+	if len(scopes) > 0 {
+		form.Set("scope", strings.Join(scopes, " "))
 	}
 
 	req, err := http.NewRequestWithContext(ctx, "POST", meta.TokenEndpoint, strings.NewReader(form.Encode()))
 	if err != nil {
-		return "", fmt.Errorf("build request: %w", err)
+		return nil, fmt.Errorf("build request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Authorization", "Bearer "+session.AccessToken)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("token exchange request: %w", err)
+		return nil, fmt.Errorf("token exchange request: %w", err)
 	}
 	defer resp.Body.Close()
 
-	var result struct {
-		AccessToken  string `json:"access_token"`
-		TokenType    string `json:"token_type"`
-		ProviderKind string `json:"provider_kind"`
-		Error        string `json:"error"`
-		ErrorDesc    string `json:"error_description"`
-	}
+	var result tokenExchangeResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", fmt.Errorf("decode token exchange response: %w", err)
+		return nil, fmt.Errorf("decode token exchange response: %w", err)
 	}
 
+	return &result, nil
+}
+
+func exchangeGatewayToken(ctx context.Context, session *auth.Session, clientID string) (string, error) {
+	result, err := exchangeToken(ctx, session, clientID, "mcp-gateway", "gateway:access")
+	if err != nil {
+		return "", err
+	}
+	if result.Error != "" {
+		return "", fmt.Errorf("gateway token exchange failed: %s: %s", result.Error, result.ErrorDesc)
+	}
+	if result.AccessToken == "" {
+		return "", fmt.Errorf("gateway token exchange returned empty access_token")
+	}
+
+	return result.AccessToken, nil
+}
+
+// exchangeCredential calls POST /oauth2/token with RFC 8693 token exchange
+// to resolve a provider credential. The user's access token serves as both
+// the subject_token and the Bearer auth — no client secret needed.
+func exchangeCredential(ctx context.Context, session *auth.Session, entry credential.Entry, clientID string) (string, error) {
+	result, err := exchangeToken(ctx, session, clientID, entry.Target())
+	if err != nil {
+		return "", err
+	}
 	if result.Error != "" {
 		if result.Error == "invalid_target" && strings.Contains(result.ErrorDesc, "not allowed") {
 			return "", fmt.Errorf("provider not connected: %s", entry.Provider)

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -283,3 +283,15 @@ func TestAgentOAuthClientID(t *testing.T) {
 		t.Fatalf("agentOAuthClientID() = %q, want %q", got, "app_agent-123")
 	}
 }
+
+func TestResolveCredentialClientID(t *testing.T) {
+	t.Parallel()
+
+	if got := resolveCredentialClientID("agent-123", "bootstrap-client"); got != "app_agent-123" {
+		t.Fatalf("resolveCredentialClientID() = %q, want %q", got, "app_agent-123")
+	}
+
+	if got := resolveCredentialClientID("", "bootstrap-client"); got != "bootstrap-client" {
+		t.Fatalf("resolveCredentialClientID() empty agent = %q, want %q", got, "bootstrap-client")
+	}
+}

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -6,11 +6,13 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/kontext-dev/kontext-cli/internal/auth"
+	"github.com/kontext-dev/kontext-cli/internal/credential"
 )
 
 func TestFilterArgs(t *testing.T) {
@@ -44,42 +46,88 @@ func TestFetchConnectURL(t *testing.T) {
 		}
 	}
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			recordHandlerErr("method = %q, want %q", r.Method, http.MethodPost)
-			http.Error(w, "bad method", http.StatusBadRequest)
-			return
-		}
-		if r.URL.Path != "/mcp/connect-session" {
-			recordHandlerErr("path = %q, want %q", r.URL.Path, "/mcp/connect-session")
-			http.Error(w, "bad path", http.StatusBadRequest)
-			return
-		}
-		if got := r.Header.Get("Authorization"); got != "Bearer test-access-token" {
-			recordHandlerErr("authorization = %q, want %q", got, "Bearer test-access-token")
-			http.Error(w, "bad auth", http.StatusUnauthorized)
-			return
-		}
-		if got := r.Header.Get("Content-Type"); got != "application/json" {
-			recordHandlerErr("content-type = %q, want %q", got, "application/json")
-			http.Error(w, "bad content-type", http.StatusBadRequest)
-			return
-		}
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"issuer":"%s","authorization_endpoint":"%s/oauth2/auth","token_endpoint":"%s/oauth2/token","jwks_uri":"%s/.well-known/jwks.json"}`, server.URL, server.URL, server.URL, server.URL)))
+		case "/oauth2/token":
+			if r.Method != http.MethodPost {
+				recordHandlerErr("token method = %q, want %q", r.Method, http.MethodPost)
+				http.Error(w, "bad method", http.StatusBadRequest)
+				return
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer test-access-token" {
+				recordHandlerErr("token authorization = %q, want %q", got, "Bearer test-access-token")
+				http.Error(w, "bad auth", http.StatusUnauthorized)
+				return
+			}
 
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			recordHandlerErr("read body: %v", err)
-			http.Error(w, "read error", http.StatusInternalServerError)
-			return
-		}
-		if got := string(body); got != "{}" {
-			recordHandlerErr("body = %q, want %q", got, "{}")
-			http.Error(w, "bad body", http.StatusBadRequest)
-			return
-		}
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				recordHandlerErr("read token body: %v", err)
+				http.Error(w, "read error", http.StatusInternalServerError)
+				return
+			}
+			values, err := url.ParseQuery(string(body))
+			if err != nil {
+				recordHandlerErr("parse token body: %v", err)
+				http.Error(w, "parse error", http.StatusBadRequest)
+				return
+			}
+			if got := values.Get("client_id"); got != "app_agent-123" {
+				recordHandlerErr("client_id = %q, want %q", got, "app_agent-123")
+				http.Error(w, "bad client", http.StatusBadRequest)
+				return
+			}
+			if got := values.Get("resource"); got != "mcp-gateway" {
+				recordHandlerErr("resource = %q, want %q", got, "mcp-gateway")
+				http.Error(w, "bad resource", http.StatusBadRequest)
+				return
+			}
+			if got := values.Get("scope"); got != "gateway:access" {
+				recordHandlerErr("scope = %q, want %q", got, "gateway:access")
+				http.Error(w, "bad scope", http.StatusBadRequest)
+				return
+			}
 
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"connectUrl":"https://app.kontext.security/providers/connect#handshake=session-123"}`))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"gateway-token"}`))
+		case "/mcp/connect-session":
+			if r.Method != http.MethodPost {
+				recordHandlerErr("connect method = %q, want %q", r.Method, http.MethodPost)
+				http.Error(w, "bad method", http.StatusBadRequest)
+				return
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer gateway-token" {
+				recordHandlerErr("connect authorization = %q, want %q", got, "Bearer gateway-token")
+				http.Error(w, "bad auth", http.StatusUnauthorized)
+				return
+			}
+			if got := r.Header.Get("Content-Type"); got != "application/json" {
+				recordHandlerErr("connect content-type = %q, want %q", got, "application/json")
+				http.Error(w, "bad content-type", http.StatusBadRequest)
+				return
+			}
+
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				recordHandlerErr("read connect body: %v", err)
+				http.Error(w, "read error", http.StatusInternalServerError)
+				return
+			}
+			if got := string(body); got != "{}" {
+				recordHandlerErr("connect body = %q, want %q", got, "{}")
+				http.Error(w, "bad body", http.StatusBadRequest)
+				return
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"connectUrl":"https://app.kontext.security/providers/connect#handshake=session-123"}`))
+		default:
+			http.NotFound(w, r)
+		}
 	}))
 	defer server.Close()
 
@@ -88,7 +136,7 @@ func TestFetchConnectURL(t *testing.T) {
 		AccessToken: "test-access-token",
 	}
 
-	got, err := fetchConnectURL(context.Background(), session)
+	got, err := fetchConnectURL(context.Background(), session, "app_agent-123")
 	if err != nil {
 		t.Fatalf("fetchConnectURL() error = %v", err)
 	}
@@ -107,8 +155,20 @@ func TestFetchConnectURL(t *testing.T) {
 func TestFetchConnectURLReturnsErrorOnNon200(t *testing.T) {
 	t.Parallel()
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "boom", http.StatusBadGateway)
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"issuer":"%s","authorization_endpoint":"%s/oauth2/auth","token_endpoint":"%s/oauth2/token","jwks_uri":"%s/.well-known/jwks.json"}`, server.URL, server.URL, server.URL, server.URL)))
+		case "/oauth2/token":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"gateway-token"}`))
+		case "/mcp/connect-session":
+			http.Error(w, "boom", http.StatusBadGateway)
+		default:
+			http.NotFound(w, r)
+		}
 	}))
 	defer server.Close()
 
@@ -117,7 +177,7 @@ func TestFetchConnectURLReturnsErrorOnNon200(t *testing.T) {
 		AccessToken: "test-access-token",
 	}
 
-	_, err := fetchConnectURL(context.Background(), session)
+	_, err := fetchConnectURL(context.Background(), session, "app_agent-123")
 	if err == nil {
 		t.Fatal("fetchConnectURL() error = nil, want non-nil")
 	}
@@ -129,9 +189,21 @@ func TestFetchConnectURLReturnsErrorOnNon200(t *testing.T) {
 func TestFetchConnectURLReturnsErrorOnEmptyConnectURL(t *testing.T) {
 	t.Parallel()
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"connectUrl":""}`))
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"issuer":"%s","authorization_endpoint":"%s/oauth2/auth","token_endpoint":"%s/oauth2/token","jwks_uri":"%s/.well-known/jwks.json"}`, server.URL, server.URL, server.URL, server.URL)))
+		case "/oauth2/token":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"gateway-token"}`))
+		case "/mcp/connect-session":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"connectUrl":""}`))
+		default:
+			http.NotFound(w, r)
+		}
 	}))
 	defer server.Close()
 
@@ -140,11 +212,74 @@ func TestFetchConnectURLReturnsErrorOnEmptyConnectURL(t *testing.T) {
 		AccessToken: "test-access-token",
 	}
 
-	_, err := fetchConnectURL(context.Background(), session)
+	_, err := fetchConnectURL(context.Background(), session, "app_agent-123")
 	if err == nil {
 		t.Fatal("fetchConnectURL() error = nil, want non-nil")
 	}
 	if !strings.Contains(err.Error(), "missing connectUrl") {
 		t.Fatalf("fetchConnectURL() error = %q, want missing connectUrl message", err)
+	}
+}
+
+func TestExchangeCredentialUsesProvidedClientID(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"issuer":"%s","authorization_endpoint":"%s/oauth2/auth","token_endpoint":"%s/oauth2/token","jwks_uri":"%s/.well-known/jwks.json"}`, server.URL, server.URL, server.URL, server.URL)))
+		case "/oauth2/token":
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			values, err := url.ParseQuery(string(body))
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			if got := values.Get("client_id"); got != "app_agent-123" {
+				http.Error(w, "wrong client_id", http.StatusBadRequest)
+				return
+			}
+			if got := values.Get("resource"); got != "github" {
+				http.Error(w, "wrong resource", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"provider-token"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	session := &auth.Session{
+		IssuerURL:   server.URL,
+		AccessToken: "test-access-token",
+	}
+
+	value, err := exchangeCredential(
+		context.Background(),
+		session,
+		credential.Entry{EnvVar: "GITHUB_TOKEN", Provider: "github"},
+		"app_agent-123",
+	)
+	if err != nil {
+		t.Fatalf("exchangeCredential() error = %v", err)
+	}
+	if value != "provider-token" {
+		t.Fatalf("exchangeCredential() = %q, want %q", value, "provider-token")
+	}
+}
+
+func TestAgentOAuthClientID(t *testing.T) {
+	t.Parallel()
+
+	if got := agentOAuthClientID("agent-123"); got != "app_agent-123" {
+		t.Fatalf("agentOAuthClientID() = %q, want %q", got, "app_agent-123")
 	}
 }


### PR DESCRIPTION
## Summary
- derive the hidden CLI agent OAuth client ID from the `CreateSession` `agentId`
- use that client ID for provider token exchange instead of the fixed bootstrap client
- mint an agent-scoped gateway token before creating hosted connect sessions

## Testing
- `go test ./internal/run -v`
- `go test ./...`
- `go vet ./...`

## Dependency
- depends on the backend change in `kontext-dev/kontext` that provisions and resolves Hydra clients for CLI agents
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kontext-dev/kontext-cli/pull/47" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
