### PR TITLE
fix(auth): reject gateway reauth account mismatch

### DIFF
--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -443,6 +443,10 @@ func credentialFailureSummary(err error) string {
 }
 
 func connectFailureSummary(err error) string {
+	var mismatch *identityMismatchError
+	if errors.As(err, &mismatch) {
+		return mismatch.Error()
+	}
 	if needsGatewayAccessReauthentication(err) {
 		return "gateway access needs authorization"
 	}
@@ -560,6 +564,9 @@ func fetchConnectURLWithGatewayLoginFallback(
 	if err != nil {
 		return "", fmt.Errorf("authorize gateway access: %w", err)
 	}
+	if err := ensureSameIdentity(session, result.Session); err != nil {
+		return "", err
+	}
 
 	gatewayToken, err := exchangeGatewayToken(ctx, result.Session, credentialClientID)
 	if err != nil {
@@ -567,6 +574,43 @@ func fetchConnectURLWithGatewayLoginFallback(
 	}
 
 	return fetchConnectURLWithGatewayToken(ctx, result.Session.IssuerURL, gatewayToken)
+}
+
+func ensureSameIdentity(active, browser *auth.Session) error {
+	activeKey, err := active.IdentityKey()
+	if err != nil {
+		return err
+	}
+	browserKey, err := browser.IdentityKey()
+	if err != nil {
+		return fmt.Errorf("browser authorization session is missing identity information: %w", err)
+	}
+	if activeKey == browserKey {
+		return nil
+	}
+
+	activeLabel := active.DisplayIdentity()
+	if activeLabel == "" {
+		activeLabel = activeKey
+	}
+	browserLabel := browser.DisplayIdentity()
+	if browserLabel == "" {
+		browserLabel = browserKey
+	}
+	return &identityMismatchError{activeLabel: activeLabel, browserLabel: browserLabel}
+}
+
+type identityMismatchError struct {
+	activeLabel  string
+	browserLabel string
+}
+
+func (e *identityMismatchError) Error() string {
+	return fmt.Sprintf(
+		"browser authorization used a different account (active CLI account: %s; browser account: %s). Run `kontext login` with the account you want to use, then retry",
+		e.activeLabel,
+		e.browserLabel,
+	)
 }
 
 func fetchConnectURL(ctx context.Context, session *auth.Session, clientID string) (string, error) {

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -184,7 +184,7 @@ func Start(ctx context.Context, opts Options) error {
 	//    so reading session fields is safe without synchronization)
 	var resolved []credential.Resolved
 	if len(templateDoc.Entries) > 0 {
-		resolved, err = resolveCredentials(ctx, session, templateDoc.Entries, credentialClientID, diagnostics)
+		resolved, err = resolveCredentials(ctx, session, templateDoc.Entries, credentialClientID, diagnostics, fetchConnectURLForConnectFlow)
 		if err != nil {
 			return err
 		}
@@ -272,8 +272,10 @@ func ensureSession(ctx context.Context, issuerURL, clientID string) (*auth.Sessi
 	return result.Session, nil
 }
 
+type connectURLFetcher func(ctx context.Context, session *auth.Session, credentialClientID string, interactive bool, login loginFunc) (string, error)
+
 // resolveCredentials exchanges each template entry for a live credential.
-func resolveCredentials(ctx context.Context, session *auth.Session, entries []credential.Entry, credentialClientID string, diagnostics diagnostic.Logger) ([]credential.Resolved, error) {
+func resolveCredentials(ctx context.Context, session *auth.Session, entries []credential.Entry, credentialClientID string, diagnostics diagnostic.Logger, fetchConnect connectURLFetcher) ([]credential.Resolved, error) {
 	fmt.Fprintln(os.Stderr, "\nResolving credentials...")
 	resolved := make([]credential.Resolved, 0, len(entries))
 	failures := make(map[string]error)
@@ -300,7 +302,7 @@ func resolveCredentials(ctx context.Context, session *auth.Session, entries []cr
 	}
 
 	interactive := isInteractiveTerminal()
-	connectURL, connectErr := fetchConnectURLForConnectFlow(
+	connectURL, connectErr := fetchConnect(
 		ctx,
 		session,
 		credentialClientID,
@@ -309,6 +311,10 @@ func resolveCredentials(ctx context.Context, session *auth.Session, entries []cr
 	)
 	if connectErr != nil {
 		diagnostics.Printf("hosted connect session failed: %v\n", connectErr)
+		var mismatch *identityMismatchError
+		if errors.As(connectErr, &mismatch) {
+			return nil, connectErr
+		}
 		if !interactive && needsGatewayAccessReauthentication(connectErr) {
 			fmt.Fprintln(os.Stderr, "⚠ Non-interactive session detected. Re-run `kontext start` in an interactive terminal to authorize hosted connect.")
 		}

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -412,6 +412,7 @@ func TestFetchConnectURLWithGatewayLoginFallback(t *testing.T) {
 
 	session := &auth.Session{
 		IssuerURL:   server.URL,
+		Subject:     "user-123",
 		AccessToken: "stale-access-token",
 	}
 
@@ -430,6 +431,7 @@ func TestFetchConnectURLWithGatewayLoginFallback(t *testing.T) {
 
 		result := &auth.LoginResult{Session: &auth.Session{
 			IssuerURL:   server.URL,
+			Subject:     "user-123",
 			AccessToken: "gateway-login-token",
 		}}
 		return result, nil
@@ -457,6 +459,78 @@ func TestFetchConnectURLWithGatewayLoginFallback(t *testing.T) {
 	want := "https://app.kontext.security/providers/connect#handshake=session-123"
 	if got != want {
 		t.Fatalf("fetchConnectURLWithGatewayLoginFallback() = %q, want %q", got, want)
+	}
+}
+
+func TestFetchConnectURLWithGatewayLoginFallbackRejectsAccountMismatch(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	var tokenExchangeCalls int
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"issuer":"%s","authorization_endpoint":"%s/oauth2/auth","token_endpoint":"%s/oauth2/token","jwks_uri":"%s/.well-known/jwks.json"}`, server.URL, server.URL, server.URL, server.URL)))
+		case "/oauth2/token":
+			tokenExchangeCalls++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"error":"invalid_scope","error_description":"Requested scope 'gateway:access' exceeds subject token scopes"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	session := &auth.Session{
+		IssuerURL:   server.URL,
+		Subject:     "active-user",
+		AccessToken: "stale-access-token",
+	}
+	session.User.Email = "active@example.com"
+
+	login := func(ctx context.Context, issuerURL, clientID string, scopes ...string) (*auth.LoginResult, error) {
+		result := &auth.LoginResult{Session: &auth.Session{
+			IssuerURL:   server.URL,
+			Subject:     "browser-user",
+			AccessToken: "gateway-login-token",
+		}}
+		result.Session.User.Email = "browser@example.com"
+		return result, nil
+	}
+
+	_, err := fetchConnectURLWithGatewayLoginFallback(
+		context.Background(),
+		session,
+		"app_agent-123",
+		login,
+	)
+	if err == nil {
+		t.Fatal("fetchConnectURLWithGatewayLoginFallback() error = nil, want mismatch")
+	}
+	if !strings.Contains(err.Error(), "different account") {
+		t.Fatalf("error = %q, want different account message", err)
+	}
+	if summary := connectFailureSummary(err); !strings.Contains(summary, "active@example.com") || !strings.Contains(summary, "browser@example.com") {
+		t.Fatalf("connectFailureSummary() = %q, want account labels", summary)
+	}
+	if tokenExchangeCalls != 1 {
+		t.Fatalf("tokenExchangeCalls = %d, want only stale-token attempt", tokenExchangeCalls)
+	}
+}
+
+func TestEnsureSameIdentityComparesIssuerAndSubject(t *testing.T) {
+	t.Parallel()
+
+	active := &auth.Session{IssuerURL: "https://issuer-a.example", Subject: "same-subject"}
+	browser := &auth.Session{IssuerURL: "https://issuer-b.example", Subject: "same-subject"}
+
+	err := ensureSameIdentity(active, browser)
+	if err == nil {
+		t.Fatal("ensureSameIdentity() error = nil, want issuer mismatch")
+	}
+	if !strings.Contains(err.Error(), "different account") {
+		t.Fatalf("ensureSameIdentity() error = %q, want different account", err)
 	}
 }
 

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/kontext-security/kontext-cli/internal/auth"
 	"github.com/kontext-security/kontext-cli/internal/credential"
+	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 )
 
 func TestFilterArgs(t *testing.T) {
@@ -516,6 +517,60 @@ func TestFetchConnectURLWithGatewayLoginFallbackRejectsAccountMismatch(t *testin
 	}
 	if tokenExchangeCalls != 1 {
 		t.Fatalf("tokenExchangeCalls = %d, want only stale-token attempt", tokenExchangeCalls)
+	}
+}
+
+func TestResolveCredentialsReturnsIdentityMismatchError(t *testing.T) {
+	t.Parallel()
+
+	fakeFetcher := func(
+		ctx context.Context,
+		session *auth.Session,
+		credentialClientID string,
+		interactive bool,
+		login loginFunc,
+	) (string, error) {
+		return "", &identityMismatchError{
+			activeLabel:  "active@example.com",
+			browserLabel: "browser@example.com",
+		}
+	}
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"issuer":"%s","authorization_endpoint":"%s/oauth2/auth","token_endpoint":"%s/oauth2/token","jwks_uri":"%s/.well-known/jwks.json"}`, server.URL, server.URL, server.URL, server.URL)))
+		case "/oauth2/token":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"error":"provider_required","error_description":"User has not configured provider 'Linear Stub'","failure_reason":"disconnected_or_reauth_required","provider_name":"Linear Stub","provider_id":"provider-linear"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	session := &auth.Session{
+		IssuerURL:   server.URL,
+		AccessToken: "test-access-token",
+	}
+
+	_, err := resolveCredentials(
+		context.Background(),
+		session,
+		[]credential.Entry{{EnvVar: "LINEAR_API_KEY", Provider: "linear"}},
+		"app_agent-123",
+		diagnostic.New(io.Discard, false),
+		fakeFetcher,
+	)
+	if err == nil {
+		t.Fatal("resolveCredentials() error = nil, want mismatch")
+	}
+
+	var mismatch *identityMismatchError
+	if !errors.As(err, &mismatch) {
+		t.Fatalf("resolveCredentials() error = %T, want *identityMismatchError", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Compares gateway-only browser auth against the active CLI session using `issuer#subject`.
- Stops before credential retries when the browser account differs from the CLI account.
- Does not persist or replace the CLI session during gateway-only authorization.

## Why

Hosted connect can open a browser that is signed into a different Kontext account. When that happens, retrying credentials is misleading and can point the user at the wrong account, so the CLI now stops with a clear mismatch message.

## Before / After Terminal Capture

Before, a second browser login could silently switch the hosted-connect account while the CLI kept using the original session:

```text
Session missing gateway access. Opening browser to authorize this CLI session...
Hosted connect is available for: linear
Press Enter after connecting...
Retrying LINEAR_API_KEY (1/3)... skipped
```

After, account drift is caught before retrying credentials:

```text
Session missing gateway access. Opening browser to authorize this CLI session...
Error: browser authorization used a different account (active CLI account: active@example.com; browser account: browser@example.com). Run `kontext login` with the account you want to use, then retry
```

## Verification

- Ran `go test ./...` on this branch.


