### PR TITLE
fix: handle provider required in hosted connect

### DIFF
--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -376,6 +376,7 @@ func exchangeCredential(ctx context.Context, session *auth.Session, entry creden
 func isNotConnectedError(err error) bool {
 	msg := err.Error()
 	return strings.Contains(msg, "not connected") ||
+		strings.Contains(msg, "provider_required") ||
 		strings.Contains(msg, "provider not found") ||
 		strings.Contains(msg, "provider_reauthorization_required")
 }

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -383,6 +383,14 @@ func TestExchangeCredentialUsesProvidedClientID(t *testing.T) {
 	}
 }
 
+func TestIsNotConnectedErrorRecognizesProviderRequired(t *testing.T) {
+	t.Parallel()
+
+	if !isNotConnectedError(fmt.Errorf("token exchange failed: provider_required: User has not configured provider 'Linear Stub'")) {
+		t.Fatal("expected provider_required to trigger hosted connect fallback")
+	}
+}
+
 func TestAgentOAuthClientID(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- treat backend `provider_required` token-exchange errors as a first-run connect condition in the CLI
- reuse the existing hosted connect fallback instead of silently skipping the credential
- add a regression test for the backend's current error contract

## Why
During full local E2E against `spaces`, `kontext start` correctly reached credential resolution for an unattached provider, but the backend returned `provider_required` and the CLI only recognized older "not connected" string shapes. That caused the CLI to skip hosted connect instead of opening it.

## Verification
- `go test ./...`
- `go vet ./...`
- `go build -o bin/kontext ./cmd/kontext`

## Follow-up E2E note
With this fix in place, the CLI now reaches the hosted connect browser flow correctly. The remaining local-only blocker is the HTTP stub provider issuer path in `spaces`, not the CLI fallback logic.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kontext-dev/kontext-cli/pull/52" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
