### PR TITLE
feat(run): require successful BootstrapCli before launching runtime

### DIFF
--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -106,63 +106,52 @@ func Start(ctx context.Context, opts Options) error {
 	fmt.Fprintf(os.Stderr, "✓ Session: %s (%s)\n", createResp.SessionName, truncateID(sessionID))
 
 	// 4. Bootstrap the shared CLI application and sync the local env file.
-	templateExists := false
-	if _, err := os.Stat(opts.TemplateFile); err == nil {
-		templateExists = true
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("stat env template: %w", err)
-	}
-
-	bootstrapResp, bootstrapErr := client.BootstrapCli(ctx, &agentv1.BootstrapCliRequest{
+	// Bootstrap is a required setup step: the backend creates or resolves the
+	// reserved kontext-cli application and marks the org as CLI-onboarded. The
+	// dashboard relies on this state to skip generic onboarding, so a failure
+	// here must abort — a half-set-up session would leave the org looking
+	// un-onboarded while the CLI appears to work.
+	bootstrapResp, err := client.BootstrapCli(ctx, &agentv1.BootstrapCliRequest{
 		AgentId: createResp.AgentId,
 	})
-	if bootstrapErr != nil && !templateExists {
-		return fmt.Errorf("bootstrap cli application: %w", bootstrapErr)
+	if err != nil {
+		return fmt.Errorf("bootstrap cli application: %w", err)
 	}
+	fmt.Fprintln(os.Stderr, "✓ Kontext CLI bootstrap complete")
 
-	var templateDoc *credential.TemplateFile
-	if bootstrapErr != nil {
-		diagnostics.Printf("provider sync skipped: %v\n", bootstrapErr)
-		fmt.Fprintln(os.Stderr, "⚠ Provider sync skipped; using the local env template.")
-		templateDoc, err = credential.LoadTemplateFile(opts.TemplateFile)
-		if err != nil {
-			return fmt.Errorf("load env template: %w", err)
-		}
-	} else {
-		syncResult, err := credential.EnsureManagedTemplate(
+	syncResult, err := credential.EnsureManagedTemplate(
+		opts.TemplateFile,
+		managedProvidersFromBootstrap(bootstrapResp.ManagedProviders),
+	)
+	if err != nil {
+		return fmt.Errorf("sync env template: %w", err)
+	}
+	templateDoc := syncResult.Template
+	if syncResult.Created {
+		fmt.Fprintf(
+			os.Stderr,
+			"✓ Created local %s automatically\n",
 			opts.TemplateFile,
-			managedProvidersFromBootstrap(bootstrapResp.ManagedProviders),
 		)
-		if err != nil {
-			return fmt.Errorf("sync env template: %w", err)
-		}
-		templateDoc = syncResult.Template
-		if syncResult.Created {
-			fmt.Fprintf(
-				os.Stderr,
-				"✓ Created local %s automatically\n",
-				opts.TemplateFile,
-			)
-		}
-		if syncResult.Updated {
-			fmt.Fprintf(
-				os.Stderr,
-				"✓ Updated %s with managed preset entries: %s\n",
-				opts.TemplateFile,
-				joinManagedEnvVars(syncResult.Added),
-			)
-		}
-		for _, provider := range syncResult.CollisionSkipped {
-			fmt.Fprintf(
-				os.Stderr,
-				"⚠ Skipped auto-adding %s because that key already exists in %s\n",
-				provider.EnvVar,
-				opts.TemplateFile,
-			)
-		}
-		if templateDoc != nil && !templateDoc.SafeToMutate && templateDoc.MutationWarning != "" {
-			fmt.Fprintf(os.Stderr, "⚠ %s\n", templateDoc.MutationWarning)
-		}
+	}
+	if syncResult.Updated {
+		fmt.Fprintf(
+			os.Stderr,
+			"✓ Updated %s with managed preset entries: %s\n",
+			opts.TemplateFile,
+			joinManagedEnvVars(syncResult.Added),
+		)
+	}
+	for _, provider := range syncResult.CollisionSkipped {
+		fmt.Fprintf(
+			os.Stderr,
+			"⚠ Skipped auto-adding %s because that key already exists in %s\n",
+			provider.EnvVar,
+			opts.TemplateFile,
+		)
+	}
+	if templateDoc != nil && !templateDoc.SafeToMutate && templateDoc.MutationWarning != "" {
+		fmt.Fprintf(os.Stderr, "⚠ %s\n", templateDoc.MutationWarning)
 	}
 
 	for _, invalid := range templateDoc.InvalidPlaceholders {


### PR DESCRIPTION
## Summary

- Make `BootstrapCli` a required setup step in `kontext start` — abort on failure instead of silently skipping when a local `.env.kontext` exists.
- Surface a clear `✓ Kontext CLI bootstrap complete` line before the runtime launches.
- Collapses the old two-branch (`if bootstrapErr != nil { skip } else { sync }`) fallback into a single linear path.

## Why

The dashboard's CLI-first onboarding routing relies on backend state set by `bootstrapCli`:
- `intent = "cli"`
- `source = "cli_bootstrap"`
- `hasCliApplication = true`
- `cliDashboardTourRequired = true`

Previously, if `BootstrapCli` failed and a local `.env.kontext` existed, the CLI continued anyway. That left orgs in a half-set-up state where the CLI session ran fine locally but the dashboard still routed the user to generic `/onboarding` — the exact case the CLI-first acceptance criteria forbid. It's also why local testing required manually seeding Postgres.

The RPC is already idempotent on the backend (resolves the reserved `kontext-cli` app when it exists), so reruns stay safe.

## Acceptance criteria covered

- [x] CLI always calls `bootstrapCli` after auth, before reporting setup complete
- [x] CLI fails clearly if bootstrap fails — no half-set-up session
- [x] No `My First App` / generic app created by the CLI (never was; confirmed)
- [x] Idempotent reruns (backend-enforced)
- [x] Dashboard-expected state (`intent=cli`, `source=cli_bootstrap`, `hasCliApplication=true`) is guaranteed after a successful `kontext start`

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/run/...` — 40 tests pass
- [ ] Manual: fresh org via CLI → open dashboard → lands on CLI tour, not `/onboarding`
- [ ] Manual: rerun `kontext start` → no duplicate `kontext-cli` app
- [ ] Manual: simulate bootstrap failure (e.g. bad token) → CLI aborts with a clear error and org is not left looking CLI-onboarded
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kontext-security/kontext-cli/pull/78" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
