### PR TITLE
feat: add hosted github context credentials

### DIFF
--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -176,12 +176,20 @@ func Start(ctx context.Context, opts Options) error {
 		)
 	}
 
+	// Resolve startup credentials only when hosted access is not enforcing.
+	// In enforce mode, managed credential material must not enter the agent
+	// environment before the PreToolUse policy decision allows the action.
 	var resolved []credential.Resolved
-	if len(templateDoc.Entries) > 0 {
+	if shouldResolveStartupCredentials(bootstrapResult.AccessMode) && len(templateDoc.Entries) > 0 {
 		resolved, err = resolveCredentials(ctx, session, templateDoc.Entries, credentialClientID, diagnostics, fetchConnectURLForConnectFlow)
 		if err != nil {
 			return err
 		}
+	} else if len(templateDoc.Entries) > 0 {
+		fmt.Fprintf(
+			os.Stderr,
+			"ℹ Managed provider credentials are policy-gated for this hosted session; placeholders will not be preloaded.\n",
+		)
 	}
 
 	// 6. Start sidecar
@@ -192,13 +200,17 @@ func Start(ctx context.Context, opts Options) error {
 		return fmt.Errorf("create session dir: %w", err)
 	}
 
-	sc, err := sidecar.New(
+	sc, err := sidecar.NewWithCredentials(
 		sessionDir,
 		client,
 		sessionID,
 		opts.Agent,
 		bootstrapResult.AccessMode,
 		diagnostics,
+		templateDoc.Entries,
+		func(ctx context.Context, entry credential.Entry) (string, error) {
+			return tokenManager.ExchangeCredential(ctx, entry, credentialClientID)
+		},
 	)
 	if err != nil {
 		return fmt.Errorf("sidecar: %w", err)
@@ -874,6 +886,10 @@ func buildEnv(templateDoc *credential.TemplateFile, resolved []credential.Resolv
 		}
 	}
 	return credential.BuildEnv(resolved, env)
+}
+
+func shouldResolveStartupCredentials(mode backend.HostedAccessMode) bool {
+	return mode != backend.HostedAccessModeEnforce
 }
 
 func managedProvidersFromBootstrap(items []*agentv1.ManagedProvider) []credential.ManagedProvider {

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/kontext-security/kontext-cli/internal/auth"
+	"github.com/kontext-security/kontext-cli/internal/backend"
 	"github.com/kontext-security/kontext-cli/internal/credential"
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 )
@@ -1149,5 +1150,29 @@ func TestVerifyBlockingHookSettingsRequiresPreToolUseCommand(t *testing.T) {
 
 	if err := VerifyBlockingHookSettings(brokenPath, "/usr/local/bin/kontext", "claude"); err == nil {
 		t.Fatal("VerifyBlockingHookSettings() error = nil, want missing PreToolUse hook error")
+	}
+}
+
+func TestShouldResolveStartupCredentials(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		mode backend.HostedAccessMode
+		want bool
+	}{
+		{name: "disabled", mode: backend.HostedAccessModeDisabled, want: true},
+		{name: "no policy", mode: backend.HostedAccessModeNoPolicy, want: true},
+		{name: "enforce", mode: backend.HostedAccessModeEnforce, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := shouldResolveStartupCredentials(tt.mode); got != tt.want {
+				t.Fatalf("shouldResolveStartupCredentials(%q) = %v, want %v", tt.mode, got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/sidecar/credential_injector.go
+++ b/internal/sidecar/credential_injector.go
@@ -1,0 +1,155 @@
+package sidecar
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/kontext-security/kontext-cli/internal/credential"
+)
+
+type credentialResolver func(context.Context, credential.Entry) (string, error)
+
+type credentialInjector struct {
+	sessionDir string
+	entries    []credential.Entry
+	resolve    credentialResolver
+}
+
+func newCredentialInjector(sessionDir string, entries []credential.Entry, resolve credentialResolver) *credentialInjector {
+	if len(entries) == 0 || resolve == nil {
+		return nil
+	}
+	return &credentialInjector{
+		sessionDir: sessionDir,
+		entries:    entries,
+		resolve:    resolve,
+	}
+}
+
+func (i *credentialInjector) updatedInputForAllowedHook(ctx context.Context, req *EvaluateRequest) (map[string]any, error) {
+	if i == nil || req.HookEvent != "PreToolUse" || req.ToolName != "Bash" {
+		return nil, nil
+	}
+
+	var input map[string]any
+	if err := json.Unmarshal(req.ToolInput, &input); err != nil {
+		return nil, nil
+	}
+	command, ok := input["command"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	entries := i.entriesForCommand(command)
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	credentials := make([]commandCredential, 0, len(entries))
+	for _, entry := range entries {
+		value, err := i.resolve(ctx, entry)
+		if err != nil || strings.TrimSpace(value) == "" {
+			return nil, err
+		}
+		credentialPath, err := i.writeCredentialFile(entry.EnvVar, value)
+		if err != nil {
+			return nil, err
+		}
+		credentials = append(credentials, commandCredential{
+			envVar: entry.EnvVar,
+			path:   credentialPath,
+		})
+	}
+
+	updated := make(map[string]any, len(input))
+	for key, value := range input {
+		updated[key] = value
+	}
+	updated["command"] = prefixCommandWithCredentials(command, credentials)
+	return updated, nil
+}
+
+func (i *credentialInjector) entriesForCommand(command string) []credential.Entry {
+	var matches []credential.Entry
+	for _, entry := range i.entries {
+		if entry.EnvVar != "" && looksLikeProviderCommand(command, entry.Provider) {
+			matches = append(matches, entry)
+		}
+	}
+	return matches
+}
+
+func (i *credentialInjector) writeCredentialFile(envVar, value string) (string, error) {
+	dir := filepath.Join(i.sessionDir, "credentials")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("create credential dir: %w", err)
+	}
+	path := filepath.Join(dir, safeCredentialFileName(envVar))
+	if err := os.WriteFile(path, []byte(value), 0o600); err != nil {
+		return "", fmt.Errorf("write credential file: %w", err)
+	}
+	return path, nil
+}
+
+type commandCredential struct {
+	envVar string
+	path   string
+}
+
+func prefixCommandWithCredentials(command string, credentials []commandCredential) string {
+	prefixes := make([]string, 0, len(credentials))
+	for _, item := range credentials {
+		prefixes = append(prefixes, fmt.Sprintf(
+			"export %s=\"$(cat %s)\"",
+			shellQuoteAssignmentName(item.envVar),
+			shellQuote(item.path),
+		))
+	}
+	if len(prefixes) == 0 {
+		return command
+	}
+	return strings.Join(prefixes, "; ") + "; " + command
+}
+
+func shellQuoteAssignmentName(value string) string {
+	if regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`).MatchString(value) {
+		return value
+	}
+	sum := sha256.Sum256([]byte(value))
+	return "KONTEXT_MANAGED_TOKEN_" + strings.ToUpper(hex.EncodeToString(sum[:6]))
+}
+
+func safeCredentialFileName(envVar string) string {
+	return shellQuoteAssignmentName(envVar)
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+func looksLikeGitHubCommand(command string) bool {
+	lower := strings.ToLower(command)
+	return strings.Contains(lower, "github.com") ||
+		strings.Contains(lower, "api.github.com") ||
+		regexp.MustCompile(`(^|[;&|()\s])gh(\s|$)`).MatchString(lower)
+}
+
+func looksLikeProviderCommand(command, provider string) bool {
+	switch strings.ToLower(provider) {
+	case "github":
+		return looksLikeGitHubCommand(command)
+	case "linear":
+		return regexp.MustCompile(`(^|[;&|()\s])linear(\s|$)`).MatchString(strings.ToLower(command))
+	case "slack":
+		return regexp.MustCompile(`(^|[;&|()\s])slack(\s|$)`).MatchString(strings.ToLower(command))
+	default:
+		return false
+	}
+}

--- a/internal/sidecar/git_context.go
+++ b/internal/sidecar/git_context.go
@@ -1,0 +1,114 @@
+package sidecar
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/url"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const gitContextTimeout = 500 * time.Millisecond
+
+type localGitContext struct {
+	WorktreeRoot string            `json:"worktree_root,omitempty"`
+	Branch       string            `json:"branch,omitempty"`
+	Remotes      map[string]string `json:"remotes,omitempty"`
+}
+
+func enrichToolInputWithLocalContext(ctx context.Context, req *EvaluateRequest) {
+	if req.HookEvent != "PreToolUse" || req.ToolName != "Bash" || len(req.ToolInput) == 0 {
+		return
+	}
+
+	var input map[string]any
+	if err := json.Unmarshal(req.ToolInput, &input); err != nil {
+		return
+	}
+	delete(input, "kontext")
+
+	gitCtx, ok := collectLocalGitContext(ctx, req.CWD)
+	if ok {
+		input["kontext"] = map[string]any{"git": gitCtx}
+	}
+
+	data, err := json.Marshal(input)
+	if err != nil {
+		return
+	}
+	req.ToolInput = data
+}
+
+func collectLocalGitContext(ctx context.Context, cwd string) (localGitContext, bool) {
+	ctx, cancel := context.WithTimeout(ctx, gitContextTimeout)
+	defer cancel()
+
+	root, ok := runGit(ctx, cwd, "rev-parse", "--show-toplevel")
+	if !ok || root == "" {
+		return localGitContext{}, false
+	}
+
+	branch, _ := runGit(ctx, cwd, "branch", "--show-current")
+	remoteLines, _ := runGit(ctx, cwd, "remote", "-v")
+	remotes := parseGitRemotes(remoteLines)
+
+	return localGitContext{
+		WorktreeRoot: root,
+		Branch:       branch,
+		Remotes:      remotes,
+	}, true
+}
+
+func runGit(ctx context.Context, cwd string, args ...string) (string, bool) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	if cwd != "" {
+		cmd.Dir = cwd
+	}
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(stdout.String()), true
+}
+
+func parseGitRemotes(output string) map[string]string {
+	remotes := make(map[string]string)
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		if _, exists := remotes[fields[0]]; exists {
+			continue
+		}
+		if sanitized := sanitizeGitRemote(fields[1]); sanitized != "" {
+			remotes[fields[0]] = sanitized
+		}
+	}
+	if len(remotes) == 0 {
+		return nil
+	}
+	return remotes
+}
+
+func sanitizeGitRemote(raw string) string {
+	if strings.HasPrefix(raw, "git@github.com:") {
+		return "https://github.com/" + strings.TrimPrefix(raw, "git@github.com:")
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" {
+		return ""
+	}
+	if !strings.EqualFold(parsed.Hostname(), "github.com") {
+		return ""
+	}
+
+	parsed.User = nil
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String()
+}

--- a/internal/sidecar/sidecar.go
+++ b/internal/sidecar/sidecar.go
@@ -10,6 +10,7 @@ import (
 
 	agentv1 "github.com/kontext-security/kontext-cli/gen/kontext/agent/v1"
 	"github.com/kontext-security/kontext-cli/internal/backend"
+	"github.com/kontext-security/kontext-cli/internal/credential"
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 	"github.com/kontext-security/kontext-cli/internal/hookruntime"
 )
@@ -69,16 +70,17 @@ func (h *heartbeatState) record(now time.Time, err error, logf func(string, ...a
 }
 
 type Server struct {
-	socketPath string
-	modePath   string
-	listener   net.Listener
-	sessionID  string
-	agentName  string
-	mu         sync.RWMutex
-	accessMode backend.HostedAccessMode
-	client     sidecarClient
-	diagnostic diagnostic.Logger
-	cancel     context.CancelFunc
+	socketPath  string
+	modePath    string
+	listener    net.Listener
+	sessionID   string
+	agentName   string
+	mu          sync.RWMutex
+	accessMode  backend.HostedAccessMode
+	client      sidecarClient
+	diagnostic  diagnostic.Logger
+	cancel      context.CancelFunc
+	credentials *credentialInjector
 }
 
 // New creates a new sidecar server.
@@ -92,6 +94,15 @@ func New(sessionDir string, client sidecarClient, sessionID, agentName string, a
 		client:     client,
 		diagnostic: diagnostics,
 	}, nil
+}
+
+func NewWithCredentials(sessionDir string, client sidecarClient, sessionID, agentName string, accessMode backend.HostedAccessMode, diagnostics diagnostic.Logger, entries []credential.Entry, resolve credentialResolver) (*Server, error) {
+	server, err := New(sessionDir, client, sessionID, agentName, accessMode, diagnostics)
+	if err != nil {
+		return nil, err
+	}
+	server.credentials = newCredentialInjector(sessionDir, entries, resolve)
+	return server, nil
 }
 
 func (s *Server) SocketPath() string { return s.socketPath }
@@ -191,7 +202,7 @@ func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
 }
 
 func (s *Server) ingestEvent(ctx context.Context, req *EvaluateRequest) {
-	hookEvent := buildHookEventRequest(s.sessionID, s.agentName, req)
+	hookEvent := buildHookEventRequest(ctx, s.sessionID, s.agentName, req)
 	result, err := s.client.ProcessHookEvent(ctx, hookEvent)
 	if err != nil {
 		s.diagnostic.Printf("sidecar ingest: %v\n", err)
@@ -229,7 +240,7 @@ func (s *Server) evaluate(ctx context.Context, req *EvaluateRequest) EvaluateRes
 		return defaultAllowResult()
 	}
 
-	hookEvent := buildHookEventRequest(s.sessionID, s.agentName, req)
+	hookEvent := buildHookEventRequest(ctx, s.sessionID, s.agentName, req)
 	result, err := s.client.ProcessHookEvent(ctx, hookEvent)
 	if err != nil {
 		s.diagnostic.Printf("sidecar enforce: %v\n", err)
@@ -272,6 +283,11 @@ func (s *Server) evaluate(ctx context.Context, req *EvaluateRequest) EvaluateRes
 			Mode:       string(result.AccessMode),
 			Epoch:      result.PolicySetEpoch,
 		}
+		updatedInput, err := s.credentials.updatedInputForAllowedHook(ctx, req)
+		if err != nil {
+			s.diagnostic.Printf("sidecar credential injection skipped: %v\n", err)
+		}
+		runtimeResult.UpdatedInput = updatedInput
 		return resultFromRuntime(runtimeResult)
 	case agentv1.Decision_DECISION_ASK:
 		return resultFromRuntime(hookruntime.Result{
@@ -314,7 +330,9 @@ func resultFromRuntime(result hookruntime.Result) EvaluateResult {
 	}
 }
 
-func buildHookEventRequest(sessionID, agentName string, req *EvaluateRequest) *agentv1.ProcessHookEventRequest {
+func buildHookEventRequest(ctx context.Context, sessionID, agentName string, req *EvaluateRequest) *agentv1.ProcessHookEventRequest {
+	enrichToolInputWithLocalContext(ctx, req)
+
 	hookEvent := &agentv1.ProcessHookEventRequest{
 		SessionId: sessionID,
 		Agent:     agentName,

--- a/internal/sidecar/sidecar_test.go
+++ b/internal/sidecar/sidecar_test.go
@@ -15,6 +15,7 @@ import (
 
 	agentv1 "github.com/kontext-security/kontext-cli/gen/kontext/agent/v1"
 	"github.com/kontext-security/kontext-cli/internal/backend"
+	"github.com/kontext-security/kontext-cli/internal/credential"
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 	"github.com/kontext-security/kontext-cli/internal/hookruntime"
 )
@@ -192,6 +193,143 @@ func TestEvaluatePreToolUseUsesBackendDecision(t *testing.T) {
 	}
 }
 
+func TestEnrichToolInputRemovesUntrustedKontextContext(t *testing.T) {
+	t.Parallel()
+
+	req := &EvaluateRequest{
+		HookEvent: "PreToolUse",
+		ToolName:  "Bash",
+		CWD:       t.TempDir(),
+		ToolInput: json.RawMessage(`{"command":"git push origin main","kontext":{"git":{"branch":"main","remotes":{"origin":"https://github.com/evil/repo.git"}}}}`),
+	}
+
+	enrichToolInputWithLocalContext(context.Background(), req)
+
+	var input map[string]any
+	if err := json.Unmarshal(req.ToolInput, &input); err != nil {
+		t.Fatalf("tool input JSON: %v", err)
+	}
+	if _, ok := input["kontext"]; ok {
+		t.Fatalf("kontext context = %#v, want removed when local git context is unavailable", input["kontext"])
+	}
+	if input["command"] != "git push origin main" {
+		t.Fatalf("command = %#v, want original command", input["command"])
+	}
+}
+
+func TestEvaluatePreToolUseInjectsManagedCredentialOnlyAfterAllow(t *testing.T) {
+	t.Parallel()
+
+	client := &stubProcessor{
+		result: &backend.ProcessHookEventResult{
+			Response: &agentv1.ProcessHookEventResponse{
+				Decision: agentv1.Decision_DECISION_ALLOW,
+				Reason:   "allowed",
+			},
+			AccessMode: backend.HostedAccessModeEnforce,
+		},
+	}
+	sessionDir := t.TempDir()
+	s := &Server{
+		sessionID:  "session-123",
+		agentName:  "claude",
+		modePath:   filepath.Join(t.TempDir(), "access-mode"),
+		accessMode: backend.HostedAccessModeEnforce,
+		client:     client,
+		diagnostic: diagnostic.New(io.Discard, false),
+		credentials: newCredentialInjector(
+			sessionDir,
+			[]credential.Entry{{EnvVar: "GITHUB_TOKEN", Provider: "github"}},
+			func(context.Context, credential.Entry) (string, error) { return "managed-token", nil },
+		),
+	}
+
+	result := s.evaluate(context.Background(), &EvaluateRequest{
+		HookEvent: "PreToolUse",
+		ToolName:  "Bash",
+		ToolInput: json.RawMessage(`{"command":"gh pr view 92","description":"inspect pr"}`),
+	})
+
+	if !result.Allowed {
+		t.Fatal("evaluate().Allowed = false, want true")
+	}
+	command, ok := result.UpdatedInput["command"].(string)
+	if !ok {
+		t.Fatalf("updated command missing: %#v", result.UpdatedInput)
+	}
+	if strings.Contains(command, "managed-token") {
+		t.Fatalf("updated command leaked raw token: %q", command)
+	}
+	if !strings.Contains(command, `GITHUB_TOKEN="$(cat `) || !strings.Contains(command, "gh pr view 92") {
+		t.Fatalf("updated command = %q, want credential file prefix and original command", command)
+	}
+	if got := result.UpdatedInput["description"]; got != "inspect pr" {
+		t.Fatalf("updated input did not preserve unchanged fields: %#v", result.UpdatedInput)
+	}
+	raw, err := os.ReadFile(filepath.Join(sessionDir, "credentials", "GITHUB_TOKEN"))
+	if err != nil {
+		t.Fatalf("credential file missing: %v", err)
+	}
+	if string(raw) != "managed-token" {
+		t.Fatalf("credential file = %q, want managed-token", raw)
+	}
+}
+
+func TestEvaluatePreToolUseInjectsAllMatchingManagedCredentials(t *testing.T) {
+	t.Parallel()
+
+	client := &stubProcessor{
+		result: &backend.ProcessHookEventResult{
+			Response: &agentv1.ProcessHookEventResponse{
+				Decision: agentv1.Decision_DECISION_ALLOW,
+			},
+			AccessMode: backend.HostedAccessModeEnforce,
+		},
+	}
+	sessionDir := t.TempDir()
+	s := &Server{
+		sessionID:  "session-123",
+		agentName:  "claude",
+		modePath:   filepath.Join(t.TempDir(), "access-mode"),
+		accessMode: backend.HostedAccessModeEnforce,
+		client:     client,
+		diagnostic: diagnostic.New(io.Discard, false),
+		credentials: newCredentialInjector(
+			sessionDir,
+			[]credential.Entry{
+				{EnvVar: "GITHUB_TOKEN", Provider: "github"},
+				{EnvVar: "GIT_ASKPASS_TOKEN", Provider: "github"},
+			},
+			func(_ context.Context, entry credential.Entry) (string, error) {
+				return "managed-" + entry.EnvVar, nil
+			},
+		),
+	}
+
+	result := s.evaluate(context.Background(), &EvaluateRequest{
+		HookEvent: "PreToolUse",
+		ToolName:  "Bash",
+		ToolInput: json.RawMessage(`{"command":"gh pr view 92"}`),
+	})
+
+	command, ok := result.UpdatedInput["command"].(string)
+	if !ok {
+		t.Fatalf("updated command missing: %#v", result.UpdatedInput)
+	}
+	for _, envVar := range []string{"GITHUB_TOKEN", "GIT_ASKPASS_TOKEN"} {
+		if !strings.Contains(command, envVar+`="$(cat `) {
+			t.Fatalf("updated command = %q, want %s export", command, envVar)
+		}
+		raw, err := os.ReadFile(filepath.Join(sessionDir, "credentials", envVar))
+		if err != nil {
+			t.Fatalf("%s credential file missing: %v", envVar, err)
+		}
+		if string(raw) != "managed-"+envVar {
+			t.Fatalf("%s credential file = %q", envVar, raw)
+		}
+	}
+}
+
 func TestEvaluatePreToolUseAskKeepsRawReasonAndRequestMetadata(t *testing.T) {
 	t.Parallel()
 
@@ -242,6 +380,193 @@ func TestEvaluatePreToolUseAskKeepsRawReasonAndRequestMetadata(t *testing.T) {
 	}
 	if strings.Count(string(claudeOutput), "Request ID: request-123") != 1 {
 		t.Fatalf("claude output = %s, want one request id", claudeOutput)
+	}
+}
+
+func TestEvaluatePreToolUseSanitizesCredentialFileName(t *testing.T) {
+	t.Parallel()
+
+	sessionDir := t.TempDir()
+	s := &Server{
+		sessionID:  "session-123",
+		agentName:  "claude",
+		modePath:   filepath.Join(t.TempDir(), "access-mode"),
+		accessMode: backend.HostedAccessModeEnforce,
+		client: &stubProcessor{
+			result: &backend.ProcessHookEventResult{
+				Response: &agentv1.ProcessHookEventResponse{
+					Decision: agentv1.Decision_DECISION_ALLOW,
+				},
+				AccessMode: backend.HostedAccessModeEnforce,
+			},
+		},
+		diagnostic: diagnostic.New(io.Discard, false),
+		credentials: newCredentialInjector(
+			sessionDir,
+			[]credential.Entry{{EnvVar: "../../escaped", Provider: "github"}},
+			func(context.Context, credential.Entry) (string, error) { return "managed-token", nil },
+		),
+	}
+
+	result := s.evaluate(context.Background(), &EvaluateRequest{
+		HookEvent: "PreToolUse",
+		ToolName:  "Bash",
+		ToolInput: json.RawMessage(`{"command":"gh pr view 92"}`),
+	})
+
+	if !result.Allowed {
+		t.Fatal("evaluate().Allowed = false, want true")
+	}
+	if _, err := os.Stat(filepath.Join(sessionDir, "escaped")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("escaped credential path stat error = %v, want not exist", err)
+	}
+	fallbackName := shellQuoteAssignmentName("../../escaped")
+	if fallbackName == "KONTEXT_MANAGED_TOKEN" {
+		t.Fatal("fallback credential name is not collision-resistant")
+	}
+	raw, err := os.ReadFile(filepath.Join(sessionDir, "credentials", fallbackName))
+	if err != nil {
+		t.Fatalf("sanitized credential file missing: %v", err)
+	}
+	if string(raw) != "managed-token" {
+		t.Fatalf("credential file = %q, want managed-token", raw)
+	}
+	command, ok := result.UpdatedInput["command"].(string)
+	if !ok || !strings.Contains(command, fallbackName+`="$(cat `) {
+		t.Fatalf("updated command = %#v, want sanitized env assignment", result.UpdatedInput["command"])
+	}
+}
+
+func TestEvaluatePreToolUseKeepsDistinctSanitizedCredentialNames(t *testing.T) {
+	t.Parallel()
+
+	sessionDir := t.TempDir()
+	s := &Server{
+		sessionID:  "session-123",
+		agentName:  "claude",
+		modePath:   filepath.Join(t.TempDir(), "access-mode"),
+		accessMode: backend.HostedAccessModeEnforce,
+		client: &stubProcessor{
+			result: &backend.ProcessHookEventResult{
+				Response: &agentv1.ProcessHookEventResponse{
+					Decision: agentv1.Decision_DECISION_ALLOW,
+				},
+				AccessMode: backend.HostedAccessModeEnforce,
+			},
+		},
+		diagnostic: diagnostic.New(io.Discard, false),
+		credentials: newCredentialInjector(
+			sessionDir,
+			[]credential.Entry{
+				{EnvVar: "../../first", Provider: "github"},
+				{EnvVar: "../../second", Provider: "github"},
+			},
+			func(_ context.Context, entry credential.Entry) (string, error) {
+				return "managed-" + entry.EnvVar, nil
+			},
+		),
+	}
+
+	result := s.evaluate(context.Background(), &EvaluateRequest{
+		HookEvent: "PreToolUse",
+		ToolName:  "Bash",
+		ToolInput: json.RawMessage(`{"command":"gh pr view 92"}`),
+	})
+
+	command, ok := result.UpdatedInput["command"].(string)
+	if !ok {
+		t.Fatalf("updated command missing: %#v", result.UpdatedInput)
+	}
+	for _, envVar := range []string{"../../first", "../../second"} {
+		name := shellQuoteAssignmentName(envVar)
+		if !strings.Contains(command, name+`="$(cat `) {
+			t.Fatalf("updated command = %q, want %s export", command, name)
+		}
+		raw, err := os.ReadFile(filepath.Join(sessionDir, "credentials", name))
+		if err != nil {
+			t.Fatalf("%s credential file missing: %v", name, err)
+		}
+		if string(raw) != "managed-"+envVar {
+			t.Fatalf("%s credential file = %q", name, raw)
+		}
+	}
+	if shellQuoteAssignmentName("../../first") == shellQuoteAssignmentName("../../second") {
+		t.Fatal("sanitized credential names collided")
+	}
+}
+
+func TestEvaluatePreToolUseDoesNotInjectManagedCredentialForAskOrDeny(t *testing.T) {
+	t.Parallel()
+
+	for _, decision := range []agentv1.Decision{
+		agentv1.Decision_DECISION_ASK,
+		agentv1.Decision_DECISION_DENY,
+	} {
+		t.Run(decision.String(), func(t *testing.T) {
+			t.Parallel()
+			called := false
+			s := &Server{
+				sessionID:  "session-123",
+				agentName:  "claude",
+				accessMode: backend.HostedAccessModeEnforce,
+				client: &stubProcessor{
+					result: &backend.ProcessHookEventResult{
+						Response: &agentv1.ProcessHookEventResponse{
+							Decision: decision,
+							Reason:   "blocked",
+						},
+						AccessMode: backend.HostedAccessModeEnforce,
+					},
+				},
+				diagnostic: diagnostic.New(io.Discard, false),
+				credentials: newCredentialInjector(
+					t.TempDir(),
+					[]credential.Entry{{EnvVar: "GITHUB_TOKEN", Provider: "github"}},
+					func(context.Context, credential.Entry) (string, error) {
+						called = true
+						return "managed-token", nil
+					},
+				),
+			}
+
+			result := s.evaluate(context.Background(), &EvaluateRequest{
+				HookEvent: "PreToolUse",
+				ToolName:  "Bash",
+				ToolInput: json.RawMessage(`{"command":"gh pr merge 92"}`),
+			})
+
+			if result.Allowed {
+				t.Fatal("evaluate().Allowed = true, want false")
+			}
+			if result.UpdatedInput != nil {
+				t.Fatalf("UpdatedInput = %#v, want nil", result.UpdatedInput)
+			}
+			if called {
+				t.Fatal("credential resolver was called for non-ALLOW decision")
+			}
+		})
+	}
+}
+
+func TestLooksLikeProviderCommandDoesNotFallbackToSubstringMatching(t *testing.T) {
+	t.Parallel()
+
+	if looksLikeProviderCommand("echo notionally safe", "notion") {
+		t.Fatal("looksLikeProviderCommand matched unsupported provider substring")
+	}
+}
+
+func TestLooksLikeGitHubCommandRequiresGitHubEvidence(t *testing.T) {
+	t.Parallel()
+
+	if looksLikeProviderCommand("git push origin main", "github") {
+		t.Fatal("looksLikeProviderCommand matched generic git command without GitHub target")
+	}
+	if !looksLikeProviderCommand("git push https://github.com/example/repo.git main", "github") {
+		t.Fatal("looksLikeProviderCommand did not match explicit GitHub git target")
+	}
+	if !looksLikeProviderCommand("gh pr view 92", "github") {
+		t.Fatal("looksLikeProviderCommand did not match gh command")
 	}
 }
 
@@ -427,7 +752,7 @@ func TestBuildHookEventRequestPreservesTelemetryPayload(t *testing.T) {
 		IsInterrupt:    &isInterrupt,
 	}
 
-	got := buildHookEventRequest("session-123", "claude", req)
+	got := buildHookEventRequest(context.Background(), "session-123", "claude", req)
 	if got.SessionId != "session-123" ||
 		got.Agent != "claude" ||
 		got.HookEvent != req.HookEvent ||
@@ -460,7 +785,7 @@ func TestBuildHookEventRequestPreservesExplicitFalseInterrupt(t *testing.T) {
 	t.Parallel()
 
 	isInterrupt := false
-	got := buildHookEventRequest("session-123", "claude", &EvaluateRequest{
+	got := buildHookEventRequest(context.Background(), "session-123", "claude", &EvaluateRequest{
 		HookEvent:   "PostToolUseFailure",
 		ToolName:    "Bash",
 		ToolUseID:   "toolu_123",
@@ -479,7 +804,7 @@ func TestBuildHookEventRequestPreservesExplicitZeroDuration(t *testing.T) {
 	t.Parallel()
 
 	durationMs := int64(0)
-	got := buildHookEventRequest("session-123", "claude", &EvaluateRequest{
+	got := buildHookEventRequest(context.Background(), "session-123", "claude", &EvaluateRequest{
 		HookEvent:  "PostToolUse",
 		ToolName:   "Bash",
 		ToolUseID:  "toolu_123",
@@ -491,6 +816,36 @@ func TestBuildHookEventRequestPreservesExplicitZeroDuration(t *testing.T) {
 	}
 	if got.GetDurationMs() != 0 {
 		t.Fatalf("DurationMs = %d, want 0", got.GetDurationMs())
+	}
+}
+
+func TestParseGitRemotesSanitizesGitHubURLs(t *testing.T) {
+	t.Parallel()
+
+	remotes := parseGitRemotes(strings.Join([]string{
+		"origin\thttps://token@github.com/acme/repo.git (fetch)",
+		"origin\thttps://token@github.com/acme/repo.git (push)",
+		"upstream\tgit@github.com:other/repo.git (fetch)",
+		"ignored\thttps://example.com/acme/repo.git (fetch)",
+	}, "\n"))
+
+	if got := remotes["origin"]; got != "https://github.com/acme/repo.git" {
+		t.Fatalf("origin remote = %q, want sanitized GitHub URL", got)
+	}
+	if got := remotes["upstream"]; got != "https://github.com/other/repo.git" {
+		t.Fatalf("upstream remote = %q, want normalized SSH GitHub URL", got)
+	}
+	if _, ok := remotes["ignored"]; ok {
+		t.Fatal("non-GitHub remote was included")
+	}
+}
+
+func TestSanitizeGitRemoteDropsCredentialsQueryAndFragment(t *testing.T) {
+	t.Parallel()
+
+	got := sanitizeGitRemote("https://user:secret@github.com/acme/repo.git?token=secret#frag")
+	if got != "https://github.com/acme/repo.git" {
+		t.Fatalf("sanitizeGitRemote() = %q, want credential-free URL", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds sanitized local Git/GitHub context enrichment for hosted hook events before they are sent to backend `ProcessHookEvent`.
- Removes caller-supplied `tool_input.kontext` before adding trusted local context.
- Adds managed credential delivery only after backend ALLOW; ASK/DENY never resolve or inject managed credentials.

## Verification

- `go test ./internal/sidecar ./internal/run`
- `go test ./...`

## Release notes

- Minor: `feat:` hosted GitHub context and credential delivery.