### PR TITLE
feat(cli): check for new releases on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ kontext start --agent claude
 - **Governance telemetry:** Claude hook events are streamed to the backend with user, session, and org attribution
 - **Secure by default:** OIDC authentication, system keyring storage, RFC 8693 token exchange, AES-256-GCM encryption at rest
 - **Lean runtime:** native Go binary, no local daemon install, no Node/Python runtime required
+- **Update notifications:** on `kontext start`, a background check queries the public GitHub releases API (cached for 24h, never blocks startup). Disable with `KONTEXT_NO_UPDATE_CHECK=1`
 
 ## Declare Credentials
 

--- a/cmd/kontext/main.go
+++ b/cmd/kontext/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -53,7 +54,7 @@ func startCmd() *cobra.Command {
 		Use:   "start [flags] [-- extra-agent-args...]",
 		Short: "Launch an agent with Kontext governance",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			updateDone := update.CheckAsync(version)
+			update.CheckAsync(version)
 			ctx := context.Background()
 			err := run.Start(ctx, run.Options{
 				Agent:        agentName,
@@ -62,7 +63,9 @@ func startCmd() *cobra.Command {
 				ClientID:     auth.DefaultClientID,
 				Args:         args,
 			})
-			<-updateDone
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				os.Exit(exitErr.ExitCode())
+			}
 			return err
 		},
 	}

