### PR TITLE
feat(hooks): quiet default allow reasons

### DIFF
--- a/internal/agent/claude/claude.go
+++ b/internal/agent/claude/claude.go
@@ -3,6 +3,7 @@ package claude
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/kontext-security/kontext-cli/internal/agent"
 )
@@ -57,7 +58,7 @@ func (c *Claude) EncodeAllow(event *agent.HookEvent, reason string) ([]byte, err
 		HookSpecificOutput: &hookSpecificOutput{
 			HookEventName:            event.HookEventName,
 			PermissionDecision:       "allow",
-			PermissionDecisionReason: reason,
+			PermissionDecisionReason: allowReason(reason),
 		},
 	}
 	return json.Marshal(out)
@@ -72,4 +73,11 @@ func (c *Claude) EncodeDeny(event *agent.HookEvent, reason string) ([]byte, erro
 		},
 	}
 	return json.Marshal(out)
+}
+
+func allowReason(reason string) string {
+	if strings.EqualFold(strings.TrimSpace(reason), "allowed") {
+		return ""
+	}
+	return reason
 }

--- a/internal/agent/claude/claude_test.go
+++ b/internal/agent/claude/claude_test.go
@@ -1,0 +1,44 @@
+package claude
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/agent"
+)
+
+func TestEncodeAllowOmitsPlaceholderReason(t *testing.T) {
+	t.Parallel()
+
+	out, err := (&Claude{}).EncodeAllow(&agent.HookEvent{HookEventName: "PreToolUse"}, "allowed")
+	if err != nil {
+		t.Fatalf("EncodeAllow() error = %v", err)
+	}
+	if strings.Contains(string(out), "permissionDecisionReason") {
+		t.Fatalf("EncodeAllow() = %s, want no placeholder reason", out)
+	}
+}
+
+func TestEncodeAllowKeepsMeaningfulReason(t *testing.T) {
+	t.Parallel()
+
+	out, err := (&Claude{}).EncodeAllow(&agent.HookEvent{HookEventName: "PreToolUse"}, "Allowed by read-only policy")
+	if err != nil {
+		t.Fatalf("EncodeAllow() error = %v", err)
+	}
+	if !strings.Contains(string(out), "Allowed by read-only policy") {
+		t.Fatalf("EncodeAllow() = %s, want meaningful reason", out)
+	}
+}
+
+func TestEncodeDenyKeepsReason(t *testing.T) {
+	t.Parallel()
+
+	out, err := (&Claude{}).EncodeDeny(&agent.HookEvent{HookEventName: "PreToolUse"}, "Blocked by policy")
+	if err != nil {
+		t.Fatalf("EncodeDeny() error = %v", err)
+	}
+	if !strings.Contains(string(out), "Blocked by policy") {
+		t.Fatalf("EncodeDeny() = %s, want deny reason", out)
+	}
+}

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -198,7 +198,7 @@ func Start(ctx context.Context, opts Options) error {
 		return fmt.Errorf("create session dir: %w", err)
 	}
 
-	sc, err := sidecar.New(sessionDir, client, sessionID, opts.Agent)
+	sc, err := sidecar.New(sessionDir, client, sessionID, opts.Agent, diagnostics)
 	if err != nil {
 		return fmt.Errorf("sidecar: %w", err)
 	}

