### PR TITLE
feat: sync managed CLI env placeholders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,7 +2,6 @@ name: Dependency Review
 
 on:
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -6,8 +6,8 @@ managed:
       value: github.com/kontext-security/kontext-cli/gen
 inputs:
   - git_repo: https://github.com/kontext-security/proto.git
-    branch: feat/cli-bootstrap-proto
-    ref: 8c96817514ab9682cd068a0f571add34abc99d70
+    branch: main
+    ref: ba2b704abfde23ec2c30bfd2b5c540a91a674f41
 plugins:
   - local: protoc-gen-go
     out: gen

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -6,8 +6,8 @@ managed:
       value: github.com/kontext-security/kontext-cli/gen
 inputs:
   - git_repo: https://github.com/kontext-security/proto.git
-    branch: main
-    ref: eb148cfee8e1d390a3f1e29116d210f2459f4670
+    branch: feat/cli-bootstrap-proto
+    ref: 8c96817514ab9682cd068a0f571add34abc99d70
 plugins:
   - local: protoc-gen-go
     out: gen

--- a/gen/kontext/agent/v1/agent.pb.go
+++ b/gen/kontext/agent/v1/agent.pb.go
@@ -377,6 +377,178 @@ func (x *CreateSessionResponse) GetAgentId() string {
 	return ""
 }
 
