### PR TITLE
feat(cli): forward Claude hook metadata

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -7,7 +7,7 @@ managed:
 inputs:
   - git_repo: https://github.com/kontext-security/proto.git
     branch: main
-    ref: ba2b704abfde23ec2c30bfd2b5c540a91a674f41
+    ref: a9da139386c97cb653497ea08ae84fe27dffc850
 plugins:
   - local: protoc-gen-go
     out: gen

--- a/cmd/kontext/main.go
+++ b/cmd/kontext/main.go
@@ -186,12 +186,16 @@ func evaluateViaSidecar(socketPath, agentName string, e *agent.HookEvent) (bool,
 	}
 
 	req := sidecar.EvaluateRequest{
-		Type:      "evaluate",
-		Agent:     agentName,
-		HookEvent: e.HookEventName,
-		ToolName:  e.ToolName,
-		ToolUseID: e.ToolUseID,
-		CWD:       e.CWD,
+		Type:           "evaluate",
+		Agent:          agentName,
+		HookEvent:      e.HookEventName,
+		ToolName:       e.ToolName,
+		ToolUseID:      e.ToolUseID,
+		CWD:            e.CWD,
+		PermissionMode: e.PermissionMode,
+		DurationMs:     e.DurationMs,
+		Error:          e.Error,
+		IsInterrupt:    e.IsInterrupt,
 	}
 
 	if e.ToolInput != nil {

--- a/gen/kontext/agent/v1/agent.pb.go
+++ b/gen/kontext/agent/v1/agent.pb.go
@@ -74,17 +74,21 @@ func (Decision) EnumDescriptor() ([]byte, []int) {
 }
 
 type ProcessHookEventRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
-	Agent         string                 `protobuf:"bytes,2,opt,name=agent,proto3" json:"agent,omitempty"`                          // "claude", "cursor", "codex"
-	HookEvent     string                 `protobuf:"bytes,3,opt,name=hook_event,json=hookEvent,proto3" json:"hook_event,omitempty"` // "PreToolUse", "PostToolUse", "UserPromptSubmit"
-	ToolName      string                 `protobuf:"bytes,4,opt,name=tool_name,json=toolName,proto3" json:"tool_name,omitempty"`
-	ToolInput     []byte                 `protobuf:"bytes,5,opt,name=tool_input,json=toolInput,proto3" json:"tool_input,omitempty"`          // JSON-encoded tool input
-	ToolResponse  []byte                 `protobuf:"bytes,6,opt,name=tool_response,json=toolResponse,proto3" json:"tool_response,omitempty"` // JSON-encoded tool response (PostToolUse only)
-	ToolUseId     string                 `protobuf:"bytes,7,opt,name=tool_use_id,json=toolUseId,proto3" json:"tool_use_id,omitempty"`
-	Cwd           string                 `protobuf:"bytes,8,opt,name=cwd,proto3" json:"cwd,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	SessionId      string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	Agent          string                 `protobuf:"bytes,2,opt,name=agent,proto3" json:"agent,omitempty"`                          // "claude", "cursor", "codex"
+	HookEvent      string                 `protobuf:"bytes,3,opt,name=hook_event,json=hookEvent,proto3" json:"hook_event,omitempty"` // "PreToolUse", "PostToolUse", "UserPromptSubmit"
+	ToolName       string                 `protobuf:"bytes,4,opt,name=tool_name,json=toolName,proto3" json:"tool_name,omitempty"`
+	ToolInput      []byte                 `protobuf:"bytes,5,opt,name=tool_input,json=toolInput,proto3" json:"tool_input,omitempty"`          // JSON-encoded tool input
+	ToolResponse   []byte                 `protobuf:"bytes,6,opt,name=tool_response,json=toolResponse,proto3" json:"tool_response,omitempty"` // JSON-encoded tool response (PostToolUse only)
+	ToolUseId      string                 `protobuf:"bytes,7,opt,name=tool_use_id,json=toolUseId,proto3" json:"tool_use_id,omitempty"`
+	Cwd            string                 `protobuf:"bytes,8,opt,name=cwd,proto3" json:"cwd,omitempty"`
+	PermissionMode *string                `protobuf:"bytes,9,opt,name=permission_mode,json=permissionMode,proto3,oneof" json:"permission_mode,omitempty"`
+	DurationMs     *int64                 `protobuf:"varint,10,opt,name=duration_ms,json=durationMs,proto3,oneof" json:"duration_ms,omitempty"`
+	Error          *string                `protobuf:"bytes,11,opt,name=error,proto3,oneof" json:"error,omitempty"`
+	IsInterrupt    *bool                  `protobuf:"varint,12,opt,name=is_interrupt,json=isInterrupt,proto3,oneof" json:"is_interrupt,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *ProcessHookEventRequest) Reset() {
@@ -171,6 +175,34 @@ func (x *ProcessHookEventRequest) GetCwd() string {
 		return x.Cwd
 	}
 	return ""
+}
+
+func (x *ProcessHookEventRequest) GetPermissionMode() string {
+	if x != nil && x.PermissionMode != nil {
+		return *x.PermissionMode
+	}
+	return ""
+}
+
+func (x *ProcessHookEventRequest) GetDurationMs() int64 {
+	if x != nil && x.DurationMs != nil {
+		return *x.DurationMs
+	}
+	return 0
+}
+
+func (x *ProcessHookEventRequest) GetError() string {
+	if x != nil && x.Error != nil {
+		return *x.Error
+	}
+	return ""
+}
+
+func (x *ProcessHookEventRequest) GetIsInterrupt() bool {
+	if x != nil && x.IsInterrupt != nil {
+		return *x.IsInterrupt
+	}
+	return false
 }
 
 type ProcessHookEventResponse struct {
@@ -713,7 +745,7 @@ var File_kontext_agent_v1_agent_proto protoreflect.FileDescriptor
 
 const file_kontext_agent_v1_agent_proto_rawDesc = "" +
 	"\n" +
-	"\x1ckontext/agent/v1/agent.proto\x12\x10kontext.agent.v1\"\x80\x02\n" +
+	"\x1ckontext/agent/v1/agent.proto\x12\x10kontext.agent.v1\"\xd6\x03\n" +
 	"\x17ProcessHookEventRequest\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x14\n" +
@@ -725,7 +757,17 @@ const file_kontext_agent_v1_agent_proto_rawDesc = "" +
 	"tool_input\x18\x05 \x01(\fR\ttoolInput\x12#\n" +
 	"\rtool_response\x18\x06 \x01(\fR\ftoolResponse\x12\x1e\n" +
 	"\vtool_use_id\x18\a \x01(\tR\ttoolUseId\x12\x10\n" +
-	"\x03cwd\x18\b \x01(\tR\x03cwd\"\x85\x01\n" +
+	"\x03cwd\x18\b \x01(\tR\x03cwd\x12,\n" +
+	"\x0fpermission_mode\x18\t \x01(\tH\x00R\x0epermissionMode\x88\x01\x01\x12$\n" +
+	"\vduration_ms\x18\n" +
+	" \x01(\x03H\x01R\n" +
+	"durationMs\x88\x01\x01\x12\x19\n" +
+	"\x05error\x18\v \x01(\tH\x02R\x05error\x88\x01\x01\x12&\n" +
+	"\fis_interrupt\x18\f \x01(\bH\x03R\visInterrupt\x88\x01\x01B\x12\n" +
+	"\x10_permission_modeB\x0e\n" +
+	"\f_duration_msB\b\n" +
+	"\x06_errorB\x0f\n" +
+	"\r_is_interrupt\"\x85\x01\n" +
 	"\x18ProcessHookEventResponse\x126\n" +
 	"\bdecision\x18\x01 \x01(\x0e2\x1a.kontext.agent.v1.DecisionR\bdecision\x12\x16\n" +
 	"\x06reason\x18\x02 \x01(\tR\x06reason\x12\x19\n" +
@@ -836,6 +878,7 @@ func file_kontext_agent_v1_agent_proto_init() {
 	if File_kontext_agent_v1_agent_proto != nil {
 		return
 	}
+	file_kontext_agent_v1_agent_proto_msgTypes[0].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -11,13 +11,17 @@ type Agent interface {
 }
 
 type HookEvent struct {
-	SessionID     string
-	HookEventName string
-	ToolName      string
-	ToolInput     map[string]any
-	ToolResponse  map[string]any
-	ToolUseID     string
-	CWD           string
+	SessionID      string
+	HookEventName  string
+	ToolName       string
+	ToolInput      map[string]any
+	ToolResponse   map[string]any
+	ToolUseID      string
+	CWD            string
+	PermissionMode string
+	DurationMs     *int64
+	Error          string
+	IsInterrupt    *bool
 }
 
 var registry = map[string]Agent{}

--- a/internal/agent/claude/claude.go
+++ b/internal/agent/claude/claude.go
@@ -17,13 +17,17 @@ type Claude struct{}
 func (c *Claude) Name() string { return "claude" }
 
 type hookInput struct {
-	SessionID     string         `json:"session_id"`
-	HookEventName string         `json:"hook_event_name"`
-	ToolName      string         `json:"tool_name"`
-	ToolInput     map[string]any `json:"tool_input"`
-	ToolResponse  map[string]any `json:"tool_response"`
-	ToolUseID     string         `json:"tool_use_id"`
-	CWD           string         `json:"cwd"`
+	SessionID      string         `json:"session_id"`
+	HookEventName  string         `json:"hook_event_name"`
+	ToolName       string         `json:"tool_name"`
+	ToolInput      map[string]any `json:"tool_input"`
+	ToolResponse   map[string]any `json:"tool_response"`
+	ToolUseID      string         `json:"tool_use_id"`
+	CWD            string         `json:"cwd"`
+	PermissionMode *string        `json:"permission_mode"`
+	DurationMs     *int64         `json:"duration_ms"`
+	Error          *string        `json:"error"`
+	IsInterrupt    *bool          `json:"is_interrupt"`
 }
 
 func (c *Claude) DecodeHookInput(input []byte) (*agent.HookEvent, error) {
@@ -32,14 +36,25 @@ func (c *Claude) DecodeHookInput(input []byte) (*agent.HookEvent, error) {
 		return nil, fmt.Errorf("claude: decode hook input: %w", err)
 	}
 	return &agent.HookEvent{
-		SessionID:     h.SessionID,
-		HookEventName: h.HookEventName,
-		ToolName:      h.ToolName,
-		ToolInput:     h.ToolInput,
-		ToolResponse:  h.ToolResponse,
-		ToolUseID:     h.ToolUseID,
-		CWD:           h.CWD,
+		SessionID:      h.SessionID,
+		HookEventName:  h.HookEventName,
+		ToolName:       h.ToolName,
+		ToolInput:      h.ToolInput,
+		ToolResponse:   h.ToolResponse,
+		ToolUseID:      h.ToolUseID,
+		CWD:            h.CWD,
+		PermissionMode: stringValue(h.PermissionMode),
+		DurationMs:     h.DurationMs,
+		Error:          stringValue(h.Error),
+		IsInterrupt:    h.IsInterrupt,
 	}, nil
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
 }
 
 type hookOutput struct {

--- a/internal/agent/claude/claude_test.go
+++ b/internal/agent/claude/claude_test.go
@@ -1,11 +1,117 @@
 package claude
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/kontext-security/kontext-cli/internal/agent"
 )
+
+func TestDecodeHookInputPreservesOptionalMetadata(t *testing.T) {
+	t.Parallel()
+
+	modes := []string{
+		"default",
+		"plan",
+		"acceptEdits",
+		"auto",
+		"dontAsk",
+		"bypassPermissions",
+		"futureUnknownMode",
+	}
+	for _, mode := range modes {
+		t.Run(mode, func(t *testing.T) {
+			t.Parallel()
+
+			input, err := json.Marshal(map[string]any{
+				"hook_event_name": "PostToolUseFailure",
+				"tool_name":       "Bash",
+				"tool_input":      map[string]any{"command": "npm test"},
+				"tool_use_id":     "toolu_123",
+				"cwd":             "/tmp/project",
+				"permission_mode": mode,
+				"duration_ms":     1234,
+				"error":           "command failed",
+				"is_interrupt":    true,
+			})
+			if err != nil {
+				t.Fatalf("json.Marshal() error = %v", err)
+			}
+
+			event, err := (&Claude{}).DecodeHookInput(input)
+			if err != nil {
+				t.Fatalf("DecodeHookInput() error = %v", err)
+			}
+			if event.PermissionMode != mode {
+				t.Fatalf("PermissionMode = %q, want %q", event.PermissionMode, mode)
+			}
+			if event.DurationMs == nil || *event.DurationMs != 1234 {
+				t.Fatalf("DurationMs = %v, want 1234", event.DurationMs)
+			}
+			if event.Error != "command failed" {
+				t.Fatalf("Error = %q, want command failed", event.Error)
+			}
+			if event.IsInterrupt == nil || !*event.IsInterrupt {
+				t.Fatalf("IsInterrupt = %v, want true", event.IsInterrupt)
+			}
+		})
+	}
+}
+
+func TestDecodeHookInputPreservesExplicitFalseInterrupt(t *testing.T) {
+	t.Parallel()
+
+	event, err := (&Claude{}).DecodeHookInput([]byte(`{"hook_event_name":"PostToolUseFailure","is_interrupt":false}`))
+	if err != nil {
+		t.Fatalf("DecodeHookInput() error = %v", err)
+	}
+	if event.IsInterrupt == nil {
+		t.Fatal("IsInterrupt = nil, want explicit false")
+	}
+	if *event.IsInterrupt {
+		t.Fatal("IsInterrupt = true, want false")
+	}
+}
+
+func TestDecodeHookInputAllowsMissingOptionalMetadata(t *testing.T) {
+	t.Parallel()
+
+	event, err := (&Claude{}).DecodeHookInput([]byte(`{"hook_event_name":"PreToolUse"}`))
+	if err != nil {
+		t.Fatalf("DecodeHookInput() error = %v", err)
+	}
+	if event.PermissionMode != "" || event.DurationMs != nil || event.Error != "" || event.IsInterrupt != nil {
+		t.Fatalf("optional metadata = %+v, want zero values", event)
+	}
+}
+
+func TestDecodeHookInputAllowsNullOptionalStringMetadata(t *testing.T) {
+	t.Parallel()
+
+	event, err := (&Claude{}).DecodeHookInput([]byte(`{"hook_event_name":"PostToolUseFailure","permission_mode":null,"error":null}`))
+	if err != nil {
+		t.Fatalf("DecodeHookInput() error = %v", err)
+	}
+	if event.PermissionMode != "" || event.Error != "" {
+		t.Fatalf("optional string metadata = %+v, want zero values", event)
+	}
+}
+
+func TestDecodeHookInputPreservesExplicitZeroDuration(t *testing.T) {
+	t.Parallel()
+
+	event, err := (&Claude{}).DecodeHookInput([]byte(`{"hook_event_name":"PostToolUse","duration_ms":0}`))
+	if err != nil {
+		t.Fatalf("DecodeHookInput() error = %v", err)
+	}
+	if event.DurationMs == nil {
+		t.Fatal("DurationMs = nil, want explicit zero")
+	}
+	if *event.DurationMs != 0 {
+		t.Fatalf("DurationMs = %d, want 0", *event.DurationMs)
+	}
+}
 
 func TestEncodeAllowOmitsPlaceholderReason(t *testing.T) {
 	t.Parallel()

--- a/internal/sidecar/protocol.go
+++ b/internal/sidecar/protocol.go
@@ -9,14 +9,18 @@ import (
 )
 
 type EvaluateRequest struct {
-	Type         string          `json:"type"`
-	Agent        string          `json:"agent"`
-	HookEvent    string          `json:"hook_event"`
-	ToolName     string          `json:"tool_name"`
-	ToolInput    json.RawMessage `json:"tool_input,omitempty"`
-	ToolResponse json.RawMessage `json:"tool_response,omitempty"`
-	ToolUseID    string          `json:"tool_use_id"`
-	CWD          string          `json:"cwd"`
+	Type           string          `json:"type"`
+	Agent          string          `json:"agent"`
+	HookEvent      string          `json:"hook_event"`
+	ToolName       string          `json:"tool_name"`
+	ToolInput      json.RawMessage `json:"tool_input,omitempty"`
+	ToolResponse   json.RawMessage `json:"tool_response,omitempty"`
+	ToolUseID      string          `json:"tool_use_id"`
+	CWD            string          `json:"cwd"`
+	PermissionMode string          `json:"permission_mode,omitempty"`
+	DurationMs     *int64          `json:"duration_ms,omitempty"`
+	Error          string          `json:"error,omitempty"`
+	IsInterrupt    *bool           `json:"is_interrupt,omitempty"`
 }
 
 type EvaluateResult struct {

--- a/internal/sidecar/sidecar.go
+++ b/internal/sidecar/sidecar.go
@@ -123,6 +123,18 @@ func buildHookEventRequest(sessionID, agentName string, req *EvaluateRequest) *a
 		ToolUseId: req.ToolUseID,
 		Cwd:       req.CWD,
 	}
+	if req.PermissionMode != "" {
+		hookEvent.PermissionMode = &req.PermissionMode
+	}
+	if req.DurationMs != nil {
+		hookEvent.DurationMs = req.DurationMs
+	}
+	if req.Error != "" {
+		hookEvent.Error = &req.Error
+	}
+	if req.IsInterrupt != nil {
+		hookEvent.IsInterrupt = req.IsInterrupt
+	}
 
 	if len(req.ToolInput) > 0 {
 		hookEvent.ToolInput = req.ToolInput

--- a/internal/sidecar/sidecar_test.go
+++ b/internal/sidecar/sidecar_test.go
@@ -49,13 +49,19 @@ func TestBuildHookEventRequestPreservesTelemetryPayload(t *testing.T) {
 
 	toolInput := json.RawMessage(`{"command":"pwd"}`)
 	toolResponse := json.RawMessage(`{"stdout":"/tmp/project"}`)
+	isInterrupt := true
+	durationMs := int64(42)
 	req := &EvaluateRequest{
-		HookEvent:    "PostToolUse",
-		ToolName:     "Bash",
-		ToolInput:    toolInput,
-		ToolResponse: toolResponse,
-		ToolUseID:    "toolu_123",
-		CWD:          "/tmp/project",
+		HookEvent:      "PostToolUse",
+		ToolName:       "Bash",
+		ToolInput:      toolInput,
+		ToolResponse:   toolResponse,
+		ToolUseID:      "toolu_123",
+		CWD:            "/tmp/project",
+		PermissionMode: "acceptEdits",
+		DurationMs:     &durationMs,
+		Error:          "failed",
+		IsInterrupt:    &isInterrupt,
 	}
 
 	got := buildHookEventRequest("session-123", "claude", req)
@@ -67,11 +73,61 @@ func TestBuildHookEventRequestPreservesTelemetryPayload(t *testing.T) {
 		got.Cwd != req.CWD {
 		t.Fatalf("buildHookEventRequest() = %+v, want copied metadata", got)
 	}
+	if got.GetPermissionMode() != req.PermissionMode {
+		t.Fatalf("PermissionMode = %q, want %q", got.GetPermissionMode(), req.PermissionMode)
+	}
+	if got.GetDurationMs() != *req.DurationMs {
+		t.Fatalf("DurationMs = %d, want %d", got.GetDurationMs(), *req.DurationMs)
+	}
+	if got.GetError() != req.Error {
+		t.Fatalf("Error = %q, want %q", got.GetError(), req.Error)
+	}
+	if got.GetIsInterrupt() != *req.IsInterrupt {
+		t.Fatalf("IsInterrupt = %t, want %t", got.GetIsInterrupt(), *req.IsInterrupt)
+	}
 	if string(got.ToolInput) != string(toolInput) {
 		t.Fatalf("ToolInput = %s, want %s", got.ToolInput, toolInput)
 	}
 	if string(got.ToolResponse) != string(toolResponse) {
 		t.Fatalf("ToolResponse = %s, want %s", got.ToolResponse, toolResponse)
+	}
+}
+
+func TestBuildHookEventRequestPreservesExplicitFalseInterrupt(t *testing.T) {
+	t.Parallel()
+
+	isInterrupt := false
+	got := buildHookEventRequest("session-123", "claude", &EvaluateRequest{
+		HookEvent:   "PostToolUseFailure",
+		ToolName:    "Bash",
+		ToolUseID:   "toolu_123",
+		IsInterrupt: &isInterrupt,
+	})
+
+	if got.IsInterrupt == nil {
+		t.Fatal("IsInterrupt = nil, want explicit false")
+	}
+	if got.GetIsInterrupt() {
+		t.Fatal("IsInterrupt = true, want false")
+	}
+}
+
+func TestBuildHookEventRequestPreservesExplicitZeroDuration(t *testing.T) {
+	t.Parallel()
+
+	durationMs := int64(0)
+	got := buildHookEventRequest("session-123", "claude", &EvaluateRequest{
+		HookEvent:  "PostToolUse",
+		ToolName:   "Bash",
+		ToolUseID:  "toolu_123",
+		DurationMs: &durationMs,
+	})
+
+	if got.DurationMs == nil {
+		t.Fatal("DurationMs = nil, want explicit zero")
+	}
+	if got.GetDurationMs() != 0 {
+		t.Fatalf("DurationMs = %d, want 0", got.GetDurationMs())
 	}
 }
 


### PR DESCRIPTION
## Summary

Forwards Claude hook metadata from the local hook decoder through the sidecar and backend request. This preserves permission mode, duration, failure errors, and interrupt state while keeping missing optional fields valid.

## Verification

- `go test ./internal/agent/claude ./internal/sidecar ./cmd/kontext`