--- a/cmd/kontext/main.go
+++ b/cmd/kontext/main.go
@@ -50,15 +50,17 @@ func startCmd() *cobra.Command {
 		Use:   "start [flags] [-- extra-agent-args...]",
 		Short: "Launch an agent with Kontext governance",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			update.CheckAsync(version)
+			updateDone := update.CheckAsync(version)
 			ctx := context.Background()
-			return run.Start(ctx, run.Options{
+			err := run.Start(ctx, run.Options{
 				Agent:        agentName,
 				TemplateFile: templateFile,
 				IssuerURL:    auth.DefaultIssuerURL,
 				ClientID:     auth.DefaultClientID,
 				Args:         args,
 			})
+			<-updateDone
+			return err
 		},
 	}
 

--- a/cmd/kontext/main.go
+++ b/cmd/kontext/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kontext-dev/kontext-cli/internal/hook"
 	"github.com/kontext-dev/kontext-cli/internal/run"
 	"github.com/kontext-dev/kontext-cli/internal/sidecar"
+	"github.com/kontext-dev/kontext-cli/internal/update"
 
 	// Register agent adapters
 	_ "github.com/kontext-dev/kontext-cli/internal/agent/claude"
@@ -49,6 +50,7 @@ func startCmd() *cobra.Command {
 		Use:   "start [flags] [-- extra-agent-args...]",
 		Short: "Launch an agent with Kontext governance",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			update.CheckAsync(version)
 			ctx := context.Background()
 			return run.Start(ctx, run.Options{
 				Agent:        agentName,

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -140,12 +140,6 @@ func Start(ctx context.Context, opts Options) error {
 
 	os.RemoveAll(sessionDir)
 
-	// Propagate agent exit code
-	if agentErr != nil {
-		if exitErr, ok := agentErr.(*exec.ExitError); ok {
-			os.Exit(exitErr.ExitCode())
-		}
-	}
 	return agentErr
 }
 

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -17,6 +17,10 @@ const (
 	cacheTTL = 24 * time.Hour
 )
 
+// githubAPIBase is the base URL for GitHub API requests. Tests override this
+// to point at an httptest server.
+var githubAPIBase = "https://api.github.com"
+
 type cachedVersion struct {
 	LatestVersion string    `json:"latest_version"`
 	CheckedAt     time.Time `json:"checked_at"`
@@ -24,15 +28,9 @@ type cachedVersion struct {
 
 // CheckAsync spawns a background goroutine that checks for a newer release.
 // It prints a one-liner to stderr if an update is available, and does nothing
-// on any error. The done channel is closed when the check completes; callers
-// should wait on it before exiting to avoid truncated output.
-func CheckAsync(currentVersion string) <-chan struct{} {
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		check(currentVersion)
-	}()
-	return done
+// on any error. The check is fully fire-and-forget — it never blocks the caller.
+func CheckAsync(currentVersion string) {
+	go check(currentVersion)
 }
 
 func check(currentVersion string) {
@@ -131,13 +129,14 @@ func writeCache(path, version string) {
 
 func fetchLatest(currentVersion string) string {
 	client := &http.Client{Timeout: 3 * time.Second}
-	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", repo)
+	url := fmt.Sprintf("%s/repos/%s/releases/latest", githubAPIBase, repo)
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return ""
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 	req.Header.Set("User-Agent", "kontext-cli/"+currentVersion)
 
 	resp, err := client.Do(req)

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -136,7 +136,7 @@ func fetchLatest(currentVersion string) string {
 		return ""
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("X-GitHub-Api-Version", "2026-03-10")
 	req.Header.Set("User-Agent", "kontext-cli/"+currentVersion)
 
 	resp, err := client.Do(req)

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -67,13 +67,13 @@ func check(currentVersion string) {
 }
 
 // newerThan returns true if version a is strictly newer than b.
-// Both must be normalised (no "v" prefix). Falls back to string
-// comparison if either version is not a valid major.minor.patch triple.
+// Both must be normalised (no "v" prefix). Returns false if either
+// version is not a valid major.minor.patch triple.
 func newerThan(a, b string) bool {
 	aParts, aOK := parseSemver(a)
 	bParts, bOK := parseSemver(b)
 	if !aOK || !bOK {
-		return a != b
+		return false
 	}
 	for i := 0; i < 3; i++ {
 		if aParts[i] != bParts[i] {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,0 +1,115 @@
+// Package update checks GitHub for newer CLI releases.
+package update
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	repo     = "kontext-dev/kontext-cli"
+	cacheTTL = 24 * time.Hour
+)
+
+type cachedVersion struct {
+	LatestVersion string    `json:"latest_version"`
+	CheckedAt     time.Time `json:"checked_at"`
+}
+
+// CheckAsync spawns a background goroutine that checks for a newer release.
+// It prints a one-liner to stderr if an update is available, and does nothing
+// on any error. The done channel is closed when the check completes.
+func CheckAsync(currentVersion string) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		check(currentVersion)
+	}()
+	return done
+}
+
+func check(currentVersion string) {
+	if currentVersion == "" || currentVersion == "dev" {
+		return
+	}
+
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return
+	}
+	cacheFile := filepath.Join(cacheDir, "kontext", "version.json")
+
+	latest, ok := readCache(cacheFile)
+	if !ok {
+		latest = fetchLatest()
+		if latest == "" {
+			return
+		}
+		writeCache(cacheFile, latest)
+	}
+
+	if latest != "" && latest != normalise(currentVersion) {
+		fmt.Fprintf(os.Stderr,
+			"\n⚠ A new version of kontext is available: %s → %s\n"+
+				"  Update: gh release download %s --repo %s --pattern '*darwin_arm64*' --dir /tmp\n\n",
+			currentVersion, latest, latest, repo)
+	}
+}
+
+func readCache(path string) (string, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+	var c cachedVersion
+	if err := json.Unmarshal(data, &c); err != nil {
+		return "", false
+	}
+	if time.Since(c.CheckedAt) > cacheTTL {
+		return "", false
+	}
+	return c.LatestVersion, true
+}
+
+func writeCache(path, version string) {
+	_ = os.MkdirAll(filepath.Dir(path), 0o755)
+	data, _ := json.Marshal(cachedVersion{
+		LatestVersion: version,
+		CheckedAt:     time.Now(),
+	})
+	_ = os.WriteFile(path, data, 0o644)
+}
+
+func fetchLatest() string {
+	client := &http.Client{Timeout: 3 * time.Second}
+	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", repo)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := client.Do(req)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return ""
+	}
+	defer resp.Body.Close()
+
+	var release struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return ""
+	}
+	return normalise(release.TagName)
+}
+
+func normalise(v string) string {
+	return strings.TrimPrefix(v, "v")
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -23,7 +24,8 @@ type cachedVersion struct {
 
 // CheckAsync spawns a background goroutine that checks for a newer release.
 // It prints a one-liner to stderr if an update is available, and does nothing
-// on any error. The done channel is closed when the check completes.
+// on any error. The done channel is closed when the check completes; callers
+// should wait on it before exiting to avoid truncated output.
 func CheckAsync(currentVersion string) <-chan struct{} {
 	done := make(chan struct{})
 	go func() {
@@ -37,6 +39,9 @@ func check(currentVersion string) {
 	if currentVersion == "" || currentVersion == "dev" {
 		return
 	}
+	if os.Getenv("KONTEXT_NO_UPDATE_CHECK") != "" {
+		return
+	}
 
 	cacheDir, err := os.UserCacheDir()
 	if err != nil {
@@ -46,19 +51,56 @@ func check(currentVersion string) {
 
 	latest, ok := readCache(cacheFile)
 	if !ok {
-		latest = fetchLatest()
+		latest = fetchLatest(currentVersion)
 		if latest == "" {
 			return
 		}
 		writeCache(cacheFile, latest)
 	}
 
-	if latest != "" && latest != normalise(currentVersion) {
+	if newerThan(latest, normalise(currentVersion)) {
 		fmt.Fprintf(os.Stderr,
 			"\n⚠ A new version of kontext is available: %s → %s\n"+
-				"  Update: gh release download %s --repo %s --pattern '*darwin_arm64*' --dir /tmp\n\n",
-			currentVersion, latest, latest, repo)
+				"  See: https://github.com/%s/releases/tag/v%s\n\n",
+			currentVersion, latest, repo, latest)
 	}
+}
+
+// newerThan returns true if version a is strictly newer than b.
+// Both must be normalised (no "v" prefix). Falls back to string
+// comparison if either version is not a valid major.minor.patch triple.
+func newerThan(a, b string) bool {
+	aParts, aOK := parseSemver(a)
+	bParts, bOK := parseSemver(b)
+	if !aOK || !bOK {
+		return a != b
+	}
+	for i := 0; i < 3; i++ {
+		if aParts[i] != bParts[i] {
+			return aParts[i] > bParts[i]
+		}
+	}
+	return false
+}
+
+func parseSemver(v string) ([3]int, bool) {
+	parts := strings.SplitN(v, ".", 3)
+	if len(parts) != 3 {
+		return [3]int{}, false
+	}
+	var out [3]int
+	for i, p := range parts {
+		// Strip pre-release suffix (e.g. "1-rc.1" → "1")
+		if idx := strings.IndexByte(p, '-'); idx != -1 {
+			p = p[:idx]
+		}
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return [3]int{}, false
+		}
+		out[i] = n
+	}
+	return out, true
 }
 
 func readCache(path string) (string, bool) {
@@ -77,7 +119,9 @@ func readCache(path string) (string, bool) {
 }
 
 func writeCache(path, version string) {
-	_ = os.MkdirAll(filepath.Dir(path), 0o755)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
 	data, _ := json.Marshal(cachedVersion{
 		LatestVersion: version,
 		CheckedAt:     time.Now(),
@@ -85,7 +129,7 @@ func writeCache(path, version string) {
 	_ = os.WriteFile(path, data, 0o644)
 }
 
-func fetchLatest() string {
+func fetchLatest(currentVersion string) string {
 	client := &http.Client{Timeout: 3 * time.Second}
 	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", repo)
 
@@ -94,12 +138,17 @@ func fetchLatest() string {
 		return ""
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "kontext-cli/"+currentVersion)
 
 	resp, err := client.Do(req)
-	if err != nil || resp.StatusCode != http.StatusOK {
+	if err != nil {
 		return ""
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
 
 	var release struct {
 		TagName string `json:"tag_name"`

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -111,8 +111,8 @@ func TestFetchLatest(t *testing.T) {
 		if r.Header.Get("User-Agent") == "" {
 			t.Error("expected User-Agent header")
 		}
-		if r.Header.Get("X-GitHub-Api-Version") != "2022-11-28" {
-			t.Errorf("expected X-GitHub-Api-Version 2022-11-28, got %q", r.Header.Get("X-GitHub-Api-Version"))
+		if r.Header.Get("X-GitHub-Api-Version") != "2026-03-10" {
+			t.Errorf("expected X-GitHub-Api-Version 2026-03-10, got %q", r.Header.Get("X-GitHub-Api-Version"))
 		}
 		json.NewEncoder(w).Encode(map[string]string{"tag_name": "v0.3.0"})
 	}))

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -107,48 +107,63 @@ func TestReadWriteCache(t *testing.T) {
 }
 
 func TestFetchLatest(t *testing.T) {
-	// Mock GitHub API.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if ua := r.Header.Get("User-Agent"); ua == "" {
+		if r.Header.Get("User-Agent") == "" {
 			t.Error("expected User-Agent header")
+		}
+		if r.Header.Get("X-GitHub-Api-Version") != "2022-11-28" {
+			t.Errorf("expected X-GitHub-Api-Version 2022-11-28, got %q", r.Header.Get("X-GitHub-Api-Version"))
 		}
 		json.NewEncoder(w).Encode(map[string]string{"tag_name": "v0.3.0"})
 	}))
 	defer srv.Close()
 
-	// Override the repo URL by testing the internal function directly isn't
-	// possible without changing the package, so we test via httptest by
-	// temporarily swapping the fetch function. Since fetchLatest hardcodes
-	// the URL, we test the response parsing logic via the mock server.
-	client := &http.Client{Timeout: 3 * time.Second}
-	req, _ := http.NewRequest("GET", srv.URL, nil)
-	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("User-Agent", "kontext-cli/test")
-	resp, err := client.Do(req)
-	if err != nil {
-		t.Fatalf("request failed: %v", err)
-	}
-	defer resp.Body.Close()
+	old := githubAPIBase
+	githubAPIBase = srv.URL
+	defer func() { githubAPIBase = old }()
 
-	var release struct {
-		TagName string `json:"tag_name"`
+	got := fetchLatest("0.1.0")
+	if got != "0.3.0" {
+		t.Errorf("fetchLatest() = %q, want %q", got, "0.3.0")
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		t.Fatalf("decode failed: %v", err)
+}
+
+func TestFetchLatestNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	old := githubAPIBase
+	githubAPIBase = srv.URL
+	defer func() { githubAPIBase = old }()
+
+	if got := fetchLatest("0.1.0"); got != "" {
+		t.Errorf("fetchLatest() on 403 = %q, want empty", got)
 	}
-	if got := normalise(release.TagName); got != "0.3.0" {
-		t.Errorf("got %q, want %q", got, "0.3.0")
+}
+
+func TestFetchLatestMalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+
+	old := githubAPIBase
+	githubAPIBase = srv.URL
+	defer func() { githubAPIBase = old }()
+
+	if got := fetchLatest("0.1.0"); got != "" {
+		t.Errorf("fetchLatest() on bad JSON = %q, want empty", got)
 	}
 }
 
 func TestCheckSkipsDevVersion(t *testing.T) {
-	// Should not panic or produce output for dev builds.
 	check("dev")
 	check("")
 }
 
 func TestCheckRespectsOptOut(t *testing.T) {
 	t.Setenv("KONTEXT_NO_UPDATE_CHECK", "1")
-	// Should return immediately without any network calls.
 	check("0.1.0")
 }

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -39,6 +39,9 @@ func TestNewerThan(t *testing.T) {
 		{"0.1.0", "0.1.1", false},
 		{"2.0.0", "1.99.99", true},
 		{"0.2.0-rc.1", "0.1.0", true},
+		{"not-semver", "0.1.0", false},
+		{"0.1.0", "not-semver", false},
+		{"foo", "bar", false},
 	}
 	for _, tt := range tests {
 		if got := newerThan(tt.a, tt.b); got != tt.want {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,0 +1,151 @@
+package update
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestNormalise(t *testing.T) {
+	tests := []struct {
+		input, want string
+	}{
+		{"v1.2.3", "1.2.3"},
+		{"1.2.3", "1.2.3"},
+		{"v0.1.0", "0.1.0"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := normalise(tt.input); got != tt.want {
+			t.Errorf("normalise(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestNewerThan(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want bool
+	}{
+		{"0.2.0", "0.1.0", true},
+		{"1.0.0", "0.9.9", true},
+		{"0.1.1", "0.1.0", true},
+		{"0.1.0", "0.1.0", false},
+		{"0.1.0", "0.2.0", false},
+		{"0.1.0", "0.1.1", false},
+		{"2.0.0", "1.99.99", true},
+		{"0.2.0-rc.1", "0.1.0", true},
+	}
+	for _, tt := range tests {
+		if got := newerThan(tt.a, tt.b); got != tt.want {
+			t.Errorf("newerThan(%q, %q) = %v, want %v", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestParseSemver(t *testing.T) {
+	tests := []struct {
+		input string
+		want  [3]int
+		ok    bool
+	}{
+		{"1.2.3", [3]int{1, 2, 3}, true},
+		{"0.1.0", [3]int{0, 1, 0}, true},
+		{"10.20.30", [3]int{10, 20, 30}, true},
+		{"1.2.3-rc.1", [3]int{1, 2, 3}, true},
+		{"1.2", [3]int{}, false},
+		{"abc", [3]int{}, false},
+		{"1.2.x", [3]int{}, false},
+		{"", [3]int{}, false},
+	}
+	for _, tt := range tests {
+		got, ok := parseSemver(tt.input)
+		if ok != tt.ok || got != tt.want {
+			t.Errorf("parseSemver(%q) = %v, %v; want %v, %v", tt.input, got, ok, tt.want, tt.ok)
+		}
+	}
+}
+
+func TestReadWriteCache(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "version.json")
+
+	// No file yet.
+	if _, ok := readCache(path); ok {
+		t.Fatal("expected cache miss on empty path")
+	}
+
+	// Write and read back.
+	writeCache(path, "0.2.0")
+	got, ok := readCache(path)
+	if !ok || got != "0.2.0" {
+		t.Fatalf("readCache() = %q, %v; want %q, true", got, ok, "0.2.0")
+	}
+
+	// Expired cache.
+	data, _ := json.Marshal(cachedVersion{
+		LatestVersion: "0.2.0",
+		CheckedAt:     time.Now().Add(-25 * time.Hour),
+	})
+	os.WriteFile(path, data, 0o644)
+	if _, ok := readCache(path); ok {
+		t.Fatal("expected cache miss on expired entry")
+	}
+
+	// Corrupt cache.
+	os.WriteFile(path, []byte("not json"), 0o644)
+	if _, ok := readCache(path); ok {
+		t.Fatal("expected cache miss on corrupt file")
+	}
+}
+
+func TestFetchLatest(t *testing.T) {
+	// Mock GitHub API.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if ua := r.Header.Get("User-Agent"); ua == "" {
+			t.Error("expected User-Agent header")
+		}
+		json.NewEncoder(w).Encode(map[string]string{"tag_name": "v0.3.0"})
+	}))
+	defer srv.Close()
+
+	// Override the repo URL by testing the internal function directly isn't
+	// possible without changing the package, so we test via httptest by
+	// temporarily swapping the fetch function. Since fetchLatest hardcodes
+	// the URL, we test the response parsing logic via the mock server.
+	client := &http.Client{Timeout: 3 * time.Second}
+	req, _ := http.NewRequest("GET", srv.URL, nil)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "kontext-cli/test")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var release struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if got := normalise(release.TagName); got != "0.3.0" {
+		t.Errorf("got %q, want %q", got, "0.3.0")
+	}
+}
+
+func TestCheckSkipsDevVersion(t *testing.T) {
+	// Should not panic or produce output for dev builds.
+	check("dev")
+	check("")
+}
+
+func TestCheckRespectsOptOut(t *testing.T) {
+	t.Setenv("KONTEXT_NO_UPDATE_CHECK", "1")
+	// Should return immediately without any network calls.
+	check("0.1.0")
+}


### PR DESCRIPTION
## Summary
- Adds a background update checker that queries the GitHub releases API on `kontext start`
- Caches the result in `~/Library/Caches/kontext/version.json` with a 24h TTL
- Prints a one-liner to stderr when a newer version is available, never blocks startup
- Respects `KONTEXT_NO_UPDATE_CHECK` env var for CI / air-gapped environments
- Uses proper semver comparison (not string equality) to avoid false positives
- Sets `User-Agent: kontext-cli/<version>` on GitHub API requests
- No authentication required — uses the public releases endpoint (60 req/hr per IP, 1 req/day with cache)

## Test plan
- [ ] Build with `go build -ldflags "-X main.version=0.0.1" ./cmd/kontext/` and run `kontext start` — should see update notice
- [ ] Run with `KONTEXT_NO_UPDATE_CHECK=1` — no update check
- [ ] Run with `version=dev` — no update check
- [ ] `go test ./internal/update/...` passes
- [ ] `go test -race ./internal/update/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kontext-dev/kontext-cli/pull/48" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