+type BootstrapCliRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	AgentId       string                 `protobuf:"bytes,1,opt,name=agent_id,json=agentId,proto3" json:"agent_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BootstrapCliRequest) Reset() {
+	*x = BootstrapCliRequest{}
+	mi := &file_kontext_agent_v1_agent_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BootstrapCliRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BootstrapCliRequest) ProtoMessage() {}
+
+func (x *BootstrapCliRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_kontext_agent_v1_agent_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BootstrapCliRequest.ProtoReflect.Descriptor instead.
+func (*BootstrapCliRequest) Descriptor() ([]byte, []int) {
+	return file_kontext_agent_v1_agent_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *BootstrapCliRequest) GetAgentId() string {
+	if x != nil {
+		return x.AgentId
+	}
+	return ""
+}
+
+type BootstrapCliResponse struct {
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	ApplicationId    string                 `protobuf:"bytes,1,opt,name=application_id,json=applicationId,proto3" json:"application_id,omitempty"`
+	ManagedProviders []*ManagedProvider     `protobuf:"bytes,2,rep,name=managed_providers,json=managedProviders,proto3" json:"managed_providers,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *BootstrapCliResponse) Reset() {
+	*x = BootstrapCliResponse{}
+	mi := &file_kontext_agent_v1_agent_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BootstrapCliResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BootstrapCliResponse) ProtoMessage() {}
+
+func (x *BootstrapCliResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_kontext_agent_v1_agent_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BootstrapCliResponse.ProtoReflect.Descriptor instead.
+func (*BootstrapCliResponse) Descriptor() ([]byte, []int) {
+	return file_kontext_agent_v1_agent_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *BootstrapCliResponse) GetApplicationId() string {
+	if x != nil {
+		return x.ApplicationId
+	}
+	return ""
+}
+
+func (x *BootstrapCliResponse) GetManagedProviders() []*ManagedProvider {
+	if x != nil {
+		return x.ManagedProviders
+	}
+	return nil
+}
+
+type ManagedProvider struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	PresetKey      string                 `protobuf:"bytes,1,opt,name=preset_key,json=presetKey,proto3" json:"preset_key,omitempty"`
+	Handle         string                 `protobuf:"bytes,2,opt,name=handle,proto3" json:"handle,omitempty"`
+	EnvVar         string                 `protobuf:"bytes,3,opt,name=env_var,json=envVar,proto3" json:"env_var,omitempty"`
+	Placeholder    string                 `protobuf:"bytes,4,opt,name=placeholder,proto3" json:"placeholder,omitempty"`
+	SeedOnFirstRun bool                   `protobuf:"varint,5,opt,name=seed_on_first_run,json=seedOnFirstRun,proto3" json:"seed_on_first_run,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *ManagedProvider) Reset() {
+	*x = ManagedProvider{}
+	mi := &file_kontext_agent_v1_agent_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ManagedProvider) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ManagedProvider) ProtoMessage() {}
+
+func (x *ManagedProvider) ProtoReflect() protoreflect.Message {
+	mi := &file_kontext_agent_v1_agent_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ManagedProvider.ProtoReflect.Descriptor instead.
+func (*ManagedProvider) Descriptor() ([]byte, []int) {
+	return file_kontext_agent_v1_agent_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *ManagedProvider) GetPresetKey() string {
+	if x != nil {
+		return x.PresetKey
+	}
+	return ""
+}
+
+func (x *ManagedProvider) GetHandle() string {
+	if x != nil {
+		return x.Handle
+	}
+	return ""
+}
+
+func (x *ManagedProvider) GetEnvVar() string {
+	if x != nil {
+		return x.EnvVar
+	}
+	return ""
+}
+
+func (x *ManagedProvider) GetPlaceholder() string {
+	if x != nil {
+		return x.Placeholder
+	}
+	return ""
+}
+
+func (x *ManagedProvider) GetSeedOnFirstRun() bool {
+	if x != nil {
+		return x.SeedOnFirstRun
+	}
+	return false
+}
+
 type HeartbeatRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
@@ -386,7 +558,7 @@ type HeartbeatRequest struct {
 
 func (x *HeartbeatRequest) Reset() {
 	*x = HeartbeatRequest{}
-	mi := &file_kontext_agent_v1_agent_proto_msgTypes[4]
+	mi := &file_kontext_agent_v1_agent_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -398,7 +570,7 @@ func (x *HeartbeatRequest) String() string {
 func (*HeartbeatRequest) ProtoMessage() {}
 
 func (x *HeartbeatRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_kontext_agent_v1_agent_proto_msgTypes[4]
+	mi := &file_kontext_agent_v1_agent_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -411,7 +583,7 @@ func (x *HeartbeatRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeartbeatRequest.ProtoReflect.Descriptor instead.
 func (*HeartbeatRequest) Descriptor() ([]byte, []int) {
-	return file_kontext_agent_v1_agent_proto_rawDescGZIP(), []int{4}
+	return file_kontext_agent_v1_agent_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *HeartbeatRequest) GetSessionId() string {
@@ -429,7 +601,7 @@ type HeartbeatResponse struct {
 
 func (x *HeartbeatResponse) Reset() {
 	*x = HeartbeatResponse{}
-	mi := &file_kontext_agent_v1_agent_proto_msgTypes[5]
+	mi := &file_kontext_agent_v1_agent_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -441,7 +613,7 @@ func (x *HeartbeatResponse) String() string {
 func (*HeartbeatResponse) ProtoMessage() {}
 
 func (x *HeartbeatResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_kontext_agent_v1_agent_proto_msgTypes[5]
+	mi := &file_kontext_agent_v1_agent_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -454,7 +626,7 @@ func (x *HeartbeatResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeartbeatResponse.ProtoReflect.Descriptor instead.
 func (*HeartbeatResponse) Descriptor() ([]byte, []int) {
-	return file_kontext_agent_v1_agent_proto_rawDescGZIP(), []int{5}
+	return file_kontext_agent_v1_agent_proto_rawDescGZIP(), []int{8}
 }
 
 type EndSessionRequest struct {
@@ -466,7 +638,7 @@ type EndSessionRequest struct {
 
 func (x *EndSessionRequest) Reset() {
 	*x = EndSessionRequest{}
-	mi := &file_kontext_agent_v1_agent_proto_msgTypes[6]
+	mi := &file_kontext_agent_v1_agent_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -478,7 +650,7 @@ func (x *EndSessionRequest) String() string {
 func (*EndSessionRequest) ProtoMessage() {}
 
 func (x *EndSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_kontext_agent_v1_agent_proto_msgTypes[6]
+	mi := &file_kontext_agent_v1_agent_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -491,7 +663,7 @@ func (x *EndSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EndSessionRequest.ProtoReflect.Descriptor instead.
 func (*EndSessionRequest) Descriptor() ([]byte, []int) {
-	return file_kontext_agent_v1_agent_proto_rawDescGZIP(), []int{6}
+	return file_kontext_agent_v1_agent_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *EndSessionRequest) GetSessionId() string {
@@ -509,7 +681,7 @@ type EndSessionResponse struct {
 
 func (x *EndSessionResponse) Reset() {
 	*x = EndSessionResponse{}
-	mi := &file_kontext_agent_v1_agent_proto_msgTypes[7]
+	mi := &file_kontext_agent_v1_agent_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -521,7 +693,7 @@ func (x *EndSessionResponse) String() string {
 func (*EndSessionResponse) ProtoMessage() {}
 
 func (x *EndSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_kontext_agent_v1_agent_proto_msgTypes[7]
+	mi := &file_kontext_agent_v1_agent_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -534,7 +706,7 @@ func (x *EndSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EndSessionResponse.ProtoReflect.Descriptor instead.
 func (*EndSessionResponse) Descriptor() ([]byte, []int) {
-	return file_kontext_agent_v1_agent_proto_rawDescGZIP(), []int{7}
+	return file_kontext_agent_v1_agent_proto_rawDescGZIP(), []int{10}
 }
 
 var File_kontext_agent_v1_agent_proto protoreflect.FileDescriptor
@@ -573,7 +745,19 @@ const file_kontext_agent_v1_agent_proto_rawDesc = "" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12!\n" +
 	"\fsession_name\x18\x02 \x01(\tR\vsessionName\x12'\n" +
 	"\x0forganization_id\x18\x03 \x01(\tR\x0eorganizationId\x12\x19\n" +
-	"\bagent_id\x18\x04 \x01(\tR\aagentId\"1\n" +
+	"\bagent_id\x18\x04 \x01(\tR\aagentId\"0\n" +
+	"\x13BootstrapCliRequest\x12\x19\n" +
+	"\bagent_id\x18\x01 \x01(\tR\aagentId\"\x8d\x01\n" +
+	"\x14BootstrapCliResponse\x12%\n" +
+	"\x0eapplication_id\x18\x01 \x01(\tR\rapplicationId\x12N\n" +
+	"\x11managed_providers\x18\x02 \x03(\v2!.kontext.agent.v1.ManagedProviderR\x10managedProviders\"\xae\x01\n" +
+	"\x0fManagedProvider\x12\x1d\n" +
+	"\n" +
+	"preset_key\x18\x01 \x01(\tR\tpresetKey\x12\x16\n" +
+	"\x06handle\x18\x02 \x01(\tR\x06handle\x12\x17\n" +
+	"\aenv_var\x18\x03 \x01(\tR\x06envVar\x12 \n" +
+	"\vplaceholder\x18\x04 \x01(\tR\vplaceholder\x12)\n" +
+	"\x11seed_on_first_run\x18\x05 \x01(\bR\x0eseedOnFirstRun\"1\n" +
 	"\x10HeartbeatRequest\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\"\x13\n" +
@@ -586,10 +770,11 @@ const file_kontext_agent_v1_agent_proto_rawDesc = "" +
 	"\x14DECISION_UNSPECIFIED\x10\x00\x12\x12\n" +
 	"\x0eDECISION_ALLOW\x10\x01\x12\x11\n" +
 	"\rDECISION_DENY\x10\x02\x12\x10\n" +
-	"\fDECISION_ASK\x10\x032\x8a\x03\n" +
+	"\fDECISION_ASK\x10\x032\xe9\x03\n" +
 	"\fAgentService\x12i\n" +
 	"\x10ProcessHookEvent\x12).kontext.agent.v1.ProcessHookEventRequest\x1a*.kontext.agent.v1.ProcessHookEventResponse\x12`\n" +
-	"\rCreateSession\x12&.kontext.agent.v1.CreateSessionRequest\x1a'.kontext.agent.v1.CreateSessionResponse\x12T\n" +
+	"\rCreateSession\x12&.kontext.agent.v1.CreateSessionRequest\x1a'.kontext.agent.v1.CreateSessionResponse\x12]\n" +
+	"\fBootstrapCli\x12%.kontext.agent.v1.BootstrapCliRequest\x1a&.kontext.agent.v1.BootstrapCliResponse\x12T\n" +
 	"\tHeartbeat\x12\".kontext.agent.v1.HeartbeatRequest\x1a#.kontext.agent.v1.HeartbeatResponse\x12W\n" +
 	"\n" +
 	"EndSession\x12#.kontext.agent.v1.EndSessionRequest\x1a$.kontext.agent.v1.EndSessionResponseB\xca\x01\n" +
@@ -609,35 +794,41 @@ func file_kontext_agent_v1_agent_proto_rawDescGZIP() []byte {
 }
 
 var file_kontext_agent_v1_agent_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_kontext_agent_v1_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_kontext_agent_v1_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_kontext_agent_v1_agent_proto_goTypes = []any{
 	(Decision)(0),                    // 0: kontext.agent.v1.Decision
 	(*ProcessHookEventRequest)(nil),  // 1: kontext.agent.v1.ProcessHookEventRequest
 	(*ProcessHookEventResponse)(nil), // 2: kontext.agent.v1.ProcessHookEventResponse
 	(*CreateSessionRequest)(nil),     // 3: kontext.agent.v1.CreateSessionRequest
 	(*CreateSessionResponse)(nil),    // 4: kontext.agent.v1.CreateSessionResponse
-	(*HeartbeatRequest)(nil),         // 5: kontext.agent.v1.HeartbeatRequest
-	(*HeartbeatResponse)(nil),        // 6: kontext.agent.v1.HeartbeatResponse
-	(*EndSessionRequest)(nil),        // 7: kontext.agent.v1.EndSessionRequest
-	(*EndSessionResponse)(nil),       // 8: kontext.agent.v1.EndSessionResponse
-	nil,                              // 9: kontext.agent.v1.CreateSessionRequest.ClientInfoEntry
+	(*BootstrapCliRequest)(nil),      // 5: kontext.agent.v1.BootstrapCliRequest
+	(*BootstrapCliResponse)(nil),     // 6: kontext.agent.v1.BootstrapCliResponse
+	(*ManagedProvider)(nil),          // 7: kontext.agent.v1.ManagedProvider
+	(*HeartbeatRequest)(nil),         // 8: kontext.agent.v1.HeartbeatRequest
+	(*HeartbeatResponse)(nil),        // 9: kontext.agent.v1.HeartbeatResponse
+	(*EndSessionRequest)(nil),        // 10: kontext.agent.v1.EndSessionRequest
+	(*EndSessionResponse)(nil),       // 11: kontext.agent.v1.EndSessionResponse
+	nil,                              // 12: kontext.agent.v1.CreateSessionRequest.ClientInfoEntry
 }
 var file_kontext_agent_v1_agent_proto_depIdxs = []int32{
-	0, // 0: kontext.agent.v1.ProcessHookEventResponse.decision:type_name -> kontext.agent.v1.Decision
-	9, // 1: kontext.agent.v1.CreateSessionRequest.client_info:type_name -> kontext.agent.v1.CreateSessionRequest.ClientInfoEntry
-	1, // 2: kontext.agent.v1.AgentService.ProcessHookEvent:input_type -> kontext.agent.v1.ProcessHookEventRequest
-	3, // 3: kontext.agent.v1.AgentService.CreateSession:input_type -> kontext.agent.v1.CreateSessionRequest
-	5, // 4: kontext.agent.v1.AgentService.Heartbeat:input_type -> kontext.agent.v1.HeartbeatRequest
-	7, // 5: kontext.agent.v1.AgentService.EndSession:input_type -> kontext.agent.v1.EndSessionRequest
-	2, // 6: kontext.agent.v1.AgentService.ProcessHookEvent:output_type -> kontext.agent.v1.ProcessHookEventResponse
-	4, // 7: kontext.agent.v1.AgentService.CreateSession:output_type -> kontext.agent.v1.CreateSessionResponse
-	6, // 8: kontext.agent.v1.AgentService.Heartbeat:output_type -> kontext.agent.v1.HeartbeatResponse
-	8, // 9: kontext.agent.v1.AgentService.EndSession:output_type -> kontext.agent.v1.EndSessionResponse
-	6, // [6:10] is the sub-list for method output_type
-	2, // [2:6] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	0,  // 0: kontext.agent.v1.ProcessHookEventResponse.decision:type_name -> kontext.agent.v1.Decision
+	12, // 1: kontext.agent.v1.CreateSessionRequest.client_info:type_name -> kontext.agent.v1.CreateSessionRequest.ClientInfoEntry
+	7,  // 2: kontext.agent.v1.BootstrapCliResponse.managed_providers:type_name -> kontext.agent.v1.ManagedProvider
+	1,  // 3: kontext.agent.v1.AgentService.ProcessHookEvent:input_type -> kontext.agent.v1.ProcessHookEventRequest
+	3,  // 4: kontext.agent.v1.AgentService.CreateSession:input_type -> kontext.agent.v1.CreateSessionRequest
+	5,  // 5: kontext.agent.v1.AgentService.BootstrapCli:input_type -> kontext.agent.v1.BootstrapCliRequest
+	8,  // 6: kontext.agent.v1.AgentService.Heartbeat:input_type -> kontext.agent.v1.HeartbeatRequest
+	10, // 7: kontext.agent.v1.AgentService.EndSession:input_type -> kontext.agent.v1.EndSessionRequest
+	2,  // 8: kontext.agent.v1.AgentService.ProcessHookEvent:output_type -> kontext.agent.v1.ProcessHookEventResponse
+	4,  // 9: kontext.agent.v1.AgentService.CreateSession:output_type -> kontext.agent.v1.CreateSessionResponse
+	6,  // 10: kontext.agent.v1.AgentService.BootstrapCli:output_type -> kontext.agent.v1.BootstrapCliResponse
+	9,  // 11: kontext.agent.v1.AgentService.Heartbeat:output_type -> kontext.agent.v1.HeartbeatResponse
+	11, // 12: kontext.agent.v1.AgentService.EndSession:output_type -> kontext.agent.v1.EndSessionResponse
+	8,  // [8:13] is the sub-list for method output_type
+	3,  // [3:8] is the sub-list for method input_type
+	3,  // [3:3] is the sub-list for extension type_name
+	3,  // [3:3] is the sub-list for extension extendee
+	0,  // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_kontext_agent_v1_agent_proto_init() }
@@ -651,7 +842,7 @@ func file_kontext_agent_v1_agent_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_kontext_agent_v1_agent_proto_rawDesc), len(file_kontext_agent_v1_agent_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   9,
+			NumMessages:   12,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/kontext/agent/v1/agentv1connect/agent.connect.go
+++ b/gen/kontext/agent/v1/agentv1connect/agent.connect.go
@@ -39,6 +39,9 @@ const (
 	// AgentServiceCreateSessionProcedure is the fully-qualified name of the AgentService's
 	// CreateSession RPC.
 	AgentServiceCreateSessionProcedure = "/kontext.agent.v1.AgentService/CreateSession"
+	// AgentServiceBootstrapCliProcedure is the fully-qualified name of the AgentService's BootstrapCli
+	// RPC.
+	AgentServiceBootstrapCliProcedure = "/kontext.agent.v1.AgentService/BootstrapCli"
 	// AgentServiceHeartbeatProcedure is the fully-qualified name of the AgentService's Heartbeat RPC.
 	AgentServiceHeartbeatProcedure = "/kontext.agent.v1.AgentService/Heartbeat"
 	// AgentServiceEndSessionProcedure is the fully-qualified name of the AgentService's EndSession RPC.
@@ -53,6 +56,10 @@ type AgentServiceClient interface {
 	// CreateSession establishes a governed agent session. Called once at the
 	// start of `kontext start`.
 	CreateSession(context.Context, *connect.Request[v1.CreateSessionRequest]) (*connect.Response[v1.CreateSessionResponse], error)
+	// BootstrapCli prepares the shared CLI application for credential
+	// resolution and returns the managed preset providers the CLI should sync
+	// into the local env file.
+	BootstrapCli(context.Context, *connect.Request[v1.BootstrapCliRequest]) (*connect.Response[v1.BootstrapCliResponse], error)
 	// Heartbeat keeps the session alive. The sidecar sends heartbeats on an
 	// interval; the backend marks sessions as disconnected if heartbeats stop.
 	Heartbeat(context.Context, *connect.Request[v1.HeartbeatRequest]) (*connect.Response[v1.HeartbeatResponse], error)
@@ -83,6 +90,12 @@ func NewAgentServiceClient(httpClient connect.HTTPClient, baseURL string, opts .
 			connect.WithSchema(agentServiceMethods.ByName("CreateSession")),
 			connect.WithClientOptions(opts...),
 		),
+		bootstrapCli: connect.NewClient[v1.BootstrapCliRequest, v1.BootstrapCliResponse](
+			httpClient,
+			baseURL+AgentServiceBootstrapCliProcedure,
+			connect.WithSchema(agentServiceMethods.ByName("BootstrapCli")),
+			connect.WithClientOptions(opts...),
+		),
 		heartbeat: connect.NewClient[v1.HeartbeatRequest, v1.HeartbeatResponse](
 			httpClient,
 			baseURL+AgentServiceHeartbeatProcedure,
@@ -102,6 +115,7 @@ func NewAgentServiceClient(httpClient connect.HTTPClient, baseURL string, opts .
 type agentServiceClient struct {
 	processHookEvent *connect.Client[v1.ProcessHookEventRequest, v1.ProcessHookEventResponse]
 	createSession    *connect.Client[v1.CreateSessionRequest, v1.CreateSessionResponse]
+	bootstrapCli     *connect.Client[v1.BootstrapCliRequest, v1.BootstrapCliResponse]
 	heartbeat        *connect.Client[v1.HeartbeatRequest, v1.HeartbeatResponse]
 	endSession       *connect.Client[v1.EndSessionRequest, v1.EndSessionResponse]
 }
@@ -114,6 +128,11 @@ func (c *agentServiceClient) ProcessHookEvent(ctx context.Context, req *connect.
 // CreateSession calls kontext.agent.v1.AgentService.CreateSession.
 func (c *agentServiceClient) CreateSession(ctx context.Context, req *connect.Request[v1.CreateSessionRequest]) (*connect.Response[v1.CreateSessionResponse], error) {
 	return c.createSession.CallUnary(ctx, req)
+}
+
+// BootstrapCli calls kontext.agent.v1.AgentService.BootstrapCli.
+func (c *agentServiceClient) BootstrapCli(ctx context.Context, req *connect.Request[v1.BootstrapCliRequest]) (*connect.Response[v1.BootstrapCliResponse], error) {
+	return c.bootstrapCli.CallUnary(ctx, req)
 }
 
 // Heartbeat calls kontext.agent.v1.AgentService.Heartbeat.
@@ -134,6 +153,10 @@ type AgentServiceHandler interface {
 	// CreateSession establishes a governed agent session. Called once at the
 	// start of `kontext start`.
 	CreateSession(context.Context, *connect.Request[v1.CreateSessionRequest]) (*connect.Response[v1.CreateSessionResponse], error)
+	// BootstrapCli prepares the shared CLI application for credential
+	// resolution and returns the managed preset providers the CLI should sync
+	// into the local env file.
+	BootstrapCli(context.Context, *connect.Request[v1.BootstrapCliRequest]) (*connect.Response[v1.BootstrapCliResponse], error)
 	// Heartbeat keeps the session alive. The sidecar sends heartbeats on an
 	// interval; the backend marks sessions as disconnected if heartbeats stop.
 	Heartbeat(context.Context, *connect.Request[v1.HeartbeatRequest]) (*connect.Response[v1.HeartbeatResponse], error)
@@ -160,6 +183,12 @@ func NewAgentServiceHandler(svc AgentServiceHandler, opts ...connect.HandlerOpti
 		connect.WithSchema(agentServiceMethods.ByName("CreateSession")),
 		connect.WithHandlerOptions(opts...),
 	)
+	agentServiceBootstrapCliHandler := connect.NewUnaryHandler(
+		AgentServiceBootstrapCliProcedure,
+		svc.BootstrapCli,
+		connect.WithSchema(agentServiceMethods.ByName("BootstrapCli")),
+		connect.WithHandlerOptions(opts...),
+	)
 	agentServiceHeartbeatHandler := connect.NewUnaryHandler(
 		AgentServiceHeartbeatProcedure,
 		svc.Heartbeat,
@@ -178,6 +207,8 @@ func NewAgentServiceHandler(svc AgentServiceHandler, opts ...connect.HandlerOpti
 			agentServiceProcessHookEventHandler.ServeHTTP(w, r)
 		case AgentServiceCreateSessionProcedure:
 			agentServiceCreateSessionHandler.ServeHTTP(w, r)
+		case AgentServiceBootstrapCliProcedure:
+			agentServiceBootstrapCliHandler.ServeHTTP(w, r)
 		case AgentServiceHeartbeatProcedure:
 			agentServiceHeartbeatHandler.ServeHTTP(w, r)
 		case AgentServiceEndSessionProcedure:
@@ -197,6 +228,10 @@ func (UnimplementedAgentServiceHandler) ProcessHookEvent(context.Context, *conne
 
 func (UnimplementedAgentServiceHandler) CreateSession(context.Context, *connect.Request[v1.CreateSessionRequest]) (*connect.Response[v1.CreateSessionResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("kontext.agent.v1.AgentService.CreateSession is not implemented"))
+}
+
+func (UnimplementedAgentServiceHandler) BootstrapCli(context.Context, *connect.Request[v1.BootstrapCliRequest]) (*connect.Response[v1.BootstrapCliResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("kontext.agent.v1.AgentService.BootstrapCli is not implemented"))
 }
 
 func (UnimplementedAgentServiceHandler) Heartbeat(context.Context, *connect.Request[v1.HeartbeatRequest]) (*connect.Response[v1.HeartbeatResponse], error) {

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -59,6 +59,15 @@ func (c *Client) CreateSession(ctx context.Context, req *agentv1.CreateSessionRe
 	return resp.Msg, nil
 }
 
+// BootstrapCli prepares the shared CLI application for env template sync.
+func (c *Client) BootstrapCli(ctx context.Context, req *agentv1.BootstrapCliRequest) (*agentv1.BootstrapCliResponse, error) {
+	resp, err := c.rpc.BootstrapCli(ctx, connect.NewRequest(req))
+	if err != nil {
+		return nil, fmt.Errorf("BootstrapCli: %w", err)
+	}
+	return resp.Msg, nil
+}
+
 // Heartbeat keeps a session alive.
 func (c *Client) Heartbeat(ctx context.Context, sessionID string) error {
 	_, err := c.rpc.Heartbeat(ctx, connect.NewRequest(&agentv1.HeartbeatRequest{

--- a/internal/credential/credential.go
+++ b/internal/credential/credential.go
@@ -12,22 +12,74 @@ var placeholder = regexp.MustCompile(`^\{\{kontext:([^}]+)\}\}$`)
 
 func normalizePlaceholderValue(value string) string {
 	trimmed := strings.TrimSpace(value)
-	if len(trimmed) < 2 {
-		return trimmed
+	if idx := inlineCommentIndex(trimmed); idx >= 0 {
+		trimmed = strings.TrimSpace(trimmed[:idx])
 	}
 
-	if (trimmed[0] == '"' && trimmed[len(trimmed)-1] == '"') ||
-		(trimmed[0] == '\'' && trimmed[len(trimmed)-1] == '\'') {
-		return strings.TrimSpace(trimmed[1 : len(trimmed)-1])
-	}
-
-	return trimmed
+	return trimMatchingQuotes(trimmed)
 }
 
 // NormalizeEnvValue trims surrounding quotes from dotenv-style values so the
 // launched process receives the literal token, not the quote characters.
 func NormalizeEnvValue(value string) string {
-	return normalizePlaceholderValue(value)
+	return trimMatchingQuotes(strings.TrimSpace(value))
+}
+
+func trimMatchingQuotes(value string) string {
+	if len(value) < 2 {
+		return value
+	}
+
+	if (value[0] == '"' && value[len(value)-1] == '"') ||
+		(value[0] == '\'' && value[len(value)-1] == '\'') {
+		return strings.TrimSpace(value[1 : len(value)-1])
+	}
+
+	return value
+}
+
+func inlineCommentIndex(value string) int {
+	inSingle := false
+	inDouble := false
+	escaped := false
+
+	for i := 0; i < len(value); i++ {
+		ch := value[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+
+		switch ch {
+		case '\\':
+			if inDouble {
+				escaped = true
+			}
+		case '\'':
+			if !inDouble {
+				inSingle = !inSingle
+			}
+		case '"':
+			if !inSingle {
+				inDouble = !inDouble
+			}
+		case '#':
+			if !inSingle && !inDouble && i > 0 && isInlineCommentWhitespace(value[i-1]) {
+				return i
+			}
+		}
+	}
+
+	return -1
+}
+
+func isInlineCommentWhitespace(ch byte) bool {
+	switch ch {
+	case ' ', '\t':
+		return true
+	default:
+		return false
+	}
 }
 
 // Entry represents a single credential placeholder from the env template.

--- a/internal/credential/credential.go
+++ b/internal/credential/credential.go
@@ -22,7 +22,7 @@ func normalizePlaceholderValue(value string) string {
 // NormalizeEnvValue trims surrounding quotes from dotenv-style values so the
 // launched process receives the literal token, not the quote characters.
 func NormalizeEnvValue(value string) string {
-	return trimMatchingQuotes(strings.TrimSpace(value))
+	return normalizePlaceholderValue(value)
 }
 
 func trimMatchingQuotes(value string) string {

--- a/internal/credential/credential.go
+++ b/internal/credential/credential.go
@@ -64,7 +64,7 @@ func inlineCommentIndex(value string) int {
 				inDouble = !inDouble
 			}
 		case '#':
-			if !inSingle && !inDouble && i > 0 && isInlineCommentWhitespace(value[i-1]) {
+			if !inSingle && !inDouble && (i == 0 || isInlineCommentWhitespace(value[i-1])) {
 				return i
 			}
 		}

--- a/internal/credential/credential.go
+++ b/internal/credential/credential.go
@@ -2,15 +2,12 @@
 package credential
 
 import (
-	"bufio"
 	"fmt"
-	"os"
 	"regexp"
-	"strings"
 )
 
 // placeholder matches {{kontext:<provider>}} or {{kontext:<provider>/<resource>}} patterns.
-var placeholder = regexp.MustCompile(`\{\{kontext:([^}]+)\}\}`)
+var placeholder = regexp.MustCompile(`^\{\{kontext:([^}]+)\}\}$`)
 
 // Entry represents a single credential placeholder from the env template.
 type Entry struct {
@@ -36,45 +33,11 @@ type Resolved struct {
 
 // ParseTemplate reads an env template file and extracts credential placeholders.
 func ParseTemplate(path string) ([]Entry, error) {
-	f, err := os.Open(path)
+	doc, err := LoadTemplateFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("open env template: %w", err)
+		return nil, fmt.Errorf("parse template: %w", err)
 	}
-	defer f.Close()
-
-	var entries []Entry
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-
-		parts := strings.SplitN(line, "=", 2)
-		if len(parts) != 2 {
-			continue
-		}
-
-		envVar := strings.TrimSpace(parts[0])
-		value := strings.TrimSpace(parts[1])
-
-		matches := placeholder.FindStringSubmatch(value)
-		if matches == nil {
-			continue
-		}
-
-		providerSpec := matches[1]
-		provider, resource, _ := strings.Cut(providerSpec, "/")
-
-		entries = append(entries, Entry{
-			EnvVar:   envVar,
-			Provider: provider,
-			Resource: resource,
-			Raw:      matches[0],
-		})
-	}
-
-	return entries, scanner.Err()
+	return doc.Entries, nil
 }
 
 // BuildEnv converts resolved credentials into environment variable assignments.

--- a/internal/credential/credential.go
+++ b/internal/credential/credential.go
@@ -24,6 +24,12 @@ func normalizePlaceholderValue(value string) string {
 	return trimmed
 }
 
+// NormalizeEnvValue trims surrounding quotes from dotenv-style values so the
+// launched process receives the literal token, not the quote characters.
+func NormalizeEnvValue(value string) string {
+	return normalizePlaceholderValue(value)
+}
+
 // Entry represents a single credential placeholder from the env template.
 type Entry struct {
 	EnvVar   string // e.g., "GITHUB_TOKEN"

--- a/internal/credential/credential.go
+++ b/internal/credential/credential.go
@@ -4,10 +4,25 @@ package credential
 import (
 	"fmt"
 	"regexp"
+	"strings"
 )
 
 // placeholder matches {{kontext:<provider>}} or {{kontext:<provider>/<resource>}} patterns.
 var placeholder = regexp.MustCompile(`^\{\{kontext:([^}]+)\}\}$`)
+
+func normalizePlaceholderValue(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if len(trimmed) < 2 {
+		return trimmed
+	}
+
+	if (trimmed[0] == '"' && trimmed[len(trimmed)-1] == '"') ||
+		(trimmed[0] == '\'' && trimmed[len(trimmed)-1] == '\'') {
+		return strings.TrimSpace(trimmed[1 : len(trimmed)-1])
+	}
+
+	return trimmed
+}
 
 // Entry represents a single credential placeholder from the env template.
 type Entry struct {

--- a/internal/credential/template_file.go
+++ b/internal/credential/template_file.go
@@ -1,0 +1,230 @@
+package credential
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type ManagedProvider struct {
+	EnvVar         string
+	Placeholder    string
+	SeedOnFirstRun bool
+}
+
+type InvalidPlaceholder struct {
+	EnvVar string
+	Value  string
+}
+
+type TemplateFile struct {
+	Entries              []Entry
+	ExistingValues       map[string]string
+	InvalidPlaceholders  []InvalidPlaceholder
+	SafeToMutate         bool
+	MutationWarning      string
+	HasManagedPlaceholds bool
+}
+
+type SyncResult struct {
+	Created          bool
+	Updated          bool
+	Added            []ManagedProvider
+	CollisionSkipped []ManagedProvider
+	Template         *TemplateFile
+}
+
+const managedHeader = "# Managed by Kontext CLI (local, gitignored).\n# You can add your own variables; the CLI will append managed entries as needed.\n"
+
+func LoadTemplateFile(path string) (*TemplateFile, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open env template: %w", err)
+	}
+	defer f.Close()
+
+	result := &TemplateFile{
+		ExistingValues: make(map[string]string),
+		SafeToMutate:   true,
+	}
+
+	seenKeys := make(map[string]struct{})
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		envVar := strings.TrimSpace(parts[0])
+		if envVar == "" {
+			result.SafeToMutate = false
+			result.MutationWarning = "Skipping env file sync because it contains an entry with an empty key."
+			continue
+		}
+		if _, exists := seenKeys[envVar]; exists {
+			result.SafeToMutate = false
+			result.MutationWarning = fmt.Sprintf(
+				"Skipping env file sync because %s is declared more than once.",
+				envVar,
+			)
+			continue
+		}
+		seenKeys[envVar] = struct{}{}
+
+		value := strings.TrimSpace(parts[1])
+		result.ExistingValues[envVar] = value
+
+		matches := placeholder.FindStringSubmatch(value)
+		if matches != nil {
+			providerSpec := matches[1]
+			provider, resource, _ := strings.Cut(providerSpec, "/")
+			if strings.TrimSpace(provider) == "" {
+				result.InvalidPlaceholders = append(result.InvalidPlaceholders, InvalidPlaceholder{
+					EnvVar: envVar,
+					Value:  value,
+				})
+				continue
+			}
+			result.HasManagedPlaceholds = true
+			result.Entries = append(result.Entries, Entry{
+				EnvVar:   envVar,
+				Provider: provider,
+				Resource: resource,
+				Raw:      matches[0],
+			})
+			continue
+		}
+
+		if strings.Contains(value, "{{kontext:") {
+			result.InvalidPlaceholders = append(result.InvalidPlaceholders, InvalidPlaceholder{
+				EnvVar: envVar,
+				Value:  value,
+			})
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func EnsureManagedTemplate(path string, managed []ManagedProvider) (*SyncResult, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		createdProviders := make([]ManagedProvider, 0, len(managed))
+		lines := []string{strings.TrimRight(managedHeader, "\n")}
+		for _, provider := range managed {
+			if !provider.SeedOnFirstRun {
+				continue
+			}
+			createdProviders = append(createdProviders, provider)
+			lines = append(lines, fmt.Sprintf("%s=%s", provider.EnvVar, provider.Placeholder))
+		}
+		content := strings.Join(lines, "\n") + "\n"
+		if err := writeFileAtomically(path, []byte(content), 0o600); err != nil {
+			return nil, err
+		}
+		template, err := LoadTemplateFile(path)
+		if err != nil {
+			return nil, err
+		}
+		return &SyncResult{
+			Created:  true,
+			Added:    createdProviders,
+			Template: template,
+		}, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	template, err := LoadTemplateFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &SyncResult{Template: template}
+	if !template.SafeToMutate {
+		return result, nil
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read env template: %w", err)
+	}
+	trimmedRight := strings.TrimRight(string(raw), "\n")
+	lines := []string{}
+	if trimmedRight != "" {
+		lines = append(lines, strings.Split(trimmedRight, "\n")...)
+	}
+
+	for _, provider := range managed {
+		existingValue, exists := template.ExistingValues[provider.EnvVar]
+		if exists {
+			if existingValue != provider.Placeholder {
+				result.CollisionSkipped = append(result.CollisionSkipped, provider)
+			}
+			continue
+		}
+
+		lines = append(lines, fmt.Sprintf("%s=%s", provider.EnvVar, provider.Placeholder))
+		template.ExistingValues[provider.EnvVar] = provider.Placeholder
+		result.Added = append(result.Added, provider)
+		result.Updated = true
+	}
+
+	if !result.Updated {
+		return result, nil
+	}
+
+	content := strings.Join(lines, "\n") + "\n"
+	if err := writeFileAtomically(path, []byte(content), 0o600); err != nil {
+		return nil, err
+	}
+
+	template, err = LoadTemplateFile(path)
+	if err != nil {
+		return nil, err
+	}
+	result.Template = template
+	return result, nil
+}
+
+func writeFileAtomically(path string, content []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create env template dir: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(dir, ".env.kontext.*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp env template: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if err := tmp.Chmod(mode); err != nil {
+		tmp.Close()
+		return fmt.Errorf("chmod temp env template: %w", err)
+	}
+	if _, err := tmp.Write(content); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write temp env template: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp env template: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("replace env template: %w", err)
+	}
+	return nil
+}

--- a/internal/credential/template_file.go
+++ b/internal/credential/template_file.go
@@ -171,7 +171,7 @@ func EnsureManagedTemplate(path string, managed []ManagedProvider) (*SyncResult,
 	for _, provider := range managed {
 		existingValue, exists := template.ExistingValues[provider.EnvVar]
 		if exists {
-			if existingValue != provider.Placeholder {
+			if normalizePlaceholderValue(existingValue) != normalizePlaceholderValue(provider.Placeholder) {
 				result.CollisionSkipped = append(result.CollisionSkipped, provider)
 			}
 			continue

--- a/internal/credential/template_file.go
+++ b/internal/credential/template_file.go
@@ -36,7 +36,7 @@ type SyncResult struct {
 	Template         *TemplateFile
 }
 
-const managedHeader = "# Managed by Kontext CLI (local, gitignored).\n# You can add your own variables; the CLI will append managed entries as needed.\n"
+const managedHeader = "# Managed by Kontext CLI (local file).\n# You can add your own variables; the CLI will append managed entries as needed.\n"
 
 func LoadTemplateFile(path string) (*TemplateFile, error) {
 	f, err := os.Open(path)
@@ -81,9 +81,10 @@ func LoadTemplateFile(path string) (*TemplateFile, error) {
 		seenKeys[envVar] = struct{}{}
 
 		value := strings.TrimSpace(parts[1])
+		normalizedValue := normalizePlaceholderValue(value)
 		result.ExistingValues[envVar] = value
 
-		matches := placeholder.FindStringSubmatch(value)
+		matches := placeholder.FindStringSubmatch(normalizedValue)
 		if matches != nil {
 			providerSpec := matches[1]
 			provider, resource, _ := strings.Cut(providerSpec, "/")
@@ -99,12 +100,12 @@ func LoadTemplateFile(path string) (*TemplateFile, error) {
 				EnvVar:   envVar,
 				Provider: provider,
 				Resource: resource,
-				Raw:      matches[0],
+				Raw:      normalizedValue,
 			})
 			continue
 		}
 
-		if strings.Contains(value, "{{kontext:") {
+		if strings.Contains(normalizedValue, "{{kontext:") {
 			result.InvalidPlaceholders = append(result.InvalidPlaceholders, InvalidPlaceholder{
 				EnvVar: envVar,
 				Value:  value,

--- a/internal/credential/template_file.go
+++ b/internal/credential/template_file.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -50,8 +51,16 @@ func LoadTemplateFile(path string) (*TemplateFile, error) {
 		SafeToMutate:   true,
 	}
 
+	type effectiveAssignment struct {
+		entry     *Entry
+		invalid   *InvalidPlaceholder
+		lastIndex int
+	}
+
+	assignments := make(map[string]effectiveAssignment)
 	seenKeys := make(map[string]struct{})
 	scanner := bufio.NewScanner(f)
+	lineIndex := 0
 	for scanner.Scan() {
 		line := scanner.Text()
 		trimmed := strings.TrimSpace(line)
@@ -76,45 +85,68 @@ func LoadTemplateFile(path string) (*TemplateFile, error) {
 				"Skipping env file sync because %s is declared more than once.",
 				envVar,
 			)
-			continue
+		} else {
+			seenKeys[envVar] = struct{}{}
 		}
-		seenKeys[envVar] = struct{}{}
 
 		value := strings.TrimSpace(parts[1])
 		normalizedValue := normalizePlaceholderValue(value)
 		result.ExistingValues[envVar] = value
+		assignment := effectiveAssignment{lastIndex: lineIndex}
+		lineIndex++
 
 		matches := placeholder.FindStringSubmatch(normalizedValue)
 		if matches != nil {
 			providerSpec := matches[1]
 			provider, resource, _ := strings.Cut(providerSpec, "/")
 			if strings.TrimSpace(provider) == "" {
-				result.InvalidPlaceholders = append(result.InvalidPlaceholders, InvalidPlaceholder{
+				assignment.invalid = &InvalidPlaceholder{
 					EnvVar: envVar,
 					Value:  value,
-				})
+				}
+				assignments[envVar] = assignment
 				continue
 			}
-			result.HasManagedPlaceholds = true
-			result.Entries = append(result.Entries, Entry{
+			assignment.entry = &Entry{
 				EnvVar:   envVar,
 				Provider: provider,
 				Resource: resource,
 				Raw:      normalizedValue,
-			})
+			}
+			assignments[envVar] = assignment
 			continue
 		}
 
 		if strings.Contains(normalizedValue, "{{kontext:") {
-			result.InvalidPlaceholders = append(result.InvalidPlaceholders, InvalidPlaceholder{
+			assignment.invalid = &InvalidPlaceholder{
 				EnvVar: envVar,
 				Value:  value,
-			})
+			}
 		}
+		assignments[envVar] = assignment
 	}
 
 	if err := scanner.Err(); err != nil {
 		return nil, err
+	}
+
+	keys := make([]string, 0, len(assignments))
+	for envVar := range assignments {
+		keys = append(keys, envVar)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return assignments[keys[i]].lastIndex < assignments[keys[j]].lastIndex
+	})
+	for _, envVar := range keys {
+		assignment := assignments[envVar]
+		if assignment.invalid != nil {
+			result.InvalidPlaceholders = append(result.InvalidPlaceholders, *assignment.invalid)
+			continue
+		}
+		if assignment.entry != nil {
+			result.HasManagedPlaceholds = true
+			result.Entries = append(result.Entries, *assignment.entry)
+		}
 	}
 
 	return result, nil

--- a/internal/credential/template_file_test.go
+++ b/internal/credential/template_file_test.go
@@ -1,0 +1,139 @@
+package credential
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEnsureManagedTemplateCreatesNewFileWithDefaults(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), ".env.kontext")
+	result, err := EnsureManagedTemplate(path, []ManagedProvider{
+		{EnvVar: "GITHUB_TOKEN", Placeholder: "{{kontext:github}}", SeedOnFirstRun: true},
+		{EnvVar: "LINEAR_API_KEY", Placeholder: "{{kontext:linear}}", SeedOnFirstRun: true},
+		{EnvVar: "SLACK_TOKEN", Placeholder: "{{kontext:slack}}", SeedOnFirstRun: false},
+	})
+	if err != nil {
+		t.Fatalf("EnsureManagedTemplate() error = %v", err)
+	}
+	if !result.Created {
+		t.Fatal("EnsureManagedTemplate() Created = false, want true")
+	}
+	if got, want := len(result.Added), 2; got != want {
+		t.Fatalf("EnsureManagedTemplate() added len = %d, want %d", got, want)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read created file: %v", err)
+	}
+	text := string(content)
+	if !strings.Contains(text, "GITHUB_TOKEN={{kontext:github}}") {
+		t.Fatalf("created file missing github placeholder: %q", text)
+	}
+	if !strings.Contains(text, "LINEAR_API_KEY={{kontext:linear}}") {
+		t.Fatalf("created file missing linear placeholder: %q", text)
+	}
+	if strings.Contains(text, "SLACK_TOKEN={{kontext:slack}}") {
+		t.Fatalf("created file unexpectedly seeded slack placeholder: %q", text)
+	}
+}
+
+func TestEnsureManagedTemplateAppendsMissingManagedEntries(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), ".env.kontext")
+	if err := os.WriteFile(path, []byte("GITHUB_TOKEN={{kontext:github}}\n"), 0o600); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+
+	result, err := EnsureManagedTemplate(path, []ManagedProvider{
+		{EnvVar: "GITHUB_TOKEN", Placeholder: "{{kontext:github}}", SeedOnFirstRun: true},
+		{EnvVar: "LINEAR_API_KEY", Placeholder: "{{kontext:linear}}", SeedOnFirstRun: true},
+	})
+	if err != nil {
+		t.Fatalf("EnsureManagedTemplate() error = %v", err)
+	}
+	if !result.Updated {
+		t.Fatal("EnsureManagedTemplate() Updated = false, want true")
+	}
+	if got, want := len(result.Added), 1; got != want {
+		t.Fatalf("EnsureManagedTemplate() added len = %d, want %d", got, want)
+	}
+	if got := result.Added[0].EnvVar; got != "LINEAR_API_KEY" {
+		t.Fatalf("EnsureManagedTemplate() added env var = %q, want %q", got, "LINEAR_API_KEY")
+	}
+}
+
+func TestEnsureManagedTemplateReportsCollisionWithoutOverwriting(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), ".env.kontext")
+	if err := os.WriteFile(path, []byte("SLACK_TOKEN=xoxb-literal\n"), 0o600); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+
+	result, err := EnsureManagedTemplate(path, []ManagedProvider{
+		{EnvVar: "SLACK_TOKEN", Placeholder: "{{kontext:slack}}", SeedOnFirstRun: false},
+	})
+	if err != nil {
+		t.Fatalf("EnsureManagedTemplate() error = %v", err)
+	}
+	if got, want := len(result.CollisionSkipped), 1; got != want {
+		t.Fatalf("EnsureManagedTemplate() collision len = %d, want %d", got, want)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read template: %v", err)
+	}
+	if got := string(content); got != "SLACK_TOKEN=xoxb-literal\n" {
+		t.Fatalf("template content = %q, want literal value preserved", got)
+	}
+}
+
+func TestLoadTemplateFileMarksDuplicateKeysUnsafeForMutation(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), ".env.kontext")
+	if err := os.WriteFile(path, []byte("GITHUB_TOKEN={{kontext:github}}\nGITHUB_TOKEN=literal\n"), 0o600); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+
+	doc, err := LoadTemplateFile(path)
+	if err != nil {
+		t.Fatalf("LoadTemplateFile() error = %v", err)
+	}
+	if doc.SafeToMutate {
+		t.Fatal("LoadTemplateFile() SafeToMutate = true, want false")
+	}
+	if !strings.Contains(doc.MutationWarning, "declared more than once") {
+		t.Fatalf("mutation warning = %q, want duplicate-key warning", doc.MutationWarning)
+	}
+}
+
+func TestLoadTemplateFileCollectsInvalidPlaceholders(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), ".env.kontext")
+	if err := os.WriteFile(path, []byte("BROKEN={{kontext:}}\nGITHUB_TOKEN={{kontext:github}}\n"), 0o600); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+
+	doc, err := LoadTemplateFile(path)
+	if err != nil {
+		t.Fatalf("LoadTemplateFile() error = %v", err)
+	}
+	if got, want := len(doc.InvalidPlaceholders), 1; got != want {
+		t.Fatalf("invalid placeholders len = %d, want %d", got, want)
+	}
+	if got := doc.InvalidPlaceholders[0].EnvVar; got != "BROKEN" {
+		t.Fatalf("invalid placeholder env var = %q, want %q", got, "BROKEN")
+	}
+	if got, want := len(doc.Entries), 1; got != want {
+		t.Fatalf("valid entries len = %d, want %d", got, want)
+	}
+}

--- a/internal/credential/template_file_test.go
+++ b/internal/credential/template_file_test.go
@@ -117,6 +117,28 @@ func TestEnsureManagedTemplateDoesNotReportCollisionForQuotedManagedPlaceholder(
 	}
 }
 
+func TestEnsureManagedTemplateDoesNotReportCollisionForCommentedManagedPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), ".env.kontext")
+	if err := os.WriteFile(path, []byte("GITHUB_TOKEN={{kontext:github}} # personal account\n"), 0o600); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+
+	result, err := EnsureManagedTemplate(path, []ManagedProvider{
+		{EnvVar: "GITHUB_TOKEN", Placeholder: "{{kontext:github}}", SeedOnFirstRun: true},
+	})
+	if err != nil {
+		t.Fatalf("EnsureManagedTemplate() error = %v", err)
+	}
+	if got := len(result.CollisionSkipped); got != 0 {
+		t.Fatalf("collision len = %d, want 0", got)
+	}
+	if result.Updated {
+		t.Fatal("EnsureManagedTemplate() Updated = true, want false")
+	}
+}
+
 func TestEnsureManagedTemplateAppendsNonSeededManagedProvidersOnExistingFiles(t *testing.T) {
 	t.Parallel()
 
@@ -191,6 +213,26 @@ func TestLoadTemplateFileAcceptsQuotedPlaceholders(t *testing.T) {
 
 	path := filepath.Join(t.TempDir(), ".env.kontext")
 	if err := os.WriteFile(path, []byte("GITHUB_TOKEN=\"{{kontext:github}}\"\n"), 0o600); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+
+	doc, err := LoadTemplateFile(path)
+	if err != nil {
+		t.Fatalf("LoadTemplateFile() error = %v", err)
+	}
+	if got, want := len(doc.Entries), 1; got != want {
+		t.Fatalf("entries len = %d, want %d", got, want)
+	}
+	if got := doc.Entries[0].Raw; got != "{{kontext:github}}" {
+		t.Fatalf("entry raw = %q, want %q", got, "{{kontext:github}}")
+	}
+}
+
+func TestLoadTemplateFileAcceptsPlaceholdersWithInlineComments(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), ".env.kontext")
+	if err := os.WriteFile(path, []byte("GITHUB_TOKEN={{kontext:github}} # personal account\n"), 0o600); err != nil {
 		t.Fatalf("write template: %v", err)
 	}
 

--- a/internal/credential/template_file_test.go
+++ b/internal/credential/template_file_test.go
@@ -95,6 +95,32 @@ func TestEnsureManagedTemplateReportsCollisionWithoutOverwriting(t *testing.T) {
 	}
 }
 
+func TestEnsureManagedTemplateAppendsNonSeededManagedProvidersOnExistingFiles(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), ".env.kontext")
+	if err := os.WriteFile(path, []byte("GITHUB_TOKEN={{kontext:github}}\n"), 0o600); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+
+	result, err := EnsureManagedTemplate(path, []ManagedProvider{
+		{EnvVar: "GITHUB_TOKEN", Placeholder: "{{kontext:github}}", SeedOnFirstRun: true},
+		{EnvVar: "SLACK_TOKEN", Placeholder: "{{kontext:slack}}", SeedOnFirstRun: false},
+	})
+	if err != nil {
+		t.Fatalf("EnsureManagedTemplate() error = %v", err)
+	}
+	if !result.Updated {
+		t.Fatal("EnsureManagedTemplate() Updated = false, want true")
+	}
+	if got, want := len(result.Added), 1; got != want {
+		t.Fatalf("EnsureManagedTemplate() added len = %d, want %d", got, want)
+	}
+	if got := result.Added[0].EnvVar; got != "SLACK_TOKEN" {
+		t.Fatalf("EnsureManagedTemplate() added env var = %q, want %q", got, "SLACK_TOKEN")
+	}
+}
+
 func TestLoadTemplateFileMarksDuplicateKeysUnsafeForMutation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/credential/template_file_test.go
+++ b/internal/credential/template_file_test.go
@@ -183,6 +183,38 @@ func TestLoadTemplateFileMarksDuplicateKeysUnsafeForMutation(t *testing.T) {
 	if !strings.Contains(doc.MutationWarning, "declared more than once") {
 		t.Fatalf("mutation warning = %q, want duplicate-key warning", doc.MutationWarning)
 	}
+	if got := doc.ExistingValues["GITHUB_TOKEN"]; got != "literal" {
+		t.Fatalf("existing value = %q, want last duplicate assignment", got)
+	}
+	if got := len(doc.Entries); got != 0 {
+		t.Fatalf("entries len = %d, want 0 after later literal override", got)
+	}
+}
+
+func TestLoadTemplateFilePreservesLastDuplicatePlaceholderAssignment(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), ".env.kontext")
+	if err := os.WriteFile(path, []byte("GITHUB_TOKEN=literal\nGITHUB_TOKEN={{kontext:github}}\n"), 0o600); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+
+	doc, err := LoadTemplateFile(path)
+	if err != nil {
+		t.Fatalf("LoadTemplateFile() error = %v", err)
+	}
+	if doc.SafeToMutate {
+		t.Fatal("LoadTemplateFile() SafeToMutate = true, want false")
+	}
+	if got := doc.ExistingValues["GITHUB_TOKEN"]; got != "{{kontext:github}}" {
+		t.Fatalf("existing value = %q, want last duplicate assignment", got)
+	}
+	if got, want := len(doc.Entries), 1; got != want {
+		t.Fatalf("entries len = %d, want %d", got, want)
+	}
+	if got := doc.Entries[0].Raw; got != "{{kontext:github}}" {
+		t.Fatalf("entry raw = %q, want %q", got, "{{kontext:github}}")
+	}
 }
 
 func TestLoadTemplateFileCollectsInvalidPlaceholders(t *testing.T) {

--- a/internal/credential/template_file_test.go
+++ b/internal/credential/template_file_test.go
@@ -95,6 +95,28 @@ func TestEnsureManagedTemplateReportsCollisionWithoutOverwriting(t *testing.T) {
 	}
 }
 
+func TestEnsureManagedTemplateDoesNotReportCollisionForQuotedManagedPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), ".env.kontext")
+	if err := os.WriteFile(path, []byte("GITHUB_TOKEN=\"{{kontext:github}}\"\n"), 0o600); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+
+	result, err := EnsureManagedTemplate(path, []ManagedProvider{
+		{EnvVar: "GITHUB_TOKEN", Placeholder: "{{kontext:github}}", SeedOnFirstRun: true},
+	})
+	if err != nil {
+		t.Fatalf("EnsureManagedTemplate() error = %v", err)
+	}
+	if got := len(result.CollisionSkipped); got != 0 {
+		t.Fatalf("collision len = %d, want 0", got)
+	}
+	if result.Updated {
+		t.Fatal("EnsureManagedTemplate() Updated = true, want false")
+	}
+}
+
 func TestEnsureManagedTemplateAppendsNonSeededManagedProvidersOnExistingFiles(t *testing.T) {
 	t.Parallel()
 

--- a/internal/credential/template_file_test.go
+++ b/internal/credential/template_file_test.go
@@ -137,3 +137,23 @@ func TestLoadTemplateFileCollectsInvalidPlaceholders(t *testing.T) {
 		t.Fatalf("valid entries len = %d, want %d", got, want)
 	}
 }
+
+func TestLoadTemplateFileAcceptsQuotedPlaceholders(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), ".env.kontext")
+	if err := os.WriteFile(path, []byte("GITHUB_TOKEN=\"{{kontext:github}}\"\n"), 0o600); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+
+	doc, err := LoadTemplateFile(path)
+	if err != nil {
+		t.Fatalf("LoadTemplateFile() error = %v", err)
+	}
+	if got, want := len(doc.Entries), 1; got != want {
+		t.Fatalf("entries len = %d, want %d", got, want)
+	}
+	if got := doc.Entries[0].Raw; got != "{{kontext:github}}" {
+		t.Fatalf("entry raw = %q, want %q", got, "{{kontext:github}}")
+	}
+}

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -83,23 +83,93 @@ func Start(ctx context.Context, opts Options) error {
 	credentialClientID := resolveCredentialClientID(createResp.AgentId, opts.ClientID)
 	fmt.Fprintf(os.Stderr, "✓ Session: %s (%s)\n", createResp.SessionName, truncateID(sessionID))
 
-	// 4. Resolve credentials (before sidecar starts — no background goroutines yet,
-	//    so reading session fields is safe without synchronization)
-	var resolved []credential.Resolved
+	// 4. Bootstrap the shared CLI application and sync the local env file.
+	templateExists := false
 	if _, err := os.Stat(opts.TemplateFile); err == nil {
-		entries, err := credential.ParseTemplate(opts.TemplateFile)
+		templateExists = true
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat env template: %w", err)
+	}
+
+	bootstrapResp, bootstrapErr := client.BootstrapCli(ctx, &agentv1.BootstrapCliRequest{
+		AgentId: createResp.AgentId,
+	})
+	if bootstrapErr != nil && !templateExists {
+		return fmt.Errorf("bootstrap cli application: %w", bootstrapErr)
+	}
+
+	var templateDoc *credential.TemplateFile
+	if bootstrapErr != nil {
+		fmt.Fprintf(os.Stderr, "⚠ Provider sync skipped (%v)\n", bootstrapErr)
+		templateDoc, err = credential.LoadTemplateFile(opts.TemplateFile)
 		if err != nil {
-			return fmt.Errorf("parse template: %w", err)
+			return fmt.Errorf("load env template: %w", err)
 		}
-		if len(entries) > 0 {
-			resolved, err = resolveCredentials(ctx, session, entries, credentialClientID)
-			if err != nil {
-				return err
+	} else {
+		syncResult, err := credential.EnsureManagedTemplate(
+			opts.TemplateFile,
+			managedProvidersFromBootstrap(bootstrapResp.ManagedProviders),
+		)
+		if err != nil {
+			return fmt.Errorf("sync env template: %w", err)
+		}
+		templateDoc = syncResult.Template
+		if syncResult.Created {
+			fmt.Fprintf(os.Stderr, "✓ Created local %s automatically", opts.TemplateFile)
+			if opts.TemplateFile == ".env.kontext" {
+				fmt.Fprint(os.Stderr, " (gitignored)")
 			}
+			fmt.Fprintln(os.Stderr)
+		}
+		if syncResult.Updated {
+			fmt.Fprintf(
+				os.Stderr,
+				"✓ Updated %s with managed preset entries: %s\n",
+				opts.TemplateFile,
+				joinManagedEnvVars(syncResult.Added),
+			)
+		}
+		for _, provider := range syncResult.CollisionSkipped {
+			fmt.Fprintf(
+				os.Stderr,
+				"⚠ Skipped auto-adding %s because that key already exists in %s\n",
+				provider.EnvVar,
+				opts.TemplateFile,
+			)
+		}
+		if templateDoc != nil && !templateDoc.SafeToMutate && templateDoc.MutationWarning != "" {
+			fmt.Fprintf(os.Stderr, "⚠ %s\n", templateDoc.MutationWarning)
 		}
 	}
 
-	// 5. Start sidecar
+	for _, invalid := range templateDoc.InvalidPlaceholders {
+		fmt.Fprintf(
+			os.Stderr,
+			"⚠ Invalid Kontext placeholder for %s: %s\n",
+			invalid.EnvVar,
+			invalid.Value,
+		)
+	}
+
+	if len(templateDoc.Entries) == 0 {
+		fmt.Fprintf(
+			os.Stderr,
+			"ℹ No provider credentials were requested from %s; continuing without managed provider env vars.\n",
+			opts.TemplateFile,
+		)
+	}
+
+	// 5. Resolve credentials (before sidecar starts — no background goroutines yet,
+	//    so reading session fields is safe without synchronization)
+	var resolved []credential.Resolved
+	if len(templateDoc.Entries) > 0 {
+		resolved, err = resolveCredentials(ctx, session, templateDoc.Entries, credentialClientID)
+		if err != nil {
+			return err
+		}
+	}
+
+	// 6. Start sidecar
 	// Use /tmp (not $TMPDIR) with a short ID to keep the Unix socket path
 	// under macOS's 104-byte sun_path limit.
 	sessionDir := filepath.Join("/tmp", "kontext", truncateID(sessionID))
@@ -116,23 +186,23 @@ func Start(ctx context.Context, opts Options) error {
 	}
 	defer sc.Stop()
 
-	// 6. Generate hook settings
+	// 7. Generate hook settings
 	kontextBin, _ := os.Executable()
 	settingsPath, err := GenerateSettings(sessionDir, kontextBin, opts.Agent)
 	if err != nil {
 		return fmt.Errorf("generate settings: %w", err)
 	}
 
-	// 7. Build env
-	env := buildEnv(resolved)
+	// 8. Build env
+	env := buildEnv(templateDoc, resolved)
 	env = append(env, "KONTEXT_SOCKET="+sc.SocketPath())
 	env = append(env, "KONTEXT_SESSION_ID="+sessionID)
 
-	// 8. Launch agent with hooks
+	// 9. Launch agent with hooks
 	fmt.Fprintf(os.Stderr, "\nLaunching %s...\n\n", opts.Agent)
 	agentErr := launchAgentWithSettings(ctx, opts.Agent, env, opts.Args, settingsPath)
 
-	// 9. Teardown (always runs, even on non-zero agent exit)
+	// 10. Teardown (always runs, even on non-zero agent exit)
 	endCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -167,38 +237,208 @@ func ensureSession(ctx context.Context, issuerURL, clientID string) (*auth.Sessi
 // resolveCredentials exchanges each template entry for a live credential.
 func resolveCredentials(ctx context.Context, session *auth.Session, entries []credential.Entry, credentialClientID string) ([]credential.Resolved, error) {
 	fmt.Fprintln(os.Stderr, "\nResolving credentials...")
-	var resolved []credential.Resolved
+	resolved := make([]credential.Resolved, 0, len(entries))
+	failures := make(map[string]error)
+	entryByEnvVar := make(map[string]credential.Entry, len(entries))
 
 	for _, entry := range entries {
+		entryByEnvVar[entry.EnvVar] = entry
 		fmt.Fprintf(os.Stderr, "  %s (%s)... ", entry.EnvVar, entry.Target())
-
 		value, err := exchangeCredential(ctx, session, entry, credentialClientID)
 		if err != nil {
-			if isNotConnectedError(err) {
-				fmt.Fprintln(os.Stderr, "not connected")
-				connectURL, connectErr := fetchConnectURLWithGatewayLoginFallback(ctx, session, credentialClientID, auth.Login)
-				if connectErr != nil {
-					err = fmt.Errorf("create connect session: %w", connectErr)
-				} else {
-					fmt.Fprintf(os.Stderr, "  Opening browser to connect %s...\n", entry.Provider)
-					fmt.Fprintf(os.Stderr, "  If the browser doesn't open, visit:\n    %s\n", connectURL)
-					_ = browser.OpenURL(connectURL)
-					fmt.Fprint(os.Stderr, "  Press Enter after connecting...")
-					bufio.NewReader(os.Stdin).ReadString('\n')
-					value, err = exchangeCredential(ctx, session, entry, credentialClientID)
-				}
-			}
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "⚠ skipped (%v)\n", err)
-				continue
-			}
+			fmt.Fprintf(os.Stderr, "⚠ skipped (%v)\n", err)
+			failures[entry.EnvVar] = err
+			continue
 		}
-
 		fmt.Fprintln(os.Stderr, "✓")
 		resolved = append(resolved, credential.Resolved{Entry: entry, Value: value})
 	}
 
+	connectable := unresolvedConnectableEntries(entryByEnvVar, failures)
+	if len(connectable) == 0 {
+		printLaunchWarnings(entryByEnvVar, failures)
+		return resolved, nil
+	}
+
+	connectURL, connectErr := fetchConnectURLWithGatewayLoginFallback(ctx, session, credentialClientID, auth.Login)
+	if connectErr != nil {
+		fmt.Fprintf(os.Stderr, "⚠ Could not create hosted connect session (%v)\n", connectErr)
+		printLaunchWarnings(entryByEnvVar, failures)
+		return resolved, nil
+	}
+
+	providerList := joinEntryProviders(connectable)
+	fmt.Fprintf(os.Stderr, "\nHosted connect is available for: %s\n", providerList)
+	fmt.Fprintf(os.Stderr, "  %s\n", connectURL)
+
+	if !isInteractiveTerminal() {
+		fmt.Fprintln(os.Stderr, "⚠ Non-interactive session detected. Open this URL in a browser, then rerun `kontext start`.")
+		printLaunchWarnings(entryByEnvVar, failures)
+		return resolved, nil
+	}
+
+	fmt.Fprintf(os.Stderr, "  Opening browser to connect %s...\n", providerList)
+	if err := browser.OpenURL(connectURL); err != nil {
+		fmt.Fprintf(os.Stderr, "  ⚠ Could not open browser automatically (%v)\n", err)
+		fmt.Fprintln(os.Stderr, "  Open the URL above to continue.")
+	}
+	fmt.Fprint(os.Stderr, "  Press Enter after connecting...")
+	bufio.NewReader(os.Stdin).ReadString('\n')
+
+	retriedResolved, remainingFailures := retryConnectableCredentials(
+		ctx,
+		session,
+		connectable,
+		credentialClientID,
+	)
+	resolved = append(resolved, retriedResolved...)
+	for _, entry := range connectable {
+		if err, ok := remainingFailures[entry.EnvVar]; ok {
+			failures[entry.EnvVar] = err
+			continue
+		}
+		delete(failures, entry.EnvVar)
+	}
+
+	printLaunchWarnings(entryByEnvVar, failures)
 	return resolved, nil
+}
+
+func unresolvedConnectableEntries(entryByEnvVar map[string]credential.Entry, failures map[string]error) []credential.Entry {
+	var entries []credential.Entry
+	for envVar, err := range failures {
+		resolutionErr, ok := err.(*credentialResolutionError)
+		if !ok || resolutionErr.Reason != failureDisconnected {
+			continue
+		}
+		entry, ok := entryByEnvVar[envVar]
+		if !ok {
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	slices.SortFunc(entries, func(a, b credential.Entry) int {
+		return strings.Compare(a.EnvVar, b.EnvVar)
+	})
+	return entries
+}
+
+func retryConnectableCredentials(
+	ctx context.Context,
+	session *auth.Session,
+	entries []credential.Entry,
+	credentialClientID string,
+) ([]credential.Resolved, map[string]error) {
+	attemptDelays := []time.Duration{0, 3 * time.Second, 7 * time.Second}
+	pending := make(map[string]credential.Entry, len(entries))
+	for _, entry := range entries {
+		pending[entry.EnvVar] = entry
+	}
+	failures := make(map[string]error, len(entries))
+	resolved := make([]credential.Resolved, 0, len(entries))
+
+	for attempt, delay := range attemptDelays {
+		if len(pending) == 0 {
+			break
+		}
+		if delay > 0 {
+			time.Sleep(delay)
+		}
+
+		for envVar, entry := range pending {
+			fmt.Fprintf(
+				os.Stderr,
+				"  Retrying %s (%d/%d)... ",
+				entry.EnvVar,
+				attempt+1,
+				len(attemptDelays),
+			)
+			value, err := exchangeCredential(ctx, session, entry, credentialClientID)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "⚠ skipped (%v)\n", err)
+				failures[envVar] = err
+				continue
+			}
+			fmt.Fprintln(os.Stderr, "✓")
+			resolved = append(resolved, credential.Resolved{Entry: entry, Value: value})
+			delete(failures, envVar)
+			delete(pending, envVar)
+		}
+	}
+
+	return resolved, failures
+}
+
+func printLaunchWarnings(entryByEnvVar map[string]credential.Entry, failures map[string]error) {
+	if len(failures) == 0 {
+		return
+	}
+
+	var skipped []string
+	for envVar, err := range failures {
+		entry, ok := entryByEnvVar[envVar]
+		if !ok {
+			continue
+		}
+		if resolutionErr, ok := err.(*credentialResolutionError); ok {
+			switch resolutionErr.Reason {
+			case failureNotAttached:
+				fmt.Fprintf(
+					os.Stderr,
+					"⚠ %s is not attached to the Kontext CLI application. Attach %s to kontext-cli in the dashboard or edit %s.\n",
+					entry.Provider,
+					entry.Provider,
+					entry.EnvVar,
+				)
+			case failureUnknown:
+				fmt.Fprintf(os.Stderr, "⚠ %s references an unknown provider handle.\n", entry.EnvVar)
+			case failureTransient:
+				fmt.Fprintf(os.Stderr, "⚠ %s could not be resolved because of a temporary exchange error.\n", entry.EnvVar)
+			case failureInvalid:
+				fmt.Fprintf(os.Stderr, "⚠ %s contains an invalid Kontext placeholder.\n", entry.EnvVar)
+			case failureDisconnected:
+				fmt.Fprintf(
+					os.Stderr,
+					"⚠ %s was not available for this launch. Connect it in hosted connect and rerun `kontext start`.\n",
+					entry.EnvVar,
+				)
+				skipped = append(skipped, entry.Provider)
+			default:
+				fmt.Fprintf(os.Stderr, "⚠ %s was skipped (%v)\n", entry.EnvVar, err)
+			}
+			continue
+		}
+
+		fmt.Fprintf(os.Stderr, "⚠ %s was skipped (%v)\n", entry.EnvVar, err)
+	}
+
+	if len(skipped) > 0 {
+		slices.Sort(skipped)
+		fmt.Fprintf(os.Stderr, "⚠ Launching without these providers: %s\n", strings.Join(slices.Compact(skipped), ", "))
+		fmt.Fprintln(os.Stderr, "⚠ Providers connected after launch become available on the next `kontext start`.")
+	}
+}
+
+func joinEntryProviders(entries []credential.Entry) string {
+	providers := make([]string, 0, len(entries))
+	seen := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		if _, ok := seen[entry.Provider]; ok {
+			continue
+		}
+		seen[entry.Provider] = struct{}{}
+		providers = append(providers, entry.Provider)
+	}
+	slices.Sort(providers)
+	return strings.Join(providers, ", ")
+}
+
+func isInteractiveTerminal() bool {
+	info, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (info.Mode() & os.ModeCharDevice) != 0
 }
 
 type loginFunc func(context.Context, string, string, ...string) (*auth.LoginResult, error)
@@ -291,11 +531,37 @@ func resolveCredentialClientID(agentID, fallback string) string {
 }
 
 type tokenExchangeResponse struct {
-	AccessToken  string `json:"access_token"`
-	TokenType    string `json:"token_type"`
-	ProviderKind string `json:"provider_kind"`
-	Error        string `json:"error"`
-	ErrorDesc    string `json:"error_description"`
+	AccessToken           string `json:"access_token"`
+	TokenType             string `json:"token_type"`
+	ProviderKind          string `json:"provider_kind"`
+	Error                 string `json:"error"`
+	ErrorDesc             string `json:"error_description"`
+	FailureReason         string `json:"failure_reason"`
+	ProviderName          string `json:"provider_name"`
+	ProviderID            string `json:"provider_id"`
+	ReauthorizationReason string `json:"reauthorization_reason"`
+}
+
+type credentialFailureReason string
+
+const (
+	failureDisconnected credentialFailureReason = "disconnected_or_reauth_required"
+	failureNotAttached  credentialFailureReason = "not_attached_to_application"
+	failureUnknown      credentialFailureReason = "unknown_provider_handle"
+	failureInvalid      credentialFailureReason = "invalid_placeholder"
+	failureTransient    credentialFailureReason = "transient_exchange_error"
+)
+
+type credentialResolutionError struct {
+	Reason       credentialFailureReason
+	Entry        credential.Entry
+	ProviderName string
+	ProviderID   string
+	Message      string
+}
+
+func (e *credentialResolutionError) Error() string {
+	return e.Message
 }
 
 func exchangeToken(ctx context.Context, session *auth.Session, clientID, resource string, scopes ...string) (*tokenExchangeResponse, error) {
@@ -357,11 +623,22 @@ func exchangeGatewayToken(ctx context.Context, session *auth.Session, clientID s
 func exchangeCredential(ctx context.Context, session *auth.Session, entry credential.Entry, clientID string) (string, error) {
 	result, err := exchangeToken(ctx, session, clientID, entry.Target())
 	if err != nil {
-		return "", err
+		return "", &credentialResolutionError{
+			Reason:  failureTransient,
+			Entry:   entry,
+			Message: fmt.Sprintf("token exchange request failed: %v", err),
+		}
 	}
 	if result.Error != "" {
-		if result.Error == "invalid_target" && strings.Contains(result.ErrorDesc, "not allowed") {
-			return "", fmt.Errorf("provider not connected: %s", entry.Provider)
+		switch credentialFailureReason(result.FailureReason) {
+		case failureDisconnected, failureNotAttached, failureUnknown, failureInvalid, failureTransient:
+			return "", &credentialResolutionError{
+				Reason:       credentialFailureReason(result.FailureReason),
+				Entry:        entry,
+				ProviderName: result.ProviderName,
+				ProviderID:   result.ProviderID,
+				Message:      fmt.Sprintf("%s: %s", result.Error, result.ErrorDesc),
+			}
 		}
 		return "", fmt.Errorf("token exchange failed: %s: %s", result.Error, result.ErrorDesc)
 	}
@@ -371,14 +648,6 @@ func exchangeCredential(ctx context.Context, session *auth.Session, entry creden
 	}
 
 	return result.AccessToken, nil
-}
-
-func isNotConnectedError(err error) bool {
-	msg := err.Error()
-	return strings.Contains(msg, "not connected") ||
-		strings.Contains(msg, "provider_required") ||
-		strings.Contains(msg, "provider not found") ||
-		strings.Contains(msg, "provider_reauthorization_required")
 }
 
 func needsGatewayAccessReauthentication(err error) bool {
@@ -391,9 +660,50 @@ func needsGatewayAccessReauthentication(err error) bool {
 		strings.Contains(msg, "gateway:access")
 }
 
-func buildEnv(resolved []credential.Resolved) []string {
+func buildEnv(templateDoc *credential.TemplateFile, resolved []credential.Resolved) []string {
 	env := append(os.Environ(), "KONTEXT_RUN=1")
+	if templateDoc != nil {
+		placeholderKeys := make(map[string]struct{}, len(templateDoc.Entries)+len(templateDoc.InvalidPlaceholders))
+		for _, entry := range templateDoc.Entries {
+			placeholderKeys[entry.EnvVar] = struct{}{}
+		}
+		for _, invalid := range templateDoc.InvalidPlaceholders {
+			placeholderKeys[invalid.EnvVar] = struct{}{}
+		}
+		for envVar, value := range templateDoc.ExistingValues {
+			if _, isPlaceholder := placeholderKeys[envVar]; isPlaceholder {
+				continue
+			}
+			env = append(env, fmt.Sprintf("%s=%s", envVar, value))
+		}
+	}
 	return credential.BuildEnv(resolved, env)
+}
+
+func managedProvidersFromBootstrap(items []*agentv1.ManagedProvider) []credential.ManagedProvider {
+	managed := make([]credential.ManagedProvider, 0, len(items))
+	for _, item := range items {
+		if item == nil {
+			continue
+		}
+		managed = append(managed, credential.ManagedProvider{
+			EnvVar:         item.EnvVar,
+			Placeholder:    item.Placeholder,
+			SeedOnFirstRun: item.SeedOnFirstRun,
+		})
+	}
+	return managed
+}
+
+func joinManagedEnvVars(items []credential.ManagedProvider) string {
+	if len(items) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(items))
+	for _, item := range items {
+		names = append(names, item.EnvVar)
+	}
+	return strings.Join(names, ", ")
 }
 
 func supportedAgents() []string {

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -83,6 +83,14 @@ func Start(ctx context.Context, opts Options) error {
 	credentialClientID := resolveCredentialClientID(createResp.AgentId, opts.ClientID)
 	fmt.Fprintf(os.Stderr, "✓ Session: %s (%s)\n", createResp.SessionName, truncateID(sessionID))
 
+	var sessionDir string
+	defer func() {
+		endManagedSession(client, sessionID, os.Stderr)
+		if sessionDir != "" {
+			os.RemoveAll(sessionDir)
+		}
+	}()
+
 	// 4. Bootstrap the shared CLI application and sync the local env file.
 	templateExists := false
 	if _, err := os.Stat(opts.TemplateFile); err == nil {
@@ -172,7 +180,7 @@ func Start(ctx context.Context, opts Options) error {
 	// 6. Start sidecar
 	// Use /tmp (not $TMPDIR) with a short ID to keep the Unix socket path
 	// under macOS's 104-byte sun_path limit.
-	sessionDir := filepath.Join("/tmp", "kontext", truncateID(sessionID))
+	sessionDir = filepath.Join("/tmp", "kontext", truncateID(sessionID))
 	if err := os.MkdirAll(sessionDir, 0o700); err != nil {
 		return fmt.Errorf("create session dir: %w", err)
 	}
@@ -202,16 +210,19 @@ func Start(ctx context.Context, opts Options) error {
 	fmt.Fprintf(os.Stderr, "\nLaunching %s...\n\n", opts.Agent)
 	agentErr := launchAgentWithSettings(ctx, opts.Agent, env, opts.Args, settingsPath)
 
-	// 10. Teardown (always runs, even on non-zero agent exit)
+	return agentErr
+}
+
+type sessionEnder interface {
+	EndSession(context.Context, string) error
+}
+
+func endManagedSession(client sessionEnder, sessionID string, out io.Writer) {
 	endCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	_ = client.EndSession(endCtx, sessionID)
-	fmt.Fprintf(os.Stderr, "\n✓ Session ended (%s)\n", truncateID(sessionID))
-
-	os.RemoveAll(sessionDir)
-
-	return agentErr
+	fmt.Fprintf(out, "\n✓ Session ended (%s)\n", truncateID(sessionID))
 }
 
 // ensureSession loads the session or triggers an interactive login.

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -670,7 +670,7 @@ func classifyCredentialFailure(
 	}
 
 	switch result.Error {
-	case "provider_required", "provider_not_configured":
+	case "provider_required", "provider_not_configured", "provider_reauthorization_required":
 		return failureDisconnected
 	default:
 		return ""

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -271,8 +271,18 @@ func resolveCredentials(ctx context.Context, session *auth.Session, entries []cr
 		return resolved, nil
 	}
 
-	connectURL, connectErr := fetchConnectURLWithGatewayLoginFallback(ctx, session, credentialClientID, auth.Login)
+	interactive := isInteractiveTerminal()
+	connectURL, connectErr := fetchConnectURLForConnectFlow(
+		ctx,
+		session,
+		credentialClientID,
+		interactive,
+		auth.Login,
+	)
 	if connectErr != nil {
+		if !interactive && needsGatewayAccessReauthentication(connectErr) {
+			fmt.Fprintln(os.Stderr, "⚠ Non-interactive session detected. Re-run `kontext start` in an interactive terminal to authorize hosted connect.")
+		}
 		fmt.Fprintf(os.Stderr, "⚠ Could not create hosted connect session (%v)\n", connectErr)
 		printLaunchWarnings(entryByEnvVar, failures)
 		return resolved, nil
@@ -282,7 +292,7 @@ func resolveCredentials(ctx context.Context, session *auth.Session, entries []cr
 	fmt.Fprintf(os.Stderr, "\nHosted connect is available for: %s\n", providerList)
 	fmt.Fprintf(os.Stderr, "  %s\n", connectURL)
 
-	if !isInteractiveTerminal() {
+	if !interactive {
 		fmt.Fprintln(os.Stderr, "⚠ Non-interactive session detected. Open this URL in a browser, then rerun `kontext start`.")
 		printLaunchWarnings(entryByEnvVar, failures)
 		return resolved, nil
@@ -453,6 +463,25 @@ func isInteractiveTerminal() bool {
 }
 
 type loginFunc func(context.Context, string, string, ...string) (*auth.LoginResult, error)
+
+func fetchConnectURLForConnectFlow(
+	ctx context.Context,
+	session *auth.Session,
+	credentialClientID string,
+	interactive bool,
+	login loginFunc,
+) (string, error) {
+	if !interactive {
+		return fetchConnectURL(ctx, session, credentialClientID)
+	}
+
+	return fetchConnectURLWithGatewayLoginFallback(
+		ctx,
+		session,
+		credentialClientID,
+		login,
+	)
+}
 
 func fetchConnectURLWithGatewayLoginFallback(
 	ctx context.Context,

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -701,9 +701,20 @@ func classifyCredentialFailure(
 	switch result.Error {
 	case "provider_required", "provider_not_configured", "provider_reauthorization_required":
 		return failureDisconnected
+	case "invalid_target":
+		if isLegacyDisconnectedInvalidTarget(result.ErrorDesc) {
+			return failureDisconnected
+		}
+		return ""
 	default:
 		return ""
 	}
+}
+
+func isLegacyDisconnectedInvalidTarget(desc string) bool {
+	normalized := strings.ToLower(desc)
+	return strings.Contains(normalized, "not connected") ||
+		strings.Contains(normalized, "not allowed")
 }
 
 func needsGatewayAccessReauthentication(err error) bool {

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -701,7 +701,7 @@ func buildEnv(templateDoc *credential.TemplateFile, resolved []credential.Resolv
 			if _, isPlaceholder := placeholderKeys[envVar]; isPlaceholder {
 				continue
 			}
-			env = append(env, fmt.Sprintf("%s=%s", envVar, value))
+			env = append(env, fmt.Sprintf("%s=%s", envVar, credential.NormalizeEnvValue(value)))
 		}
 	}
 	return credential.BuildEnv(resolved, env)

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -115,11 +115,11 @@ func Start(ctx context.Context, opts Options) error {
 		}
 		templateDoc = syncResult.Template
 		if syncResult.Created {
-			fmt.Fprintf(os.Stderr, "✓ Created local %s automatically", opts.TemplateFile)
-			if opts.TemplateFile == ".env.kontext" {
-				fmt.Fprint(os.Stderr, " (gitignored)")
-			}
-			fmt.Fprintln(os.Stderr)
+			fmt.Fprintf(
+				os.Stderr,
+				"✓ Created local %s automatically\n",
+				opts.TemplateFile,
+			)
 		}
 		if syncResult.Updated {
 			fmt.Fprintf(
@@ -630,10 +630,10 @@ func exchangeCredential(ctx context.Context, session *auth.Session, entry creden
 		}
 	}
 	if result.Error != "" {
-		switch credentialFailureReason(result.FailureReason) {
+		switch classifyCredentialFailure(result) {
 		case failureDisconnected, failureNotAttached, failureUnknown, failureInvalid, failureTransient:
 			return "", &credentialResolutionError{
-				Reason:       credentialFailureReason(result.FailureReason),
+				Reason:       classifyCredentialFailure(result),
 				Entry:        entry,
 				ProviderName: result.ProviderName,
 				ProviderID:   result.ProviderID,
@@ -648,6 +648,22 @@ func exchangeCredential(ctx context.Context, session *auth.Session, entry creden
 	}
 
 	return result.AccessToken, nil
+}
+
+func classifyCredentialFailure(
+	result *tokenExchangeResponse,
+) credentialFailureReason {
+	switch credentialFailureReason(result.FailureReason) {
+	case failureDisconnected, failureNotAttached, failureUnknown, failureInvalid, failureTransient:
+		return credentialFailureReason(result.FailureReason)
+	}
+
+	switch result.Error {
+	case "provider_required", "provider_not_configured":
+		return failureDisconnected
+	default:
+		return ""
+	}
 }
 
 func needsGatewayAccessReauthentication(err error) bool {

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -726,6 +726,27 @@ func TestBuildEnvPreservesLiteralHashFragmentsWithoutWhitespace(t *testing.T) {
 	}
 }
 
+func TestBuildEnvTreatsCommentOnlyRightHandSideAsEmpty(t *testing.T) {
+	t.Parallel()
+
+	env := buildEnv(
+		&credential.TemplateFile{
+			ExistingValues: map[string]string{
+				"OPENAI_API_KEY": " # set later",
+			},
+		},
+		nil,
+	)
+
+	joined := strings.Join(env, "\n")
+	if !strings.Contains(joined, "OPENAI_API_KEY=") {
+		t.Fatalf("buildEnv() missing empty env assignment: %q", joined)
+	}
+	if strings.Contains(joined, "OPENAI_API_KEY=# set later") {
+		t.Fatalf("buildEnv() preserved comment-only value: %q", joined)
+	}
+}
+
 type recordingSessionEnder struct {
 	sessionID string
 	calls     int

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -557,6 +557,48 @@ func TestExchangeCredentialClassifiesLegacyProviderReauthorizationRequired(t *te
 	}
 }
 
+func TestExchangeCredentialClassifiesLegacyInvalidTargetNotAllowed(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"issuer":"%s","authorization_endpoint":"%s/oauth2/auth","token_endpoint":"%s/oauth2/token","jwks_uri":"%s/.well-known/jwks.json"}`, server.URL, server.URL, server.URL, server.URL)))
+		case "/oauth2/token":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"error":"invalid_target","error_description":"Resource 'linear' is not allowed for this application"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	session := &auth.Session{
+		IssuerURL:   server.URL,
+		AccessToken: "test-access-token",
+	}
+
+	_, err := exchangeCredential(
+		context.Background(),
+		session,
+		credential.Entry{EnvVar: "LINEAR_API_KEY", Provider: "linear"},
+		"app_agent-123",
+	)
+	if err == nil {
+		t.Fatal("exchangeCredential() error = nil, want non-nil")
+	}
+
+	resolutionErr, ok := err.(*credentialResolutionError)
+	if !ok {
+		t.Fatalf("exchangeCredential() error type = %T, want *credentialResolutionError", err)
+	}
+	if resolutionErr.Reason != failureDisconnected {
+		t.Fatalf("resolutionErr.Reason = %q, want %q", resolutionErr.Reason, failureDisconnected)
+	}
+}
+
 func TestAgentOAuthClientID(t *testing.T) {
 	t.Parallel()
 

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -383,11 +383,45 @@ func TestExchangeCredentialUsesProvidedClientID(t *testing.T) {
 	}
 }
 
-func TestIsNotConnectedErrorRecognizesProviderRequired(t *testing.T) {
+func TestExchangeCredentialReturnsTypedFailureReason(t *testing.T) {
 	t.Parallel()
 
-	if !isNotConnectedError(fmt.Errorf("token exchange failed: provider_required: User has not configured provider 'Linear Stub'")) {
-		t.Fatal("expected provider_required to trigger hosted connect fallback")
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"issuer":"%s","authorization_endpoint":"%s/oauth2/auth","token_endpoint":"%s/oauth2/token","jwks_uri":"%s/.well-known/jwks.json"}`, server.URL, server.URL, server.URL, server.URL)))
+		case "/oauth2/token":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"error":"provider_required","error_description":"User has not configured provider 'Linear Stub'","failure_reason":"disconnected_or_reauth_required","provider_name":"Linear Stub","provider_id":"provider-linear"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	session := &auth.Session{
+		IssuerURL:   server.URL,
+		AccessToken: "test-access-token",
+	}
+
+	_, err := exchangeCredential(
+		context.Background(),
+		session,
+		credential.Entry{EnvVar: "LINEAR_API_KEY", Provider: "linear"},
+		"app_agent-123",
+	)
+	if err == nil {
+		t.Fatal("exchangeCredential() error = nil, want non-nil")
+	}
+
+	resolutionErr, ok := err.(*credentialResolutionError)
+	if !ok {
+		t.Fatalf("exchangeCredential() error type = %T, want *credentialResolutionError", err)
+	}
+	if resolutionErr.Reason != failureDisconnected {
+		t.Fatalf("resolutionErr.Reason = %q, want %q", resolutionErr.Reason, failureDisconnected)
 	}
 }
 
@@ -408,5 +442,38 @@ func TestResolveCredentialClientID(t *testing.T) {
 
 	if got := resolveCredentialClientID("", "bootstrap-client"); got != "bootstrap-client" {
 		t.Fatalf("resolveCredentialClientID() empty agent = %q, want %q", got, "bootstrap-client")
+	}
+}
+
+func TestBuildEnvUsesLiteralValuesAndResolvedPlaceholders(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "shell-token")
+
+	env := buildEnv(
+		&credential.TemplateFile{
+			Entries: []credential.Entry{
+				{EnvVar: "GITHUB_TOKEN", Provider: "github"},
+			},
+			ExistingValues: map[string]string{
+				"GITHUB_TOKEN":   "{{kontext:github}}",
+				"LINEAR_API_KEY": "literal-linear-token",
+			},
+		},
+		[]credential.Resolved{
+			{
+				Entry: credential.Entry{
+					EnvVar:   "GITHUB_TOKEN",
+					Provider: "github",
+				},
+				Value: "resolved-github-token",
+			},
+		},
+	)
+
+	joined := strings.Join(env, "\n")
+	if !strings.Contains(joined, "GITHUB_TOKEN=resolved-github-token") {
+		t.Fatalf("buildEnv() missing resolved github token: %q", joined)
+	}
+	if !strings.Contains(joined, "LINEAR_API_KEY=literal-linear-token") {
+		t.Fatalf("buildEnv() missing literal linear token: %q", joined)
 	}
 }

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -638,6 +638,52 @@ func TestBuildEnvNormalizesQuotedLiteralValues(t *testing.T) {
 	}
 }
 
+func TestBuildEnvStripsInlineCommentsFromLiteralValues(t *testing.T) {
+	t.Parallel()
+
+	env := buildEnv(
+		&credential.TemplateFile{
+			ExistingValues: map[string]string{
+				"OPENAI_API_KEY": "sk-test-token # production",
+				"CALLBACK_URL":   "\"https://example.com/callback\" # main callback",
+			},
+		},
+		nil,
+	)
+
+	joined := strings.Join(env, "\n")
+	if !strings.Contains(joined, "OPENAI_API_KEY=sk-test-token") {
+		t.Fatalf("buildEnv() missing stripped literal token: %q", joined)
+	}
+	if strings.Contains(joined, "OPENAI_API_KEY=sk-test-token # production") {
+		t.Fatalf("buildEnv() preserved inline comment on token: %q", joined)
+	}
+	if !strings.Contains(joined, "CALLBACK_URL=https://example.com/callback") {
+		t.Fatalf("buildEnv() missing stripped callback url: %q", joined)
+	}
+	if strings.Contains(joined, "CALLBACK_URL=\"https://example.com/callback\" # main callback") {
+		t.Fatalf("buildEnv() preserved inline comment on callback url: %q", joined)
+	}
+}
+
+func TestBuildEnvPreservesLiteralHashFragmentsWithoutWhitespace(t *testing.T) {
+	t.Parallel()
+
+	env := buildEnv(
+		&credential.TemplateFile{
+			ExistingValues: map[string]string{
+				"CALLBACK_URL": "https://example.com/callback#fragment",
+			},
+		},
+		nil,
+	)
+
+	joined := strings.Join(env, "\n")
+	if !strings.Contains(joined, "CALLBACK_URL=https://example.com/callback#fragment") {
+		t.Fatalf("buildEnv() lost url fragment: %q", joined)
+	}
+}
+
 type recordingSessionEnder struct {
 	sessionID string
 	calls     int

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -468,6 +468,48 @@ func TestExchangeCredentialClassifiesLegacyProviderRequired(t *testing.T) {
 	}
 }
 
+func TestExchangeCredentialClassifiesLegacyProviderReauthorizationRequired(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"issuer":"%s","authorization_endpoint":"%s/oauth2/auth","token_endpoint":"%s/oauth2/token","jwks_uri":"%s/.well-known/jwks.json"}`, server.URL, server.URL, server.URL, server.URL)))
+		case "/oauth2/token":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"error":"provider_reauthorization_required","error_description":"User must reconnect provider 'Linear Stub'","provider_name":"Linear Stub","provider_id":"provider-linear","reauthorization_reason":"missing_scopes"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	session := &auth.Session{
+		IssuerURL:   server.URL,
+		AccessToken: "test-access-token",
+	}
+
+	_, err := exchangeCredential(
+		context.Background(),
+		session,
+		credential.Entry{EnvVar: "LINEAR_API_KEY", Provider: "linear"},
+		"app_agent-123",
+	)
+	if err == nil {
+		t.Fatal("exchangeCredential() error = nil, want non-nil")
+	}
+
+	resolutionErr, ok := err.(*credentialResolutionError)
+	if !ok {
+		t.Fatalf("exchangeCredential() error type = %T, want *credentialResolutionError", err)
+	}
+	if resolutionErr.Reason != failureDisconnected {
+		t.Fatalf("resolutionErr.Reason = %q, want %q", resolutionErr.Reason, failureDisconnected)
+	}
+}
+
 func TestAgentOAuthClientID(t *testing.T) {
 	t.Parallel()
 

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -517,5 +518,35 @@ func TestBuildEnvUsesLiteralValuesAndResolvedPlaceholders(t *testing.T) {
 	}
 	if !strings.Contains(joined, "LINEAR_API_KEY=literal-linear-token") {
 		t.Fatalf("buildEnv() missing literal linear token: %q", joined)
+	}
+}
+
+type recordingSessionEnder struct {
+	sessionID string
+	calls     int
+}
+
+func (r *recordingSessionEnder) EndSession(_ context.Context, sessionID string) error {
+	r.calls++
+	r.sessionID = sessionID
+	return nil
+}
+
+func TestEndManagedSessionEndsTheManagedSession(t *testing.T) {
+	t.Parallel()
+
+	client := &recordingSessionEnder{}
+	var output bytes.Buffer
+
+	endManagedSession(client, "session-1234567890", &output)
+
+	if client.calls != 1 {
+		t.Fatalf("EndSession calls = %d, want 1", client.calls)
+	}
+	if client.sessionID != "session-1234567890" {
+		t.Fatalf("EndSession sessionID = %q, want %q", client.sessionID, "session-1234567890")
+	}
+	if got := output.String(); !strings.Contains(got, "Session ended") {
+		t.Fatalf("output = %q, want session-ended message", got)
 	}
 }

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -329,6 +329,53 @@ func TestFetchConnectURLWithGatewayLoginFallback(t *testing.T) {
 	}
 }
 
+func TestFetchConnectURLForConnectFlowSkipsLoginWhenNonInteractive(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"issuer":"%s","authorization_endpoint":"%s/oauth2/auth","token_endpoint":"%s/oauth2/token","jwks_uri":"%s/.well-known/jwks.json"}`, server.URL, server.URL, server.URL, server.URL)))
+		case "/oauth2/token":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"error":"invalid_scope","error_description":"Requested scope 'gateway:access' exceeds subject token scopes"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	session := &auth.Session{
+		IssuerURL:   server.URL,
+		AccessToken: "stale-access-token",
+	}
+
+	var loginCalls int
+	login := func(ctx context.Context, issuerURL, clientID string, scopes ...string) (*auth.LoginResult, error) {
+		loginCalls++
+		return nil, fmt.Errorf("login should not be called")
+	}
+
+	_, err := fetchConnectURLForConnectFlow(
+		context.Background(),
+		session,
+		"app_agent-123",
+		false,
+		login,
+	)
+	if err == nil {
+		t.Fatal("fetchConnectURLForConnectFlow() error = nil, want non-nil")
+	}
+	if loginCalls != 0 {
+		t.Fatalf("loginCalls = %d, want 0", loginCalls)
+	}
+	if !needsGatewayAccessReauthentication(err) {
+		t.Fatalf("err = %v, want gateway reauthentication failure", err)
+	}
+}
+
 func TestExchangeCredentialUsesProvidedClientID(t *testing.T) {
 	t.Parallel()
 

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -425,6 +425,48 @@ func TestExchangeCredentialReturnsTypedFailureReason(t *testing.T) {
 	}
 }
 
+func TestExchangeCredentialClassifiesLegacyProviderRequired(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"issuer":"%s","authorization_endpoint":"%s/oauth2/auth","token_endpoint":"%s/oauth2/token","jwks_uri":"%s/.well-known/jwks.json"}`, server.URL, server.URL, server.URL, server.URL)))
+		case "/oauth2/token":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"error":"provider_required","error_description":"User has not configured provider 'Linear Stub'","provider_name":"Linear Stub","provider_id":"provider-linear"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	session := &auth.Session{
+		IssuerURL:   server.URL,
+		AccessToken: "test-access-token",
+	}
+
+	_, err := exchangeCredential(
+		context.Background(),
+		session,
+		credential.Entry{EnvVar: "LINEAR_API_KEY", Provider: "linear"},
+		"app_agent-123",
+	)
+	if err == nil {
+		t.Fatal("exchangeCredential() error = nil, want non-nil")
+	}
+
+	resolutionErr, ok := err.(*credentialResolutionError)
+	if !ok {
+		t.Fatalf("exchangeCredential() error type = %T, want *credentialResolutionError", err)
+	}
+	if resolutionErr.Reason != failureDisconnected {
+		t.Fatalf("resolutionErr.Reason = %q, want %q", resolutionErr.Reason, failureDisconnected)
+	}
+}
+
 func TestAgentOAuthClientID(t *testing.T) {
 	t.Parallel()
 

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -521,6 +521,34 @@ func TestBuildEnvUsesLiteralValuesAndResolvedPlaceholders(t *testing.T) {
 	}
 }
 
+func TestBuildEnvNormalizesQuotedLiteralValues(t *testing.T) {
+	t.Parallel()
+
+	env := buildEnv(
+		&credential.TemplateFile{
+			ExistingValues: map[string]string{
+				"OPENAI_API_KEY": "\"sk-test-token\"",
+				"CALLBACK_URL":   "'https://example.com/callback'",
+			},
+		},
+		nil,
+	)
+
+	joined := strings.Join(env, "\n")
+	if !strings.Contains(joined, "OPENAI_API_KEY=sk-test-token") {
+		t.Fatalf("buildEnv() missing normalized openai token: %q", joined)
+	}
+	if strings.Contains(joined, "OPENAI_API_KEY=\"sk-test-token\"") {
+		t.Fatalf("buildEnv() preserved quoted openai token: %q", joined)
+	}
+	if !strings.Contains(joined, "CALLBACK_URL=https://example.com/callback") {
+		t.Fatalf("buildEnv() missing normalized callback url: %q", joined)
+	}
+	if strings.Contains(joined, "CALLBACK_URL='https://example.com/callback'") {
+		t.Fatalf("buildEnv() preserved quoted callback url: %q", joined)
+	}
+}
+
 type recordingSessionEnder struct {
 	sessionID string
 	calls     int


### PR DESCRIPTION
## Summary
- call the new CLI bootstrap RPC before credential resolution
- generate and update local .env.kontext files additively for managed preset providers
- classify exchange failures, open hosted connect only when it can help, and retry with a bounded window

## Dependencies
- requires https://github.com/kontext-security/proto/pull/6
- pairs with the backend bootstrap work in kontext-security/kontext

## Testing
- go test ./internal/... ./cmd/...
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kontext-security/kontext-cli/pull/61" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