--- a/internal/sidecar/sidecar.go
+++ b/internal/sidecar/sidecar.go
@@ -2,7 +2,6 @@ package sidecar
 
 import (
 	"context"
-	"log"
 	"net"
 	"os"
 	"path/filepath"
@@ -10,6 +9,7 @@ import (
 
 	agentv1 "github.com/kontext-security/kontext-cli/gen/kontext/agent/v1"
 	"github.com/kontext-security/kontext-cli/internal/backend"
+	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 )
 
 type Server struct {
@@ -18,15 +18,18 @@ type Server struct {
 	sessionID  string
 	agentName  string
 	client     *backend.Client
+	diagnostic diagnostic.Logger
 	cancel     context.CancelFunc
 }
 
-func New(sessionDir string, client *backend.Client, sessionID, agentName string) (*Server, error) {
+// New creates a new sidecar server.
+func New(sessionDir string, client *backend.Client, sessionID, agentName string, diagnostics diagnostic.Logger) (*Server, error) {
 	return &Server{
 		socketPath: filepath.Join(sessionDir, "kontext.sock"),
 		sessionID:  sessionID,
 		agentName:  agentName,
 		client:     client,
+		diagnostic: diagnostics,
 	}, nil
 }
 
@@ -67,10 +70,10 @@ func (s *Server) acceptLoop(ctx context.Context) {
 				return
 			default:
 				if ne, ok := err.(net.Error); ok && ne.Temporary() {
-					log.Printf("sidecar: accept temporary error: %v", err)
+					s.diagnostic.Printf("sidecar accept temporary error: %v\n", err)
 					continue
 				}
-				log.Printf("sidecar: accept: %v", err)
+				s.diagnostic.Printf("sidecar accept: %v\n", err)
 				return
 			}
 		}
@@ -81,19 +84,19 @@ func (s *Server) acceptLoop(ctx context.Context) {
 func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
 	defer conn.Close()
 	if err := conn.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
-		log.Printf("sidecar: deadline: %v", err)
+		s.diagnostic.Printf("sidecar deadline: %v\n", err)
 		return
 	}
 
 	var req EvaluateRequest
 	if err := ReadMessage(conn, &req); err != nil {
-		log.Printf("sidecar: read: %v", err)
+		s.diagnostic.Printf("sidecar read: %v\n", err)
 		return
 	}
 
-	result := EvaluateResult{Type: "result", Allowed: true, Reason: "allowed"}
+	result := defaultAllowResult()
 	if err := WriteMessage(conn, result); err != nil {
-		log.Printf("sidecar: write: %v", err)
+		s.diagnostic.Printf("sidecar write: %v\n", err)
 		return
 	}
 
@@ -101,9 +104,20 @@ func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
 }
 
 func (s *Server) ingestEvent(ctx context.Context, req *EvaluateRequest) {
+	hookEvent := buildHookEventRequest(s.sessionID, s.agentName, req)
+	if err := s.client.IngestEvent(ctx, hookEvent); err != nil {
+		s.diagnostic.Printf("sidecar ingest: %v\n", err)
+	}
+}
+
+func defaultAllowResult() EvaluateResult {
+	return EvaluateResult{Type: "result", Allowed: true}
+}
+
+func buildHookEventRequest(sessionID, agentName string, req *EvaluateRequest) *agentv1.ProcessHookEventRequest {
 	hookEvent := &agentv1.ProcessHookEventRequest{
-		SessionId: s.sessionID,
-		Agent:     s.agentName,
+		SessionId: sessionID,
+		Agent:     agentName,
 		HookEvent: req.HookEvent,
 		ToolName:  req.ToolName,
 		ToolUseId: req.ToolUseID,
@@ -117,9 +131,7 @@ func (s *Server) ingestEvent(ctx context.Context, req *EvaluateRequest) {
 		hookEvent.ToolResponse = req.ToolResponse
 	}
 
-	if err := s.client.IngestEvent(ctx, hookEvent); err != nil {
-		log.Printf("sidecar: ingest: %v", err)
-	}
+	return hookEvent
 }
 
 func (s *Server) heartbeatLoop(ctx context.Context) {
@@ -131,7 +143,7 @@ func (s *Server) heartbeatLoop(ctx context.Context) {
 			return
 		case <-ticker.C:
 			if err := s.client.Heartbeat(ctx, s.sessionID); err != nil {
-				log.Printf("sidecar: heartbeat: %v", err)
+				s.diagnostic.Printf("sidecar heartbeat: %v\n", err)
 			}
 		}
 	}

--- a/internal/sidecar/sidecar_test.go
+++ b/internal/sidecar/sidecar_test.go
@@ -2,6 +2,7 @@ package sidecar
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net"
 	"testing"
@@ -28,6 +29,49 @@ func TestAcceptLoopReturnsOnListenerError(t *testing.T) {
 
 	if got := ln.accepts; got != 1 {
 		t.Fatalf("Accept() calls = %d, want 1", got)
+	}
+}
+
+func TestDefaultAllowResultOmitsPlaceholderReason(t *testing.T) {
+	t.Parallel()
+
+	result := defaultAllowResult()
+	if !result.Allowed {
+		t.Fatal("defaultAllowResult().Allowed = false, want true")
+	}
+	if result.Reason != "" {
+		t.Fatalf("defaultAllowResult().Reason = %q, want empty", result.Reason)
+	}
+}
+
+func TestBuildHookEventRequestPreservesTelemetryPayload(t *testing.T) {
+	t.Parallel()
+
+	toolInput := json.RawMessage(`{"command":"pwd"}`)
+	toolResponse := json.RawMessage(`{"stdout":"/tmp/project"}`)
+	req := &EvaluateRequest{
+		HookEvent:    "PostToolUse",
+		ToolName:     "Bash",
+		ToolInput:    toolInput,
+		ToolResponse: toolResponse,
+		ToolUseID:    "toolu_123",
+		CWD:          "/tmp/project",
+	}
+
+	got := buildHookEventRequest("session-123", "claude", req)
+	if got.SessionId != "session-123" ||
+		got.Agent != "claude" ||
+		got.HookEvent != req.HookEvent ||
+		got.ToolName != req.ToolName ||
+		got.ToolUseId != req.ToolUseID ||
+		got.Cwd != req.CWD {
+		t.Fatalf("buildHookEventRequest() = %+v, want copied metadata", got)
+	}
+	if string(got.ToolInput) != string(toolInput) {
+		t.Fatalf("ToolInput = %s, want %s", got.ToolInput, toolInput)
+	}
+	if string(got.ToolResponse) != string(toolResponse) {
+		t.Fatalf("ToolResponse = %s, want %s", got.ToolResponse, toolResponse)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Keeps hook telemetry streaming to the API unchanged.
- Suppresses placeholder local allow reasons like `allowed` in Claude-visible hook output.
- Preserves deny reasons, local failure explanations, and future meaningful allow reasons.
- Routes sidecar diagnostics through the redacted verbose logger instead of unconditional background logs.

## Why

The API still needs the full hook stream, but Claude and the terminal do not need placeholder text that only says `allowed`. The local output is quieter while policy denials and meaningful explanations still show up.

## Before / After Terminal Capture

Before, default allow responses surfaced placeholder text locally:

```json
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"allowed"}}
```

After, default allow output is quieter:

```json
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}
```

Meaningful policy reasons still surface:

```json
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"Allowed by read-only policy"}}
```

Hook telemetry payloads are still sent to the API with the same event fields:

```json
{"session_id":"session-123","agent":"claude","hook_event":"PostToolUse","tool_name":"Bash","tool_use_id":"toolu_123","cwd":"/tmp/project"}
```

## Verification

- Ran `go test ./...` on this branch.


