### PR TITLE
fix: cut over github org and release links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,10 +1,10 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security issue
-    url: https://github.com/kontext-dev/kontext-cli/security/advisories/new
+    url: https://github.com/kontext-security/kontext-cli/security/advisories/new
     about: Report security vulnerabilities privately
   - name: Documentation
-    url: https://kontext.security/docs
+    url: https://docs.kontext.security/getting-started/welcome
     about: Read the official docs before opening a support request
   - name: Discord
     url: https://discord.gg/gw9UpFUhyY

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -55,7 +55,7 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: kontext-dev/homebrew-tap
+          repository: kontext-security/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: homebrew-tap
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,60 +1,60 @@
 # Changelog
 
-## [0.2.1](https://github.com/kontext-dev/kontext-cli/compare/v0.2.0...v0.2.1) (2026-04-10)
+## [0.2.1](https://github.com/kontext-security/kontext-cli/compare/v0.2.0...v0.2.1) (2026-04-10)
 
 
 ### Bug Fixes
 
-* handle provider required in hosted connect ([#52](https://github.com/kontext-dev/kontext-cli/issues/52)) ([93bae50](https://github.com/kontext-dev/kontext-cli/commit/93bae50afcefa1ccd56f76685eaeea4bee303d07))
+* handle provider required in hosted connect ([#52](https://github.com/kontext-security/kontext-cli/issues/52)) ([93bae50](https://github.com/kontext-security/kontext-cli/commit/93bae50afcefa1ccd56f76685eaeea4bee303d07))
 
-## [0.2.0](https://github.com/kontext-dev/kontext-cli/compare/v0.1.1...v0.2.0) (2026-04-09)
+## [0.2.0](https://github.com/kontext-security/kontext-cli/compare/v0.1.1...v0.2.0) (2026-04-09)
 
 
 ### Features
 
-* **cli:** add logout command ([#46](https://github.com/kontext-dev/kontext-cli/issues/46)) ([840c98c](https://github.com/kontext-dev/kontext-cli/commit/840c98cec7eb85c8812b43664f02f3264e2cc340))
-* **cli:** check for new releases on startup ([#48](https://github.com/kontext-dev/kontext-cli/issues/48)) ([ef435d6](https://github.com/kontext-dev/kontext-cli/commit/ef435d6e6cd0f74b9c0fe0291c9b66bb64c11440))
+* **cli:** add logout command ([#46](https://github.com/kontext-security/kontext-cli/issues/46)) ([840c98c](https://github.com/kontext-security/kontext-cli/commit/840c98cec7eb85c8812b43664f02f3264e2cc340))
+* **cli:** check for new releases on startup ([#48](https://github.com/kontext-security/kontext-cli/issues/48)) ([ef435d6](https://github.com/kontext-security/kontext-cli/commit/ef435d6e6cd0f74b9c0fe0291c9b66bb64c11440))
 
 
 ### Bug Fixes
 
-* **cli:** exchange gateway token after agent auth ([#50](https://github.com/kontext-dev/kontext-cli/issues/50)) ([77608e2](https://github.com/kontext-dev/kontext-cli/commit/77608e2fbdcfad5448e3bc19f61c1bb53f1066ff))
-* **cli:** scope exchanges to the session agent ([#47](https://github.com/kontext-dev/kontext-cli/issues/47)) ([3c236bc](https://github.com/kontext-dev/kontext-cli/commit/3c236bc239ad6e321d0bc8ed399bc0eb3174e0b5))
-* **cli:** use agent-scoped gateway login for connect sessions ([#49](https://github.com/kontext-dev/kontext-cli/issues/49)) ([0ab023c](https://github.com/kontext-dev/kontext-cli/commit/0ab023cc5d336a3c03966ce6f8679f83ea80bc2a))
-* use connect-session URL for provider auth ([8aeede0](https://github.com/kontext-dev/kontext-cli/commit/8aeede08b0714c3af4ec55ed542816916b45630e))
+* **cli:** exchange gateway token after agent auth ([#50](https://github.com/kontext-security/kontext-cli/issues/50)) ([77608e2](https://github.com/kontext-security/kontext-cli/commit/77608e2fbdcfad5448e3bc19f61c1bb53f1066ff))
+* **cli:** scope exchanges to the session agent ([#47](https://github.com/kontext-security/kontext-cli/issues/47)) ([3c236bc](https://github.com/kontext-security/kontext-cli/commit/3c236bc239ad6e321d0bc8ed399bc0eb3174e0b5))
+* **cli:** use agent-scoped gateway login for connect sessions ([#49](https://github.com/kontext-security/kontext-cli/issues/49)) ([0ab023c](https://github.com/kontext-security/kontext-cli/commit/0ab023cc5d336a3c03966ce6f8679f83ea80bc2a))
+* use connect-session URL for provider auth ([8aeede0](https://github.com/kontext-security/kontext-cli/commit/8aeede08b0714c3af4ec55ed542816916b45630e))
 
-## [0.1.1](https://github.com/kontext-dev/kontext-cli/compare/v0.1.0...v0.1.1) (2026-04-09)
+## [0.1.1](https://github.com/kontext-security/kontext-cli/compare/v0.1.0...v0.1.1) (2026-04-09)
 
 
 ### Bug Fixes
 
-* handle provider_reauthorization_required as reconnect-needed ([#27](https://github.com/kontext-dev/kontext-cli/issues/27)) ([8e89e26](https://github.com/kontext-dev/kontext-cli/commit/8e89e2674ac88f5fe2f8f5907034bd851a15ff97))
-* harden CLI repo for public release ([075d44f](https://github.com/kontext-dev/kontext-cli/commit/075d44ffd014a911ef6a8e63a19d7868cfbc407b))
+* handle provider_reauthorization_required as reconnect-needed ([#27](https://github.com/kontext-security/kontext-cli/issues/27)) ([8e89e26](https://github.com/kontext-security/kontext-cli/commit/8e89e2674ac88f5fe2f8f5907034bd851a15ff97))
+* harden CLI repo for public release ([075d44f](https://github.com/kontext-security/kontext-cli/commit/075d44ffd014a911ef6a8e63a19d7868cfbc407b))
 
 ## 0.1.0 (2026-04-09)
 
 
 ### Features
 
-* implement kontext login — OIDC PKCE with system keyring ([c692eb5](https://github.com/kontext-dev/kontext-cli/commit/c692eb5c6de63534a128ea977d72b3d46692ae8f))
-* implement kontext start — unified first-run experience ([067d199](https://github.com/kontext-dev/kontext-cli/commit/067d199b6c507b5ab20541c75fec808246219189))
-* initial CLI package — kontext start with Claude Code hooks ([6f3e99f](https://github.com/kontext-dev/kontext-cli/commit/6f3e99fe32a286f500404b7b7d6c21542c282096))
-* interactive template creation on first run ([3e55beb](https://github.com/kontext-dev/kontext-cli/commit/3e55beb5047a466c2e26ca7c4bb3ca09f1447cb8))
-* rewrite CLI in Go with protobuf service definitions ([a6e6c3d](https://github.com/kontext-dev/kontext-cli/commit/a6e6c3d109c9e046abeb10611a46168bcd3200d0))
-* wire full governance telemetry pipeline ([#3](https://github.com/kontext-dev/kontext-cli/issues/3)) ([bd16ef2](https://github.com/kontext-dev/kontext-cli/commit/bd16ef281e8fc6dda1e45154e63a27fa56fbc526))
-* wire up credential exchange via RFC 8693 + OIDC token refresh ([#7](https://github.com/kontext-dev/kontext-cli/issues/7)) ([0eb1840](https://github.com/kontext-dev/kontext-cli/commit/0eb184021a8416d8e270113576d333d7571d4b38))
+* implement kontext login — OIDC PKCE with system keyring ([c692eb5](https://github.com/kontext-security/kontext-cli/commit/c692eb5c6de63534a128ea977d72b3d46692ae8f))
+* implement kontext start — unified first-run experience ([067d199](https://github.com/kontext-security/kontext-cli/commit/067d199b6c507b5ab20541c75fec808246219189))
+* initial CLI package — kontext start with Claude Code hooks ([6f3e99f](https://github.com/kontext-security/kontext-cli/commit/6f3e99fe32a286f500404b7b7d6c21542c282096))
+* interactive template creation on first run ([3e55beb](https://github.com/kontext-security/kontext-cli/commit/3e55beb5047a466c2e26ca7c4bb3ca09f1447cb8))
+* rewrite CLI in Go with protobuf service definitions ([a6e6c3d](https://github.com/kontext-security/kontext-cli/commit/a6e6c3d109c9e046abeb10611a46168bcd3200d0))
+* wire full governance telemetry pipeline ([#3](https://github.com/kontext-security/kontext-cli/issues/3)) ([bd16ef2](https://github.com/kontext-security/kontext-cli/commit/bd16ef281e8fc6dda1e45154e63a27fa56fbc526))
+* wire up credential exchange via RFC 8693 + OIDC token refresh ([#7](https://github.com/kontext-security/kontext-cli/issues/7)) ([0eb1840](https://github.com/kontext-security/kontext-cli/commit/0eb184021a8416d8e270113576d333d7571d4b38))
 
 
 ### Bug Fixes
 
-* **ci:** pass github_token to buf-setup-action ([#5](https://github.com/kontext-dev/kontext-cli/issues/5)) ([13e1f89](https://github.com/kontext-dev/kontext-cli/commit/13e1f89e64baa80a90951eb367ebda56dca2de1c))
-* default API URL to api.kontext.security ([4907c76](https://github.com/kontext-dev/kontext-cli/commit/4907c76143fd120058af760628dc20ab99991889))
-* gitignore .env.kontext (user-specific) ([590f451](https://github.com/kontext-dev/kontext-cli/commit/590f451a640f05e7964e00e282e2a6f02ffc8d13))
-* launch agent without template instead of blocking ([5293c6b](https://github.com/kontext-dev/kontext-cli/commit/5293c6b20acfb25db897aee3d1ce6487f24347b1))
-* pass full parent env to agent subprocess ([318fb77](https://github.com/kontext-dev/kontext-cli/commit/318fb77c2dfdc5cef9ee99b11295c5d9c78d3015))
-* propagate IngestEvent errors and document HTTP/2 requirement ([#15](https://github.com/kontext-dev/kontext-cli/issues/15)) ([5e7e2e2](https://github.com/kontext-dev/kontext-cli/commit/5e7e2e2eb757dfd990e9b9487559e6ba39f4612a))
-* remove Setpgid — let agent control the terminal ([b2b4478](https://github.com/kontext-dev/kontext-cli/commit/b2b447856f3a294ceae98b4d65ec66678124651e))
-* replace interactive init with dashboard pointer ([ab3b1e3](https://github.com/kontext-dev/kontext-cli/commit/ab3b1e30e8516e323feb006009f66f0afabf6fec))
-* skip failed credential exchanges instead of aborting ([747184d](https://github.com/kontext-dev/kontext-cli/commit/747184dbcc9bb17545afceff3da3c35c67c9a263))
-* use buf managed mode for go_package override ([#6](https://github.com/kontext-dev/kontext-cli/issues/6)) ([dcc9d7a](https://github.com/kontext-dev/kontext-cli/commit/dcc9d7a49117d4ee20d1a7ffe2ee50ca602f17f0))
-* use OAuth authorization server metadata instead of OIDC discovery ([acd0cde](https://github.com/kontext-dev/kontext-cli/commit/acd0cde591d9fe5f7e4a410dfd1e01e39643e0d9))
+* **ci:** pass github_token to buf-setup-action ([#5](https://github.com/kontext-security/kontext-cli/issues/5)) ([13e1f89](https://github.com/kontext-security/kontext-cli/commit/13e1f89e64baa80a90951eb367ebda56dca2de1c))
+* default API URL to api.kontext.security ([4907c76](https://github.com/kontext-security/kontext-cli/commit/4907c76143fd120058af760628dc20ab99991889))
+* gitignore .env.kontext (user-specific) ([590f451](https://github.com/kontext-security/kontext-cli/commit/590f451a640f05e7964e00e282e2a6f02ffc8d13))
+* launch agent without template instead of blocking ([5293c6b](https://github.com/kontext-security/kontext-cli/commit/5293c6b20acfb25db897aee3d1ce6487f24347b1))
+* pass full parent env to agent subprocess ([318fb77](https://github.com/kontext-security/kontext-cli/commit/318fb77c2dfdc5cef9ee99b11295c5d9c78d3015))
+* propagate IngestEvent errors and document HTTP/2 requirement ([#15](https://github.com/kontext-security/kontext-cli/issues/15)) ([5e7e2e2](https://github.com/kontext-security/kontext-cli/commit/5e7e2e2eb757dfd990e9b9487559e6ba39f4612a))
+* remove Setpgid — let agent control the terminal ([b2b4478](https://github.com/kontext-security/kontext-cli/commit/b2b447856f3a294ceae98b4d65ec66678124651e))
+* replace interactive init with dashboard pointer ([ab3b1e3](https://github.com/kontext-security/kontext-cli/commit/ab3b1e30e8516e323feb006009f66f0afabf6fec))
+* skip failed credential exchanges instead of aborting ([747184d](https://github.com/kontext-security/kontext-cli/commit/747184dbcc9bb17545afceff3da3c35c67c9a263))
+* use buf managed mode for go_package override ([#6](https://github.com/kontext-security/kontext-cli/issues/6)) ([dcc9d7a](https://github.com/kontext-security/kontext-cli/commit/dcc9d7a49117d4ee20d1a7ffe2ee50ca602f17f0))
+* use OAuth authorization server metadata instead of OIDC discovery ([acd0cde](https://github.com/kontext-security/kontext-cli/commit/acd0cde591d9fe5f7e4a410dfd1e01e39643e0d9))

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Store Credentials. Inject At Runtime. Agents Never Store The Keys.
 
-[Website](https://kontext.security) · [Documentation](https://kontext.security/docs) · [Discord](https://discord.gg/gw9UpFUhyY)
+[Website](https://kontext.security) · [Documentation](https://docs.kontext.security/getting-started/welcome) · [Discord](https://discord.gg/gw9UpFUhyY)
 
 </div>
 
@@ -21,14 +21,14 @@ Kontext CLI is an open-source command-line tool that wraps AI coding agents with
 ## Quick Start
 
 ```bash
-brew install kontext-dev/tap/kontext
+brew install kontext-security/tap/kontext
 ```
 
 If you prefer a direct binary install, download the latest GitHub Release instead:
 
 ```bash
 tmpdir="$(mktemp -d)" \
-  && gh release download --repo kontext-dev/kontext-cli --pattern 'kontext_*_darwin_arm64.tar.gz' --dir "$tmpdir" \
+  && gh release download --repo kontext-security/kontext-cli --pattern 'kontext_*_darwin_arm64.tar.gz' --dir "$tmpdir" \
   && archive="$(find "$tmpdir" -maxdepth 1 -name 'kontext_*_darwin_arm64.tar.gz' -print -quit)" \
   && tar -xzf "$archive" -C "$tmpdir" \
   && sudo install -m 0755 "$tmpdir/kontext" /usr/local/bin/kontext
@@ -130,7 +130,7 @@ ln -sf $(pwd)/bin/kontext ~/.local/bin/kontext
 
 ## Protocol
 
-Service definitions: [kontext-dev/proto `agent.proto`](https://github.com/kontext-dev/proto/blob/main/proto/kontext/agent/v1/agent.proto)
+Service definitions: [kontext-security/proto `agent.proto`](https://github.com/kontext-security/proto/blob/main/proto/kontext/agent/v1/agent.proto)
 
 The CLI communicates with the Kontext backend exclusively via ConnectRPC. Hook handlers communicate with the sidecar over a Unix socket using length-prefixed JSON.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,7 +4,7 @@ Use the right channel so we can help quickly:
 
 - Bug reports and feature requests: open a GitHub issue.
 - Security reports: use private vulnerability reporting or follow [SECURITY.md](SECURITY.md).
-- Questions about setup or product usage: use the [Kontext docs](https://kontext.security/docs) or join the [Discord community](https://discord.gg/gw9UpFUhyY).
+- Questions about setup or product usage: use the [Kontext docs](https://docs.kontext.security/getting-started/welcome) or join the [Discord community](https://discord.gg/gw9UpFUhyY).
 
 When asking for help, include:
 

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -3,9 +3,9 @@ managed:
   enabled: true
   override:
     - file_option: go_package_prefix
-      value: github.com/kontext-dev/kontext-cli/gen
+      value: github.com/kontext-security/kontext-cli/gen
 inputs:
-  - git_repo: https://github.com/kontext-dev/proto.git
+  - git_repo: https://github.com/kontext-security/proto.git
     branch: main
     ref: eb148cfee8e1d390a3f1e29116d210f2459f4670
 plugins:

--- a/cmd/kontext/main.go
+++ b/cmd/kontext/main.go
@@ -13,15 +13,15 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/zalando/go-keyring"
 
-	"github.com/kontext-dev/kontext-cli/internal/agent"
-	"github.com/kontext-dev/kontext-cli/internal/auth"
-	"github.com/kontext-dev/kontext-cli/internal/hook"
-	"github.com/kontext-dev/kontext-cli/internal/run"
-	"github.com/kontext-dev/kontext-cli/internal/sidecar"
-	"github.com/kontext-dev/kontext-cli/internal/update"
+	"github.com/kontext-security/kontext-cli/internal/agent"
+	"github.com/kontext-security/kontext-cli/internal/auth"
+	"github.com/kontext-security/kontext-cli/internal/hook"
+	"github.com/kontext-security/kontext-cli/internal/run"
+	"github.com/kontext-security/kontext-cli/internal/sidecar"
+	"github.com/kontext-security/kontext-cli/internal/update"
 
 	// Register agent adapters
-	_ "github.com/kontext-dev/kontext-cli/internal/agent/claude"
+	_ "github.com/kontext-security/kontext-cli/internal/agent/claude"
 )
 
 var version = "dev"

--- a/gen/kontext/agent/v1/agent.pb.go
+++ b/gen/kontext/agent/v1/agent.pb.go
@@ -592,9 +592,9 @@ const file_kontext_agent_v1_agent_proto_rawDesc = "" +
 	"\rCreateSession\x12&.kontext.agent.v1.CreateSessionRequest\x1a'.kontext.agent.v1.CreateSessionResponse\x12T\n" +
 	"\tHeartbeat\x12\".kontext.agent.v1.HeartbeatRequest\x1a#.kontext.agent.v1.HeartbeatResponse\x12W\n" +
 	"\n" +
-	"EndSession\x12#.kontext.agent.v1.EndSessionRequest\x1a$.kontext.agent.v1.EndSessionResponseB\xc5\x01\n" +
+	"EndSession\x12#.kontext.agent.v1.EndSessionRequest\x1a$.kontext.agent.v1.EndSessionResponseB\xca\x01\n" +
 	"\x14com.kontext.agent.v1B\n" +
-	"AgentProtoP\x01Z?github.com/kontext-dev/kontext-cli/gen/kontext/agent/v1;agentv1\xa2\x02\x03KAX\xaa\x02\x10Kontext.Agent.V1\xca\x02\x10Kontext\\Agent\\V1\xe2\x02\x1cKontext\\Agent\\V1\\GPBMetadata\xea\x02\x12Kontext::Agent::V1b\x06proto3"
+	"AgentProtoP\x01ZDgithub.com/kontext-security/kontext-cli/gen/kontext/agent/v1;agentv1\xa2\x02\x03KAX\xaa\x02\x10Kontext.Agent.V1\xca\x02\x10Kontext\\Agent\\V1\xe2\x02\x1cKontext\\Agent\\V1\\GPBMetadata\xea\x02\x12Kontext::Agent::V1b\x06proto3"
 
 var (
 	file_kontext_agent_v1_agent_proto_rawDescOnce sync.Once

--- a/gen/kontext/agent/v1/agentv1connect/agent.connect.go
+++ b/gen/kontext/agent/v1/agentv1connect/agent.connect.go
@@ -8,7 +8,7 @@ import (
 	connect "connectrpc.com/connect"
 	context "context"
 	errors "errors"
-	v1 "github.com/kontext-dev/kontext-cli/gen/kontext/agent/v1"
+	v1 "github.com/kontext-security/kontext-cli/gen/kontext/agent/v1"
 	http "net/http"
 	strings "strings"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kontext-dev/kontext-cli
+module github.com/kontext-security/kontext-cli
 
 go 1.25.9
 

--- a/internal/agent/claude/claude.go
+++ b/internal/agent/claude/claude.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/kontext-dev/kontext-cli/internal/agent"
+	"github.com/kontext-security/kontext-cli/internal/agent"
 )
 
 func init() {

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -12,8 +12,8 @@ import (
 
 	"connectrpc.com/connect"
 
-	agentv1 "github.com/kontext-dev/kontext-cli/gen/kontext/agent/v1"
-	"github.com/kontext-dev/kontext-cli/gen/kontext/agent/v1/agentv1connect"
+	agentv1 "github.com/kontext-security/kontext-cli/gen/kontext/agent/v1"
+	"github.com/kontext-security/kontext-cli/gen/kontext/agent/v1/agentv1connect"
 )
 
 // TokenSource returns a valid access token, refreshing if necessary.

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/kontext-dev/kontext-cli/internal/agent"
+	"github.com/kontext-security/kontext-cli/internal/agent"
 )
 
 // Run processes a single hook event. Called by `kontext hook --agent <name>`.

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -22,12 +22,12 @@ import (
 
 	"github.com/cli/browser"
 
-	agentv1 "github.com/kontext-dev/kontext-cli/gen/kontext/agent/v1"
-	"github.com/kontext-dev/kontext-cli/internal/agent"
-	"github.com/kontext-dev/kontext-cli/internal/auth"
-	"github.com/kontext-dev/kontext-cli/internal/backend"
-	"github.com/kontext-dev/kontext-cli/internal/credential"
-	"github.com/kontext-dev/kontext-cli/internal/sidecar"
+	agentv1 "github.com/kontext-security/kontext-cli/gen/kontext/agent/v1"
+	"github.com/kontext-security/kontext-cli/internal/agent"
+	"github.com/kontext-security/kontext-cli/internal/auth"
+	"github.com/kontext-security/kontext-cli/internal/backend"
+	"github.com/kontext-security/kontext-cli/internal/credential"
+	"github.com/kontext-security/kontext-cli/internal/sidecar"
 )
 
 // Options configures a kontext start run.

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kontext-dev/kontext-cli/internal/auth"
-	"github.com/kontext-dev/kontext-cli/internal/credential"
+	"github.com/kontext-security/kontext-cli/internal/auth"
+	"github.com/kontext-security/kontext-cli/internal/credential"
 )
 
 func TestFilterArgs(t *testing.T) {

--- a/internal/sidecar/sidecar.go
+++ b/internal/sidecar/sidecar.go
@@ -11,8 +11,8 @@ import (
 	"path/filepath"
 	"time"
 
-	agentv1 "github.com/kontext-dev/kontext-cli/gen/kontext/agent/v1"
-	"github.com/kontext-dev/kontext-cli/internal/backend"
+	agentv1 "github.com/kontext-security/kontext-cli/gen/kontext/agent/v1"
+	"github.com/kontext-security/kontext-cli/internal/backend"
 )
 
 // Server is the local sidecar that hook handlers communicate with.

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	repo     = "kontext-dev/kontext-cli"
+	repo     = "kontext-security/kontext-cli"
 	cacheTTL = 24 * time.Hour
 )
 

--- a/scripts/render-homebrew-formula.sh
+++ b/scripts/render-homebrew-formula.sh
@@ -50,22 +50,22 @@ class Kontext < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/kontext-dev/kontext-cli/releases/download/v${version}/${darwin_amd64_archive}"
+      url "https://github.com/kontext-security/kontext-cli/releases/download/v${version}/${darwin_amd64_archive}"
       sha256 "${darwin_amd64_sha}"
     end
     if Hardware::CPU.arm?
-      url "https://github.com/kontext-dev/kontext-cli/releases/download/v${version}/${darwin_arm64_archive}"
+      url "https://github.com/kontext-security/kontext-cli/releases/download/v${version}/${darwin_arm64_archive}"
       sha256 "${darwin_arm64_sha}"
     end
   end
 
   on_linux do
     if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
-      url "https://github.com/kontext-dev/kontext-cli/releases/download/v${version}/${linux_amd64_archive}"
+      url "https://github.com/kontext-security/kontext-cli/releases/download/v${version}/${linux_amd64_archive}"
       sha256 "${linux_amd64_sha}"
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/kontext-dev/kontext-cli/releases/download/v${version}/${linux_arm64_archive}"
+      url "https://github.com/kontext-security/kontext-cli/releases/download/v${version}/${linux_arm64_archive}"
       sha256 "${linux_arm64_sha}"
     end
   end


### PR DESCRIPTION
## What changed
- hard-cut the CLI module and import paths from `kontext-dev` to `kontext-security`
- updated public docs, issue template links, the release update checker, and changelog links to the new repo/docs locations
- switched release automation and Homebrew formula rendering to publish artifacts and tap updates from the `kontext-security` org
- repointed protobuf generation to `kontext-security/proto`

## Why
The GitHub repository moved to `kontext-security/kontext-cli`. Without this cutover, release notifications, direct downloads, Homebrew formula URLs, and release automation would still reference the old location.

## Validation
- `buf generate`
- `gofmt -w ./cmd ./internal ./gen`
- `go build ./cmd/kontext`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- rendered the Homebrew formula and verified it points to `https://github.com/kontext-security/kontext-cli/releases/download/...`
