### PR TITLE
refactor: split enforcement and telemetry

### DIFF
--- a/internal/guard/app/hooks/claudecode/client.go
+++ b/internal/guard/app/hooks/claudecode/client.go
@@ -30,7 +30,11 @@ func (c Client) Process(ctx context.Context, event hook.Event) (hook.Result, err
 	if err != nil {
 		return hook.Result{}, err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/api/hooks/process", bytes.NewReader(body))
+	endpoint := "/api/hooks/ingest"
+	if event.HookName.CanBlock() {
+		endpoint = "/api/hooks/evaluate"
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+endpoint, bytes.NewReader(body))
 	if err != nil {
 		return hook.Result{}, err
 	}

--- a/internal/guard/app/hooks/claudecode/client_test.go
+++ b/internal/guard/app/hooks/claudecode/client_test.go
@@ -16,8 +16,8 @@ func TestProcessPostsHookEventAndMapsResult(t *testing.T) {
 	t.Parallel()
 
 	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/hooks/process" {
-			t.Fatalf("path = %q, want /api/hooks/process", r.URL.Path)
+		if r.URL.Path != "/api/hooks/evaluate" {
+			t.Fatalf("path = %q, want /api/hooks/evaluate", r.URL.Path)
 		}
 		var event risk.HookEvent
 		if err := json.NewDecoder(r.Body).Decode(&event); err != nil {
@@ -52,5 +52,45 @@ func TestProcessPostsHookEventAndMapsResult(t *testing.T) {
 	}
 	if result.ReasonCode != "credential_access_without_intent" || result.EventID != "evt-123" {
 		t.Fatalf("result = %+v, want metadata preserved", result)
+	}
+}
+
+func TestProcessPostsTelemetryEventsToIngest(t *testing.T) {
+	t.Parallel()
+
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/hooks/ingest" {
+			t.Fatalf("path = %q, want /api/hooks/ingest", r.URL.Path)
+		}
+		var event risk.HookEvent
+		if err := json.NewDecoder(r.Body).Decode(&event); err != nil {
+			t.Fatalf("Decode() error = %v", err)
+		}
+		if event.HookEventName != "PostToolUse" || event.ToolName != "Bash" {
+			t.Fatalf("event = %+v, want telemetry hook fields preserved", event)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(server.ProcessResponse{
+			Decision:   risk.DecisionAllow,
+			Reason:     "async telemetry event recorded",
+			ReasonCode: "async_telemetry",
+			EventID:    "evt-telemetry",
+		}); err != nil {
+			t.Fatalf("Encode() error = %v", err)
+		}
+	}))
+	t.Cleanup(httpServer.Close)
+
+	result, err := NewClient(httpServer.URL).Process(context.Background(), hook.Event{
+		SessionID: "session-123",
+		HookName:  hook.HookPostToolUse,
+		ToolName:  "Bash",
+		ToolInput: map[string]any{"command": "git status"},
+	})
+	if err != nil {
+		t.Fatalf("Process() error = %v", err)
+	}
+	if result.Decision != hook.DecisionAllow || result.ReasonCode != "async_telemetry" || result.EventID != "evt-telemetry" {
+		t.Fatalf("result = %+v, want telemetry result preserved", result)
 	}
 }

--- a/internal/guard/app/server/server.go
+++ b/internal/guard/app/server/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
 	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
 	dashboardassets "github.com/kontext-security/kontext-cli/internal/guard/web/assets"
