### PR TITLE
feat: share claude hook runtime

### DIFF
--- a/cmd/kontext/main.go
+++ b/cmd/kontext/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/auth"
 	guardcli "github.com/kontext-security/kontext-cli/internal/guard/cli"
 	"github.com/kontext-security/kontext-cli/internal/hook"
+	"github.com/kontext-security/kontext-cli/internal/hookruntime"
 	"github.com/kontext-security/kontext-cli/internal/run"
 	"github.com/kontext-security/kontext-cli/internal/sidecar"
 	"github.com/kontext-security/kontext-cli/internal/update"
@@ -182,14 +183,15 @@ func hookCmd() *cobra.Command {
 
 			socketPath := os.Getenv("KONTEXT_SOCKET")
 			if socketPath == "" {
-				hook.Run(a, func(e *agent.HookEvent) (bool, string, error) {
-					return true, "no sidecar", nil
+				hook.Run(a, func(e *agent.HookEvent) (hookruntime.Result, error) {
+					return hookruntime.Result{Decision: hookruntime.DecisionAllow, Reason: "no sidecar"}, nil
 				})
 				return nil
 			}
 
-			hook.Run(a, func(e *agent.HookEvent) (bool, string, error) {
-				return evaluateViaSidecar(socketPath, agentName, e)
+			hook.Run(a, func(e *agent.HookEvent) (hookruntime.Result, error) {
+				allowed, reason, err := evaluateViaSidecar(socketPath, agentName, e)
+				return hookruntime.ResultFromBool(allowed, reason), err
 			})
 			return nil
 		},

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -5,7 +5,7 @@ type Agent interface {
 
 	DecodeHookInput(input []byte) (*HookEvent, error)
 
-	EncodeAllow(event *HookEvent, reason string) ([]byte, error)
+	EncodeAllow(event *HookEvent, reason string, updatedInput map[string]any) ([]byte, error)
 
 	EncodeDeny(event *HookEvent, reason string) ([]byte, error)
 }

--- a/internal/agent/claude/claude.go
+++ b/internal/agent/claude/claude.go
@@ -1,11 +1,8 @@
 package claude
 
 import (
-	"encoding/json"
-	"fmt"
-	"strings"
-
 	"github.com/kontext-security/kontext-cli/internal/agent"
+	"github.com/kontext-security/kontext-cli/internal/hookruntime"
 )
 
 func init() {
@@ -16,83 +13,37 @@ type Claude struct{}
 
 func (c *Claude) Name() string { return "claude" }
 
-type hookInput struct {
-	SessionID      string         `json:"session_id"`
-	HookEventName  string         `json:"hook_event_name"`
-	ToolName       string         `json:"tool_name"`
-	ToolInput      map[string]any `json:"tool_input"`
-	ToolResponse   map[string]any `json:"tool_response"`
-	ToolUseID      string         `json:"tool_use_id"`
-	CWD            string         `json:"cwd"`
-	PermissionMode *string        `json:"permission_mode"`
-	DurationMs     *int64         `json:"duration_ms"`
-	Error          *string        `json:"error"`
-	IsInterrupt    *bool          `json:"is_interrupt"`
-}
-
 func (c *Claude) DecodeHookInput(input []byte) (*agent.HookEvent, error) {
-	var h hookInput
-	if err := json.Unmarshal(input, &h); err != nil {
-		return nil, fmt.Errorf("claude: decode hook input: %w", err)
+	event, err := hookruntime.DecodeClaudeEvent(input, c.Name())
+	if err != nil {
+		return nil, err
 	}
 	return &agent.HookEvent{
-		SessionID:      h.SessionID,
-		HookEventName:  h.HookEventName,
-		ToolName:       h.ToolName,
-		ToolInput:      h.ToolInput,
-		ToolResponse:   h.ToolResponse,
-		ToolUseID:      h.ToolUseID,
-		CWD:            h.CWD,
-		PermissionMode: stringValue(h.PermissionMode),
-		DurationMs:     h.DurationMs,
-		Error:          stringValue(h.Error),
-		IsInterrupt:    h.IsInterrupt,
+		SessionID:      event.SessionID,
+		HookEventName:  event.HookEventName,
+		ToolName:       event.ToolName,
+		ToolInput:      event.ToolInput,
+		ToolResponse:   event.ToolResponse,
+		ToolUseID:      event.ToolUseID,
+		CWD:            event.CWD,
+		PermissionMode: event.PermissionMode,
+		DurationMs:     event.DurationMs,
+		Error:          event.Error,
+		IsInterrupt:    event.IsInterrupt,
 	}, nil
 }
 
-func stringValue(value *string) string {
-	if value == nil {
-		return ""
-	}
-	return *value
-}
-
-type hookOutput struct {
-	HookSpecificOutput *hookSpecificOutput `json:"hookSpecificOutput,omitempty"`
-}
-
-type hookSpecificOutput struct {
-	HookEventName            string `json:"hookEventName"`
-	PermissionDecision       string `json:"permissionDecision,omitempty"`
-	PermissionDecisionReason string `json:"permissionDecisionReason,omitempty"`
-	AdditionalContext        string `json:"additionalContext,omitempty"`
-}
-
-func (c *Claude) EncodeAllow(event *agent.HookEvent, reason string) ([]byte, error) {
-	out := hookOutput{
-		HookSpecificOutput: &hookSpecificOutput{
-			HookEventName:            event.HookEventName,
-			PermissionDecision:       "allow",
-			PermissionDecisionReason: allowReason(reason),
-		},
-	}
-	return json.Marshal(out)
+func (c *Claude) EncodeAllow(event *agent.HookEvent, reason string, updatedInput map[string]any) ([]byte, error) {
+	return hookruntime.EncodeClaudeResult(event.HookEventName, hookruntime.Result{
+		Decision:     hookruntime.DecisionAllow,
+		Reason:       reason,
+		UpdatedInput: updatedInput,
+	})
 }
 
 func (c *Claude) EncodeDeny(event *agent.HookEvent, reason string) ([]byte, error) {
-	out := hookOutput{
-		HookSpecificOutput: &hookSpecificOutput{
-			HookEventName:            event.HookEventName,
-			PermissionDecision:       "deny",
-			PermissionDecisionReason: reason,
-		},
-	}
-	return json.Marshal(out)
-}
-
-func allowReason(reason string) string {
-	if strings.EqualFold(strings.TrimSpace(reason), "allowed") {
-		return ""
-	}
-	return reason
+	return hookruntime.EncodeClaudeResult(event.HookEventName, hookruntime.Result{
+		Decision: hookruntime.DecisionDeny,
+		Reason:   reason,
+	})
 }

--- a/internal/agent/claude/claude_test.go
+++ b/internal/agent/claude/claude_test.go
@@ -185,20 +185,40 @@ func TestEncodeAllowIncludesUpdatedInput(t *testing.T) {
 	}
 }
 
-func TestEncodeClaudeResultPreservesAskDecision(t *testing.T) {
+func TestEncodeClaudeResultMapsAskToDeny(t *testing.T) {
 	t.Parallel()
 
 	out, err := hookruntime.EncodeClaudeResult("PreToolUse", hookruntime.Result{
-		Decision: hookruntime.DecisionAsk,
-		Reason:   "approval required",
+		Decision:  hookruntime.DecisionAsk,
+		Reason:    "approval required",
+		RequestID: "req-123",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(out), `"permissionDecision":"ask"`) {
+	if !strings.Contains(string(out), `"permissionDecision":"deny"`) {
 		t.Fatalf("output = %s", string(out))
 	}
-	if !strings.Contains(string(out), `"permissionDecisionReason":"approval required"`) {
+	if !strings.Contains(string(out), `"permissionDecisionReason":"approval required Request ID: req-123"`) {
+		t.Fatalf("output = %s", string(out))
+	}
+}
+
+func TestEncodeClaudeResultDoesNotDuplicateAskRequestID(t *testing.T) {
+	t.Parallel()
+
+	out, err := hookruntime.EncodeClaudeResult("PreToolUse", hookruntime.Result{
+		Decision:  hookruntime.DecisionAsk,
+		Reason:    "approval required. Request ID: req-123",
+		RequestID: "req-123",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(string(out), "Request ID: req-123"); got != 1 {
+		t.Fatalf("output = %s, request id count = %d", string(out), got)
+	}
+	if !strings.Contains(string(out), `"permissionDecision":"deny"`) {
 		t.Fatalf("output = %s", string(out))
 	}
 }

--- a/internal/agent/claude/claude_test.go
+++ b/internal/agent/claude/claude_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/kontext-security/kontext-cli/internal/agent"
+	"github.com/kontext-security/kontext-cli/internal/hookruntime"
 )
 
 func TestDecodeHookInputPreservesOptionalMetadata(t *testing.T) {
@@ -181,6 +182,24 @@ func TestEncodeAllowIncludesUpdatedInput(t *testing.T) {
 	}
 	if !strings.Contains(string(out), "suppressOutput") {
 		t.Fatalf("EncodeAllow() = %s, want suppressOutput", out)
+	}
+}
+
+func TestEncodeClaudeResultPreservesAskDecision(t *testing.T) {
+	t.Parallel()
+
+	out, err := hookruntime.EncodeClaudeResult("PreToolUse", hookruntime.Result{
+		Decision: hookruntime.DecisionAsk,
+		Reason:   "approval required",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(out), `"permissionDecision":"ask"`) {
+		t.Fatalf("output = %s", string(out))
+	}
+	if !strings.Contains(string(out), `"permissionDecisionReason":"approval required"`) {
+		t.Fatalf("output = %s", string(out))
 	}
 }
 

--- a/internal/agent/claude/claude_test.go
+++ b/internal/agent/claude/claude_test.go
@@ -74,6 +74,34 @@ func TestDecodeHookInputPreservesExplicitFalseInterrupt(t *testing.T) {
 	}
 }
 
+func TestDecodeHookInputPreservesLegacyAliases(t *testing.T) {
+	t.Parallel()
+
+	event, err := (&Claude{}).DecodeHookInput([]byte(`{"sessionId":"s1","hookEventName":"PreToolUse","toolName":"Read","toolInput":{"file_path":"README.md"},"toolUseID":"toolu_123"}`))
+	if err != nil {
+		t.Fatalf("DecodeHookInput() error = %v", err)
+	}
+	if event.SessionID != "s1" ||
+		event.HookEventName != "PreToolUse" ||
+		event.ToolName != "Read" ||
+		event.ToolUseID != "toolu_123" ||
+		event.ToolInput["file_path"] != "README.md" {
+		t.Fatalf("event = %+v, want legacy aliases decoded", event)
+	}
+}
+
+func TestDecodeHookInputPreservesLegacyHookEventAlias(t *testing.T) {
+	t.Parallel()
+
+	event, err := (&Claude{}).DecodeHookInput([]byte(`{"hook_event":"PreToolUse"}`))
+	if err != nil {
+		t.Fatalf("DecodeHookInput() error = %v", err)
+	}
+	if event.HookEventName != "PreToolUse" {
+		t.Fatalf("HookEventName = %q, want PreToolUse", event.HookEventName)
+	}
+}
+
 func TestDecodeHookInputAllowsMissingOptionalMetadata(t *testing.T) {
 	t.Parallel()
 
@@ -116,7 +144,7 @@ func TestDecodeHookInputPreservesExplicitZeroDuration(t *testing.T) {
 func TestEncodeAllowOmitsPlaceholderReason(t *testing.T) {
 	t.Parallel()
 
-	out, err := (&Claude{}).EncodeAllow(&agent.HookEvent{HookEventName: "PreToolUse"}, "allowed")
+	out, err := (&Claude{}).EncodeAllow(&agent.HookEvent{HookEventName: "PreToolUse"}, "allowed", nil)
 	if err != nil {
 		t.Fatalf("EncodeAllow() error = %v", err)
 	}
@@ -128,12 +156,31 @@ func TestEncodeAllowOmitsPlaceholderReason(t *testing.T) {
 func TestEncodeAllowKeepsMeaningfulReason(t *testing.T) {
 	t.Parallel()
 
-	out, err := (&Claude{}).EncodeAllow(&agent.HookEvent{HookEventName: "PreToolUse"}, "Allowed by read-only policy")
+	out, err := (&Claude{}).EncodeAllow(&agent.HookEvent{HookEventName: "PreToolUse"}, "Allowed by read-only policy", nil)
 	if err != nil {
 		t.Fatalf("EncodeAllow() error = %v", err)
 	}
 	if !strings.Contains(string(out), "Allowed by read-only policy") {
 		t.Fatalf("EncodeAllow() = %s, want meaningful reason", out)
+	}
+}
+
+func TestEncodeAllowIncludesUpdatedInput(t *testing.T) {
+	t.Parallel()
+
+	out, err := (&Claude{}).EncodeAllow(
+		&agent.HookEvent{HookEventName: "PreToolUse"},
+		"allowed",
+		map[string]any{"command": `GITHUB_TOKEN="$(cat '/tmp/token')" gh pr view`},
+	)
+	if err != nil {
+		t.Fatalf("EncodeAllow() error = %v", err)
+	}
+	if !strings.Contains(string(out), "updatedInput") {
+		t.Fatalf("EncodeAllow() = %s, want updatedInput", out)
+	}
+	if !strings.Contains(string(out), "suppressOutput") {
+		t.Fatalf("EncodeAllow() = %s, want suppressOutput", out)
 	}
 }
 

--- a/internal/guard/hookruntime/claude.go
+++ b/internal/guard/hookruntime/claude.go
@@ -50,7 +50,7 @@ func (ClaudeAdapter) Encode(out io.Writer, result Result) error {
 	if result.Mode == ModeEnforce && result.CanBlock {
 		switch result.Decision {
 		case risk.DecisionAsk:
-			decision = sharedhook.DecisionAsk
+			decision = sharedhook.DecisionDeny
 		case risk.DecisionDeny:
 			decision = sharedhook.DecisionDeny
 		}

--- a/internal/guard/hookruntime/claude.go
+++ b/internal/guard/hookruntime/claude.go
@@ -1,43 +1,36 @@
 package hookruntime
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"time"
 
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
+	sharedhook "github.com/kontext-security/kontext-cli/internal/hookruntime"
 )
 
 type ClaudeAdapter struct{}
 
 func (ClaudeAdapter) Decode(r io.Reader) (Event, error) {
-	var raw map[string]any
-	if err := json.NewDecoder(r).Decode(&raw); err != nil {
+	input, err := io.ReadAll(r)
+	if err != nil {
+		return Event{}, err
+	}
+	sharedEvent, err := sharedhook.DecodeClaudeEvent(input, "claude-code")
+	if err != nil {
 		return Event{}, err
 	}
 	event := risk.HookEvent{
-		SessionID:     stringValue(raw, "session_id", "sessionId"),
-		Agent:         "claude-code",
-		HookEventName: stringValue(raw, "hook_event_name", "hookEventName"),
-		ToolName:      stringValue(raw, "tool_name", "toolName"),
-		ToolUseID:     stringValue(raw, "tool_use_id", "toolUseID", "toolUseId"),
-		CWD:           stringValue(raw, "cwd"),
+		SessionID:     sharedEvent.SessionID,
+		Agent:         sharedEvent.Agent,
+		HookEventName: sharedEvent.HookEventName,
+		ToolName:      sharedEvent.ToolName,
+		ToolInput:     sharedEvent.ToolInput,
+		ToolResponse:  sharedEvent.ToolResponse,
+		ToolUseID:     sharedEvent.ToolUseID,
+		CWD:           sharedEvent.CWD,
 		Timestamp:     time.Now().UTC(),
-	}
-	if event.HookEventName == "" {
-		event.HookEventName = stringValue(raw, "hook_event")
-	}
-	if input, ok := raw["tool_input"].(map[string]any); ok {
-		event.ToolInput = input
-	} else if input, ok := raw["toolInput"].(map[string]any); ok {
-		event.ToolInput = input
-	}
-	if response, ok := raw["tool_response"].(map[string]any); ok {
-		event.ToolResponse = response
-	} else if response, ok := raw["toolResponse"].(map[string]any); ok {
-		event.ToolResponse = response
 	}
 	if event.HookEventName == "" {
 		return Event{}, errors.New("hook event name missing")
@@ -53,18 +46,24 @@ func (ClaudeAdapter) Decode(r io.Reader) (Event, error) {
 }
 
 func (ClaudeAdapter) Encode(out io.Writer, result Result) error {
-	permissionDecision := "allow"
-	if result.Mode == ModeEnforce && result.CanBlock && (result.Decision == risk.DecisionAsk || result.Decision == risk.DecisionDeny) {
-		permissionDecision = "deny"
+	decision := sharedhook.DecisionAllow
+	if result.Mode == ModeEnforce && result.CanBlock {
+		switch result.Decision {
+		case risk.DecisionAsk:
+			decision = sharedhook.DecisionAsk
+		case risk.DecisionDeny:
+			decision = sharedhook.DecisionDeny
+		}
 	}
-	payload := map[string]any{
-		"hookSpecificOutput": map[string]any{
-			"hookEventName":            result.HookName,
-			"permissionDecision":       permissionDecision,
-			"permissionDecisionReason": formatReason(result.Decision, result.Reason, result.Mode),
-		},
+	payload, err := sharedhook.EncodeClaudeResult(result.HookName, sharedhook.Result{
+		Decision: decision,
+		Reason:   formatReason(result.Decision, result.Reason, result.Mode),
+	})
+	if err != nil {
+		return err
 	}
-	return json.NewEncoder(out).Encode(payload)
+	_, err = out.Write(append(payload, '\n'))
+	return err
 }
 
 func (ClaudeAdapter) MalformedHookName() string {
@@ -79,15 +78,6 @@ func formatReason(decision risk.Decision, reason string, mode Mode) string {
 		return fmt.Sprintf("Kontext observe mode: would %s; %s", decision, reason)
 	}
 	return reason
-}
-
-func stringValue(raw map[string]any, keys ...string) string {
-	for _, key := range keys {
-		if value, ok := raw[key].(string); ok {
-			return value
-		}
-	}
-	return ""
 }
 
 var _ Adapter = ClaudeAdapter{}

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -35,6 +35,9 @@ func (c agentCodec) DecodeHookEvent(input []byte) (hookruntime.Event, error) {
 
 func (c agentCodec) EncodeHookResult(event hookruntime.Event, result hookruntime.Result) ([]byte, error) {
 	agentEvent := agentEventFromRuntime(event)
+	if result.Decision == hookruntime.DecisionAsk {
+		return hookruntime.EncodeClaudeResult(agentEvent.HookEventName, result)
+	}
 	if result.Allowed() {
 		return c.agent.EncodeAllow(agentEvent, result.ClaudeReason(), result.UpdatedInput)
 	}

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -1,61 +1,58 @@
 package hook
 
 import (
-	"fmt"
 	"io"
 	"os"
 
 	"github.com/kontext-security/kontext-cli/internal/agent"
+	"github.com/kontext-security/kontext-cli/internal/hookruntime"
 )
 
-func Run(a agent.Agent, evaluate func(*agent.HookEvent) (bool, string, error)) {
+func Run(a agent.Agent, evaluate func(*agent.HookEvent) (hookruntime.Result, error)) {
 	os.Exit(run(os.Stdin, os.Stdout, os.Stderr, a, evaluate))
 }
 
-func run(stdin io.Reader, stdout, stderr io.Writer, a agent.Agent, evaluate func(*agent.HookEvent) (bool, string, error)) int {
-	input, err := io.ReadAll(stdin)
-	if err != nil {
-		fmt.Fprintf(stderr, "kontext: failed to read stdin: %v\n", err)
-		return 2
-	}
+func run(stdin io.Reader, stdout, stderr io.Writer, a agent.Agent, evaluate func(*agent.HookEvent) (hookruntime.Result, error)) int {
+	codec := agentCodec{agentName: a.Name(), agent: a}
+	sink := hookruntime.SinkFunc(func(event hookruntime.Event) (hookruntime.Result, error) {
+		return evaluate(agentEventFromRuntime(event))
+	})
+	return hookruntime.Run(stdin, stdout, stderr, codec, sink)
+}
 
-	event, err := a.DecodeHookInput(input)
-	if err != nil {
-		fmt.Fprintf(stderr, "kontext: failed to decode hook input: %v\n", err)
-		return 2
-	}
+type agentCodec struct {
+	agentName string
+	agent     agent.Agent
+}
 
-	allowed, reason, err := evaluate(event)
+func (c agentCodec) DecodeHookEvent(input []byte) (hookruntime.Event, error) {
+	event, err := c.agent.DecodeHookInput(input)
 	if err != nil {
-		fmt.Fprintf(stderr, "kontext: evaluation error: %v\n", err)
-		return 2
+		return hookruntime.Event{}, err
 	}
+	return hookruntime.EventFromAgent(c.agentName, event), nil
+}
 
-	if !allowed {
-		out, err := a.EncodeDeny(event, reason)
-		if err != nil {
-			fmt.Fprintf(stderr, "kontext: failed to encode deny output: %v\n", err)
-			return 2
-		}
-		if _, err := fmt.Fprintf(stderr, "Blocked by Kontext: %s\n", reason); err != nil {
-			fmt.Fprintf(stderr, "kontext: failed to write deny message: %v\n", err)
-			return 2
-		}
-		if _, err := stdout.Write(out); err != nil {
-			fmt.Fprintf(stderr, "kontext: failed to write hook output: %v\n", err)
-			return 2
-		}
-		return 2
+func (c agentCodec) EncodeHookResult(event hookruntime.Event, result hookruntime.Result) ([]byte, error) {
+	agentEvent := agentEventFromRuntime(event)
+	if result.Allowed() {
+		return c.agent.EncodeAllow(agentEvent, result.ClaudeReason(), result.UpdatedInput)
 	}
+	return c.agent.EncodeDeny(agentEvent, result.ClaudeReason())
+}
 
-	out, err := a.EncodeAllow(event, reason)
-	if err != nil {
-		fmt.Fprintf(stderr, "kontext: failed to encode allow output: %v\n", err)
-		return 2
+func agentEventFromRuntime(event hookruntime.Event) *agent.HookEvent {
+	return &agent.HookEvent{
+		SessionID:      event.SessionID,
+		HookEventName:  event.HookEventName,
+		ToolName:       event.ToolName,
+		ToolInput:      event.ToolInput,
+		ToolResponse:   event.ToolResponse,
+		ToolUseID:      event.ToolUseID,
+		CWD:            event.CWD,
+		PermissionMode: event.PermissionMode,
+		DurationMs:     event.DurationMs,
+		Error:          event.Error,
+		IsInterrupt:    event.IsInterrupt,
 	}
-	if _, err := stdout.Write(out); err != nil {
-		fmt.Fprintf(stderr, "kontext: failed to write hook output: %v\n", err)
-		return 2
-	}
-	return 0
 }

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -8,12 +8,15 @@ import (
 	"testing"
 
 	"github.com/kontext-security/kontext-cli/internal/agent"
+	"github.com/kontext-security/kontext-cli/internal/hookruntime"
 )
 
 type stubAgent struct {
-	decodeErr error
-	allowErr  error
-	denyErr   error
+	decodeErr         error
+	allowErr          error
+	denyErr           error
+	allowUpdatedInput map[string]any
+	denyReason        string
 }
 
 func (s *stubAgent) Name() string { return "stub" }
@@ -25,10 +28,11 @@ func (s *stubAgent) DecodeHookInput(input []byte) (*agent.HookEvent, error) {
 	return &agent.HookEvent{HookEventName: "PreToolUse"}, nil
 }
 
-func (s *stubAgent) EncodeAllow(event *agent.HookEvent, reason string) ([]byte, error) {
+func (s *stubAgent) EncodeAllow(event *agent.HookEvent, reason string, updatedInput map[string]any) ([]byte, error) {
 	if s.allowErr != nil {
 		return nil, s.allowErr
 	}
+	s.allowUpdatedInput = updatedInput
 	return []byte("ALLOW"), nil
 }
 
@@ -36,6 +40,7 @@ func (s *stubAgent) EncodeDeny(event *agent.HookEvent, reason string) ([]byte, e
 	if s.denyErr != nil {
 		return nil, s.denyErr
 	}
+	s.denyReason = reason
 	return []byte("DENY"), nil
 }
 
@@ -45,11 +50,13 @@ func TestRunAllowsAndWritesOutput(t *testing.T) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 
-	code := run(strings.NewReader(`{"hook_event_name":"PreToolUse"}`), stdout, stderr, &stubAgent{}, func(event *agent.HookEvent) (bool, string, error) {
+	stub := &stubAgent{}
+	updatedInput := map[string]any{"command": "echo ok"}
+	code := run(strings.NewReader(`{"hook_event_name":"PreToolUse"}`), stdout, stderr, stub, func(event *agent.HookEvent) (hookruntime.Result, error) {
 		if event.HookEventName != "PreToolUse" {
 			t.Fatalf("event.HookEventName = %q, want %q", event.HookEventName, "PreToolUse")
 		}
-		return true, "ok", nil
+		return hookruntime.Result{Decision: hookruntime.DecisionAllow, Reason: "ok", UpdatedInput: updatedInput}, nil
 	})
 
 	if code != 0 {
@@ -61,6 +68,35 @@ func TestRunAllowsAndWritesOutput(t *testing.T) {
 	if got := stderr.String(); got != "" {
 		t.Fatalf("stderr = %q, want empty", got)
 	}
+	if stub.allowUpdatedInput["command"] != "echo ok" {
+		t.Fatalf("updated input = %#v, want command", stub.allowUpdatedInput)
+	}
+}
+
+func TestRunPreservesAskReason(t *testing.T) {
+	t.Parallel()
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	stub := &stubAgent{}
+
+	code := run(strings.NewReader(`{"hook_event_name":"PreToolUse"}`), stdout, stderr, stub, func(*agent.HookEvent) (hookruntime.Result, error) {
+		return hookruntime.Result{
+			Decision:  hookruntime.DecisionAsk,
+			Reason:    "approval required",
+			RequestID: "req-123",
+		}, nil
+	})
+
+	if code != 2 {
+		t.Fatalf("run() exit code = %d, want 2", code)
+	}
+	if got := stdout.String(); got != "DENY" {
+		t.Fatalf("stdout = %q, want DENY", got)
+	}
+	if !strings.Contains(stub.denyReason, "Request ID: req-123") {
+		t.Fatalf("deny reason = %q, want request id", stub.denyReason)
+	}
 }
 
 func TestRunReturnsErrorWhenAllowEncodingFails(t *testing.T) {
@@ -69,14 +105,14 @@ func TestRunReturnsErrorWhenAllowEncodingFails(t *testing.T) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 
-	code := run(strings.NewReader(`{"hook_event_name":"PreToolUse"}`), stdout, stderr, &stubAgent{allowErr: errors.New("encode failed")}, func(*agent.HookEvent) (bool, string, error) {
-		return true, "ok", nil
+	code := run(strings.NewReader(`{"hook_event_name":"PreToolUse"}`), stdout, stderr, &stubAgent{allowErr: errors.New("encode failed")}, func(*agent.HookEvent) (hookruntime.Result, error) {
+		return hookruntime.Result{Decision: hookruntime.DecisionAllow, Reason: "ok"}, nil
 	})
 
 	if code != 2 {
 		t.Fatalf("run() exit code = %d, want 2", code)
 	}
-	if !strings.Contains(stderr.String(), "failed to encode allow output") {
+	if !strings.Contains(stderr.String(), "failed to encode hook output") {
 		t.Fatalf("stderr = %q, want encode failure", stderr.String())
 	}
 	if got := stdout.String(); got != "" {
@@ -89,8 +125,8 @@ func TestRunReturnsErrorWhenWriteFails(t *testing.T) {
 
 	stderr := &bytes.Buffer{}
 
-	code := run(strings.NewReader(`{"hook_event_name":"PreToolUse"}`), errWriter{}, stderr, &stubAgent{}, func(*agent.HookEvent) (bool, string, error) {
-		return true, "ok", nil
+	code := run(strings.NewReader(`{"hook_event_name":"PreToolUse"}`), errWriter{}, stderr, &stubAgent{}, func(*agent.HookEvent) (hookruntime.Result, error) {
+		return hookruntime.Result{Decision: hookruntime.DecisionAllow, Reason: "ok"}, nil
 	})
 
 	if code != 2 {
@@ -107,14 +143,14 @@ func TestRunReturnsErrorWhenDenyEncodingFails(t *testing.T) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 
-	code := run(strings.NewReader(`{"hook_event_name":"PreToolUse"}`), stdout, stderr, &stubAgent{denyErr: errors.New("encode failed")}, func(*agent.HookEvent) (bool, string, error) {
-		return false, "blocked", nil
+	code := run(strings.NewReader(`{"hook_event_name":"PreToolUse"}`), stdout, stderr, &stubAgent{denyErr: errors.New("encode failed")}, func(*agent.HookEvent) (hookruntime.Result, error) {
+		return hookruntime.Result{Decision: hookruntime.DecisionDeny, Reason: "blocked"}, nil
 	})
 
 	if code != 2 {
 		t.Fatalf("run() exit code = %d, want 2", code)
 	}
-	if !strings.Contains(stderr.String(), "failed to encode deny output") {
+	if !strings.Contains(stderr.String(), "failed to encode hook output") {
 		t.Fatalf("stderr = %q, want encode failure", stderr.String())
 	}
 }

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -73,7 +73,7 @@ func TestRunAllowsAndWritesOutput(t *testing.T) {
 	}
 }
 
-func TestRunPreservesAskReason(t *testing.T) {
+func TestRunMapsAskToBlockingDenyWithRequestID(t *testing.T) {
 	t.Parallel()
 
 	stdout := &bytes.Buffer{}
@@ -91,11 +91,14 @@ func TestRunPreservesAskReason(t *testing.T) {
 	if code != 2 {
 		t.Fatalf("run() exit code = %d, want 2", code)
 	}
-	if got := stdout.String(); got != "DENY" {
-		t.Fatalf("stdout = %q, want DENY", got)
+	if !strings.Contains(stdout.String(), `"permissionDecision":"deny"`) {
+		t.Fatalf("stdout = %q, want deny decision", stdout.String())
 	}
-	if !strings.Contains(stub.denyReason, "Request ID: req-123") {
-		t.Fatalf("deny reason = %q, want request id", stub.denyReason)
+	if !strings.Contains(stdout.String(), "Request ID: req-123") {
+		t.Fatalf("stdout = %q, want request id", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "Request ID: req-123") {
+		t.Fatalf("stderr = %q, want request id", stderr.String())
 	}
 }
 

--- a/internal/hookruntime/claude.go
+++ b/internal/hookruntime/claude.go
@@ -1,0 +1,109 @@
+package hookruntime
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type ClaudeHookInput struct {
+	SessionID        string         `json:"session_id"`
+	SessionIDAlt     string         `json:"sessionId"`
+	HookEventName    string         `json:"hook_event_name"`
+	HookEventNameAlt string         `json:"hookEventName"`
+	HookEventLegacy  string         `json:"hook_event"`
+	ToolName         string         `json:"tool_name"`
+	ToolNameAlt      string         `json:"toolName"`
+	ToolInput        map[string]any `json:"tool_input"`
+	ToolInputAlt     map[string]any `json:"toolInput"`
+	ToolResponse     map[string]any `json:"tool_response"`
+	ToolResponseAlt  map[string]any `json:"toolResponse"`
+	ToolUseID        string         `json:"tool_use_id"`
+	ToolUseIDAlt     string         `json:"toolUseId"`
+	ToolUseIDUpper   string         `json:"toolUseID"`
+	CWD              string         `json:"cwd"`
+	PermissionMode   *string        `json:"permission_mode"`
+	DurationMs       *int64         `json:"duration_ms"`
+	Error            *string        `json:"error"`
+	IsInterrupt      *bool          `json:"is_interrupt"`
+}
+
+type claudeHookOutput struct {
+	HookSpecificOutput *claudeHookSpecificOutput `json:"hookSpecificOutput,omitempty"`
+	SuppressOutput     bool                      `json:"suppressOutput,omitempty"`
+}
+
+type claudeHookSpecificOutput struct {
+	HookEventName            string         `json:"hookEventName"`
+	PermissionDecision       string         `json:"permissionDecision,omitempty"`
+	PermissionDecisionReason string         `json:"permissionDecisionReason,omitempty"`
+	AdditionalContext        string         `json:"additionalContext,omitempty"`
+	UpdatedInput             map[string]any `json:"updatedInput,omitempty"`
+}
+
+func DecodeClaudeEvent(input []byte, agentName string) (Event, error) {
+	var h ClaudeHookInput
+	if err := json.Unmarshal(input, &h); err != nil {
+		return Event{}, fmt.Errorf("claude: decode hook input: %w", err)
+	}
+	return Event{
+		SessionID:      firstString(h.SessionID, h.SessionIDAlt),
+		Agent:          agentName,
+		HookEventName:  firstString(h.HookEventName, h.HookEventNameAlt, h.HookEventLegacy),
+		ToolName:       firstString(h.ToolName, h.ToolNameAlt),
+		ToolInput:      firstMap(h.ToolInput, h.ToolInputAlt),
+		ToolResponse:   firstMap(h.ToolResponse, h.ToolResponseAlt),
+		ToolUseID:      firstString(h.ToolUseID, h.ToolUseIDAlt, h.ToolUseIDUpper),
+		CWD:            h.CWD,
+		PermissionMode: stringPtrValue(h.PermissionMode),
+		DurationMs:     h.DurationMs,
+		Error:          stringPtrValue(h.Error),
+		IsInterrupt:    h.IsInterrupt,
+	}, nil
+}
+
+func firstString(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func firstMap(values ...map[string]any) map[string]any {
+	for _, value := range values {
+		if value != nil {
+			return value
+		}
+	}
+	return nil
+}
+
+func EncodeClaudeResult(hookEventName string, result Result) ([]byte, error) {
+	permissionDecision := "allow"
+	if result.Decision == DecisionAsk || result.Decision == DecisionDeny {
+		permissionDecision = "deny"
+	}
+	reason := result.ClaudeReason()
+	if permissionDecision == "allow" && strings.EqualFold(strings.TrimSpace(reason), "allowed") {
+		reason = ""
+	}
+	out := claudeHookOutput{
+		HookSpecificOutput: &claudeHookSpecificOutput{
+			HookEventName:            hookEventName,
+			PermissionDecision:       permissionDecision,
+			PermissionDecisionReason: reason,
+			UpdatedInput:             result.UpdatedInput,
+		},
+		SuppressOutput: result.UpdatedInput != nil,
+	}
+	return json.Marshal(out)
+}
+
+func stringPtrValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}

--- a/internal/hookruntime/claude.go
+++ b/internal/hookruntime/claude.go
@@ -82,10 +82,7 @@ func firstMap(values ...map[string]any) map[string]any {
 
 func EncodeClaudeResult(hookEventName string, result Result) ([]byte, error) {
 	permissionDecision := "allow"
-	if result.Decision == DecisionAsk {
-		permissionDecision = "ask"
-	}
-	if result.Decision == DecisionDeny {
+	if result.Decision == DecisionAsk || result.Decision == DecisionDeny {
 		permissionDecision = "deny"
 	}
 	reason := result.ClaudeReason()

--- a/internal/hookruntime/claude.go
+++ b/internal/hookruntime/claude.go
@@ -82,7 +82,10 @@ func firstMap(values ...map[string]any) map[string]any {
 
 func EncodeClaudeResult(hookEventName string, result Result) ([]byte, error) {
 	permissionDecision := "allow"
-	if result.Decision == DecisionAsk || result.Decision == DecisionDeny {
+	if result.Decision == DecisionAsk {
+		permissionDecision = "ask"
+	}
+	if result.Decision == DecisionDeny {
 		permissionDecision = "deny"
 	}
 	reason := result.ClaudeReason()

--- a/internal/hookruntime/runner.go
+++ b/internal/hookruntime/runner.go
@@ -48,7 +48,10 @@ func Run(stdin io.Reader, stdout, stderr io.Writer, codec Codec, sink Sink) int 
 		fmt.Fprintf(stderr, "kontext: failed to write hook output: %v\n", err)
 		return 2
 	}
-	if !result.Allowed() {
+	if result.Decision == DecisionAsk || result.Decision == DecisionDeny {
+		if reason := result.ClaudeReason(); reason != "" {
+			fmt.Fprintln(stderr, reason)
+		}
 		return 2
 	}
 	return 0

--- a/internal/hookruntime/runner.go
+++ b/internal/hookruntime/runner.go
@@ -1,0 +1,55 @@
+package hookruntime
+
+import (
+	"fmt"
+	"io"
+)
+
+type Codec interface {
+	DecodeHookEvent([]byte) (Event, error)
+	EncodeHookResult(Event, Result) ([]byte, error)
+}
+
+type Sink interface {
+	ProcessHookEvent(Event) (Result, error)
+}
+
+type SinkFunc func(Event) (Result, error)
+
+func (f SinkFunc) ProcessHookEvent(event Event) (Result, error) {
+	return f(event)
+}
+
+func Run(stdin io.Reader, stdout, stderr io.Writer, codec Codec, sink Sink) int {
+	input, err := io.ReadAll(stdin)
+	if err != nil {
+		fmt.Fprintf(stderr, "kontext: failed to read stdin: %v\n", err)
+		return 2
+	}
+
+	event, err := codec.DecodeHookEvent(input)
+	if err != nil {
+		fmt.Fprintf(stderr, "kontext: failed to decode hook input: %v\n", err)
+		return 2
+	}
+
+	result, err := sink.ProcessHookEvent(event)
+	if err != nil {
+		fmt.Fprintf(stderr, "kontext: evaluation error: %v\n", err)
+		return 2
+	}
+
+	out, err := codec.EncodeHookResult(event, result)
+	if err != nil {
+		fmt.Fprintf(stderr, "kontext: failed to encode hook output: %v\n", err)
+		return 2
+	}
+	if _, err := stdout.Write(out); err != nil {
+		fmt.Fprintf(stderr, "kontext: failed to write hook output: %v\n", err)
+		return 2
+	}
+	if !result.Allowed() {
+		return 2
+	}
+	return 0
+}

--- a/internal/hookruntime/runner_test.go
+++ b/internal/hookruntime/runner_test.go
@@ -1,0 +1,81 @@
+package hookruntime
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestRunWritesBlockedReasonToStderr(t *testing.T) {
+	t.Parallel()
+
+	codec := stubCodec{
+		event: Event{HookEventName: "PreToolUse"},
+		out:   []byte(`{"hookSpecificOutput":{"permissionDecision":"deny"}}`),
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	code := Run(
+		bytes.NewBufferString(`{"hook_event_name":"PreToolUse"}`),
+		stdout,
+		stderr,
+		codec,
+		SinkFunc(func(Event) (Result, error) {
+			return Result{Decision: DecisionDeny, Reason: "blocked by policy"}, nil
+		}),
+	)
+
+	if code != 2 {
+		t.Fatalf("Run() exit code = %d, want 2", code)
+	}
+	if stdout.String() != string(codec.out) {
+		t.Fatalf("stdout = %q, want encoded output", stdout.String())
+	}
+	if stderr.String() != "blocked by policy\n" {
+		t.Fatalf("stderr = %q, want blocked reason", stderr.String())
+	}
+}
+
+func TestRunBlocksForAskDecision(t *testing.T) {
+	t.Parallel()
+
+	codec := stubCodec{
+		event: Event{HookEventName: "PreToolUse"},
+		out:   []byte(`{"hookSpecificOutput":{"permissionDecision":"deny"}}`),
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	code := Run(
+		bytes.NewBufferString(`{"hook_event_name":"PreToolUse"}`),
+		stdout,
+		stderr,
+		codec,
+		SinkFunc(func(Event) (Result, error) {
+			return Result{Decision: DecisionAsk, Reason: "approval required"}, nil
+		}),
+	)
+
+	if code != 2 {
+		t.Fatalf("Run() exit code = %d, want 2", code)
+	}
+	if stdout.String() != string(codec.out) {
+		t.Fatalf("stdout = %q, want encoded output", stdout.String())
+	}
+	if stderr.String() != "approval required\n" {
+		t.Fatalf("stderr = %q, want approval reason", stderr.String())
+	}
+}
+
+type stubCodec struct {
+	event Event
+	out   []byte
+}
+
+func (s stubCodec) DecodeHookEvent([]byte) (Event, error) {
+	return s.event, nil
+}
+
+func (s stubCodec) EncodeHookResult(Event, Result) ([]byte, error) {
+	return s.out, nil
+}

--- a/internal/hookruntime/runtime.go
+++ b/internal/hookruntime/runtime.go
@@ -1,0 +1,104 @@
+package hookruntime
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/kontext-security/kontext-cli/internal/agent"
+)
+
+type Decision string
+
+const (
+	DecisionAllow Decision = "ALLOW"
+	DecisionAsk   Decision = "ASK"
+	DecisionDeny  Decision = "DENY"
+)
+
+type Event struct {
+	SessionID      string
+	Agent          string
+	HookEventName  string
+	ToolName       string
+	ToolInput      map[string]any
+	ToolResponse   map[string]any
+	ToolUseID      string
+	CWD            string
+	PermissionMode string
+	DurationMs     *int64
+	Error          string
+	IsInterrupt    *bool
+}
+
+type Result struct {
+	Decision     Decision
+	Reason       string
+	ReasonCode   string
+	RequestID    string
+	Mode         string
+	Epoch        string
+	UpdatedInput map[string]any
+}
+
+type Processor interface {
+	ProcessHookEvent(Event) (Result, error)
+}
+
+func EventFromAgent(agentName string, event *agent.HookEvent) Event {
+	if event == nil {
+		return Event{Agent: agentName}
+	}
+	return Event{
+		SessionID:      event.SessionID,
+		Agent:          agentName,
+		HookEventName:  event.HookEventName,
+		ToolName:       event.ToolName,
+		ToolInput:      event.ToolInput,
+		ToolResponse:   event.ToolResponse,
+		ToolUseID:      event.ToolUseID,
+		CWD:            event.CWD,
+		PermissionMode: event.PermissionMode,
+		DurationMs:     event.DurationMs,
+		Error:          event.Error,
+		IsInterrupt:    event.IsInterrupt,
+	}
+}
+
+func ResultFromBool(allowed bool, reason string) Result {
+	if allowed {
+		return Result{Decision: DecisionAllow, Reason: reason}
+	}
+	return Result{Decision: DecisionDeny, Reason: reason}
+}
+
+func (r Result) Allowed() bool {
+	return r.Decision == DecisionAllow
+}
+
+func (r Result) ClaudeReason() string {
+	reason := r.Reason
+	if r.Decision == DecisionAsk && r.RequestID != "" {
+		if reason != "" {
+			return fmt.Sprintf("%s Request ID: %s", reason, r.RequestID)
+		}
+		return fmt.Sprintf("Kontext access policy requires approval. Request ID: %s", r.RequestID)
+	}
+	if reason == "" && r.Decision == DecisionAsk {
+		return "Kontext access policy requires approval."
+	}
+	if reason == "" && r.Decision == DecisionDeny {
+		return "Blocked by Kontext access policy."
+	}
+	return reason
+}
+
+func MarshalMap(value map[string]any) (json.RawMessage, error) {
+	if value == nil {
+		return nil, nil
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}

--- a/internal/hookruntime/runtime.go
+++ b/internal/hookruntime/runtime.go
@@ -3,6 +3,7 @@ package hookruntime
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/kontext-security/kontext-cli/internal/agent"
 )
@@ -79,6 +80,9 @@ func (r Result) ClaudeReason() string {
 	reason := r.Reason
 	if r.Decision == DecisionAsk && r.RequestID != "" {
 		if reason != "" {
+			if containsRequestID(reason) {
+				return reason
+			}
 			return fmt.Sprintf("%s Request ID: %s", reason, r.RequestID)
 		}
 		return fmt.Sprintf("Kontext access policy requires approval. Request ID: %s", r.RequestID)
@@ -90,6 +94,10 @@ func (r Result) ClaudeReason() string {
 		return "Blocked by Kontext access policy."
 	}
 	return reason
+}
+
+func containsRequestID(reason string) bool {
+	return strings.Contains(strings.ToLower(reason), "request id")
 }
 
 func MarshalMap(value map[string]any) (json.RawMessage, error) {


### PR DESCRIPTION
## Summary

- Introduces a neutral shared Claude hook event/result runtime and runner.
- Moves hosted hook execution to `hookruntime.Result` so ASK/DENY are not collapsed into a boolean.
- Reuses the shared Claude protocol decode/encode path from Guard without changing Guard risk decisions.

Refs #91.

## Verification

- `go test ./...`

## Release notes

- Minor: `feat:` shared hook runtime foundation.