### PR TITLE
refactor(guard): extract hook runtime

### DIFF
--- a/internal/guard/cli/cli.go
+++ b/internal/guard/cli/cli.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -20,6 +19,7 @@ import (
 
 	"github.com/kontext-security/kontext-cli/internal/guard/app/hooks/claudecode"
 	"github.com/kontext-security/kontext-cli/internal/guard/app/server"
+	"github.com/kontext-security/kontext-cli/internal/guard/hookruntime"
 	"github.com/kontext-security/kontext-cli/internal/guard/markov"
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
 	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
@@ -29,13 +29,6 @@ import (
 const (
 	defaultBaseURL   = "http://" + server.DefaultAddr
 	defaultModelPath = "models/guard/coding-agent-v0.json"
-)
-
-type hookMode string
-
-const (
-	hookModeObserve hookMode = "observe"
-	hookModeEnforce hookMode = "enforce"
 )
 
 // Run executes the Kontext command line.
@@ -163,112 +156,15 @@ func runHook(ctx context.Context, args []string, stdin io.Reader, stdout, stderr
 	fs := flag.NewFlagSet("hook claude-code", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	baseURL := fs.String("daemon-url", envString("KONTEXT_DAEMON_URL", defaultBaseURL), "local daemon URL")
-	mode := fs.String("mode", envString("KONTEXT_MODE", string(hookModeObserve)), "hook mode: observe or enforce")
+	mode := fs.String("mode", envString("KONTEXT_MODE", string(hookruntime.ModeObserve)), "hook mode: observe or enforce")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	hookMode, err := parseHookMode(*mode)
+	hookMode, err := hookruntime.ParseMode(*mode)
 	if err != nil {
 		return err
 	}
-	event, err := decodeClaudeHook(stdin)
-	if err != nil {
-		fmt.Fprintf(stderr, "kontext: malformed hook input: %v\n", err)
-		writeClaudeDecision(stdout, "PreToolUse", risk.DecisionDeny, "malformed hook input", hookMode)
-		return nil
-	}
-	client := claudecode.NewClient(*baseURL)
-	result, err := client.Process(ctx, event)
-	if err != nil {
-		if event.HookEventName == "PreToolUse" && hookMode == hookModeEnforce {
-			writeClaudeDecision(stdout, event.HookEventName, risk.DecisionDeny, "Kontext daemon unavailable", hookMode)
-			return nil
-		}
-		fmt.Fprintf(stderr, "kontext: async hook ingestion failed: %v\n", err)
-		writeClaudeDecision(stdout, event.HookEventName, risk.DecisionAllow, "telemetry allowed", hookMode)
-		return nil
-	}
-	decision := result.Decision
-	if decision != risk.DecisionAllow && decision != risk.DecisionAsk && decision != risk.DecisionDeny {
-		decision = risk.DecisionDeny
-	}
-	if event.HookEventName != "PreToolUse" {
-		decision = risk.DecisionAllow
-	}
-	writeClaudeDecision(stdout, event.HookEventName, decision, result.Reason, hookMode)
-	return nil
-}
-
-func parseHookMode(value string) (hookMode, error) {
-	switch hookMode(strings.ToLower(strings.TrimSpace(value))) {
-	case "", hookModeObserve:
-		return hookModeObserve, nil
-	case hookModeEnforce:
-		return hookModeEnforce, nil
-	default:
-		return "", fmt.Errorf("unknown hook mode %q; use observe or enforce", value)
-	}
-}
-
-func decodeClaudeHook(r io.Reader) (risk.HookEvent, error) {
-	var raw map[string]any
-	if err := json.NewDecoder(r).Decode(&raw); err != nil {
-		return risk.HookEvent{}, err
-	}
-	event := risk.HookEvent{
-		SessionID:     stringValue(raw, "session_id", "sessionId"),
-		Agent:         "claude-code",
-		HookEventName: stringValue(raw, "hook_event_name", "hookEventName"),
-		ToolName:      stringValue(raw, "tool_name", "toolName"),
-		ToolUseID:     stringValue(raw, "tool_use_id", "toolUseID", "toolUseId"),
-		CWD:           stringValue(raw, "cwd"),
-		Timestamp:     time.Now().UTC(),
-	}
-	if event.HookEventName == "" {
-		event.HookEventName = stringValue(raw, "hook_event")
-	}
-	if input, ok := raw["tool_input"].(map[string]any); ok {
-		event.ToolInput = input
-	} else if input, ok := raw["toolInput"].(map[string]any); ok {
-		event.ToolInput = input
-	}
-	if response, ok := raw["tool_response"].(map[string]any); ok {
-		event.ToolResponse = response
-	} else if response, ok := raw["toolResponse"].(map[string]any); ok {
-		event.ToolResponse = response
-	}
-	if event.HookEventName == "" {
-		return risk.HookEvent{}, errors.New("hook event name missing")
-	}
-	if event.SessionID == "" {
-		event.SessionID = "local"
-	}
-	return event, nil
-}
-
-func writeClaudeDecision(out io.Writer, hookEventName string, decision risk.Decision, reason string, mode hookMode) {
-	permissionDecision := "allow"
-	if mode == hookModeEnforce && (decision == risk.DecisionAsk || decision == risk.DecisionDeny) {
-		permissionDecision = "deny"
-	}
-	payload := map[string]any{
-		"hookSpecificOutput": map[string]any{
-			"hookEventName":            hookEventName,
-			"permissionDecision":       permissionDecision,
-			"permissionDecisionReason": formatHookReason(decision, reason, mode),
-		},
-	}
-	_ = json.NewEncoder(out).Encode(payload)
-}
-
-func formatHookReason(decision risk.Decision, reason string, mode hookMode) string {
-	if reason == "" {
-		reason = "no reason provided"
-	}
-	if mode == hookModeObserve {
-		return fmt.Sprintf("Kontext observe mode: would %s; %s", decision, reason)
-	}
-	return reason
+	return hookruntime.Run(ctx, hookruntime.ClaudeAdapter{}, claudecode.NewClient(*baseURL), hookMode, stdin, stdout, stderr)
 }
 
 func runStatus(ctx context.Context, args []string, out io.Writer) error {
@@ -703,15 +599,6 @@ func runTrainFixtureModel(args []string, out io.Writer) error {
 	}
 	fmt.Fprintf(out, "wrote %s from %d events, %d sessions, %d states\n", *outputPath, len(events), len(sessions), len(model.States))
 	return nil
-}
-
-func stringValue(raw map[string]any, keys ...string) string {
-	for _, key := range keys {
-		if value, ok := raw[key].(string); ok {
-			return value
-		}
-	}
-	return ""
 }
 
 func envString(key, fallback string) string {

--- a/internal/guard/hookruntime/claude.go
+++ b/internal/guard/hookruntime/claude.go
@@ -1,0 +1,93 @@
+package hookruntime
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/guard/risk"
+)
+
+type ClaudeAdapter struct{}
+
+func (ClaudeAdapter) Decode(r io.Reader) (Event, error) {
+	var raw map[string]any
+	if err := json.NewDecoder(r).Decode(&raw); err != nil {
+		return Event{}, err
+	}
+	event := risk.HookEvent{
+		SessionID:     stringValue(raw, "session_id", "sessionId"),
+		Agent:         "claude-code",
+		HookEventName: stringValue(raw, "hook_event_name", "hookEventName"),
+		ToolName:      stringValue(raw, "tool_name", "toolName"),
+		ToolUseID:     stringValue(raw, "tool_use_id", "toolUseID", "toolUseId"),
+		CWD:           stringValue(raw, "cwd"),
+		Timestamp:     time.Now().UTC(),
+	}
+	if event.HookEventName == "" {
+		event.HookEventName = stringValue(raw, "hook_event")
+	}
+	if input, ok := raw["tool_input"].(map[string]any); ok {
+		event.ToolInput = input
+	} else if input, ok := raw["toolInput"].(map[string]any); ok {
+		event.ToolInput = input
+	}
+	if response, ok := raw["tool_response"].(map[string]any); ok {
+		event.ToolResponse = response
+	} else if response, ok := raw["toolResponse"].(map[string]any); ok {
+		event.ToolResponse = response
+	}
+	if event.HookEventName == "" {
+		return Event{}, errors.New("hook event name missing")
+	}
+	if event.SessionID == "" {
+		event.SessionID = "local"
+	}
+	return Event{
+		HookName:  event.HookEventName,
+		CanBlock:  event.HookEventName == "PreToolUse",
+		RiskEvent: event,
+	}, nil
+}
+
+func (ClaudeAdapter) Encode(out io.Writer, result Result) error {
+	permissionDecision := "allow"
+	if result.Mode == ModeEnforce && result.CanBlock && (result.Decision == risk.DecisionAsk || result.Decision == risk.DecisionDeny) {
+		permissionDecision = "deny"
+	}
+	payload := map[string]any{
+		"hookSpecificOutput": map[string]any{
+			"hookEventName":            result.HookName,
+			"permissionDecision":       permissionDecision,
+			"permissionDecisionReason": formatReason(result.Decision, result.Reason, result.Mode),
+		},
+	}
+	return json.NewEncoder(out).Encode(payload)
+}
+
+func (ClaudeAdapter) MalformedHookName() string {
+	return "PreToolUse"
+}
+
+func formatReason(decision risk.Decision, reason string, mode Mode) string {
+	if reason == "" {
+		reason = "no reason provided"
+	}
+	if mode == ModeObserve {
+		return fmt.Sprintf("Kontext observe mode: would %s; %s", decision, reason)
+	}
+	return reason
+}
+
+func stringValue(raw map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value, ok := raw[key].(string); ok {
+			return value
+		}
+	}
+	return ""
+}
+
+var _ Adapter = ClaudeAdapter{}

--- a/internal/guard/hookruntime/claude_test.go
+++ b/internal/guard/hookruntime/claude_test.go
@@ -1,0 +1,73 @@
+package hookruntime
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/guard/risk"
+)
+
+func TestClaudeAdapterDecodePreservesHookEvent(t *testing.T) {
+	t.Parallel()
+
+	input := strings.NewReader(`{"session_id":"s1","hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{"file_path":".env"},"tool_use_id":"toolu_123","cwd":"/tmp/project"}`)
+	event, err := ClaudeAdapter{}.Decode(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.HookName != "PreToolUse" || !event.CanBlock {
+		t.Fatalf("event = %+v, want blocking PreToolUse", event)
+	}
+	if event.RiskEvent.Agent != "claude-code" ||
+		event.RiskEvent.SessionID != "s1" ||
+		event.RiskEvent.ToolName != "Read" ||
+		event.RiskEvent.ToolUseID != "toolu_123" ||
+		event.RiskEvent.CWD != "/tmp/project" {
+		t.Fatalf("risk event = %+v, want decoded metadata", event.RiskEvent)
+	}
+	if event.RiskEvent.ToolInput["file_path"] != ".env" {
+		t.Fatalf("tool input = %+v", event.RiskEvent.ToolInput)
+	}
+}
+
+func TestClaudeAdapterEncodeObserveModeAllowsWouldDeny(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	err := ClaudeAdapter{}.Encode(&out, Result{
+		HookName: "PreToolUse",
+		CanBlock: true,
+		Decision: risk.DecisionDeny,
+		Reason:   "blocked",
+		Mode:     ModeObserve,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"permissionDecision":"allow"`) {
+		t.Fatalf("output = %s", out.String())
+	}
+	if !strings.Contains(out.String(), `would deny; blocked`) {
+		t.Fatalf("output = %s", out.String())
+	}
+}
+
+func TestClaudeAdapterEncodeEnforceModeDeniesAsk(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	err := ClaudeAdapter{}.Encode(&out, Result{
+		HookName: "PreToolUse",
+		CanBlock: true,
+		Decision: risk.DecisionAsk,
+		Reason:   "needs review",
+		Mode:     ModeEnforce,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"permissionDecision":"deny"`) {
+		t.Fatalf("output = %s", out.String())
+	}
+}

--- a/internal/guard/hookruntime/runtime.go
+++ b/internal/guard/hookruntime/runtime.go
@@ -1,0 +1,116 @@
+package hookruntime
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/kontext-security/kontext-cli/internal/guard/app/server"
+	"github.com/kontext-security/kontext-cli/internal/guard/risk"
+)
+
+type Mode string
+
+const (
+	ModeObserve Mode = "observe"
+	ModeEnforce Mode = "enforce"
+)
+
+type Adapter interface {
+	Decode(io.Reader) (Event, error)
+	Encode(io.Writer, Result) error
+	MalformedHookName() string
+}
+
+type Processor interface {
+	Process(ctx context.Context, event risk.HookEvent) (server.ProcessResponse, error)
+}
+
+type Event struct {
+	HookName  string
+	CanBlock  bool
+	RiskEvent risk.HookEvent
+}
+
+type Result struct {
+	HookName string
+	CanBlock bool
+	Decision risk.Decision
+	Reason   string
+	Mode     Mode
+}
+
+func Run(ctx context.Context, adapter Adapter, processor Processor, mode Mode, stdin io.Reader, stdout, stderr io.Writer) error {
+	event, err := adapter.Decode(stdin)
+	if err != nil {
+		fmt.Fprintf(stderr, "kontext: malformed hook input: %v\n", err)
+		return adapter.Encode(stdout, Result{
+			HookName: adapter.MalformedHookName(),
+			CanBlock: true,
+			Decision: risk.DecisionDeny,
+			Reason:   "malformed hook input",
+			Mode:     mode,
+		})
+	}
+
+	result, err := processor.Process(ctx, event.RiskEvent)
+	if err != nil {
+		if event.CanBlock && mode == ModeEnforce {
+			return adapter.Encode(stdout, Result{
+				HookName: event.outputHookName(),
+				CanBlock: event.CanBlock,
+				Decision: risk.DecisionDeny,
+				Reason:   "Kontext daemon unavailable",
+				Mode:     mode,
+			})
+		}
+		fmt.Fprintf(stderr, "kontext: async hook ingestion failed: %v\n", err)
+		return adapter.Encode(stdout, Result{
+			HookName: event.outputHookName(),
+			CanBlock: event.CanBlock,
+			Decision: risk.DecisionAllow,
+			Reason:   "telemetry allowed",
+			Mode:     mode,
+		})
+	}
+
+	decision := normalizeDecision(result.Decision)
+	if !event.CanBlock {
+		decision = risk.DecisionAllow
+	}
+	return adapter.Encode(stdout, Result{
+		HookName: event.outputHookName(),
+		CanBlock: event.CanBlock,
+		Decision: decision,
+		Reason:   result.Reason,
+		Mode:     mode,
+	})
+}
+
+func ParseMode(value string) (Mode, error) {
+	switch Mode(strings.ToLower(strings.TrimSpace(value))) {
+	case "", ModeObserve:
+		return ModeObserve, nil
+	case ModeEnforce:
+		return ModeEnforce, nil
+	default:
+		return "", fmt.Errorf("unknown hook mode %q; use observe or enforce", value)
+	}
+}
+
+func (e Event) outputHookName() string {
+	if e.HookName != "" {
+		return e.HookName
+	}
+	return e.RiskEvent.HookEventName
+}
+
+func normalizeDecision(decision risk.Decision) risk.Decision {
+	switch decision {
+	case risk.DecisionAllow, risk.DecisionAsk, risk.DecisionDeny:
+		return decision
+	default:
+		return risk.DecisionDeny
+	}
+}

--- a/internal/guard/hookruntime/runtime_test.go
+++ b/internal/guard/hookruntime/runtime_test.go
@@ -1,0 +1,122 @@
+package hookruntime
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/guard/app/server"
+	"github.com/kontext-security/kontext-cli/internal/guard/risk"
+)
+
+func TestRunObserveModeAllowsUnavailableBlockingHook(t *testing.T) {
+	t.Parallel()
+
+	adapter := &stubAdapter{
+		event: Event{
+			HookName:  "PreToolUse",
+			CanBlock:  true,
+			RiskEvent: risk.HookEvent{HookEventName: "PreToolUse"},
+		},
+	}
+	err := Run(context.Background(), adapter, stubProcessor{err: errors.New("offline")}, ModeObserve, bytes.NewReader(nil), io.Discard, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if adapter.result.Decision != risk.DecisionAllow {
+		t.Fatalf("decision = %s, want allow", adapter.result.Decision)
+	}
+	if adapter.result.Reason != "telemetry allowed" {
+		t.Fatalf("reason = %q", adapter.result.Reason)
+	}
+}
+
+func TestRunEnforceModeDeniesUnavailableBlockingHook(t *testing.T) {
+	t.Parallel()
+
+	adapter := &stubAdapter{
+		event: Event{
+			HookName:  "PreToolUse",
+			CanBlock:  true,
+			RiskEvent: risk.HookEvent{HookEventName: "PreToolUse"},
+		},
+	}
+	err := Run(context.Background(), adapter, stubProcessor{err: errors.New("offline")}, ModeEnforce, bytes.NewReader(nil), io.Discard, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if adapter.result.Decision != risk.DecisionDeny {
+		t.Fatalf("decision = %s, want deny", adapter.result.Decision)
+	}
+	if adapter.result.Reason != "Kontext daemon unavailable" {
+		t.Fatalf("reason = %q", adapter.result.Reason)
+	}
+}
+
+func TestRunNonBlockingHookCannotBlock(t *testing.T) {
+	t.Parallel()
+
+	adapter := &stubAdapter{
+		event: Event{
+			HookName:  "PostToolUse",
+			CanBlock:  false,
+			RiskEvent: risk.HookEvent{HookEventName: "PostToolUse"},
+		},
+	}
+	err := Run(context.Background(), adapter, stubProcessor{resp: server.ProcessResponse{Decision: risk.DecisionDeny, Reason: "blocked"}}, ModeEnforce, bytes.NewReader(nil), io.Discard, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if adapter.result.Decision != risk.DecisionAllow {
+		t.Fatalf("decision = %s, want allow", adapter.result.Decision)
+	}
+}
+
+func TestRunUnknownDecisionFailsClosedForBlockingHook(t *testing.T) {
+	t.Parallel()
+
+	adapter := &stubAdapter{
+		event: Event{
+			HookName:  "PreToolUse",
+			CanBlock:  true,
+			RiskEvent: risk.HookEvent{HookEventName: "PreToolUse"},
+		},
+	}
+	err := Run(context.Background(), adapter, stubProcessor{resp: server.ProcessResponse{Decision: "unexpected"}}, ModeObserve, bytes.NewReader(nil), io.Discard, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if adapter.result.Decision != risk.DecisionDeny {
+		t.Fatalf("decision = %s, want deny", adapter.result.Decision)
+	}
+}
+
+type stubProcessor struct {
+	resp server.ProcessResponse
+	err  error
+}
+
+func (p stubProcessor) Process(context.Context, risk.HookEvent) (server.ProcessResponse, error) {
+	return p.resp, p.err
+}
+
+type stubAdapter struct {
+	event     Event
+	decodeErr error
+	result    Result
+}
+
+func (a *stubAdapter) Decode(io.Reader) (Event, error) {
+	return a.event, a.decodeErr
+}
+
+func (a *stubAdapter) Encode(_ io.Writer, result Result) error {
+	a.result = result
+	return nil
+}
+
+func (a *stubAdapter) MalformedHookName() string {
+	return "PreToolUse"
+}


### PR DESCRIPTION
## Summary

- Extract the Guard hook execution path from `internal/guard/cli` into a shared `internal/guard/hookruntime` package.
- Keep Claude Code behavior unchanged by moving Claude-specific hook decoding/encoding into a `ClaudeAdapter`.
- Add focused runtime tests for observe/enforce behavior, daemon failures, non-blocking hooks, and unknown decisions.

## Verification

- [x] `go test ./...`

## Notes

This is intentionally a refactor-only PR. It creates the adapter boundary needed for later Cursor hook support without adding Cursor behavior yet.
