### PR TITLE
fix(cli): exchange gateway token after agent auth

### DIFF
--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -220,7 +220,12 @@ func fetchConnectURLWithGatewayLoginFallback(
 		return "", fmt.Errorf("authorize gateway access: %w", err)
 	}
 
-	return fetchConnectURLWithGatewayToken(ctx, session.IssuerURL, result.Session.AccessToken)
+	gatewayToken, err := exchangeGatewayToken(ctx, result.Session, credentialClientID)
+	if err != nil {
+		return "", fmt.Errorf("exchange gateway token after authorize: %w", err)
+	}
+
+	return fetchConnectURLWithGatewayToken(ctx, result.Session.IssuerURL, gatewayToken)
 }
 
 func fetchConnectURL(ctx context.Context, session *auth.Session, clientID string) (string, error) {

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -225,6 +225,7 @@ func TestFetchConnectURLWithGatewayLoginFallback(t *testing.T) {
 	t.Parallel()
 
 	var server *httptest.Server
+	var tokenExchangeCalls int
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/.well-known/oauth-authorization-server":
@@ -246,13 +247,26 @@ func TestFetchConnectURLWithGatewayLoginFallback(t *testing.T) {
 				return
 			}
 			w.Header().Set("Content-Type", "application/json")
-			if got := r.Header.Get("Authorization"); got != "Bearer stale-access-token" {
-				http.Error(w, "wrong stale authorization", http.StatusUnauthorized)
+			tokenExchangeCalls++
+			switch tokenExchangeCalls {
+			case 1:
+				if got := r.Header.Get("Authorization"); got != "Bearer stale-access-token" {
+					http.Error(w, "wrong stale authorization", http.StatusUnauthorized)
+					return
+				}
+				_, _ = w.Write([]byte(`{"error":"invalid_scope","error_description":"Requested scope 'gateway:access' exceeds subject token scopes"}`))
+			case 2:
+				if got := r.Header.Get("Authorization"); got != "Bearer gateway-login-token" {
+					http.Error(w, "wrong gateway-login authorization", http.StatusUnauthorized)
+					return
+				}
+				_, _ = w.Write([]byte(`{"access_token":"gateway-exchange-token"}`))
+			default:
+				http.Error(w, "unexpected token exchange call", http.StatusBadRequest)
 				return
 			}
-			_, _ = w.Write([]byte(`{"error":"invalid_scope","error_description":"Requested scope 'gateway:access' exceeds subject token scopes"}`))
 		case "/mcp/connect-session":
-			if got := r.Header.Get("Authorization"); got != "Bearer gateway-login-token" {
+			if got := r.Header.Get("Authorization"); got != "Bearer gateway-exchange-token" {
 				http.Error(w, "wrong gateway authorization", http.StatusUnauthorized)
 				return
 			}
@@ -300,6 +314,9 @@ func TestFetchConnectURLWithGatewayLoginFallback(t *testing.T) {
 	}
 	if loginCalls != 1 {
 		t.Fatalf("loginCalls = %d, want 1", loginCalls)
+	}
+	if tokenExchangeCalls != 2 {
+		t.Fatalf("tokenExchangeCalls = %d, want 2", tokenExchangeCalls)
 	}
 	if session.AccessToken != "stale-access-token" {
 		t.Fatalf("session.AccessToken = %q, want stale token unchanged", session.AccessToken)


### PR DESCRIPTION
## Summary
- exchange the fresh agent-scoped login token into the real gateway token before calling `/mcp/connect-session`
- keep the existing one-shot agent auth fallback, but stop sending the raw OAuth access token to the hosted connect-session endpoint
- update the fallback test to cover both token exchange hops

## Testing
- go test ./internal/run ./internal/auth
- go test ./...
- go vet ./...

## Hosted verification
- deployed backend revision `api-00280-tvw` is serving image `gcr.io/spaces-479912/api:e65aeeb0622efe1aefbb263e89e96f2f8d00c1e3`
- live agent-scoped browser auth completed against `app_8112a731-0d0f-4115-b46c-3cf55bfb73d0`
- live `POST /mcp/connect-session` returned `200 OK` with a hosted connect URL after the extra gateway token exchange

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kontext-dev/kontext-cli/pull/50" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
