### PR TITLE
feat: add hosted access enforcement

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -6,8 +6,8 @@ managed:
       value: github.com/kontext-security/kontext-cli/gen
 inputs:
   - git_repo: https://github.com/kontext-security/proto.git
-    branch: main
-    ref: a9da139386c97cb653497ea08ae84fe27dffc850
+    branch: feat/hosted-access-response-metadata
+    ref: 10b65e8a783e3462596d233254bb43cc4bc7b862
 plugins:
   - local: protoc-gen-go
     out: gen

--- a/cmd/kontext/main.go
+++ b/cmd/kontext/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -14,8 +13,10 @@ import (
 
 	"github.com/kontext-security/kontext-cli/internal/agent"
 	"github.com/kontext-security/kontext-cli/internal/auth"
+	"github.com/kontext-security/kontext-cli/internal/backend"
 	guardcli "github.com/kontext-security/kontext-cli/internal/guard/cli"
 	"github.com/kontext-security/kontext-cli/internal/hook"
+	"github.com/kontext-security/kontext-cli/internal/hookruntime"
 	"github.com/kontext-security/kontext-cli/internal/run"
 	"github.com/kontext-security/kontext-cli/internal/sidecar"
 	"github.com/kontext-security/kontext-cli/internal/update"
@@ -92,7 +93,7 @@ func startCmd() *cobra.Command {
 			err := run.Start(ctx, run.Options{
 				Agent:        agentName,
 				TemplateFile: templateFile,
-				IssuerURL:    auth.DefaultIssuerURL,
+				IssuerURL:    backend.BaseURL(),
 				ClientID:     auth.DefaultClientID,
 				Verbose:      verbose,
 				Args:         args,
@@ -182,14 +183,15 @@ func hookCmd() *cobra.Command {
 
 			socketPath := os.Getenv("KONTEXT_SOCKET")
 			if socketPath == "" {
-				hook.Run(a, func(e *agent.HookEvent) (bool, string, error) {
-					return true, "no sidecar", nil
+				hook.Run(a, func(e *agent.HookEvent) (bool, string, map[string]any, error) {
+					return true, "no sidecar", nil, nil
 				})
 				return nil
 			}
 
-			hook.Run(a, func(e *agent.HookEvent) (bool, string, error) {
-				return evaluateViaSidecar(socketPath, agentName, e)
+			hook.Run(a, func(e *agent.HookEvent) (bool, string, map[string]any, error) {
+				result, err := evaluateViaSidecar(socketPath, hookruntime.EventFromAgent(agentName, e))
+				return result.Allowed(), result.ClaudeReason(), result.UpdatedInput, err
 			})
 			return nil
 		},
@@ -200,61 +202,66 @@ func hookCmd() *cobra.Command {
 	return cmd
 }
 
-func evaluateViaSidecar(socketPath, agentName string, e *agent.HookEvent) (bool, string, error) {
+func evaluateViaSidecar(socketPath string, event hookruntime.Event) (hookruntime.Result, error) {
 	conn, err := net.DialTimeout("unix", socketPath, 5*time.Second)
 	if err != nil {
-		return true, "sidecar unreachable", nil
+		return hookruntime.Result{Decision: hookruntime.DecisionAllow, Reason: "sidecar unreachable"}, nil
 	}
 	defer conn.Close()
 	if err := conn.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
-		return true, "sidecar deadline error", nil
+		return hookruntime.Result{Decision: hookruntime.DecisionAllow, Reason: "sidecar deadline error"}, nil
 	}
 
 	req := sidecar.EvaluateRequest{
 		Type:           "evaluate",
-		Agent:          agentName,
-		HookEvent:      e.HookEventName,
-		ToolName:       e.ToolName,
-		ToolUseID:      e.ToolUseID,
-		CWD:            e.CWD,
-		PermissionMode: e.PermissionMode,
-		DurationMs:     e.DurationMs,
-		Error:          e.Error,
-		IsInterrupt:    e.IsInterrupt,
+		Agent:          event.Agent,
+		HookEvent:      event.HookEventName,
+		ToolName:       event.ToolName,
+		ToolUseID:      event.ToolUseID,
+		CWD:            event.CWD,
+		PermissionMode: event.PermissionMode,
+		DurationMs:     event.DurationMs,
+		Error:          event.Error,
+		IsInterrupt:    event.IsInterrupt,
 	}
 
-	if e.ToolInput != nil {
-		data, err := marshalJSON(e.ToolInput)
+	if event.ToolInput != nil {
+		data, err := hookruntime.MarshalMap(event.ToolInput)
 		if err != nil {
-			return true, "sidecar marshal error", nil
+			return hookruntime.Result{Decision: hookruntime.DecisionAllow, Reason: "sidecar marshal error"}, nil
 		}
 		req.ToolInput = data
 	}
-	if e.ToolResponse != nil {
-		data, err := marshalJSON(e.ToolResponse)
+	if event.ToolResponse != nil {
+		data, err := hookruntime.MarshalMap(event.ToolResponse)
 		if err != nil {
-			return true, "sidecar marshal error", nil
+			return hookruntime.Result{Decision: hookruntime.DecisionAllow, Reason: "sidecar marshal error"}, nil
 		}
 		req.ToolResponse = data
 	}
 
 	if err := sidecar.WriteMessage(conn, req); err != nil {
-		return true, "sidecar write error", nil
+		return hookruntime.Result{Decision: hookruntime.DecisionAllow, Reason: "sidecar write error"}, nil
 	}
 
 	var result sidecar.EvaluateResult
 	if err := sidecar.ReadMessage(conn, &result); err != nil {
-		return true, "sidecar read error", nil
+		return hookruntime.Result{Decision: hookruntime.DecisionAllow, Reason: "sidecar read error"}, nil
 	}
 
-	return result.Allowed, result.Reason, nil
-}
-
-func marshalJSON(v any) ([]byte, error) {
-	if v == nil {
-		return nil, nil
+	decision := hookruntime.Decision(result.Decision)
+	if decision == "" {
+		decision = hookruntime.ResultFromBool(result.Allowed, result.Reason).Decision
 	}
-	return json.Marshal(v)
+	return hookruntime.Result{
+		Decision:     decision,
+		Reason:       result.Reason,
+		ReasonCode:   result.ReasonCode,
+		RequestID:    result.RequestID,
+		Mode:         result.Mode,
+		Epoch:        result.Epoch,
+		UpdatedInput: result.UpdatedInput,
+	}, nil
 }
 
 // isInteractivePrompt reports whether both stdin (where the answer is read)

--- a/cmd/kontext/main.go
+++ b/cmd/kontext/main.go
@@ -183,15 +183,14 @@ func hookCmd() *cobra.Command {
 
 			socketPath := os.Getenv("KONTEXT_SOCKET")
 			if socketPath == "" {
-				hook.Run(a, func(e *agent.HookEvent) (bool, string, map[string]any, error) {
-					return true, "no sidecar", nil, nil
+				hook.Run(a, func(e *agent.HookEvent) (hookruntime.Result, error) {
+					return hookruntime.Result{Decision: hookruntime.DecisionAllow, Reason: "no sidecar"}, nil
 				})
 				return nil
 			}
 
-			hook.Run(a, func(e *agent.HookEvent) (bool, string, map[string]any, error) {
-				result, err := evaluateViaSidecar(socketPath, hookruntime.EventFromAgent(agentName, e))
-				return result.Allowed(), result.ClaudeReason(), result.UpdatedInput, err
+			hook.Run(a, func(e *agent.HookEvent) (hookruntime.Result, error) {
+				return evaluateViaSidecar(socketPath, hookruntime.EventFromAgent(agentName, e))
 			})
 			return nil
 		},
@@ -205,11 +204,11 @@ func hookCmd() *cobra.Command {
 func evaluateViaSidecar(socketPath string, event hookruntime.Event) (hookruntime.Result, error) {
 	conn, err := net.DialTimeout("unix", socketPath, 5*time.Second)
 	if err != nil {
-		return hookruntime.Result{Decision: hookruntime.DecisionAllow, Reason: "sidecar unreachable"}, nil
+		return sidecarFailureResult(event, "sidecar unreachable"), nil
 	}
 	defer conn.Close()
 	if err := conn.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
-		return hookruntime.Result{Decision: hookruntime.DecisionAllow, Reason: "sidecar deadline error"}, nil
+		return sidecarFailureResult(event, "sidecar deadline error"), nil
 	}
 
 	req := sidecar.EvaluateRequest{
@@ -228,25 +227,25 @@ func evaluateViaSidecar(socketPath string, event hookruntime.Event) (hookruntime
 	if event.ToolInput != nil {
 		data, err := hookruntime.MarshalMap(event.ToolInput)
 		if err != nil {
-			return hookruntime.Result{Decision: hookruntime.DecisionAllow, Reason: "sidecar marshal error"}, nil
+			return sidecarFailureResult(event, "sidecar marshal error"), nil
 		}
 		req.ToolInput = data
 	}
 	if event.ToolResponse != nil {
 		data, err := hookruntime.MarshalMap(event.ToolResponse)
 		if err != nil {
-			return hookruntime.Result{Decision: hookruntime.DecisionAllow, Reason: "sidecar marshal error"}, nil
+			return sidecarFailureResult(event, "sidecar marshal error"), nil
 		}
 		req.ToolResponse = data
 	}
 
 	if err := sidecar.WriteMessage(conn, req); err != nil {
-		return hookruntime.Result{Decision: hookruntime.DecisionAllow, Reason: "sidecar write error"}, nil
+		return sidecarFailureResult(event, "sidecar write error"), nil
 	}
 
 	var result sidecar.EvaluateResult
 	if err := sidecar.ReadMessage(conn, &result); err != nil {
-		return hookruntime.Result{Decision: hookruntime.DecisionAllow, Reason: "sidecar read error"}, nil
+		return sidecarFailureResult(event, "sidecar read error"), nil
 	}
 
 	decision := hookruntime.Decision(result.Decision)
@@ -262,6 +261,13 @@ func evaluateViaSidecar(socketPath string, event hookruntime.Event) (hookruntime
 		Epoch:        result.Epoch,
 		UpdatedInput: result.UpdatedInput,
 	}, nil
+}
+
+func sidecarFailureResult(event hookruntime.Event, reason string) hookruntime.Result {
+	if event.HookEventName == "PreToolUse" && os.Getenv("KONTEXT_ACCESS_MODE") == "enforce" {
+		return hookruntime.Result{Decision: hookruntime.DecisionDeny, Reason: reason, Mode: "enforce"}
+	}
+	return hookruntime.Result{Decision: hookruntime.DecisionAllow, Reason: reason}
 }
 
 // isInteractivePrompt reports whether both stdin (where the answer is read)

--- a/cmd/kontext/main_test.go
+++ b/cmd/kontext/main_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/kontext-security/kontext-cli/internal/agent"
+	"github.com/kontext-security/kontext-cli/internal/hookruntime"
 	"github.com/zalando/go-keyring"
 )
 
@@ -109,15 +110,15 @@ func TestEvaluateViaSidecarFailsOpenOnMarshalErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			allowed, reason, err := evaluateViaSidecar(socketPath, "claude", tt.event)
+			result, err := evaluateViaSidecar(socketPath, hookruntime.EventFromAgent("claude", tt.event))
 			if err != nil {
 				t.Fatalf("evaluateViaSidecar() error = %v", err)
 			}
-			if !allowed {
+			if !result.Allowed() {
 				t.Fatal("evaluateViaSidecar() allowed = false, want true")
 			}
-			if reason != "sidecar marshal error" {
-				t.Fatalf("evaluateViaSidecar() reason = %q, want sidecar marshal error", reason)
+			if result.Reason != "sidecar marshal error" {
+				t.Fatalf("evaluateViaSidecar() reason = %q, want sidecar marshal error", result.Reason)
 			}
 		})
 	}

--- a/cmd/kontext/main_test.go
+++ b/cmd/kontext/main_test.go
@@ -123,3 +123,40 @@ func TestEvaluateViaSidecarFailsOpenOnMarshalErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestEvaluateViaSidecarFailsClosedWhenEnforceSidecarUnavailable(t *testing.T) {
+	t.Setenv("KONTEXT_ACCESS_MODE", "enforce")
+
+	socketPath := fmt.Sprintf("/tmp/kontext-missing-%d.sock", time.Now().UnixNano())
+	result, err := evaluateViaSidecar(socketPath, hookruntime.Event{
+		Agent:         "claude",
+		HookEventName: "PreToolUse",
+		ToolName:      "Bash",
+	})
+	if err != nil {
+		t.Fatalf("evaluateViaSidecar() error = %v", err)
+	}
+	if result.Decision != hookruntime.DecisionDeny {
+		t.Fatalf("decision = %q, want DENY", result.Decision)
+	}
+	if result.Mode != "enforce" {
+		t.Fatalf("mode = %q, want enforce", result.Mode)
+	}
+}
+
+func TestEvaluateViaSidecarFailsOpenWhenObserveSidecarUnavailable(t *testing.T) {
+	t.Setenv("KONTEXT_ACCESS_MODE", "no_policy")
+
+	socketPath := fmt.Sprintf("/tmp/kontext-missing-%d.sock", time.Now().UnixNano())
+	result, err := evaluateViaSidecar(socketPath, hookruntime.Event{
+		Agent:         "claude",
+		HookEventName: "PreToolUse",
+		ToolName:      "Bash",
+	})
+	if err != nil {
+		t.Fatalf("evaluateViaSidecar() error = %v", err)
+	}
+	if result.Decision != hookruntime.DecisionAllow {
+		t.Fatalf("decision = %q, want ALLOW", result.Decision)
+	}
+}

--- a/gen/kontext/agent/v1/agent.pb.go
+++ b/gen/kontext/agent/v1/agent.pb.go
@@ -206,12 +206,16 @@ func (x *ProcessHookEventRequest) GetIsInterrupt() bool {
 }
 
 type ProcessHookEventResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Decision      Decision               `protobuf:"varint,1,opt,name=decision,proto3,enum=kontext.agent.v1.Decision" json:"decision,omitempty"`
-	Reason        string                 `protobuf:"bytes,2,opt,name=reason,proto3" json:"reason,omitempty"`
-	EventId       string                 `protobuf:"bytes,3,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Decision       Decision               `protobuf:"varint,1,opt,name=decision,proto3,enum=kontext.agent.v1.Decision" json:"decision,omitempty"`
+	Reason         string                 `protobuf:"bytes,2,opt,name=reason,proto3" json:"reason,omitempty"`
+	EventId        string                 `protobuf:"bytes,3,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
+	ReasonCode     string                 `protobuf:"bytes,4,opt,name=reason_code,json=reasonCode,proto3" json:"reason_code,omitempty"`
+	RequestId      string                 `protobuf:"bytes,5,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+	AccessMode     string                 `protobuf:"bytes,6,opt,name=access_mode,json=accessMode,proto3" json:"access_mode,omitempty"`
+	PolicySetEpoch string                 `protobuf:"bytes,7,opt,name=policy_set_epoch,json=policySetEpoch,proto3" json:"policy_set_epoch,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *ProcessHookEventResponse) Reset() {
@@ -261,6 +265,34 @@ func (x *ProcessHookEventResponse) GetReason() string {
 func (x *ProcessHookEventResponse) GetEventId() string {
 	if x != nil {
 		return x.EventId
+	}
+	return ""
+}
+
+func (x *ProcessHookEventResponse) GetReasonCode() string {
+	if x != nil {
+		return x.ReasonCode
+	}
+	return ""
+}
+
+func (x *ProcessHookEventResponse) GetRequestId() string {
+	if x != nil {
+		return x.RequestId
+	}
+	return ""
+}
+
+func (x *ProcessHookEventResponse) GetAccessMode() string {
+	if x != nil {
+		return x.AccessMode
+	}
+	return ""
+}
+
+func (x *ProcessHookEventResponse) GetPolicySetEpoch() string {
+	if x != nil {
+		return x.PolicySetEpoch
 	}
 	return ""
 }
@@ -457,6 +489,8 @@ type BootstrapCliResponse struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
 	ApplicationId    string                 `protobuf:"bytes,1,opt,name=application_id,json=applicationId,proto3" json:"application_id,omitempty"`
 	ManagedProviders []*ManagedProvider     `protobuf:"bytes,2,rep,name=managed_providers,json=managedProviders,proto3" json:"managed_providers,omitempty"`
+	AccessMode       string                 `protobuf:"bytes,3,opt,name=access_mode,json=accessMode,proto3" json:"access_mode,omitempty"`
+	PolicySetEpoch   string                 `protobuf:"bytes,4,opt,name=policy_set_epoch,json=policySetEpoch,proto3" json:"policy_set_epoch,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
@@ -503,6 +537,20 @@ func (x *BootstrapCliResponse) GetManagedProviders() []*ManagedProvider {
 		return x.ManagedProviders
 	}
 	return nil
+}
+
+func (x *BootstrapCliResponse) GetAccessMode() string {
+	if x != nil {
+		return x.AccessMode
+	}
+	return ""
+}
+
+func (x *BootstrapCliResponse) GetPolicySetEpoch() string {
+	if x != nil {
+		return x.PolicySetEpoch
+	}
+	return ""
 }
 
 type ManagedProvider struct {
@@ -767,11 +815,18 @@ const file_kontext_agent_v1_agent_proto_rawDesc = "" +
 	"\x10_permission_modeB\x0e\n" +
 	"\f_duration_msB\b\n" +
 	"\x06_errorB\x0f\n" +
-	"\r_is_interrupt\"\x85\x01\n" +
+	"\r_is_interrupt\"\x90\x02\n" +
 	"\x18ProcessHookEventResponse\x126\n" +
 	"\bdecision\x18\x01 \x01(\x0e2\x1a.kontext.agent.v1.DecisionR\bdecision\x12\x16\n" +
 	"\x06reason\x18\x02 \x01(\tR\x06reason\x12\x19\n" +
-	"\bevent_id\x18\x03 \x01(\tR\aeventId\"\x8b\x02\n" +
+	"\bevent_id\x18\x03 \x01(\tR\aeventId\x12\x1f\n" +
+	"\vreason_code\x18\x04 \x01(\tR\n" +
+	"reasonCode\x12\x1d\n" +
+	"\n" +
+	"request_id\x18\x05 \x01(\tR\trequestId\x12\x1f\n" +
+	"\vaccess_mode\x18\x06 \x01(\tR\n" +
+	"accessMode\x12(\n" +
+	"\x10policy_set_epoch\x18\a \x01(\tR\x0epolicySetEpoch\"\x8b\x02\n" +
 	"\x14CreateSessionRequest\x12\x17\n" +
 	"\auser_id\x18\x01 \x01(\tR\x06userId\x12\x14\n" +
 	"\x05agent\x18\x02 \x01(\tR\x05agent\x12\x1a\n" +
@@ -789,10 +844,13 @@ const file_kontext_agent_v1_agent_proto_rawDesc = "" +
 	"\x0forganization_id\x18\x03 \x01(\tR\x0eorganizationId\x12\x19\n" +
 	"\bagent_id\x18\x04 \x01(\tR\aagentId\"0\n" +
 	"\x13BootstrapCliRequest\x12\x19\n" +
-	"\bagent_id\x18\x01 \x01(\tR\aagentId\"\x8d\x01\n" +
+	"\bagent_id\x18\x01 \x01(\tR\aagentId\"\xd8\x01\n" +
 	"\x14BootstrapCliResponse\x12%\n" +
 	"\x0eapplication_id\x18\x01 \x01(\tR\rapplicationId\x12N\n" +
-	"\x11managed_providers\x18\x02 \x03(\v2!.kontext.agent.v1.ManagedProviderR\x10managedProviders\"\xae\x01\n" +
+	"\x11managed_providers\x18\x02 \x03(\v2!.kontext.agent.v1.ManagedProviderR\x10managedProviders\x12\x1f\n" +
+	"\vaccess_mode\x18\x03 \x01(\tR\n" +
+	"accessMode\x12(\n" +
+	"\x10policy_set_epoch\x18\x04 \x01(\tR\x0epolicySetEpoch\"\xae\x01\n" +
 	"\x0fManagedProvider\x12\x1d\n" +
 	"\n" +
 	"preset_key\x18\x01 \x01(\tR\tpresetKey\x12\x16\n" +

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -5,7 +5,7 @@ type Agent interface {
 
 	DecodeHookInput(input []byte) (*HookEvent, error)
 
-	EncodeAllow(event *HookEvent, reason string) ([]byte, error)
+	EncodeAllow(event *HookEvent, reason string, updatedInput map[string]any) ([]byte, error)
 
 	EncodeDeny(event *HookEvent, reason string) ([]byte, error)
 }

--- a/internal/agent/claude/claude.go
+++ b/internal/agent/claude/claude.go
@@ -1,11 +1,8 @@
 package claude
 
 import (
-	"encoding/json"
-	"fmt"
-	"strings"
-
 	"github.com/kontext-security/kontext-cli/internal/agent"
+	"github.com/kontext-security/kontext-cli/internal/hookruntime"
 )
 
 func init() {
@@ -16,83 +13,37 @@ type Claude struct{}
 
 func (c *Claude) Name() string { return "claude" }
 
-type hookInput struct {
-	SessionID      string         `json:"session_id"`
-	HookEventName  string         `json:"hook_event_name"`
-	ToolName       string         `json:"tool_name"`
-	ToolInput      map[string]any `json:"tool_input"`
-	ToolResponse   map[string]any `json:"tool_response"`
-	ToolUseID      string         `json:"tool_use_id"`
-	CWD            string         `json:"cwd"`
-	PermissionMode *string        `json:"permission_mode"`
-	DurationMs     *int64         `json:"duration_ms"`
-	Error          *string        `json:"error"`
-	IsInterrupt    *bool          `json:"is_interrupt"`
-}
-
 func (c *Claude) DecodeHookInput(input []byte) (*agent.HookEvent, error) {
-	var h hookInput
-	if err := json.Unmarshal(input, &h); err != nil {
-		return nil, fmt.Errorf("claude: decode hook input: %w", err)
+	event, err := hookruntime.DecodeClaudeEvent(input, c.Name())
+	if err != nil {
+		return nil, err
 	}
 	return &agent.HookEvent{
-		SessionID:      h.SessionID,
-		HookEventName:  h.HookEventName,
-		ToolName:       h.ToolName,
-		ToolInput:      h.ToolInput,
-		ToolResponse:   h.ToolResponse,
-		ToolUseID:      h.ToolUseID,
-		CWD:            h.CWD,
-		PermissionMode: stringValue(h.PermissionMode),
-		DurationMs:     h.DurationMs,
-		Error:          stringValue(h.Error),
-		IsInterrupt:    h.IsInterrupt,
+		SessionID:      event.SessionID,
+		HookEventName:  event.HookEventName,
+		ToolName:       event.ToolName,
+		ToolInput:      event.ToolInput,
+		ToolResponse:   event.ToolResponse,
+		ToolUseID:      event.ToolUseID,
+		CWD:            event.CWD,
+		PermissionMode: event.PermissionMode,
+		DurationMs:     event.DurationMs,
+		Error:          event.Error,
+		IsInterrupt:    event.IsInterrupt,
 	}, nil
 }
 
-func stringValue(value *string) string {
-	if value == nil {
-		return ""
-	}
-	return *value
-}
-
-type hookOutput struct {
-	HookSpecificOutput *hookSpecificOutput `json:"hookSpecificOutput,omitempty"`
-}
-
-type hookSpecificOutput struct {
-	HookEventName            string `json:"hookEventName"`
-	PermissionDecision       string `json:"permissionDecision,omitempty"`
-	PermissionDecisionReason string `json:"permissionDecisionReason,omitempty"`
-	AdditionalContext        string `json:"additionalContext,omitempty"`
-}
-
-func (c *Claude) EncodeAllow(event *agent.HookEvent, reason string) ([]byte, error) {
-	out := hookOutput{
-		HookSpecificOutput: &hookSpecificOutput{
-			HookEventName:            event.HookEventName,
-			PermissionDecision:       "allow",
-			PermissionDecisionReason: allowReason(reason),
-		},
-	}
-	return json.Marshal(out)
+func (c *Claude) EncodeAllow(event *agent.HookEvent, reason string, updatedInput map[string]any) ([]byte, error) {
+	return hookruntime.EncodeClaudeResult(event.HookEventName, hookruntime.Result{
+		Decision:     hookruntime.DecisionAllow,
+		Reason:       reason,
+		UpdatedInput: updatedInput,
+	})
 }
 
 func (c *Claude) EncodeDeny(event *agent.HookEvent, reason string) ([]byte, error) {
-	out := hookOutput{
-		HookSpecificOutput: &hookSpecificOutput{
-			HookEventName:            event.HookEventName,
-			PermissionDecision:       "deny",
-			PermissionDecisionReason: reason,
-		},
-	}
-	return json.Marshal(out)
-}
-
-func allowReason(reason string) string {
-	if strings.EqualFold(strings.TrimSpace(reason), "allowed") {
-		return ""
-	}
-	return reason
+	return hookruntime.EncodeClaudeResult(event.HookEventName, hookruntime.Result{
+		Decision: hookruntime.DecisionDeny,
+		Reason:   reason,
+	})
 }

--- a/internal/agent/claude/claude_test.go
+++ b/internal/agent/claude/claude_test.go
@@ -116,7 +116,7 @@ func TestDecodeHookInputPreservesExplicitZeroDuration(t *testing.T) {
 func TestEncodeAllowOmitsPlaceholderReason(t *testing.T) {
 	t.Parallel()
 
-	out, err := (&Claude{}).EncodeAllow(&agent.HookEvent{HookEventName: "PreToolUse"}, "allowed")
+	out, err := (&Claude{}).EncodeAllow(&agent.HookEvent{HookEventName: "PreToolUse"}, "allowed", nil)
 	if err != nil {
 		t.Fatalf("EncodeAllow() error = %v", err)
 	}
@@ -128,12 +128,31 @@ func TestEncodeAllowOmitsPlaceholderReason(t *testing.T) {
 func TestEncodeAllowKeepsMeaningfulReason(t *testing.T) {
 	t.Parallel()
 
-	out, err := (&Claude{}).EncodeAllow(&agent.HookEvent{HookEventName: "PreToolUse"}, "Allowed by read-only policy")
+	out, err := (&Claude{}).EncodeAllow(&agent.HookEvent{HookEventName: "PreToolUse"}, "Allowed by read-only policy", nil)
 	if err != nil {
 		t.Fatalf("EncodeAllow() error = %v", err)
 	}
 	if !strings.Contains(string(out), "Allowed by read-only policy") {
 		t.Fatalf("EncodeAllow() = %s, want meaningful reason", out)
+	}
+}
+
+func TestEncodeAllowIncludesUpdatedInput(t *testing.T) {
+	t.Parallel()
+
+	out, err := (&Claude{}).EncodeAllow(
+		&agent.HookEvent{HookEventName: "PreToolUse"},
+		"allowed",
+		map[string]any{"command": `GITHUB_TOKEN="$(cat '/tmp/token')" gh pr view`},
+	)
+	if err != nil {
+		t.Fatalf("EncodeAllow() error = %v", err)
+	}
+	if !strings.Contains(string(out), "updatedInput") {
+		t.Fatalf("EncodeAllow() = %s, want updatedInput", out)
+	}
+	if !strings.Contains(string(out), "suppressOutput") {
+		t.Fatalf("EncodeAllow() = %s, want suppressOutput", out)
 	}
 }
 

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -26,6 +26,28 @@ type Client struct {
 	rpc agentv1connect.AgentServiceClient
 }
 
+type HostedAccessMode string
+
+const (
+	HostedAccessModeDisabled HostedAccessMode = "disabled"
+	HostedAccessModeNoPolicy HostedAccessMode = "no_policy"
+	HostedAccessModeEnforce  HostedAccessMode = "enforce"
+)
+
+type BootstrapCliResult struct {
+	Response       *agentv1.BootstrapCliResponse
+	AccessMode     HostedAccessMode
+	PolicySetEpoch string
+}
+
+type ProcessHookEventResult struct {
+	Response       *agentv1.ProcessHookEventResponse
+	ReasonCode     string
+	RequestID      string
+	AccessMode     HostedAccessMode
+	PolicySetEpoch string
+}
+
 // NewClient creates a ConnectRPC client that fetches a fresh token per request.
 func NewClient(baseURL string, ts TokenSource) *Client {
 	httpClient := &http.Client{
@@ -62,12 +84,28 @@ func (c *Client) CreateSession(ctx context.Context, req *agentv1.CreateSessionRe
 }
 
 // BootstrapCli prepares the shared CLI application for env template sync.
-func (c *Client) BootstrapCli(ctx context.Context, req *agentv1.BootstrapCliRequest) (*agentv1.BootstrapCliResponse, error) {
+func (c *Client) BootstrapCli(ctx context.Context, req *agentv1.BootstrapCliRequest) (*BootstrapCliResult, error) {
 	resp, err := c.rpc.BootstrapCli(ctx, connect.NewRequest(req))
 	if err != nil {
 		return nil, fmt.Errorf("BootstrapCli: %w", err)
 	}
-	return resp.Msg, nil
+	mode := HostedAccessMode(resp.Msg.GetAccessMode())
+	if mode == "" {
+		mode = HostedAccessMode(resp.Header().Get("x-kontext-access-mode"))
+	}
+	if mode == "" {
+		return nil, fmt.Errorf("BootstrapCli: missing hosted access mode")
+	}
+	switch mode {
+	case HostedAccessModeDisabled, HostedAccessModeNoPolicy, HostedAccessModeEnforce:
+	default:
+		return nil, fmt.Errorf("BootstrapCli: unknown hosted access mode %q", mode)
+	}
+	return &BootstrapCliResult{
+		Response:       resp.Msg,
+		AccessMode:     mode,
+		PolicySetEpoch: firstNonEmpty(resp.Msg.GetPolicySetEpoch(), resp.Header().Get("x-kontext-policy-set-epoch")),
+	}, nil
 }
 
 // Heartbeat keeps a session alive.
@@ -86,13 +124,49 @@ func (c *Client) EndSession(ctx context.Context, sessionID string) error {
 	return err
 }
 
-// IngestEvent sends a single hook event via the ProcessHookEvent unary RPC.
-func (c *Client) IngestEvent(ctx context.Context, req *agentv1.ProcessHookEventRequest) error {
-	_, err := c.rpc.ProcessHookEvent(ctx, connect.NewRequest(req))
+// ProcessHookEvent sends a single hook event via the ProcessHookEvent unary RPC.
+func (c *Client) ProcessHookEvent(ctx context.Context, req *agentv1.ProcessHookEventRequest) (*ProcessHookEventResult, error) {
+	resp, err := c.rpc.ProcessHookEvent(ctx, connect.NewRequest(req))
 	if err != nil {
-		return fmt.Errorf("ProcessHookEvent: %w", err)
+		return nil, fmt.Errorf("ProcessHookEvent: %w", err)
 	}
-	return nil
+	mode := HostedAccessMode(resp.Header().Get("x-kontext-access-mode"))
+	if mode == "" {
+		mode = HostedAccessMode(resp.Msg.GetAccessMode())
+	}
+	switch mode {
+	case "", HostedAccessModeDisabled, HostedAccessModeNoPolicy, HostedAccessModeEnforce:
+	default:
+		return nil, fmt.Errorf("ProcessHookEvent: unknown hosted access mode %q", mode)
+	}
+	reasonCode := resp.Msg.GetReasonCode()
+	if reasonCode == "" {
+		reasonCode = resp.Header().Get("x-kontext-access-reason-code")
+	}
+	requestID := resp.Msg.GetRequestId()
+	if requestID == "" {
+		requestID = resp.Header().Get("x-kontext-access-request-id")
+	}
+	policySetEpoch := resp.Msg.GetPolicySetEpoch()
+	if policySetEpoch == "" {
+		policySetEpoch = resp.Header().Get("x-kontext-policy-set-epoch")
+	}
+	return &ProcessHookEventResult{
+		Response:       resp.Msg,
+		ReasonCode:     reasonCode,
+		RequestID:      requestID,
+		AccessMode:     mode,
+		PolicySetEpoch: policySetEpoch,
+	}, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 // bearerTransport fetches a fresh token for every outgoing request.

--- a/internal/guard/hookruntime/claude.go
+++ b/internal/guard/hookruntime/claude.go
@@ -1,43 +1,36 @@
 package hookruntime
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"time"
 
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
+	sharedhook "github.com/kontext-security/kontext-cli/internal/hookruntime"
 )
 
 type ClaudeAdapter struct{}
 
 func (ClaudeAdapter) Decode(r io.Reader) (Event, error) {
-	var raw map[string]any
-	if err := json.NewDecoder(r).Decode(&raw); err != nil {
+	input, err := io.ReadAll(r)
+	if err != nil {
+		return Event{}, err
+	}
+	sharedEvent, err := sharedhook.DecodeClaudeEvent(input, "claude-code")
+	if err != nil {
 		return Event{}, err
 	}
 	event := risk.HookEvent{
-		SessionID:     stringValue(raw, "session_id", "sessionId"),
-		Agent:         "claude-code",
-		HookEventName: stringValue(raw, "hook_event_name", "hookEventName"),
-		ToolName:      stringValue(raw, "tool_name", "toolName"),
-		ToolUseID:     stringValue(raw, "tool_use_id", "toolUseID", "toolUseId"),
-		CWD:           stringValue(raw, "cwd"),
+		SessionID:     sharedEvent.SessionID,
+		Agent:         sharedEvent.Agent,
+		HookEventName: sharedEvent.HookEventName,
+		ToolName:      sharedEvent.ToolName,
+		ToolInput:     sharedEvent.ToolInput,
+		ToolResponse:  sharedEvent.ToolResponse,
+		ToolUseID:     sharedEvent.ToolUseID,
+		CWD:           sharedEvent.CWD,
 		Timestamp:     time.Now().UTC(),
-	}
-	if event.HookEventName == "" {
-		event.HookEventName = stringValue(raw, "hook_event")
-	}
-	if input, ok := raw["tool_input"].(map[string]any); ok {
-		event.ToolInput = input
-	} else if input, ok := raw["toolInput"].(map[string]any); ok {
-		event.ToolInput = input
-	}
-	if response, ok := raw["tool_response"].(map[string]any); ok {
-		event.ToolResponse = response
-	} else if response, ok := raw["toolResponse"].(map[string]any); ok {
-		event.ToolResponse = response
 	}
 	if event.HookEventName == "" {
 		return Event{}, errors.New("hook event name missing")
@@ -53,18 +46,24 @@ func (ClaudeAdapter) Decode(r io.Reader) (Event, error) {
 }
 
 func (ClaudeAdapter) Encode(out io.Writer, result Result) error {
-	permissionDecision := "allow"
-	if result.Mode == ModeEnforce && result.CanBlock && (result.Decision == risk.DecisionAsk || result.Decision == risk.DecisionDeny) {
-		permissionDecision = "deny"
+	decision := sharedhook.DecisionAllow
+	if result.Mode == ModeEnforce && result.CanBlock {
+		switch result.Decision {
+		case risk.DecisionAsk:
+			decision = sharedhook.DecisionAsk
+		case risk.DecisionDeny:
+			decision = sharedhook.DecisionDeny
+		}
 	}
-	payload := map[string]any{
-		"hookSpecificOutput": map[string]any{
-			"hookEventName":            result.HookName,
-			"permissionDecision":       permissionDecision,
-			"permissionDecisionReason": formatReason(result.Decision, result.Reason, result.Mode),
-		},
+	payload, err := sharedhook.EncodeClaudeResult(result.HookName, sharedhook.Result{
+		Decision: decision,
+		Reason:   formatReason(result.Decision, result.Reason, result.Mode),
+	})
+	if err != nil {
+		return err
 	}
-	return json.NewEncoder(out).Encode(payload)
+	_, err = out.Write(append(payload, '\n'))
+	return err
 }
 
 func (ClaudeAdapter) MalformedHookName() string {
@@ -79,15 +78,6 @@ func formatReason(decision risk.Decision, reason string, mode Mode) string {
 		return fmt.Sprintf("Kontext observe mode: would %s; %s", decision, reason)
 	}
 	return reason
-}
-
-func stringValue(raw map[string]any, keys ...string) string {
-	for _, key := range keys {
-		if value, ok := raw[key].(string); ok {
-			return value
-		}
-	}
-	return ""
 }
 
 var _ Adapter = ClaudeAdapter{}

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -8,11 +8,11 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/agent"
 )
 
-func Run(a agent.Agent, evaluate func(*agent.HookEvent) (bool, string, error)) {
+func Run(a agent.Agent, evaluate func(*agent.HookEvent) (bool, string, map[string]any, error)) {
 	os.Exit(run(os.Stdin, os.Stdout, os.Stderr, a, evaluate))
 }
 
-func run(stdin io.Reader, stdout, stderr io.Writer, a agent.Agent, evaluate func(*agent.HookEvent) (bool, string, error)) int {
+func run(stdin io.Reader, stdout, stderr io.Writer, a agent.Agent, evaluate func(*agent.HookEvent) (bool, string, map[string]any, error)) int {
 	input, err := io.ReadAll(stdin)
 	if err != nil {
 		fmt.Fprintf(stderr, "kontext: failed to read stdin: %v\n", err)
@@ -25,7 +25,7 @@ func run(stdin io.Reader, stdout, stderr io.Writer, a agent.Agent, evaluate func
 		return 2
 	}
 
-	allowed, reason, err := evaluate(event)
+	allowed, reason, updatedInput, err := evaluate(event)
 	if err != nil {
 		fmt.Fprintf(stderr, "kontext: evaluation error: %v\n", err)
 		return 2
@@ -48,7 +48,7 @@ func run(stdin io.Reader, stdout, stderr io.Writer, a agent.Agent, evaluate func
 		return 2
 	}
 
-	out, err := a.EncodeAllow(event, reason)
+	out, err := a.EncodeAllow(event, reason, updatedInput)
 	if err != nil {
 		fmt.Fprintf(stderr, "kontext: failed to encode allow output: %v\n", err)
 		return 2

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -1,61 +1,58 @@
 package hook
 
 import (
-	"fmt"
 	"io"
 	"os"
 
 	"github.com/kontext-security/kontext-cli/internal/agent"
+	"github.com/kontext-security/kontext-cli/internal/hookruntime"
 )
 
-func Run(a agent.Agent, evaluate func(*agent.HookEvent) (bool, string, map[string]any, error)) {
+func Run(a agent.Agent, evaluate func(*agent.HookEvent) (hookruntime.Result, error)) {
 	os.Exit(run(os.Stdin, os.Stdout, os.Stderr, a, evaluate))
 }
 
-func run(stdin io.Reader, stdout, stderr io.Writer, a agent.Agent, evaluate func(*agent.HookEvent) (bool, string, map[string]any, error)) int {
-	input, err := io.ReadAll(stdin)
-	if err != nil {
-		fmt.Fprintf(stderr, "kontext: failed to read stdin: %v\n", err)
-		return 2
-	}
+func run(stdin io.Reader, stdout, stderr io.Writer, a agent.Agent, evaluate func(*agent.HookEvent) (hookruntime.Result, error)) int {
+	codec := agentCodec{agentName: a.Name(), agent: a}
+	sink := hookruntime.SinkFunc(func(event hookruntime.Event) (hookruntime.Result, error) {
+		return evaluate(agentEventFromRuntime(event))
+	})
+	return hookruntime.Run(stdin, stdout, stderr, codec, sink)
+}
 
-	event, err := a.DecodeHookInput(input)
-	if err != nil {
-		fmt.Fprintf(stderr, "kontext: failed to decode hook input: %v\n", err)
-		return 2
-	}
+type agentCodec struct {
+	agentName string
+	agent     agent.Agent
+}
 
-	allowed, reason, updatedInput, err := evaluate(event)
+func (c agentCodec) DecodeHookEvent(input []byte) (hookruntime.Event, error) {
+	event, err := c.agent.DecodeHookInput(input)
 	if err != nil {
-		fmt.Fprintf(stderr, "kontext: evaluation error: %v\n", err)
-		return 2
+		return hookruntime.Event{}, err
 	}
+	return hookruntime.EventFromAgent(c.agentName, event), nil
+}
 
-	if !allowed {
-		out, err := a.EncodeDeny(event, reason)
-		if err != nil {
-			fmt.Fprintf(stderr, "kontext: failed to encode deny output: %v\n", err)
-			return 2
-		}
-		if _, err := fmt.Fprintf(stderr, "Blocked by Kontext: %s\n", reason); err != nil {
-			fmt.Fprintf(stderr, "kontext: failed to write deny message: %v\n", err)
-			return 2
-		}
-		if _, err := stdout.Write(out); err != nil {
-			fmt.Fprintf(stderr, "kontext: failed to write hook output: %v\n", err)
-			return 2
-		}
-		return 2
+func (c agentCodec) EncodeHookResult(event hookruntime.Event, result hookruntime.Result) ([]byte, error) {
+	agentEvent := agentEventFromRuntime(event)
+	if result.Allowed() {
+		return c.agent.EncodeAllow(agentEvent, result.ClaudeReason(), result.UpdatedInput)
 	}
+	return c.agent.EncodeDeny(agentEvent, result.ClaudeReason())
+}
 
-	out, err := a.EncodeAllow(event, reason, updatedInput)
-	if err != nil {
-		fmt.Fprintf(stderr, "kontext: failed to encode allow output: %v\n", err)
-		return 2
+func agentEventFromRuntime(event hookruntime.Event) *agent.HookEvent {
+	return &agent.HookEvent{
+		SessionID:      event.SessionID,
+		HookEventName:  event.HookEventName,
+		ToolName:       event.ToolName,
+		ToolInput:      event.ToolInput,
+		ToolResponse:   event.ToolResponse,
+		ToolUseID:      event.ToolUseID,
+		CWD:            event.CWD,
+		PermissionMode: event.PermissionMode,
+		DurationMs:     event.DurationMs,
+		Error:          event.Error,
+		IsInterrupt:    event.IsInterrupt,
 	}
-	if _, err := stdout.Write(out); err != nil {
-		fmt.Fprintf(stderr, "kontext: failed to write hook output: %v\n", err)
-		return 2
-	}
-	return 0
 }

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/kontext-security/kontext-cli/internal/agent"
+	"github.com/kontext-security/kontext-cli/internal/hookruntime"
 )
 
 type stubAgent struct {
@@ -15,6 +16,7 @@ type stubAgent struct {
 	allowErr          error
 	denyErr           error
 	allowUpdatedInput map[string]any
+	denyReason        string
 }
 
 func (s *stubAgent) Name() string { return "stub" }
@@ -38,6 +40,7 @@ func (s *stubAgent) EncodeDeny(event *agent.HookEvent, reason string) ([]byte, e
 	if s.denyErr != nil {
 		return nil, s.denyErr
 	}
+	s.denyReason = reason
 	return []byte("DENY"), nil
 }
 
@@ -49,11 +52,11 @@ func TestRunAllowsAndWritesOutput(t *testing.T) {
 
 	stub := &stubAgent{}
 	updatedInput := map[string]any{"command": "echo ok"}
-	code := run(strings.NewReader(`{"hook_event_name":"PreToolUse"}`), stdout, stderr, stub, func(event *agent.HookEvent) (bool, string, map[string]any, error) {
+	code := run(strings.NewReader(`{"hook_event_name":"PreToolUse"}`), stdout, stderr, stub, func(event *agent.HookEvent) (hookruntime.Result, error) {
 		if event.HookEventName != "PreToolUse" {
 			t.Fatalf("event.HookEventName = %q, want %q", event.HookEventName, "PreToolUse")
 		}
-		return true, "ok", updatedInput, nil
+		return hookruntime.Result{Decision: hookruntime.DecisionAllow, Reason: "ok", UpdatedInput: updatedInput}, nil
 	})
 
 	if code != 0 {
@@ -70,20 +73,46 @@ func TestRunAllowsAndWritesOutput(t *testing.T) {
 	}
 }
 
+func TestRunPreservesAskReason(t *testing.T) {
+	t.Parallel()
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	stub := &stubAgent{}
+
+	code := run(strings.NewReader(`{"hook_event_name":"PreToolUse"}`), stdout, stderr, stub, func(*agent.HookEvent) (hookruntime.Result, error) {
+		return hookruntime.Result{
+			Decision:  hookruntime.DecisionAsk,
+			Reason:    "approval required",
+			RequestID: "req-123",
+		}, nil
+	})
+
+	if code != 2 {
+		t.Fatalf("run() exit code = %d, want 2", code)
+	}
+	if got := stdout.String(); got != "DENY" {
+		t.Fatalf("stdout = %q, want DENY", got)
+	}
+	if !strings.Contains(stub.denyReason, "Request ID: req-123") {
+		t.Fatalf("deny reason = %q, want request id", stub.denyReason)
+	}
+}
+
 func TestRunReturnsErrorWhenAllowEncodingFails(t *testing.T) {
 	t.Parallel()
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 
-	code := run(strings.NewReader(`{"hook_event_name":"PreToolUse"}`), stdout, stderr, &stubAgent{allowErr: errors.New("encode failed")}, func(*agent.HookEvent) (bool, string, map[string]any, error) {
-		return true, "ok", nil, nil
+	code := run(strings.NewReader(`{"hook_event_name":"PreToolUse"}`), stdout, stderr, &stubAgent{allowErr: errors.New("encode failed")}, func(*agent.HookEvent) (hookruntime.Result, error) {
+		return hookruntime.Result{Decision: hookruntime.DecisionAllow, Reason: "ok"}, nil
 	})
 
 	if code != 2 {
 		t.Fatalf("run() exit code = %d, want 2", code)
 	}
-	if !strings.Contains(stderr.String(), "failed to encode allow output") {
+	if !strings.Contains(stderr.String(), "failed to encode hook output") {
 		t.Fatalf("stderr = %q, want encode failure", stderr.String())
 	}
 	if got := stdout.String(); got != "" {
@@ -96,8 +125,8 @@ func TestRunReturnsErrorWhenWriteFails(t *testing.T) {
 
 	stderr := &bytes.Buffer{}
 
-	code := run(strings.NewReader(`{"hook_event_name":"PreToolUse"}`), errWriter{}, stderr, &stubAgent{}, func(*agent.HookEvent) (bool, string, map[string]any, error) {
-		return true, "ok", nil, nil
+	code := run(strings.NewReader(`{"hook_event_name":"PreToolUse"}`), errWriter{}, stderr, &stubAgent{}, func(*agent.HookEvent) (hookruntime.Result, error) {
+		return hookruntime.Result{Decision: hookruntime.DecisionAllow, Reason: "ok"}, nil
 	})
 
 	if code != 2 {
@@ -114,14 +143,14 @@ func TestRunReturnsErrorWhenDenyEncodingFails(t *testing.T) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 
-	code := run(strings.NewReader(`{"hook_event_name":"PreToolUse"}`), stdout, stderr, &stubAgent{denyErr: errors.New("encode failed")}, func(*agent.HookEvent) (bool, string, map[string]any, error) {
-		return false, "blocked", nil, nil
+	code := run(strings.NewReader(`{"hook_event_name":"PreToolUse"}`), stdout, stderr, &stubAgent{denyErr: errors.New("encode failed")}, func(*agent.HookEvent) (hookruntime.Result, error) {
+		return hookruntime.Result{Decision: hookruntime.DecisionDeny, Reason: "blocked"}, nil
 	})
 
 	if code != 2 {
 		t.Fatalf("run() exit code = %d, want 2", code)
 	}
-	if !strings.Contains(stderr.String(), "failed to encode deny output") {
+	if !strings.Contains(stderr.String(), "failed to encode hook output") {
 		t.Fatalf("stderr = %q, want encode failure", stderr.String())
 	}
 }

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -11,9 +11,10 @@ import (
 )
 
 type stubAgent struct {
-	decodeErr error
-	allowErr  error
-	denyErr   error
+	decodeErr         error
+	allowErr          error
+	denyErr           error
+	allowUpdatedInput map[string]any
 }
 
 func (s *stubAgent) Name() string { return "stub" }
@@ -25,10 +26,11 @@ func (s *stubAgent) DecodeHookInput(input []byte) (*agent.HookEvent, error) {
 	return &agent.HookEvent{HookEventName: "PreToolUse"}, nil
 }
 
-func (s *stubAgent) EncodeAllow(event *agent.HookEvent, reason string) ([]byte, error) {
+func (s *stubAgent) EncodeAllow(event *agent.HookEvent, reason string, updatedInput map[string]any) ([]byte, error) {
 	if s.allowErr != nil {
 		return nil, s.allowErr
 	}
+	s.allowUpdatedInput = updatedInput
 	return []byte("ALLOW"), nil
 }
 
@@ -45,11 +47,13 @@ func TestRunAllowsAndWritesOutput(t *testing.T) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 
-	code := run(strings.NewReader(`{"hook_event_name":"PreToolUse"}`), stdout, stderr, &stubAgent{}, func(event *agent.HookEvent) (bool, string, error) {
+	stub := &stubAgent{}
+	updatedInput := map[string]any{"command": "echo ok"}
+	code := run(strings.NewReader(`{"hook_event_name":"PreToolUse"}`), stdout, stderr, stub, func(event *agent.HookEvent) (bool, string, map[string]any, error) {
 		if event.HookEventName != "PreToolUse" {
 			t.Fatalf("event.HookEventName = %q, want %q", event.HookEventName, "PreToolUse")
 		}
-		return true, "ok", nil
+		return true, "ok", updatedInput, nil
 	})
 
 	if code != 0 {
@@ -61,6 +65,9 @@ func TestRunAllowsAndWritesOutput(t *testing.T) {
 	if got := stderr.String(); got != "" {
 		t.Fatalf("stderr = %q, want empty", got)
 	}
+	if stub.allowUpdatedInput["command"] != "echo ok" {
+		t.Fatalf("updated input = %#v, want command", stub.allowUpdatedInput)
+	}
 }
 
 func TestRunReturnsErrorWhenAllowEncodingFails(t *testing.T) {
@@ -69,8 +76,8 @@ func TestRunReturnsErrorWhenAllowEncodingFails(t *testing.T) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 
-	code := run(strings.NewReader(`{"hook_event_name":"PreToolUse"}`), stdout, stderr, &stubAgent{allowErr: errors.New("encode failed")}, func(*agent.HookEvent) (bool, string, error) {
-		return true, "ok", nil
+	code := run(strings.NewReader(`{"hook_event_name":"PreToolUse"}`), stdout, stderr, &stubAgent{allowErr: errors.New("encode failed")}, func(*agent.HookEvent) (bool, string, map[string]any, error) {
+		return true, "ok", nil, nil
 	})
 
 	if code != 2 {
@@ -89,8 +96,8 @@ func TestRunReturnsErrorWhenWriteFails(t *testing.T) {
 
 	stderr := &bytes.Buffer{}
 
-	code := run(strings.NewReader(`{"hook_event_name":"PreToolUse"}`), errWriter{}, stderr, &stubAgent{}, func(*agent.HookEvent) (bool, string, error) {
-		return true, "ok", nil
+	code := run(strings.NewReader(`{"hook_event_name":"PreToolUse"}`), errWriter{}, stderr, &stubAgent{}, func(*agent.HookEvent) (bool, string, map[string]any, error) {
+		return true, "ok", nil, nil
 	})
 
 	if code != 2 {
@@ -107,8 +114,8 @@ func TestRunReturnsErrorWhenDenyEncodingFails(t *testing.T) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 
-	code := run(strings.NewReader(`{"hook_event_name":"PreToolUse"}`), stdout, stderr, &stubAgent{denyErr: errors.New("encode failed")}, func(*agent.HookEvent) (bool, string, error) {
-		return false, "blocked", nil
+	code := run(strings.NewReader(`{"hook_event_name":"PreToolUse"}`), stdout, stderr, &stubAgent{denyErr: errors.New("encode failed")}, func(*agent.HookEvent) (bool, string, map[string]any, error) {
+		return false, "blocked", nil, nil
 	})
 
 	if code != 2 {

--- a/internal/hookruntime/claude.go
+++ b/internal/hookruntime/claude.go
@@ -1,0 +1,83 @@
+package hookruntime
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type ClaudeHookInput struct {
+	SessionID      string         `json:"session_id"`
+	HookEventName  string         `json:"hook_event_name"`
+	ToolName       string         `json:"tool_name"`
+	ToolInput      map[string]any `json:"tool_input"`
+	ToolResponse   map[string]any `json:"tool_response"`
+	ToolUseID      string         `json:"tool_use_id"`
+	CWD            string         `json:"cwd"`
+	PermissionMode *string        `json:"permission_mode"`
+	DurationMs     *int64         `json:"duration_ms"`
+	Error          *string        `json:"error"`
+	IsInterrupt    *bool          `json:"is_interrupt"`
+}
+
+type claudeHookOutput struct {
+	HookSpecificOutput *claudeHookSpecificOutput `json:"hookSpecificOutput,omitempty"`
+	SuppressOutput     bool                      `json:"suppressOutput,omitempty"`
+}
+
+type claudeHookSpecificOutput struct {
+	HookEventName            string         `json:"hookEventName"`
+	PermissionDecision       string         `json:"permissionDecision,omitempty"`
+	PermissionDecisionReason string         `json:"permissionDecisionReason,omitempty"`
+	AdditionalContext        string         `json:"additionalContext,omitempty"`
+	UpdatedInput             map[string]any `json:"updatedInput,omitempty"`
+}
+
+func DecodeClaudeEvent(input []byte, agentName string) (Event, error) {
+	var h ClaudeHookInput
+	if err := json.Unmarshal(input, &h); err != nil {
+		return Event{}, fmt.Errorf("claude: decode hook input: %w", err)
+	}
+	return Event{
+		SessionID:      h.SessionID,
+		Agent:          agentName,
+		HookEventName:  h.HookEventName,
+		ToolName:       h.ToolName,
+		ToolInput:      h.ToolInput,
+		ToolResponse:   h.ToolResponse,
+		ToolUseID:      h.ToolUseID,
+		CWD:            h.CWD,
+		PermissionMode: stringPtrValue(h.PermissionMode),
+		DurationMs:     h.DurationMs,
+		Error:          stringPtrValue(h.Error),
+		IsInterrupt:    h.IsInterrupt,
+	}, nil
+}
+
+func EncodeClaudeResult(hookEventName string, result Result) ([]byte, error) {
+	permissionDecision := "allow"
+	if result.Decision == DecisionAsk || result.Decision == DecisionDeny {
+		permissionDecision = "deny"
+	}
+	reason := result.ClaudeReason()
+	if permissionDecision == "allow" && strings.EqualFold(strings.TrimSpace(reason), "allowed") {
+		reason = ""
+	}
+	out := claudeHookOutput{
+		HookSpecificOutput: &claudeHookSpecificOutput{
+			HookEventName:            hookEventName,
+			PermissionDecision:       permissionDecision,
+			PermissionDecisionReason: reason,
+			UpdatedInput:             result.UpdatedInput,
+		},
+		SuppressOutput: result.UpdatedInput != nil,
+	}
+	return json.Marshal(out)
+}
+
+func stringPtrValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}

--- a/internal/hookruntime/runner.go
+++ b/internal/hookruntime/runner.go
@@ -1,0 +1,55 @@
+package hookruntime
+
+import (
+	"fmt"
+	"io"
+)
+
+type Codec interface {
+	DecodeHookEvent([]byte) (Event, error)
+	EncodeHookResult(Event, Result) ([]byte, error)
+}
+
+type Sink interface {
+	ProcessHookEvent(Event) (Result, error)
+}
+
+type SinkFunc func(Event) (Result, error)
+
+func (f SinkFunc) ProcessHookEvent(event Event) (Result, error) {
+	return f(event)
+}
+
+func Run(stdin io.Reader, stdout, stderr io.Writer, codec Codec, sink Sink) int {
+	input, err := io.ReadAll(stdin)
+	if err != nil {
+		fmt.Fprintf(stderr, "kontext: failed to read stdin: %v\n", err)
+		return 2
+	}
+
+	event, err := codec.DecodeHookEvent(input)
+	if err != nil {
+		fmt.Fprintf(stderr, "kontext: failed to decode hook input: %v\n", err)
+		return 2
+	}
+
+	result, err := sink.ProcessHookEvent(event)
+	if err != nil {
+		fmt.Fprintf(stderr, "kontext: evaluation error: %v\n", err)
+		return 2
+	}
+
+	out, err := codec.EncodeHookResult(event, result)
+	if err != nil {
+		fmt.Fprintf(stderr, "kontext: failed to encode hook output: %v\n", err)
+		return 2
+	}
+	if _, err := stdout.Write(out); err != nil {
+		fmt.Fprintf(stderr, "kontext: failed to write hook output: %v\n", err)
+		return 2
+	}
+	if !result.Allowed() {
+		return 2
+	}
+	return 0
+}

--- a/internal/hookruntime/runtime.go
+++ b/internal/hookruntime/runtime.go
@@ -1,0 +1,104 @@
+package hookruntime
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/kontext-security/kontext-cli/internal/agent"
+)
+
+type Decision string
+
+const (
+	DecisionAllow Decision = "ALLOW"
+	DecisionAsk   Decision = "ASK"
+	DecisionDeny  Decision = "DENY"
+)
+
+type Event struct {
+	SessionID      string
+	Agent          string
+	HookEventName  string
+	ToolName       string
+	ToolInput      map[string]any
+	ToolResponse   map[string]any
+	ToolUseID      string
+	CWD            string
+	PermissionMode string
+	DurationMs     *int64
+	Error          string
+	IsInterrupt    *bool
+}
+
+type Result struct {
+	Decision     Decision
+	Reason       string
+	ReasonCode   string
+	RequestID    string
+	Mode         string
+	Epoch        string
+	UpdatedInput map[string]any
+}
+
+type Processor interface {
+	ProcessHookEvent(Event) (Result, error)
+}
+
+func EventFromAgent(agentName string, event *agent.HookEvent) Event {
+	if event == nil {
+		return Event{Agent: agentName}
+	}
+	return Event{
+		SessionID:      event.SessionID,
+		Agent:          agentName,
+		HookEventName:  event.HookEventName,
+		ToolName:       event.ToolName,
+		ToolInput:      event.ToolInput,
+		ToolResponse:   event.ToolResponse,
+		ToolUseID:      event.ToolUseID,
+		CWD:            event.CWD,
+		PermissionMode: event.PermissionMode,
+		DurationMs:     event.DurationMs,
+		Error:          event.Error,
+		IsInterrupt:    event.IsInterrupt,
+	}
+}
+
+func ResultFromBool(allowed bool, reason string) Result {
+	if allowed {
+		return Result{Decision: DecisionAllow, Reason: reason}
+	}
+	return Result{Decision: DecisionDeny, Reason: reason}
+}
+
+func (r Result) Allowed() bool {
+	return r.Decision == DecisionAllow
+}
+
+func (r Result) ClaudeReason() string {
+	reason := r.Reason
+	if r.Decision == DecisionAsk && r.RequestID != "" {
+		if reason != "" {
+			return fmt.Sprintf("%s Request ID: %s", reason, r.RequestID)
+		}
+		return fmt.Sprintf("Kontext access policy requires approval. Request ID: %s", r.RequestID)
+	}
+	if reason == "" && r.Decision == DecisionAsk {
+		return "Kontext access policy requires approval."
+	}
+	if reason == "" && r.Decision == DecisionDeny {
+		return "Blocked by Kontext access policy."
+	}
+	return reason
+}
+
+func MarshalMap(value map[string]any) (json.RawMessage, error) {
+	if value == nil {
+		return nil, nil
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}

--- a/internal/run/hooks.go
+++ b/internal/run/hooks.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 type claudeSettings struct {
@@ -55,4 +56,27 @@ func GenerateSettings(sessionDir, kontextBinary, agentName string) (string, erro
 	}
 
 	return settingsPath, nil
+}
+
+func VerifyBlockingHookSettings(settingsPath, kontextBinary, agentName string) error {
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		return fmt.Errorf("read settings: %w", err)
+	}
+
+	var settings claudeSettings
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return fmt.Errorf("parse settings: %w", err)
+	}
+
+	wantCommand := fmt.Sprintf("%s hook --agent %s", kontextBinary, agentName)
+	for _, group := range settings.Hooks["PreToolUse"] {
+		for _, hook := range group.Hooks {
+			if hook.Type == "command" && hook.Command == wantCommand && hook.Timeout > 0 {
+				return nil
+			}
+		}
+	}
+
+	return fmt.Errorf("PreToolUse command hook missing for %s", strings.TrimSpace(wantCommand))
 }

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -235,6 +235,7 @@ func Start(ctx context.Context, opts Options) error {
 	env := buildEnv(templateDoc, resolved)
 	env = append(env, "KONTEXT_SOCKET="+sc.SocketPath())
 	env = append(env, "KONTEXT_SESSION_ID="+sessionID)
+	env = append(env, "KONTEXT_ACCESS_MODE="+string(bootstrapResult.AccessMode))
 
 	// 9. Launch agent with hooks
 	fmt.Fprintf(os.Stderr, "\nLaunching %s...\n\n", opts.Agent)

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -111,13 +111,17 @@ func Start(ctx context.Context, opts Options) error {
 	// dashboard relies on this state to skip generic onboarding, so a failure
 	// here must abort — a half-set-up session would leave the org looking
 	// un-onboarded while the CLI appears to work.
-	bootstrapResp, err := client.BootstrapCli(ctx, &agentv1.BootstrapCliRequest{
+	bootstrapResult, err := client.BootstrapCli(ctx, &agentv1.BootstrapCliRequest{
 		AgentId: createResp.AgentId,
 	})
 	if err != nil {
 		return fmt.Errorf("bootstrap cli application: %w", err)
 	}
-	fmt.Fprintln(os.Stderr, "✓ Kontext CLI bootstrap complete")
+	bootstrapResp := bootstrapResult.Response
+	if bootstrapResult.AccessMode == backend.HostedAccessModeEnforce && bootstrapResult.PolicySetEpoch == "" {
+		return errors.New("bootstrap cli application: enforce mode missing policy epoch")
+	}
+	fmt.Fprintf(os.Stderr, "✓ Kontext CLI bootstrap complete (%s)\n", bootstrapResult.AccessMode)
 
 	syncResult, err := credential.EnsureManagedTemplate(
 		opts.TemplateFile,
@@ -171,14 +175,20 @@ func Start(ctx context.Context, opts Options) error {
 		)
 	}
 
-	// 5. Resolve credentials (before sidecar starts — no background goroutines yet,
-	//    so reading session fields is safe without synchronization)
+	// 5. Resolve startup credentials only when hosted access is not enforcing.
+	// In enforce mode, managed credential material must not enter the agent
+	// environment before the PreToolUse policy decision allows the action.
 	var resolved []credential.Resolved
-	if len(templateDoc.Entries) > 0 {
+	if shouldResolveStartupCredentials(bootstrapResult.AccessMode) && len(templateDoc.Entries) > 0 {
 		resolved, err = resolveCredentials(ctx, session, templateDoc.Entries, credentialClientID, diagnostics, fetchConnectURLForConnectFlow)
 		if err != nil {
 			return err
 		}
+	} else if len(templateDoc.Entries) > 0 {
+		fmt.Fprintf(
+			os.Stderr,
+			"ℹ Managed provider credentials are policy-gated for this hosted session; placeholders will not be preloaded.\n",
+		)
 	}
 
 	// 6. Start sidecar
@@ -189,7 +199,18 @@ func Start(ctx context.Context, opts Options) error {
 		return fmt.Errorf("create session dir: %w", err)
 	}
 
-	sc, err := sidecar.New(sessionDir, client, sessionID, opts.Agent, diagnostics)
+	sc, err := sidecar.NewWithCredentials(
+		sessionDir,
+		client,
+		sessionID,
+		opts.Agent,
+		bootstrapResult.AccessMode,
+		diagnostics,
+		templateDoc.Entries,
+		func(ctx context.Context, entry credential.Entry) (string, error) {
+			return exchangeCredential(ctx, session, entry, credentialClientID)
+		},
+	)
 	if err != nil {
 		return fmt.Errorf("sidecar: %w", err)
 	}
@@ -203,6 +224,11 @@ func Start(ctx context.Context, opts Options) error {
 	settingsPath, err := GenerateSettings(sessionDir, kontextBin, opts.Agent)
 	if err != nil {
 		return fmt.Errorf("generate settings: %w", err)
+	}
+	if bootstrapResult.AccessMode == backend.HostedAccessModeEnforce {
+		if err := VerifyBlockingHookSettings(settingsPath, kontextBin, opts.Agent); err != nil {
+			return fmt.Errorf("verify enforce hook settings: %w", err)
+		}
 	}
 
 	// 8. Build env
@@ -857,6 +883,10 @@ func buildEnv(templateDoc *credential.TemplateFile, resolved []credential.Resolv
 		}
 	}
 	return credential.BuildEnv(resolved, env)
+}
+
+func shouldResolveStartupCredentials(mode backend.HostedAccessMode) bool {
+	return mode != backend.HostedAccessModeEnforce
 }
 
 func managedProvidersFromBootstrap(items []*agentv1.ManagedProvider) []credential.ManagedProvider {

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/kontext-security/kontext-cli/internal/auth"
+	"github.com/kontext-security/kontext-cli/internal/backend"
 	"github.com/kontext-security/kontext-cli/internal/credential"
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 )
@@ -995,6 +996,30 @@ func TestBuildEnvTreatsCommentOnlyRightHandSideAsEmpty(t *testing.T) {
 	}
 }
 
+func TestShouldResolveStartupCredentials(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		mode backend.HostedAccessMode
+		want bool
+	}{
+		{name: "disabled", mode: backend.HostedAccessModeDisabled, want: true},
+		{name: "no policy", mode: backend.HostedAccessModeNoPolicy, want: true},
+		{name: "enforce", mode: backend.HostedAccessModeEnforce, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := shouldResolveStartupCredentials(tt.mode); got != tt.want {
+				t.Fatalf("shouldResolveStartupCredentials(%q) = %v, want %v", tt.mode, got, tt.want)
+			}
+		})
+	}
+}
+
 type recordingSessionEnder struct {
 	sessionID string
 	calls     int
@@ -1118,5 +1143,36 @@ func TestGenerateSettingsWritesClaudeHooks(t *testing.T) {
 		if hook.Timeout != 10 {
 			t.Fatalf("%s hook timeout = %d, want 10", event, hook.Timeout)
 		}
+	}
+}
+
+func TestVerifyBlockingHookSettingsRequiresPreToolUseCommand(t *testing.T) {
+	t.Parallel()
+
+	sessionDir := t.TempDir()
+	settingsPath, err := GenerateSettings(sessionDir, "/usr/local/bin/kontext", "claude")
+	if err != nil {
+		t.Fatalf("GenerateSettings() error = %v", err)
+	}
+	if err := VerifyBlockingHookSettings(settingsPath, "/usr/local/bin/kontext", "claude"); err != nil {
+		t.Fatalf("VerifyBlockingHookSettings() error = %v", err)
+	}
+
+	settings := claudeSettings{
+		Hooks: map[string][]hookGroup{
+			"PostToolUse": commandHookGroups("/usr/local/bin/kontext hook --agent claude"),
+		},
+	}
+	data, err := json.Marshal(settings)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	brokenPath := filepath.Join(sessionDir, "broken-settings.json")
+	if err := os.WriteFile(brokenPath, data, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	if err := VerifyBlockingHookSettings(brokenPath, "/usr/local/bin/kontext", "claude"); err == nil {
+		t.Fatal("VerifyBlockingHookSettings() error = nil, want missing PreToolUse hook error")
 	}
 }

--- a/internal/sidecar/credential_injector.go
+++ b/internal/sidecar/credential_injector.go
@@ -1,0 +1,116 @@
+package sidecar
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/kontext-security/kontext-cli/internal/credential"
+)
+
+type credentialResolver func(context.Context, credential.Entry) (string, error)
+
+type credentialInjector struct {
+	sessionDir string
+	entries    []credential.Entry
+	resolve    credentialResolver
+}
+
+func newCredentialInjector(sessionDir string, entries []credential.Entry, resolve credentialResolver) *credentialInjector {
+	if len(entries) == 0 || resolve == nil {
+		return nil
+	}
+	return &credentialInjector{
+		sessionDir: sessionDir,
+		entries:    entries,
+		resolve:    resolve,
+	}
+}
+
+func (i *credentialInjector) updatedInputForAllowedHook(ctx context.Context, req *EvaluateRequest) (map[string]any, error) {
+	if i == nil || req.HookEvent != "PreToolUse" || req.ToolName != "Bash" {
+		return nil, nil
+	}
+
+	var input map[string]any
+	if err := json.Unmarshal(req.ToolInput, &input); err != nil {
+		return nil, nil
+	}
+	command, ok := input["command"].(string)
+	if !ok || !looksLikeGitHubCommand(command) {
+		return nil, nil
+	}
+
+	entry, ok := i.entryForProvider("github")
+	if !ok {
+		return nil, nil
+	}
+	value, err := i.resolve(ctx, entry)
+	if err != nil || strings.TrimSpace(value) == "" {
+		return nil, err
+	}
+	credentialPath, err := i.writeCredentialFile(entry.EnvVar, value)
+	if err != nil {
+		return nil, err
+	}
+
+	updated := make(map[string]any, len(input))
+	for key, value := range input {
+		updated[key] = value
+	}
+	updated["command"] = prefixCommandWithCredential(command, entry.EnvVar, credentialPath)
+	return updated, nil
+}
+
+func (i *credentialInjector) entryForProvider(provider string) (credential.Entry, bool) {
+	for _, entry := range i.entries {
+		if entry.Provider == provider && entry.EnvVar != "" {
+			return entry, true
+		}
+	}
+	return credential.Entry{}, false
+}
+
+func (i *credentialInjector) writeCredentialFile(envVar, value string) (string, error) {
+	dir := filepath.Join(i.sessionDir, "credentials")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("create credential dir: %w", err)
+	}
+	path := filepath.Join(dir, envVar)
+	if err := os.WriteFile(path, []byte(value), 0o600); err != nil {
+		return "", fmt.Errorf("write credential file: %w", err)
+	}
+	return path, nil
+}
+
+func prefixCommandWithCredential(command, envVar, credentialPath string) string {
+	return fmt.Sprintf(
+		"%s=\"$(cat %s)\" %s",
+		shellQuoteAssignmentName(envVar),
+		shellQuote(credentialPath),
+		command,
+	)
+}
+
+func shellQuoteAssignmentName(value string) string {
+	if regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`).MatchString(value) {
+		return value
+	}
+	return "KONTEXT_MANAGED_TOKEN"
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+func looksLikeGitHubCommand(command string) bool {
+	lower := strings.ToLower(command)
+	return strings.Contains(lower, "github.com") ||
+		strings.Contains(lower, "api.github.com") ||
+		regexp.MustCompile(`(^|[;&|()\s])gh(\s|$)`).MatchString(lower) ||
+		regexp.MustCompile(`(^|[;&|()\s])git\s+(fetch|pull|push|clone|ls-remote|remote|submodule)\b`).MatchString(lower)
+}

--- a/internal/sidecar/git_context.go
+++ b/internal/sidecar/git_context.go
@@ -1,0 +1,117 @@
+package sidecar
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/url"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const gitContextTimeout = 500 * time.Millisecond
+
+type localGitContext struct {
+	WorktreeRoot string            `json:"worktree_root,omitempty"`
+	Branch       string            `json:"branch,omitempty"`
+	Remotes      map[string]string `json:"remotes,omitempty"`
+}
+
+func enrichToolInputWithLocalContext(ctx context.Context, req *EvaluateRequest) {
+	if req.HookEvent != "PreToolUse" || req.ToolName != "Bash" || len(req.ToolInput) == 0 {
+		return
+	}
+
+	var input map[string]any
+	if err := json.Unmarshal(req.ToolInput, &input); err != nil {
+		return
+	}
+	if _, exists := input["kontext"]; exists {
+		return
+	}
+
+	gitCtx, ok := collectLocalGitContext(ctx, req.CWD)
+	if !ok {
+		return
+	}
+	input["kontext"] = map[string]any{"git": gitCtx}
+
+	data, err := json.Marshal(input)
+	if err != nil {
+		return
+	}
+	req.ToolInput = data
+}
+
+func collectLocalGitContext(ctx context.Context, cwd string) (localGitContext, bool) {
+	ctx, cancel := context.WithTimeout(ctx, gitContextTimeout)
+	defer cancel()
+
+	root, ok := runGit(ctx, cwd, "rev-parse", "--show-toplevel")
+	if !ok || root == "" {
+		return localGitContext{}, false
+	}
+
+	branch, _ := runGit(ctx, cwd, "branch", "--show-current")
+	remoteLines, _ := runGit(ctx, cwd, "remote", "-v")
+	remotes := parseGitRemotes(remoteLines)
+
+	return localGitContext{
+		WorktreeRoot: root,
+		Branch:       branch,
+		Remotes:      remotes,
+	}, true
+}
+
+func runGit(ctx context.Context, cwd string, args ...string) (string, bool) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	if cwd != "" {
+		cmd.Dir = cwd
+	}
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(stdout.String()), true
+}
+
+func parseGitRemotes(output string) map[string]string {
+	remotes := make(map[string]string)
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		if _, exists := remotes[fields[0]]; exists {
+			continue
+		}
+		if sanitized := sanitizeGitRemote(fields[1]); sanitized != "" {
+			remotes[fields[0]] = sanitized
+		}
+	}
+	if len(remotes) == 0 {
+		return nil
+	}
+	return remotes
+}
+
+func sanitizeGitRemote(raw string) string {
+	if strings.HasPrefix(raw, "git@github.com:") {
+		return "https://github.com/" + strings.TrimPrefix(raw, "git@github.com:")
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" {
+		return ""
+	}
+	if !strings.EqualFold(parsed.Hostname(), "github.com") {
+		return ""
+	}
+
+	parsed.User = nil
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String()
+}

--- a/internal/sidecar/protocol.go
+++ b/internal/sidecar/protocol.go
@@ -24,9 +24,15 @@ type EvaluateRequest struct {
 }
 
 type EvaluateResult struct {
-	Type    string `json:"type"`
-	Allowed bool   `json:"allowed"`
-	Reason  string `json:"reason"`
+	Type         string         `json:"type"`
+	Decision     string         `json:"decision,omitempty"`
+	Allowed      bool           `json:"allowed"`
+	Reason       string         `json:"reason"`
+	ReasonCode   string         `json:"reason_code,omitempty"`
+	RequestID    string         `json:"request_id,omitempty"`
+	Mode         string         `json:"mode,omitempty"`
+	Epoch        string         `json:"epoch,omitempty"`
+	UpdatedInput map[string]any `json:"updated_input,omitempty"`
 }
 
 func WriteMessage(conn net.Conn, v any) error {

--- a/internal/sidecar/sidecar.go
+++ b/internal/sidecar/sidecar.go
@@ -5,16 +5,20 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	agentv1 "github.com/kontext-security/kontext-cli/gen/kontext/agent/v1"
+	"github.com/kontext-security/kontext-cli/internal/backend"
+	"github.com/kontext-security/kontext-cli/internal/credential"
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
+	"github.com/kontext-security/kontext-cli/internal/hookruntime"
 )
 
 // sidecarClient is the backend surface used by the sidecar.
 type sidecarClient interface {
 	Heartbeat(ctx context.Context, sessionID string) error
-	IngestEvent(ctx context.Context, req *agentv1.ProcessHookEventRequest) error
+	ProcessHookEvent(context.Context, *agentv1.ProcessHookEventRequest) (*backend.ProcessHookEventResult, error)
 }
 
 const (
@@ -66,27 +70,55 @@ func (h *heartbeatState) record(now time.Time, err error, logf func(string, ...a
 }
 
 type Server struct {
-	socketPath string
-	listener   net.Listener
-	sessionID  string
-	agentName  string
-	client     sidecarClient
-	diagnostic diagnostic.Logger
-	cancel     context.CancelFunc
+	socketPath  string
+	listener    net.Listener
+	sessionID   string
+	agentName   string
+	mu          sync.RWMutex
+	accessMode  backend.HostedAccessMode
+	client      sidecarClient
+	diagnostic  diagnostic.Logger
+	cancel      context.CancelFunc
+	credentials *credentialInjector
 }
 
 // New creates a new sidecar server.
-func New(sessionDir string, client sidecarClient, sessionID, agentName string, diagnostics diagnostic.Logger) (*Server, error) {
+func New(sessionDir string, client sidecarClient, sessionID, agentName string, accessMode backend.HostedAccessMode, diagnostics diagnostic.Logger) (*Server, error) {
 	return &Server{
 		socketPath: filepath.Join(sessionDir, "kontext.sock"),
 		sessionID:  sessionID,
 		agentName:  agentName,
+		accessMode: accessMode,
 		client:     client,
 		diagnostic: diagnostics,
 	}, nil
 }
 
+func NewWithCredentials(sessionDir string, client sidecarClient, sessionID, agentName string, accessMode backend.HostedAccessMode, diagnostics diagnostic.Logger, entries []credential.Entry, resolve credentialResolver) (*Server, error) {
+	server, err := New(sessionDir, client, sessionID, agentName, accessMode, diagnostics)
+	if err != nil {
+		return nil, err
+	}
+	server.credentials = newCredentialInjector(sessionDir, entries, resolve)
+	return server, nil
+}
+
 func (s *Server) SocketPath() string { return s.socketPath }
+
+func (s *Server) currentAccessMode() backend.HostedAccessMode {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.accessMode
+}
+
+func (s *Server) refreshAccessMode(mode backend.HostedAccessMode) {
+	if mode == "" {
+		return
+	}
+	s.mu.Lock()
+	s.accessMode = mode
+	s.mu.Unlock()
+}
 
 func (s *Server) Start(ctx context.Context) error {
 	os.Remove(s.socketPath)
@@ -147,18 +179,20 @@ func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
 		return
 	}
 
-	result := defaultAllowResult()
+	result := s.evaluate(ctx, &req)
 	if err := WriteMessage(conn, result); err != nil {
 		s.diagnostic.Printf("sidecar write: %v\n", err)
 		return
 	}
 
-	go s.ingestEvent(ctx, &req)
+	if req.HookEvent != "PreToolUse" {
+		go s.ingestEvent(ctx, &req)
+	}
 }
 
 func (s *Server) ingestEvent(ctx context.Context, req *EvaluateRequest) {
 	hookEvent := buildHookEventRequest(s.sessionID, s.agentName, req)
-	if err := s.client.IngestEvent(ctx, hookEvent); err != nil {
+	if _, err := s.client.ProcessHookEvent(ctx, hookEvent); err != nil {
 		s.diagnostic.Printf("sidecar ingest: %v\n", err)
 	}
 }
@@ -185,11 +219,93 @@ func (s *Server) heartbeatLoop(ctx context.Context) {
 	}
 }
 
+func (s *Server) evaluate(ctx context.Context, req *EvaluateRequest) EvaluateResult {
+	if req.HookEvent != "PreToolUse" {
+		return defaultAllowResult()
+	}
+
+	hookEvent := buildHookEventRequest(s.sessionID, s.agentName, req)
+	result, err := s.client.ProcessHookEvent(ctx, hookEvent)
+	if err != nil {
+		s.diagnostic.Printf("sidecar enforce: %v\n", err)
+		accessMode := s.currentAccessMode()
+		if accessMode != backend.HostedAccessModeEnforce {
+			return resultFromRuntime(hookruntime.Result{
+				Decision: hookruntime.DecisionAllow,
+				Reason:   "Kontext hosted access is not enforcing.",
+				Mode:     string(accessMode),
+			})
+		}
+		return EvaluateResult{
+			Type:     "result",
+			Decision: string(hookruntime.DecisionDeny),
+			Allowed:  false,
+			Reason:   "Kontext access policy could not be evaluated.",
+		}
+	}
+	s.refreshAccessMode(result.AccessMode)
+
+	resp := result.Response
+	switch resp.GetDecision() {
+	case agentv1.Decision_DECISION_ALLOW:
+		runtimeResult := hookruntime.Result{
+			Decision:   hookruntime.DecisionAllow,
+			Reason:     resp.GetReason(),
+			ReasonCode: result.ReasonCode,
+			RequestID:  result.RequestID,
+			Mode:       string(result.AccessMode),
+			Epoch:      result.PolicySetEpoch,
+		}
+		updatedInput, err := s.credentials.updatedInputForAllowedHook(ctx, req)
+		if err != nil {
+			s.diagnostic.Printf("sidecar credential injection skipped: %v\n", err)
+		}
+		runtimeResult.UpdatedInput = updatedInput
+		return resultFromRuntime(runtimeResult)
+	case agentv1.Decision_DECISION_ASK:
+		return resultFromRuntime(hookruntime.Result{
+			Decision:   hookruntime.DecisionAsk,
+			Reason:     resp.GetReason(),
+			ReasonCode: result.ReasonCode,
+			RequestID:  result.RequestID,
+			Mode:       string(result.AccessMode),
+			Epoch:      result.PolicySetEpoch,
+		})
+	case agentv1.Decision_DECISION_DENY:
+		fallthrough
+	default:
+		return resultFromRuntime(hookruntime.Result{
+			Decision:   hookruntime.DecisionDeny,
+			Reason:     resp.GetReason(),
+			ReasonCode: result.ReasonCode,
+			RequestID:  result.RequestID,
+			Mode:       string(result.AccessMode),
+			Epoch:      result.PolicySetEpoch,
+		})
+	}
+}
+
 func defaultAllowResult() EvaluateResult {
-	return EvaluateResult{Type: "result", Allowed: true}
+	return resultFromRuntime(hookruntime.Result{Decision: hookruntime.DecisionAllow})
+}
+
+func resultFromRuntime(result hookruntime.Result) EvaluateResult {
+	return EvaluateResult{
+		Type:         "result",
+		Decision:     string(result.Decision),
+		Allowed:      result.Allowed(),
+		Reason:       result.ClaudeReason(),
+		ReasonCode:   result.ReasonCode,
+		RequestID:    result.RequestID,
+		Mode:         result.Mode,
+		Epoch:        result.Epoch,
+		UpdatedInput: result.UpdatedInput,
+	}
 }
 
 func buildHookEventRequest(sessionID, agentName string, req *EvaluateRequest) *agentv1.ProcessHookEventRequest {
+	enrichToolInputWithLocalContext(context.Background(), req)
+
 	hookEvent := &agentv1.ProcessHookEventRequest{
 		SessionId: sessionID,
 		Agent:     agentName,

--- a/internal/sidecar/sidecar_test.go
+++ b/internal/sidecar/sidecar_test.go
@@ -5,11 +5,17 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	agentv1 "github.com/kontext-security/kontext-cli/gen/kontext/agent/v1"
+	"github.com/kontext-security/kontext-cli/internal/backend"
+	"github.com/kontext-security/kontext-cli/internal/credential"
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 )
 
@@ -117,6 +123,279 @@ func TestDefaultAllowResultOmitsPlaceholderReason(t *testing.T) {
 	}
 }
 
+func TestEvaluatePreToolUseUsesBackendDecision(t *testing.T) {
+	t.Parallel()
+
+	client := &stubProcessor{
+		result: &backend.ProcessHookEventResult{
+			Response: &agentv1.ProcessHookEventResponse{
+				Decision: agentv1.Decision_DECISION_DENY,
+				Reason:   "blocked",
+			},
+			ReasonCode:     "DENY_POLICY_CHECK",
+			RequestID:      "request-1",
+			AccessMode:     backend.HostedAccessModeEnforce,
+			PolicySetEpoch: "4",
+		},
+	}
+	s := &Server{
+		sessionID: "session-123",
+		agentName: "claude",
+		client:    client,
+	}
+
+	result := s.evaluate(context.Background(), &EvaluateRequest{
+		HookEvent: "PreToolUse",
+		ToolName:  "Bash",
+		ToolInput: json.RawMessage(`{"command":"gh repo delete"}`),
+	})
+
+	if result.Allowed {
+		t.Fatal("evaluate().Allowed = true, want false")
+	}
+	if result.Reason != "blocked" {
+		t.Fatalf("evaluate().Reason = %q, want blocked", result.Reason)
+	}
+	if result.ReasonCode != "DENY_POLICY_CHECK" || result.RequestID != "request-1" || result.Mode != "enforce" || result.Epoch != "4" {
+		t.Fatalf("evaluate() metadata = reasonCode:%q requestID:%q mode:%q epoch:%q", result.ReasonCode, result.RequestID, result.Mode, result.Epoch)
+	}
+	if client.processCalls != 1 {
+		t.Fatalf("ProcessHookEvent calls = %d, want 1", client.processCalls)
+	}
+}
+
+func TestEvaluatePreToolUseInjectsManagedCredentialOnlyAfterAllow(t *testing.T) {
+	t.Parallel()
+
+	client := &stubProcessor{
+		result: &backend.ProcessHookEventResult{
+			Response: &agentv1.ProcessHookEventResponse{
+				Decision: agentv1.Decision_DECISION_ALLOW,
+				Reason:   "allowed",
+			},
+			AccessMode: backend.HostedAccessModeEnforce,
+		},
+	}
+	sessionDir := t.TempDir()
+	s := &Server{
+		sessionID:  "session-123",
+		agentName:  "claude",
+		accessMode: backend.HostedAccessModeEnforce,
+		client:     client,
+		diagnostic: diagnostic.New(io.Discard, false),
+		credentials: newCredentialInjector(
+			sessionDir,
+			[]credential.Entry{{EnvVar: "GITHUB_TOKEN", Provider: "github"}},
+			func(context.Context, credential.Entry) (string, error) { return "managed-token", nil },
+		),
+	}
+
+	result := s.evaluate(context.Background(), &EvaluateRequest{
+		HookEvent: "PreToolUse",
+		ToolName:  "Bash",
+		ToolInput: json.RawMessage(`{"command":"gh pr view 92","description":"inspect pr"}`),
+	})
+
+	if !result.Allowed {
+		t.Fatal("evaluate().Allowed = false, want true")
+	}
+	command, ok := result.UpdatedInput["command"].(string)
+	if !ok {
+		t.Fatalf("updated command missing: %#v", result.UpdatedInput)
+	}
+	if strings.Contains(command, "managed-token") {
+		t.Fatalf("updated command leaked raw token: %q", command)
+	}
+	if !strings.Contains(command, `GITHUB_TOKEN="$(cat `) || !strings.Contains(command, "gh pr view 92") {
+		t.Fatalf("updated command = %q, want credential file prefix and original command", command)
+	}
+	if got := result.UpdatedInput["description"]; got != "inspect pr" {
+		t.Fatalf("updated input did not preserve unchanged fields: %#v", result.UpdatedInput)
+	}
+	raw, err := os.ReadFile(filepath.Join(sessionDir, "credentials", "GITHUB_TOKEN"))
+	if err != nil {
+		t.Fatalf("credential file missing: %v", err)
+	}
+	if string(raw) != "managed-token" {
+		t.Fatalf("credential file = %q, want managed-token", raw)
+	}
+}
+
+func TestEvaluatePreToolUseDoesNotInjectManagedCredentialForAskOrDeny(t *testing.T) {
+	t.Parallel()
+
+	for _, decision := range []agentv1.Decision{
+		agentv1.Decision_DECISION_ASK,
+		agentv1.Decision_DECISION_DENY,
+	} {
+		t.Run(decision.String(), func(t *testing.T) {
+			t.Parallel()
+			called := false
+			s := &Server{
+				sessionID:  "session-123",
+				agentName:  "claude",
+				accessMode: backend.HostedAccessModeEnforce,
+				client: &stubProcessor{
+					result: &backend.ProcessHookEventResult{
+						Response: &agentv1.ProcessHookEventResponse{
+							Decision: decision,
+							Reason:   "blocked",
+						},
+						AccessMode: backend.HostedAccessModeEnforce,
+					},
+				},
+				diagnostic: diagnostic.New(io.Discard, false),
+				credentials: newCredentialInjector(
+					t.TempDir(),
+					[]credential.Entry{{EnvVar: "GITHUB_TOKEN", Provider: "github"}},
+					func(context.Context, credential.Entry) (string, error) {
+						called = true
+						return "managed-token", nil
+					},
+				),
+			}
+
+			result := s.evaluate(context.Background(), &EvaluateRequest{
+				HookEvent: "PreToolUse",
+				ToolName:  "Bash",
+				ToolInput: json.RawMessage(`{"command":"gh pr merge 92"}`),
+			})
+
+			if result.Allowed {
+				t.Fatal("evaluate().Allowed = true, want false")
+			}
+			if result.UpdatedInput != nil {
+				t.Fatalf("UpdatedInput = %#v, want nil", result.UpdatedInput)
+			}
+			if called {
+				t.Fatal("credential resolver was called for non-ALLOW decision")
+			}
+		})
+	}
+}
+
+func TestEvaluatePreToolUseFailsClosedOnBackendError(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{
+		sessionID:  "session-123",
+		agentName:  "claude",
+		accessMode: backend.HostedAccessModeEnforce,
+		client:     &stubProcessor{err: errors.New("backend down")},
+		diagnostic: diagnostic.New(io.Discard, false),
+	}
+
+	result := s.evaluate(context.Background(), &EvaluateRequest{HookEvent: "PreToolUse"})
+
+	if result.Allowed {
+		t.Fatal("evaluate().Allowed = true, want false")
+	}
+	if result.Reason == "" {
+		t.Fatal("evaluate().Reason = empty, want failure reason")
+	}
+}
+
+func TestEvaluatePreToolUseFailsOpenWhenNotEnforcing(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{
+		sessionID:  "session-123",
+		agentName:  "claude",
+		accessMode: backend.HostedAccessModeNoPolicy,
+		client:     &stubProcessor{err: errors.New("backend down")},
+		diagnostic: diagnostic.New(io.Discard, false),
+	}
+
+	result := s.evaluate(context.Background(), &EvaluateRequest{HookEvent: "PreToolUse"})
+
+	if !result.Allowed {
+		t.Fatal("evaluate().Allowed = false, want true")
+	}
+	if result.Mode != string(backend.HostedAccessModeNoPolicy) {
+		t.Fatalf("evaluate().Mode = %q, want no_policy", result.Mode)
+	}
+}
+
+func TestEvaluateRefreshesAccessModeForLaterFailures(t *testing.T) {
+	t.Parallel()
+
+	client := &stubProcessor{
+		result: &backend.ProcessHookEventResult{
+			Response: &agentv1.ProcessHookEventResponse{
+				Decision: agentv1.Decision_DECISION_ALLOW,
+			},
+			AccessMode: backend.HostedAccessModeEnforce,
+		},
+	}
+	s := &Server{
+		sessionID:  "session-123",
+		agentName:  "claude",
+		accessMode: backend.HostedAccessModeNoPolicy,
+		client:     client,
+		diagnostic: diagnostic.New(io.Discard, false),
+	}
+
+	first := s.evaluate(context.Background(), &EvaluateRequest{HookEvent: "PreToolUse"})
+	if !first.Allowed {
+		t.Fatal("first evaluate().Allowed = false, want true")
+	}
+
+	client.err = errors.New("backend down")
+	second := s.evaluate(context.Background(), &EvaluateRequest{HookEvent: "PreToolUse"})
+	if second.Allowed {
+		t.Fatal("second evaluate().Allowed = true, want enforce-mode fail closed")
+	}
+}
+
+func TestEvaluateRefreshesAccessModeBackToFailOpen(t *testing.T) {
+	t.Parallel()
+
+	client := &stubProcessor{
+		result: &backend.ProcessHookEventResult{
+			Response: &agentv1.ProcessHookEventResponse{
+				Decision: agentv1.Decision_DECISION_ALLOW,
+			},
+			AccessMode: backend.HostedAccessModeNoPolicy,
+		},
+	}
+	s := &Server{
+		sessionID:  "session-123",
+		agentName:  "claude",
+		accessMode: backend.HostedAccessModeEnforce,
+		client:     client,
+		diagnostic: diagnostic.New(io.Discard, false),
+	}
+
+	first := s.evaluate(context.Background(), &EvaluateRequest{HookEvent: "PreToolUse"})
+	if !first.Allowed {
+		t.Fatal("first evaluate().Allowed = false, want true")
+	}
+
+	client.err = errors.New("backend down")
+	second := s.evaluate(context.Background(), &EvaluateRequest{HookEvent: "PreToolUse"})
+	if !second.Allowed {
+		t.Fatal("second evaluate().Allowed = false, want no-policy fail open")
+	}
+	if second.Mode != string(backend.HostedAccessModeNoPolicy) {
+		t.Fatalf("second evaluate().Mode = %q, want no_policy", second.Mode)
+	}
+}
+
+func TestEvaluateNonPreToolUseDoesNotCallBackend(t *testing.T) {
+	t.Parallel()
+
+	client := &stubProcessor{}
+	s := &Server{client: client}
+	result := s.evaluate(context.Background(), &EvaluateRequest{HookEvent: "PostToolUse"})
+
+	if !result.Allowed {
+		t.Fatal("evaluate().Allowed = false, want true")
+	}
+	if client.processCalls != 0 {
+		t.Fatalf("ProcessHookEvent calls = %d, want 0", client.processCalls)
+	}
+}
+
 func TestBuildHookEventRequestPreservesTelemetryPayload(t *testing.T) {
 	t.Parallel()
 
@@ -204,6 +483,36 @@ func TestBuildHookEventRequestPreservesExplicitZeroDuration(t *testing.T) {
 	}
 }
 
+func TestParseGitRemotesSanitizesGitHubURLs(t *testing.T) {
+	t.Parallel()
+
+	remotes := parseGitRemotes(strings.Join([]string{
+		"origin\thttps://token@github.com/acme/repo.git (fetch)",
+		"origin\thttps://token@github.com/acme/repo.git (push)",
+		"upstream\tgit@github.com:other/repo.git (fetch)",
+		"ignored\thttps://example.com/acme/repo.git (fetch)",
+	}, "\n"))
+
+	if got := remotes["origin"]; got != "https://github.com/acme/repo.git" {
+		t.Fatalf("origin remote = %q, want sanitized GitHub URL", got)
+	}
+	if got := remotes["upstream"]; got != "https://github.com/other/repo.git" {
+		t.Fatalf("upstream remote = %q, want normalized SSH GitHub URL", got)
+	}
+	if _, ok := remotes["ignored"]; ok {
+		t.Fatal("non-GitHub remote was included")
+	}
+}
+
+func TestSanitizeGitRemoteDropsCredentialsQueryAndFragment(t *testing.T) {
+	t.Parallel()
+
+	got := sanitizeGitRemote("https://user:secret@github.com/acme/repo.git?token=secret#frag")
+	if got != "https://github.com/acme/repo.git" {
+		t.Fatalf("sanitizeGitRemote() = %q, want credential-free URL", got)
+	}
+}
+
 type stubListener struct {
 	accepts   int
 	acceptErr error
@@ -223,3 +532,24 @@ type stubAddr string
 func (a stubAddr) Network() string { return string(a) }
 
 func (a stubAddr) String() string { return string(a) }
+
+type stubProcessor struct {
+	result       *backend.ProcessHookEventResult
+	err          error
+	processCalls int
+}
+
+func (s *stubProcessor) ProcessHookEvent(context.Context, *agentv1.ProcessHookEventRequest) (*backend.ProcessHookEventResult, error) {
+	s.processCalls++
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.result != nil {
+		return s.result, nil
+	}
+	return &backend.ProcessHookEventResult{
+		Response: &agentv1.ProcessHookEventResponse{Decision: agentv1.Decision_DECISION_ALLOW},
+	}, nil
+}
+
+func (s *stubProcessor) Heartbeat(context.Context, string) error { return nil }


### PR DESCRIPTION
## Summary

- Implements the hosted Claude hook runtime path for Kontext CLI and closes the shared-hook extraction work for #91.
- Adds first-class generated proto fields for hosted access mode, policy epoch, reason code, and request id.
- Reuses one Claude hook adapter for hosted and local Guard mode, preserving Guard behavior while moving decode/encode logic into `internal/hookruntime`.
- Makes hosted `PreToolUse` synchronous through the sidecar, with enforce-mode fail-closed behavior and disabled/no-policy fail-open behavior.
- Adds sanitized GitHub git context enrichment for Bash hooks and verifies blocking hook settings before launching an enforcing hosted session.
- Gates managed GitHub credential delivery on backend ALLOW by returning Claude `updatedInput` for the current Bash command only; ASK/DENY never resolve or inject managed credentials.

Closes #91.

## Verification

- [x] `buf generate`
- [x] `go test ./...`
- [x] `git diff --check`

## Notes

- Depends on `kontext-security/proto#8` for the response metadata contract.
- In enforce mode, managed provider credentials are not preloaded into the Claude process. For allowed GitHub Bash tool calls, the sidecar exchanges the managed credential after the backend ALLOW decision and returns a command-scoped `updatedInput` that reads the token from a session-local 0600 file, so raw token material is not emitted in hook JSON.

## Release impact

- Minor: `feat:` hosted access enforcement path and generated protocol fields.