### PR TITLE
fix(cli): use agent-scoped gateway login for connect sessions

### DIFF
--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -25,6 +25,13 @@ const (
 	DefaultIssuerURL = "https://api.kontext.security"
 )
 
+var defaultLoginScopes = []string{
+	"openid",
+	"email",
+	"profile",
+	"offline_access",
+}
+
 // LoginResult is the output of a successful login flow.
 type LoginResult struct {
 	Session *Session
@@ -66,7 +73,8 @@ func DiscoverEndpoints(ctx context.Context, baseURL string) (*OAuthMetadata, err
 }
 
 // Login performs the browser-based OAuth PKCE login flow.
-func Login(ctx context.Context, issuerURL, clientID string) (*LoginResult, error) {
+// When scopes are omitted, the default CLI login scopes are used.
+func Login(ctx context.Context, issuerURL, clientID string, scopes ...string) (*LoginResult, error) {
 	// 1. Discover endpoints
 	meta, err := DiscoverEndpoints(ctx, issuerURL)
 	if err != nil {
@@ -101,7 +109,7 @@ func Login(ctx context.Context, issuerURL, clientID string) (*LoginResult, error
 			TokenURL: meta.TokenEndpoint,
 		},
 		RedirectURL: redirectURI,
-		Scopes:      []string{"openid", "email", "profile", "offline_access"},
+		Scopes:      resolveLoginScopes(scopes),
 	}
 
 	// 5. Generate state parameter
@@ -173,6 +181,14 @@ func Login(ctx context.Context, issuerURL, clientID string) (*LoginResult, error
 	}
 
 	return &LoginResult{Session: session}, nil
+}
+
+func resolveLoginScopes(scopes []string) []string {
+	if len(scopes) > 0 {
+		return append([]string(nil), scopes...)
+	}
+
+	return append([]string(nil), defaultLoginScopes...)
 }
 
 // RefreshSession attempts to refresh an expired session using the refresh token.

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -1,0 +1,41 @@
+package auth
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestResolveLoginScopesDefaults(t *testing.T) {
+	t.Parallel()
+
+	got := resolveLoginScopes(nil)
+	want := []string{
+		"openid",
+		"email",
+		"profile",
+		"offline_access",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("resolveLoginScopes(nil) = %#v, want %#v", got, want)
+	}
+
+	got[0] = "mutated"
+	if reflect.DeepEqual(got, resolveLoginScopes(nil)) {
+		t.Fatal("resolveLoginScopes(nil) returned a shared slice")
+	}
+}
+
+func TestResolveLoginScopesCustom(t *testing.T) {
+	t.Parallel()
+
+	input := []string{"gateway:access"}
+	got := resolveLoginScopes(input)
+	if !reflect.DeepEqual(got, input) {
+		t.Fatalf("resolveLoginScopes(%#v) = %#v", input, got)
+	}
+
+	got[0] = "mutated"
+	if reflect.DeepEqual(got, resolveLoginScopes(input)) {
+		t.Fatal("resolveLoginScopes(custom) returned a shared slice")
+	}
+}

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -165,18 +165,18 @@ func ensureSession(ctx context.Context, issuerURL, clientID string) (*auth.Sessi
 }
 
 // resolveCredentials exchanges each template entry for a live credential.
-func resolveCredentials(ctx context.Context, session *auth.Session, entries []credential.Entry, clientID string) ([]credential.Resolved, error) {
+func resolveCredentials(ctx context.Context, session *auth.Session, entries []credential.Entry, credentialClientID string) ([]credential.Resolved, error) {
 	fmt.Fprintln(os.Stderr, "\nResolving credentials...")
 	var resolved []credential.Resolved
 
 	for _, entry := range entries {
 		fmt.Fprintf(os.Stderr, "  %s (%s)... ", entry.EnvVar, entry.Target())
 
-		value, err := exchangeCredential(ctx, session, entry, clientID)
+		value, err := exchangeCredential(ctx, session, entry, credentialClientID)
 		if err != nil {
 			if isNotConnectedError(err) {
 				fmt.Fprintln(os.Stderr, "not connected")
-				connectURL, connectErr := fetchConnectURL(ctx, session, clientID)
+				connectURL, connectErr := fetchConnectURLWithGatewayLoginFallback(ctx, session, credentialClientID, auth.Login)
 				if connectErr != nil {
 					err = fmt.Errorf("create connect session: %w", connectErr)
 				} else {
@@ -185,7 +185,7 @@ func resolveCredentials(ctx context.Context, session *auth.Session, entries []cr
 					_ = browser.OpenURL(connectURL)
 					fmt.Fprint(os.Stderr, "  Press Enter after connecting...")
 					bufio.NewReader(os.Stdin).ReadString('\n')
-					value, err = exchangeCredential(ctx, session, entry, clientID)
+					value, err = exchangeCredential(ctx, session, entry, credentialClientID)
 				}
 			}
 			if err != nil {
@@ -201,13 +201,39 @@ func resolveCredentials(ctx context.Context, session *auth.Session, entries []cr
 	return resolved, nil
 }
 
+type loginFunc func(context.Context, string, string, ...string) (*auth.LoginResult, error)
+
+func fetchConnectURLWithGatewayLoginFallback(
+	ctx context.Context,
+	session *auth.Session,
+	credentialClientID string,
+	login loginFunc,
+) (string, error) {
+	connectURL, err := fetchConnectURL(ctx, session, credentialClientID)
+	if err == nil || !needsGatewayAccessReauthentication(err) {
+		return connectURL, err
+	}
+
+	fmt.Fprintln(os.Stderr, "  Session missing gateway access. Opening browser to authorize this CLI session...")
+	result, err := login(ctx, session.IssuerURL, credentialClientID, "gateway:access")
+	if err != nil {
+		return "", fmt.Errorf("authorize gateway access: %w", err)
+	}
+
+	return fetchConnectURLWithGatewayToken(ctx, session.IssuerURL, result.Session.AccessToken)
+}
+
 func fetchConnectURL(ctx context.Context, session *auth.Session, clientID string) (string, error) {
 	gatewayToken, err := exchangeGatewayToken(ctx, session, clientID)
 	if err != nil {
 		return "", err
 	}
 
-	connectSessionURL := strings.TrimRight(session.IssuerURL, "/") + "/mcp/connect-session"
+	return fetchConnectURLWithGatewayToken(ctx, session.IssuerURL, gatewayToken)
+}
+
+func fetchConnectURLWithGatewayToken(ctx context.Context, issuerURL, gatewayToken string) (string, error) {
+	connectSessionURL := strings.TrimRight(issuerURL, "/") + "/mcp/connect-session"
 
 	req, err := http.NewRequestWithContext(ctx, "POST", connectSessionURL, strings.NewReader("{}"))
 	if err != nil {
@@ -347,6 +373,16 @@ func isNotConnectedError(err error) bool {
 	return strings.Contains(msg, "not connected") ||
 		strings.Contains(msg, "provider not found") ||
 		strings.Contains(msg, "provider_reauthorization_required")
+}
+
+func needsGatewayAccessReauthentication(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	msg := err.Error()
+	return strings.Contains(msg, "invalid_scope") &&
+		strings.Contains(msg, "gateway:access")
 }
 
 func buildEnv(resolved []credential.Resolved) []string {

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -221,6 +221,96 @@ func TestFetchConnectURLReturnsErrorOnEmptyConnectURL(t *testing.T) {
 	}
 }
 
+func TestFetchConnectURLWithGatewayLoginFallback(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"issuer":"%s","authorization_endpoint":"%s/oauth2/auth","token_endpoint":"%s/oauth2/token","jwks_uri":"%s/.well-known/jwks.json"}`, server.URL, server.URL, server.URL, server.URL)))
+		case "/oauth2/token":
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			values, err := url.ParseQuery(string(body))
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			if values.Get("resource") != "mcp-gateway" {
+				http.Error(w, "wrong resource", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			if got := r.Header.Get("Authorization"); got != "Bearer stale-access-token" {
+				http.Error(w, "wrong stale authorization", http.StatusUnauthorized)
+				return
+			}
+			_, _ = w.Write([]byte(`{"error":"invalid_scope","error_description":"Requested scope 'gateway:access' exceeds subject token scopes"}`))
+		case "/mcp/connect-session":
+			if got := r.Header.Get("Authorization"); got != "Bearer gateway-login-token" {
+				http.Error(w, "wrong gateway authorization", http.StatusUnauthorized)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"connectUrl":"https://app.kontext.security/providers/connect#handshake=session-123"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	session := &auth.Session{
+		IssuerURL:   server.URL,
+		AccessToken: "stale-access-token",
+	}
+
+	var loginCalls int
+	login := func(ctx context.Context, issuerURL, clientID string, scopes ...string) (*auth.LoginResult, error) {
+		loginCalls++
+		if issuerURL != server.URL {
+			t.Fatalf("login issuerURL = %q, want %q", issuerURL, server.URL)
+		}
+		if clientID != "app_agent-123" {
+			t.Fatalf("login clientID = %q, want %q", clientID, "app_agent-123")
+		}
+		if got := strings.Join(scopes, " "); got != "gateway:access" {
+			t.Fatalf("login scopes = %q, want %q", got, "gateway:access")
+		}
+
+		result := &auth.LoginResult{Session: &auth.Session{
+			IssuerURL:   server.URL,
+			AccessToken: "gateway-login-token",
+		}}
+		return result, nil
+	}
+
+	got, err := fetchConnectURLWithGatewayLoginFallback(
+		context.Background(),
+		session,
+		"app_agent-123",
+		login,
+	)
+	if err != nil {
+		t.Fatalf("fetchConnectURLWithGatewayLoginFallback() error = %v", err)
+	}
+	if loginCalls != 1 {
+		t.Fatalf("loginCalls = %d, want 1", loginCalls)
+	}
+	if session.AccessToken != "stale-access-token" {
+		t.Fatalf("session.AccessToken = %q, want stale token unchanged", session.AccessToken)
+	}
+
+	want := "https://app.kontext.security/providers/connect#handshake=session-123"
+	if got != want {
+		t.Fatalf("fetchConnectURLWithGatewayLoginFallback() = %q, want %q", got, want)
+	}
+}
+
 func TestExchangeCredentialUsesProvidedClientID(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- keep the normal CLI login flow on the public client
- fall back to a one-shot agent-scoped browser login when connect-session needs gateway access
- add focused coverage for the gateway login fallback and login scope handling

## Testing
- go test ./internal/auth ./internal/run
- go test ./...
- go vet ./...
- hosted smoke test: normal login still works and kontext start still resolves Linear on hosted
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kontext-dev/kontext-cli/pull/49" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
