### PR TITLE
fix(ci): run release please with app token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,15 +17,26 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      - name: Create release bot token
+        id: release-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.KONTEXT_RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.KONTEXT_RELEASE_APP_PRIVATE_KEY }}
+          repositories: kontext-cli
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
+
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         id: release
         with:
+          token: ${{ steps.release-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Summary

- Run Release Please with a dedicated GitHub App installation token instead of the default `GITHUB_TOKEN`.
- Keep the release workflow trigger, branch protection checks, and GoReleaser job unchanged.
- Scope the release job default `GITHUB_TOKEN` down to read-only because writes come from the minted app token.

## Verification

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-please.yml"); puts "release-please.yml parses"'`\n- `actionlint .github/workflows/release-please.yml`\n- Confirmed main still requires `verify`, `proto`, and `dependency-review`.\n\n## Deployment note\n\nBefore this merges, configure `KONTEXT_RELEASE_APP_CLIENT_ID` and `KONTEXT_RELEASE_APP_PRIVATE_KEY` for the repo with credentials from the `kontext-release-bot` GitHub App.