### PR TITLE
fix(auth): classify invalid_grant refresh errors as permanent

### DIFF
--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -16,6 +17,12 @@ import (
 	"github.com/cli/browser"
 	"golang.org/x/oauth2"
 )
+
+// ErrInvalidGrant indicates that the refresh token has been permanently
+// rejected by the authorization server (RFC 6749 "invalid_grant"). Retrying
+// with the same refresh token will not succeed — the user must re-authenticate
+// via `kontext login`. Callers should use errors.Is to detect this condition.
+var ErrInvalidGrant = errors.New("refresh token rejected (invalid_grant)")
 
 const (
 	// Well-known public client for the Kontext CLI. No secret.
@@ -217,6 +224,10 @@ func RefreshSession(ctx context.Context, session *Session) (*Session, error) {
 
 	newToken, err := tokenSource.Token()
 	if err != nil {
+		var retrieveErr *oauth2.RetrieveError
+		if errors.As(err, &retrieveErr) && retrieveErr.ErrorCode == "invalid_grant" {
+			return nil, fmt.Errorf("refresh token: %w", ErrInvalidGrant)
+		}
 		return nil, fmt.Errorf("refresh token: %w", err)
 	}
 

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -1,8 +1,14 @@
 package auth
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestResolveLoginScopesDefaults(t *testing.T) {
@@ -37,5 +43,133 @@ func TestResolveLoginScopesCustom(t *testing.T) {
 	got[0] = "mutated"
 	if reflect.DeepEqual(got, resolveLoginScopes(input)) {
 		t.Fatal("resolveLoginScopes(custom) returned a shared slice")
+	}
+}
+
+// fakeIssuer is a minimal OAuth authorization server for RefreshSession tests.
+// It serves /.well-known/oauth-authorization-server and a configurable token
+// endpoint handler.
+type fakeIssuer struct {
+	server      *httptest.Server
+	tokenHandle http.HandlerFunc
+}
+
+func newFakeIssuer(t *testing.T, tokenHandle http.HandlerFunc) *fakeIssuer {
+	t.Helper()
+	fi := &fakeIssuer{tokenHandle: tokenHandle}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(OAuthMetadata{
+			Issuer:                fi.server.URL,
+			AuthorizationEndpoint: fi.server.URL + "/oauth2/auth",
+			TokenEndpoint:         fi.server.URL + "/oauth2/token",
+			JwksURI:               fi.server.URL + "/jwks.json",
+		})
+	})
+	mux.HandleFunc("/oauth2/token", func(w http.ResponseWriter, r *http.Request) {
+		fi.tokenHandle(w, r)
+	})
+	fi.server = httptest.NewServer(mux)
+	t.Cleanup(fi.server.Close)
+	return fi
+}
+
+func TestRefreshSession_InvalidGrantIsPermanent(t *testing.T) {
+	t.Parallel()
+
+	fi := newFakeIssuer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"refresh token expired"}`))
+	})
+
+	session := &Session{
+		IssuerURL:    fi.server.URL,
+		AccessToken:  "old-access",
+		RefreshToken: "dead-refresh",
+		ExpiresAt:    time.Now().Add(-time.Hour),
+	}
+
+	_, err := RefreshSession(context.Background(), session)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrInvalidGrant) {
+		t.Fatalf("errors.Is(err, ErrInvalidGrant) = false; err = %v", err)
+	}
+}
+
+func TestRefreshSession_ServerErrorIsNotPermanent(t *testing.T) {
+	t.Parallel()
+
+	fi := newFakeIssuer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	session := &Session{
+		IssuerURL:    fi.server.URL,
+		RefreshToken: "still-valid",
+		ExpiresAt:    time.Now().Add(-time.Hour),
+	}
+
+	_, err := RefreshSession(context.Background(), session)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if errors.Is(err, ErrInvalidGrant) {
+		t.Fatalf("errors.Is(err, ErrInvalidGrant) = true; want false for 500 response; err = %v", err)
+	}
+}
+
+func TestRefreshSession_NoRefreshTokenIsNotInvalidGrant(t *testing.T) {
+	t.Parallel()
+
+	session := &Session{
+		IssuerURL:    "http://127.0.0.1:1", // never contacted
+		RefreshToken: "",
+	}
+
+	_, err := RefreshSession(context.Background(), session)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if errors.Is(err, ErrInvalidGrant) {
+		t.Fatalf("missing refresh token should not classify as ErrInvalidGrant; err = %v", err)
+	}
+}
+
+func TestRefreshSession_Success(t *testing.T) {
+	t.Parallel()
+
+	fi := newFakeIssuer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"access_token":"new-access",
+			"refresh_token":"new-refresh",
+			"token_type":"Bearer",
+			"expires_in":3600
+		}`))
+	})
+
+	session := &Session{
+		IssuerURL:    fi.server.URL,
+		AccessToken:  "old-access",
+		RefreshToken: "old-refresh",
+		ExpiresAt:    time.Now().Add(-time.Hour),
+	}
+
+	updated, err := RefreshSession(context.Background(), session)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if updated.AccessToken != "new-access" {
+		t.Errorf("AccessToken = %q, want %q", updated.AccessToken, "new-access")
+	}
+	if updated.RefreshToken != "new-refresh" {
+		t.Errorf("RefreshToken = %q, want %q", updated.RefreshToken, "new-refresh")
+	}
+	if !updated.ExpiresAt.After(time.Now()) {
+		t.Errorf("ExpiresAt = %v, want future", updated.ExpiresAt)
 	}
 }


### PR DESCRIPTION
## Summary

- explain the user-facing change
- link the issue or context if relevant

## Verification

- [ ] `go test ./...`
- [ ] `go test -race ./...`
- [ ] `go vet ./...`
- [ ] `buf generate` if protobuf or generated code changed

## Release notes

- [ ] conventional commit title matches semver intent

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kontext-dev/kontext-cli/pull/55" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