+	"github.com/kontext-security/kontext-cli/internal/hook"
 )
 
 const (
@@ -64,6 +65,8 @@ func (s *Server) ListenAndServe(addr string) error {
 
 func (s *Server) routes() {
 	s.mux.HandleFunc("GET /healthz", s.handleHealth)
+	s.mux.HandleFunc("POST /api/hooks/evaluate", s.handleEvaluate)
+	s.mux.HandleFunc("POST /api/hooks/ingest", s.handleIngest)
 	s.mux.HandleFunc("POST /api/hooks/process", s.handleProcess)
 	s.mux.HandleFunc("GET /api/summary", s.handleSummary)
 	s.mux.HandleFunc("GET /api/sessions", s.handleSessions)
@@ -71,7 +74,25 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /", s.handleDashboard)
 }
 
+func (s *Server) EvaluateHook(ctx context.Context, event risk.HookEvent) (risk.RiskDecision, error) {
+	if event.HookEventName != hook.HookPreToolUse.String() {
+		return risk.RiskDecision{}, fmt.Errorf("hook event %q cannot be evaluated for enforcement", event.HookEventName)
+	}
+	return s.decideAndRecord(ctx, event)
+}
+
+func (s *Server) IngestEvent(ctx context.Context, event risk.HookEvent) (risk.RiskDecision, error) {
+	return s.decideAndRecord(ctx, event)
+}
+
 func (s *Server) ProcessHookEvent(ctx context.Context, event risk.HookEvent) (risk.RiskDecision, error) {
+	if event.HookEventName == hook.HookPreToolUse.String() {
+		return s.EvaluateHook(ctx, event)
+	}
+	return s.IngestEvent(ctx, event)
+}
+
+func (s *Server) decideAndRecord(ctx context.Context, event risk.HookEvent) (risk.RiskDecision, error) {
 	if event.HookEventName == "" {
 		return risk.RiskDecision{}, errors.New("hook_event_name is required")
 	}
@@ -95,13 +116,25 @@ func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
+func (s *Server) handleEvaluate(w http.ResponseWriter, r *http.Request) {
+	s.handleHook(w, r, s.EvaluateHook)
+}
+
+func (s *Server) handleIngest(w http.ResponseWriter, r *http.Request) {
+	s.handleHook(w, r, s.IngestEvent)
+}
+
 func (s *Server) handleProcess(w http.ResponseWriter, r *http.Request) {
+	s.handleHook(w, r, s.ProcessHookEvent)
+}
+
+func (s *Server) handleHook(w http.ResponseWriter, r *http.Request, process func(context.Context, risk.HookEvent) (risk.RiskDecision, error)) {
 	var event risk.HookEvent
 	if err := json.NewDecoder(r.Body).Decode(&event); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid hook event")
 		return
 	}
-	decision, err := s.ProcessHookEvent(r.Context(), event)
+	decision, err := process(r.Context(), event)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return

--- a/internal/guard/app/server/server.go
+++ b/internal/guard/app/server/server.go
@@ -75,18 +75,21 @@ func (s *Server) routes() {
 }
 
 func (s *Server) EvaluateHook(ctx context.Context, event risk.HookEvent) (risk.RiskDecision, error) {
-	if event.HookEventName != hook.HookPreToolUse.String() {
+	if !hook.HookName(event.HookEventName).CanBlock() {
 		return risk.RiskDecision{}, fmt.Errorf("hook event %q cannot be evaluated for enforcement", event.HookEventName)
 	}
 	return s.decideAndRecord(ctx, event)
 }
 
 func (s *Server) IngestEvent(ctx context.Context, event risk.HookEvent) (risk.RiskDecision, error) {
+	if hook.HookName(event.HookEventName).CanBlock() {
+		return risk.RiskDecision{}, fmt.Errorf("hook event %q must be evaluated for enforcement", event.HookEventName)
+	}
 	return s.decideAndRecord(ctx, event)
 }
 
 func (s *Server) ProcessHookEvent(ctx context.Context, event risk.HookEvent) (risk.RiskDecision, error) {
-	if event.HookEventName == hook.HookPreToolUse.String() {
+	if hook.HookName(event.HookEventName).CanBlock() {
 		return s.EvaluateHook(ctx, event)
 	}
 	return s.IngestEvent(ctx, event)

--- a/internal/guard/app/server/server_test.go
+++ b/internal/guard/app/server/server_test.go
@@ -102,6 +102,59 @@ func TestProcessHookEventUsesPolicyProvider(t *testing.T) {
 	}
 }
 
+func TestEvaluateHookRejectsTelemetryEvents(t *testing.T) {
+	store, err := sqlite.OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	server := NewServer(store, risk.NoopScorer{})
+	_, err = server.EvaluateHook(context.Background(), risk.HookEvent{
+		SessionID:     "s1",
+		HookEventName: "PostToolUse",
+		ToolName:      "Bash",
+		ToolInput:     map[string]any{"command": "git status"},
+	})
+	if err == nil {
+		t.Fatal("EvaluateHook() error = nil, want telemetry rejection")
+	}
+	summary, err := store.Summary(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.Actions != 0 {
+		t.Fatalf("summary = %+v, want no persisted action", summary)
+	}
+}
+
+func TestIngestEventRecordsTelemetry(t *testing.T) {
+	store, err := sqlite.OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	server := NewServer(store, risk.NoopScorer{})
+	decision, err := server.IngestEvent(context.Background(), risk.HookEvent{
+		SessionID:     "s1",
+		HookEventName: "PostToolUse",
+		ToolName:      "Bash",
+		ToolInput:     map[string]any{"command": "git status"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Decision != risk.DecisionAllow || decision.ReasonCode != "async_telemetry" || decision.EventID == "" {
+		t.Fatalf("decision = %+v, want telemetry allow decision", decision)
+	}
+	summary, err := store.Summary(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.Actions != 1 || summary.Warnings != 0 || summary.Critical != 0 {
+		t.Fatalf("summary = %+v", summary)
+	}
+}
+
 type failingScorer struct {
 	err error
 }

--- a/internal/guard/app/server/server_test.go
+++ b/internal/guard/app/server/server_test.go
@@ -155,6 +155,31 @@ func TestIngestEventRecordsTelemetry(t *testing.T) {
 	}
 }
 
+func TestIngestEventRejectsBlockingEvents(t *testing.T) {
+	store, err := sqlite.OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	server := NewServer(store, risk.NoopScorer{})
+	_, err = server.IngestEvent(context.Background(), risk.HookEvent{
+		SessionID:     "s1",
+		HookEventName: "PreToolUse",
+		ToolName:      "Bash",
+		ToolInput:     map[string]any{"command": "drop database"},
+	})
+	if err == nil {
+		t.Fatal("IngestEvent() error = nil, want blocking event rejection")
+	}
+	summary, err := store.Summary(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.Actions != 0 {
+		t.Fatalf("summary = %+v, want no persisted action", summary)
+	}
+}
+
 type failingScorer struct {
 	err error
 }


### PR DESCRIPTION
## Summary

- Focusing step 3 in https://github.com/kontext-security/kontext-cli/issues/104
- previously enforcement and telemetry was intertwined, this PR introduces `EvaluateHook` and `IngestEvent` to separate enforcement and telemetry.

Part of ENG-320