### PR TITLE
refactor: introduce runtimecore hook facade

### DIFF
--- a/internal/guard/app/server/runtime.go
+++ b/internal/guard/app/server/runtime.go
@@ -20,28 +20,36 @@ func newGuardHookRuntime(store *sqlite.Store, policy PolicyProvider) guardHookRu
 }
 
 func (r guardHookRuntime) EvaluateHook(ctx context.Context, event hook.Event) (hook.Result, error) {
-	return r.decideAndRecord(ctx, riskEventFromHookEvent(event))
+	decision, err := r.decideAndRecord(ctx, riskEventFromHookEvent(event))
+	if err != nil {
+		return hook.Result{}, err
+	}
+	return hookResultFromRiskDecision(decision), nil
 }
 
 func (r guardHookRuntime) IngestEvent(ctx context.Context, event hook.Event) (hook.Result, error) {
-	return r.decideAndRecord(ctx, riskEventFromHookEvent(event))
+	decision, err := r.decideAndRecord(ctx, riskEventFromHookEvent(event))
+	if err != nil {
+		return hook.Result{}, err
+	}
+	return hookResultFromRiskDecision(decision), nil
 }
 
-func (r guardHookRuntime) decideAndRecord(ctx context.Context, event risk.HookEvent) (hook.Result, error) {
+func (r guardHookRuntime) decideAndRecord(ctx context.Context, event risk.HookEvent) (risk.RiskDecision, error) {
 	if event.Timestamp.IsZero() {
 		event.Timestamp = time.Now().UTC()
 	}
 	decision, err := r.policy.DecideHook(ctx, event)
 	if err != nil {
-		return hook.Result{}, err
+		return risk.RiskDecision{}, err
 	}
 	record, err := r.store.SaveDecision(ctx, event, decision)
 	if err != nil {
-		return hook.Result{}, err
+		return risk.RiskDecision{}, err
 	}
 	decision.EventID = record.ID
 	notify.Decision(decision)
-	return hookResultFromRiskDecision(decision), nil
+	return decision, nil
 }
 
 func riskEventFromHookEvent(event hook.Event) risk.HookEvent {
@@ -71,15 +79,18 @@ func hookEventFromRiskEvent(event risk.HookEvent) hook.Event {
 }
 
 func hookResultFromRiskDecision(decision risk.RiskDecision) hook.Result {
-	return hook.Result{
+	return hook.WithMetadata(hook.Result{
 		Decision:   hook.Decision(decision.Decision),
 		Reason:     decision.Reason,
 		ReasonCode: decision.ReasonCode,
 		EventID:    decision.EventID,
-	}
+	}, decision)
 }
 
 func riskDecisionFromHookResult(result hook.Result) risk.RiskDecision {
+	if decision, ok := result.Metadata().(risk.RiskDecision); ok {
+		return decision
+	}
 	return risk.RiskDecision{
 		Decision:   risk.Decision(result.Decision),
 		Reason:     result.Reason,

--- a/internal/guard/app/server/runtime.go
+++ b/internal/guard/app/server/runtime.go
@@ -1,0 +1,89 @@
+package server
+
+import (
+	"context"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/guard/app/notify"
+	"github.com/kontext-security/kontext-cli/internal/guard/risk"
+	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
+	"github.com/kontext-security/kontext-cli/internal/hook"
+)
+
+type guardHookRuntime struct {
+	store  *sqlite.Store
+	policy PolicyProvider
+}
+
+func newGuardHookRuntime(store *sqlite.Store, policy PolicyProvider) guardHookRuntime {
+	return guardHookRuntime{store: store, policy: policy}
+}
+
+func (r guardHookRuntime) EvaluateHook(ctx context.Context, event hook.Event) (hook.Result, error) {
+	return r.decideAndRecord(ctx, riskEventFromHookEvent(event))
+}
+
+func (r guardHookRuntime) IngestEvent(ctx context.Context, event hook.Event) (hook.Result, error) {
+	return r.decideAndRecord(ctx, riskEventFromHookEvent(event))
+}
+
+func (r guardHookRuntime) decideAndRecord(ctx context.Context, event risk.HookEvent) (hook.Result, error) {
+	if event.Timestamp.IsZero() {
+		event.Timestamp = time.Now().UTC()
+	}
+	decision, err := r.policy.DecideHook(ctx, event)
+	if err != nil {
+		return hook.Result{}, err
+	}
+	record, err := r.store.SaveDecision(ctx, event, decision)
+	if err != nil {
+		return hook.Result{}, err
+	}
+	decision.EventID = record.ID
+	notify.Decision(decision)
+	return hookResultFromRiskDecision(decision), nil
+}
+
+func riskEventFromHookEvent(event hook.Event) risk.HookEvent {
+	return risk.HookEvent{
+		SessionID:     event.SessionID,
+		Agent:         event.Agent,
+		HookEventName: event.HookName.String(),
+		ToolName:      event.ToolName,
+		ToolInput:     event.ToolInput,
+		ToolResponse:  event.ToolResponse,
+		ToolUseID:     event.ToolUseID,
+		CWD:           event.CWD,
+	}
+}
+
+func hookEventFromRiskEvent(event risk.HookEvent) hook.Event {
+	return hook.Event{
+		SessionID:    event.SessionID,
+		Agent:        event.Agent,
+		HookName:     hook.HookName(event.HookEventName),
+		ToolName:     event.ToolName,
+		ToolInput:    event.ToolInput,
+		ToolResponse: event.ToolResponse,
+		ToolUseID:    event.ToolUseID,
+		CWD:          event.CWD,
+	}
+}
+
+func hookResultFromRiskDecision(decision risk.RiskDecision) hook.Result {
+	return hook.Result{
+		Decision:   hook.Decision(decision.Decision),
+		Reason:     decision.Reason,
+		ReasonCode: decision.ReasonCode,
+		EventID:    decision.EventID,
+	}
+}
+
+func riskDecisionFromHookResult(result hook.Result) risk.RiskDecision {
+	return risk.RiskDecision{
+		Decision:   risk.Decision(result.Decision),
+		Reason:     result.Reason,
+		ReasonCode: result.ReasonCode,
+		EventID:    result.EventID,
+	}
+}

--- a/internal/guard/app/server/server.go
+++ b/internal/guard/app/server/server.go
@@ -3,18 +3,16 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/fs"
 	"net/http"
 	"strings"
 	"time"
 
-	"github.com/kontext-security/kontext-cli/internal/guard/app/notify"
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
 	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
 	dashboardassets "github.com/kontext-security/kontext-cli/internal/guard/web/assets"
-	"github.com/kontext-security/kontext-cli/internal/hook"
+	"github.com/kontext-security/kontext-cli/internal/runtimecore"
 )
 
 const (
@@ -22,9 +20,9 @@ const (
 )
 
 type Server struct {
-	store  *sqlite.Store
-	policy PolicyProvider
-	mux    *http.ServeMux
+	store *sqlite.Store
+	core  *runtimecore.Core
+	mux   *http.ServeMux
 }
 
 type ProcessResponse struct {
@@ -45,7 +43,11 @@ func NewServerWithPolicy(store *sqlite.Store, policy PolicyProvider) *Server {
 	if policy == nil {
 		policy = NewRiskPolicyProvider(nil)
 	}
-	server := &Server{store: store, policy: policy, mux: http.NewServeMux()}
+	core, err := runtimecore.New(newGuardHookRuntime(store, policy))
+	if err != nil {
+		panic(err)
+	}
+	server := &Server{store: store, core: core, mux: http.NewServeMux()}
 	server.routes()
 	return server
 }
@@ -75,44 +77,18 @@ func (s *Server) routes() {
 }
 
 func (s *Server) EvaluateHook(ctx context.Context, event risk.HookEvent) (risk.RiskDecision, error) {
-	if !hook.HookName(event.HookEventName).CanBlock() {
-		return risk.RiskDecision{}, fmt.Errorf("hook event %q cannot be evaluated for enforcement", event.HookEventName)
-	}
-	return s.decideAndRecord(ctx, event)
+	result, err := s.core.EvaluateHook(ctx, hookEventFromRiskEvent(event))
+	return riskDecisionFromHookResult(result), err
 }
 
 func (s *Server) IngestEvent(ctx context.Context, event risk.HookEvent) (risk.RiskDecision, error) {
-	if hook.HookName(event.HookEventName).CanBlock() {
-		return risk.RiskDecision{}, fmt.Errorf("hook event %q must be evaluated for enforcement", event.HookEventName)
-	}
-	return s.decideAndRecord(ctx, event)
+	result, err := s.core.IngestEvent(ctx, hookEventFromRiskEvent(event))
+	return riskDecisionFromHookResult(result), err
 }
 
 func (s *Server) ProcessHookEvent(ctx context.Context, event risk.HookEvent) (risk.RiskDecision, error) {
-	if hook.HookName(event.HookEventName).CanBlock() {
-		return s.EvaluateHook(ctx, event)
-	}
-	return s.IngestEvent(ctx, event)
-}
-
-func (s *Server) decideAndRecord(ctx context.Context, event risk.HookEvent) (risk.RiskDecision, error) {
-	if event.HookEventName == "" {
-		return risk.RiskDecision{}, errors.New("hook_event_name is required")
-	}
-	if event.Timestamp.IsZero() {
-		event.Timestamp = time.Now().UTC()
-	}
-	decision, err := s.policy.DecideHook(ctx, event)
-	if err != nil {
-		return risk.RiskDecision{}, err
-	}
-	record, err := s.store.SaveDecision(ctx, event, decision)
-	if err != nil {
-		return risk.RiskDecision{}, err
-	}
-	decision.EventID = record.ID
-	notify.Decision(decision)
-	return decision, nil
+	result, err := s.core.ProcessHook(ctx, hookEventFromRiskEvent(event))
+	return riskDecisionFromHookResult(result), err
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {

--- a/internal/guard/app/server/server.go
+++ b/internal/guard/app/server/server.go
@@ -43,7 +43,8 @@ func NewServerWithPolicy(store *sqlite.Store, policy PolicyProvider) *Server {
 	if policy == nil {
 		policy = NewRiskPolicyProvider(nil)
 	}
-	core, err := runtimecore.New(newGuardHookRuntime(store, policy))
+	runtime := newGuardHookRuntime(store, policy)
+	core, err := runtimecore.New(runtime)
 	if err != nil {
 		panic(err)
 	}
@@ -78,17 +79,26 @@ func (s *Server) routes() {
 
 func (s *Server) EvaluateHook(ctx context.Context, event risk.HookEvent) (risk.RiskDecision, error) {
 	result, err := s.core.EvaluateHook(ctx, hookEventFromRiskEvent(event))
-	return riskDecisionFromHookResult(result), err
+	if err != nil {
+		return risk.RiskDecision{}, err
+	}
+	return riskDecisionFromHookResult(result), nil
 }
 
 func (s *Server) IngestEvent(ctx context.Context, event risk.HookEvent) (risk.RiskDecision, error) {
 	result, err := s.core.IngestEvent(ctx, hookEventFromRiskEvent(event))
-	return riskDecisionFromHookResult(result), err
+	if err != nil {
+		return risk.RiskDecision{}, err
+	}
+	return riskDecisionFromHookResult(result), nil
 }
 
 func (s *Server) ProcessHookEvent(ctx context.Context, event risk.HookEvent) (risk.RiskDecision, error) {
 	result, err := s.core.ProcessHook(ctx, hookEventFromRiskEvent(event))
-	return riskDecisionFromHookResult(result), err
+	if err != nil {
+		return risk.RiskDecision{}, err
+	}
+	return riskDecisionFromHookResult(result), nil
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {

--- a/internal/guard/app/server/server_test.go
+++ b/internal/guard/app/server/server_test.go
@@ -102,6 +102,51 @@ func TestProcessHookEventUsesPolicyProvider(t *testing.T) {
 	}
 }
 
+func TestProcessHookEventPreservesRiskMetadata(t *testing.T) {
+	store, err := sqlite.OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	score := 0.91
+	threshold := 0.8
+	policy := recordingPolicy{
+		decision: risk.RiskDecision{
+			Decision:     risk.DecisionDeny,
+			Reason:       "custom policy",
+			ReasonCode:   "custom_policy",
+			RiskScore:    &score,
+			Threshold:    &threshold,
+			ModelVersion: "model-v1",
+			GuardID:      "guard-1",
+			RiskEvent: risk.RiskEvent{
+				Type:         risk.EventDirectProviderAPICall,
+				ModelVersion: "model-v1",
+				GuardID:      "guard-1",
+			},
+		},
+	}
+	server := NewServerWithPolicy(store, &policy)
+	decision, err := server.ProcessHookEvent(context.Background(), risk.HookEvent{
+		SessionID:     "s1",
+		HookEventName: "PreToolUse",
+		ToolName:      "Bash",
+		ToolInput:     map[string]any{"command": "curl https://api.example.com"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.RiskScore == nil || *decision.RiskScore != score {
+		t.Fatalf("RiskScore = %+v, want %v", decision.RiskScore, score)
+	}
+	if decision.Threshold == nil || *decision.Threshold != threshold {
+		t.Fatalf("Threshold = %+v, want %v", decision.Threshold, threshold)
+	}
+	if decision.ModelVersion != "model-v1" || decision.GuardID != "guard-1" || decision.RiskEvent.Type != risk.EventDirectProviderAPICall {
+		t.Fatalf("decision metadata = %+v", decision)
+	}
+}
+
 func TestEvaluateHookRejectsTelemetryEvents(t *testing.T) {
 	store, err := sqlite.OpenStore(t.TempDir() + "/guard.db")
 	if err != nil {

--- a/internal/guard/auth_isolation_test.go
+++ b/internal/guard/auth_isolation_test.go
@@ -32,7 +32,7 @@ func TestGuardRuntimeDoesNotImportHostedRuntime(t *testing.T) {
 		for _, imported := range file.Imports {
 			value := strings.Trim(imported.Path.Value, `"`)
 			for _, blocked := range disallowed {
-				if strings.HasPrefix(value, blocked) {
+				if value == blocked || strings.HasPrefix(value, blocked+"/") {
 					t.Fatalf("Guard local mode must not import hosted runtime package %q from %s", value, path)
 				}
 			}

--- a/internal/hook/domain.go
+++ b/internal/hook/domain.go
@@ -67,6 +67,16 @@ type Result struct {
 	Mode         string
 	Epoch        string
 	UpdatedInput map[string]any
+	metadata     any
+}
+
+func WithMetadata(result Result, metadata any) Result {
+	result.metadata = metadata
+	return result
+}
+
+func (r Result) Metadata() any {
+	return r.metadata
 }
 
 func (r Result) Allowed() bool {

--- a/internal/runtimecore/core.go
+++ b/internal/runtimecore/core.go
@@ -1,0 +1,52 @@
+package runtimecore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/kontext-security/kontext-cli/internal/hook"
+)
+
+type HookRuntime interface {
+	EvaluateHook(context.Context, hook.Event) (hook.Result, error)
+	IngestEvent(context.Context, hook.Event) (hook.Result, error)
+}
+
+type Core struct {
+	runtime HookRuntime
+}
+
+func New(runtime HookRuntime) (*Core, error) {
+	if runtime == nil {
+		return nil, errors.New("runtime core requires hook runtime")
+	}
+	return &Core{runtime: runtime}, nil
+}
+
+func (c *Core) EvaluateHook(ctx context.Context, event hook.Event) (hook.Result, error) {
+	if event.HookName == "" {
+		return hook.Result{}, errors.New("hook event name is required")
+	}
+	if !event.HookName.CanBlock() {
+		return hook.Result{}, fmt.Errorf("hook event %q cannot be evaluated for enforcement", event.HookName)
+	}
+	return c.runtime.EvaluateHook(ctx, event)
+}
+
+func (c *Core) IngestEvent(ctx context.Context, event hook.Event) (hook.Result, error) {
+	if event.HookName == "" {
+		return hook.Result{}, errors.New("hook event name is required")
+	}
+	if event.HookName.CanBlock() {
+		return hook.Result{}, fmt.Errorf("hook event %q must be evaluated for enforcement", event.HookName)
+	}
+	return c.runtime.IngestEvent(ctx, event)
+}
+
+func (c *Core) ProcessHook(ctx context.Context, event hook.Event) (hook.Result, error) {
+	if event.HookName.CanBlock() {
+		return c.EvaluateHook(ctx, event)
+	}
+	return c.IngestEvent(ctx, event)
+}

--- a/internal/runtimecore/core.go
+++ b/internal/runtimecore/core.go
@@ -25,23 +25,40 @@ func New(runtime HookRuntime) (*Core, error) {
 }
 
 func (c *Core) EvaluateHook(ctx context.Context, event hook.Event) (hook.Result, error) {
-	if event.HookName == "" {
-		return hook.Result{}, errors.New("hook event name is required")
-	}
-	if !event.HookName.CanBlock() {
-		return hook.Result{}, fmt.Errorf("hook event %q cannot be evaluated for enforcement", event.HookName)
+	if err := ValidateEvaluateHook(event); err != nil {
+		return hook.Result{}, err
 	}
 	return c.runtime.EvaluateHook(ctx, event)
 }
 
-func (c *Core) IngestEvent(ctx context.Context, event hook.Event) (hook.Result, error) {
+func ValidateEvaluateHook(event hook.Event) error {
 	if event.HookName == "" {
-		return hook.Result{}, errors.New("hook event name is required")
+		return errors.New("hook event name is required")
+	}
+	if !event.HookName.CanBlock() {
+		return fmt.Errorf("hook event %q cannot be evaluated for enforcement", event.HookName)
+	}
+	return nil
+}
+
+func (c *Core) IngestEvent(ctx context.Context, event hook.Event) (hook.Result, error) {
+	if err := ValidateIngestEvent(event); err != nil {
+		return hook.Result{}, err
 	}
 	if event.HookName.CanBlock() {
 		return hook.Result{}, fmt.Errorf("hook event %q must be evaluated for enforcement", event.HookName)
 	}
 	return c.runtime.IngestEvent(ctx, event)
+}
+
+func ValidateIngestEvent(event hook.Event) error {
+	if event.HookName == "" {
+		return errors.New("hook event name is required")
+	}
+	if event.HookName.CanBlock() {
+		return fmt.Errorf("hook event %q must be evaluated for enforcement", event.HookName)
+	}
+	return nil
 }
 
 func (c *Core) ProcessHook(ctx context.Context, event hook.Event) (hook.Result, error) {

--- a/internal/runtimecore/core_test.go
+++ b/internal/runtimecore/core_test.go
@@ -1,0 +1,82 @@
+package runtimecore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/hook"
+)
+
+func TestEvaluateHookRejectsTelemetryHooks(t *testing.T) {
+	core, err := New(&recordingRuntime{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = core.EvaluateHook(context.Background(), hook.Event{HookName: hook.HookPostToolUse})
+	if err == nil {
+		t.Fatal("EvaluateHook() error = nil, want non-blocking hook rejection")
+	}
+}
+
+func TestProcessHookRoutesByBlockingCapability(t *testing.T) {
+	runtime := &recordingRuntime{
+		evaluateResult: hook.Result{Decision: hook.DecisionAsk, Reason: "review"},
+		ingestResult:   hook.Result{Decision: hook.DecisionAllow, Reason: "recorded"},
+	}
+	core, err := New(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	evaluate, err := core.ProcessHook(context.Background(), hook.Event{HookName: hook.HookPreToolUse})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ingest, err := core.ProcessHook(context.Background(), hook.Event{HookName: hook.HookPostToolUse})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.evaluateCalls != 1 || runtime.ingestCalls != 1 {
+		t.Fatalf("calls evaluate=%d ingest=%d", runtime.evaluateCalls, runtime.ingestCalls)
+	}
+	if evaluate.Decision != hook.DecisionAsk || ingest.Reason != "recorded" {
+		t.Fatalf("evaluate=%+v ingest=%+v", evaluate, ingest)
+	}
+}
+
+func TestNewRejectsMissingRuntime(t *testing.T) {
+	if _, err := New(nil); err == nil {
+		t.Fatal("New(nil) error = nil, want error")
+	}
+}
+
+type recordingRuntime struct {
+	evaluateCalls  int
+	ingestCalls    int
+	evaluateResult hook.Result
+	ingestResult   hook.Result
+	err            error
+}
+
+func (r *recordingRuntime) EvaluateHook(context.Context, hook.Event) (hook.Result, error) {
+	r.evaluateCalls++
+	if r.err != nil {
+		return hook.Result{}, r.err
+	}
+	if r.evaluateResult.Decision == "" {
+		return hook.Result{Decision: hook.DecisionAllow}, nil
+	}
+	return r.evaluateResult, nil
+}
+
+func (r *recordingRuntime) IngestEvent(context.Context, hook.Event) (hook.Result, error) {
+	r.ingestCalls++
+	if r.err != nil {
+		return hook.Result{}, r.err
+	}
+	if r.ingestResult.Decision == "" {
+		return hook.Result{Decision: hook.DecisionAllow}, nil
+	}
+	return r.ingestResult, nil
+}
+
+var _ HookRuntime = (*recordingRuntime)(nil)

--- a/internal/runtimecore/core_test.go
+++ b/internal/runtimecore/core_test.go
@@ -18,6 +18,17 @@ func TestEvaluateHookRejectsTelemetryHooks(t *testing.T) {
 	}
 }
 
+func TestIngestEventRejectsBlockingHooks(t *testing.T) {
+	core, err := New(&recordingRuntime{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = core.IngestEvent(context.Background(), hook.Event{HookName: hook.HookPreToolUse})
+	if err == nil {
+		t.Fatal("IngestEvent() error = nil, want blocking hook rejection")
+	}
+}
+
 func TestProcessHookRoutesByBlockingCapability(t *testing.T) {
 	runtime := &recordingRuntime{
 		evaluateResult: hook.Result{Decision: hook.DecisionAsk, Reason: "review"},

--- a/internal/sidecar/runtime.go
+++ b/internal/sidecar/runtime.go
@@ -1,0 +1,84 @@
+package sidecar
+
+import (
+	"context"
+
+	"github.com/kontext-security/kontext-cli/internal/backend"
+	"github.com/kontext-security/kontext-cli/internal/diagnostic"
+	"github.com/kontext-security/kontext-cli/internal/hook"
+)
+
+type hostedHookRuntime struct {
+	client            sidecarClient
+	sessionID         string
+	agentName         string
+	diagnostic        diagnostic.Logger
+	currentAccessMode func() backend.HostedAccessMode
+	refreshAccessMode func(backend.HostedAccessMode) error
+}
+
+func (r hostedHookRuntime) EvaluateHook(ctx context.Context, event hook.Event) (hook.Result, error) {
+	evalCtx, cancel := context.WithTimeout(ctx, hookEvalTimeout)
+	defer cancel()
+
+	result, err := r.processHostedHookEvent(evalCtx, event)
+	if err != nil {
+		r.diagnostic.Printf("sidecar enforce: %v\n", err)
+		accessMode := r.currentAccessMode()
+		if accessMode != backend.HostedAccessModeEnforce {
+			return hook.Result{
+				Decision: hook.DecisionAllow,
+				Reason:   "Kontext hosted access is not enforcing.",
+				Mode:     string(accessMode),
+			}, nil
+		}
+		return hook.Result{
+			Decision: hook.DecisionDeny,
+			Reason:   "Kontext access policy could not be evaluated.",
+		}, nil
+	}
+
+	if err := r.refreshAccessMode(result.AccessMode); err != nil {
+		r.diagnostic.Printf("sidecar access mode persist: %v\n", err)
+		if result.AccessMode == backend.HostedAccessModeEnforce {
+			return hook.Result{
+				Decision: hook.DecisionDeny,
+				Reason:   "Kontext access policy mode could not be persisted.",
+				Mode:     string(result.AccessMode),
+			}, nil
+		}
+	}
+
+	accessMode := result.AccessMode
+	if accessMode == "" {
+		accessMode = r.currentAccessMode()
+	}
+	return HookResultFromHostedResult(result, accessMode), nil
+}
+
+func (r hostedHookRuntime) IngestEvent(ctx context.Context, event hook.Event) (hook.Result, error) {
+	result, err := r.processHostedHookEvent(ctx, event)
+	if err != nil {
+		return hook.Result{}, err
+	}
+	if err := r.refreshAccessMode(result.AccessMode); err != nil {
+		return hook.Result{}, err
+	}
+	accessMode := result.AccessMode
+	if accessMode == "" {
+		accessMode = r.currentAccessMode()
+	}
+	return HookResultFromHostedResult(result, accessMode), nil
+}
+
+func (r hostedHookRuntime) processHostedHookEvent(ctx context.Context, event hook.Event) (*backend.ProcessHookEventResult, error) {
+	return r.client.ProcessHookEvent(ctx, buildHookEventRequestFromEvent(withHostedSession(event, r.sessionID, r.agentName)))
+}
+
+func withHostedSession(event hook.Event, sessionID, agentName string) hook.Event {
+	event.SessionID = sessionID
+	if event.Agent == "" {
+		event.Agent = agentName
+	}
+	return event
+}

--- a/internal/sidecar/sidecar.go
+++ b/internal/sidecar/sidecar.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/backend"
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 	"github.com/kontext-security/kontext-cli/internal/hook"
+	"github.com/kontext-security/kontext-cli/internal/runtimecore"
 )
 
 // sidecarClient is the backend surface used by the sidecar.
@@ -90,13 +91,14 @@ type Server struct {
 	mu         sync.RWMutex
 	accessMode backend.HostedAccessMode
 	client     sidecarClient
+	core       *runtimecore.Core
 	diagnostic diagnostic.Logger
 	cancel     context.CancelFunc
 }
 
 // New creates a new sidecar server.
 func New(sessionDir string, client sidecarClient, sessionID, agentName string, accessMode backend.HostedAccessMode, diagnostics diagnostic.Logger) (*Server, error) {
-	return &Server{
+	s := &Server{
 		socketPath: filepath.Join(sessionDir, "kontext.sock"),
 		modePath:   filepath.Join(sessionDir, "access-mode"),
 		sessionID:  sessionID,
@@ -104,12 +106,41 @@ func New(sessionDir string, client sidecarClient, sessionID, agentName string, a
 		accessMode: accessMode,
 		client:     client,
 		diagnostic: diagnostics,
-	}, nil
+	}
+	core, err := runtimecore.New(s.hostedRuntime())
+	if err != nil {
+		return nil, err
+	}
+	s.core = core
+	return s, nil
 }
 
 func (s *Server) SocketPath() string { return s.socketPath }
 
 func (s *Server) AccessModePath() string { return s.modePath }
+
+func (s *Server) runtimeCore() *runtimecore.Core {
+	if s.core != nil {
+		return s.core
+	}
+	core, err := runtimecore.New(s.hostedRuntime())
+	if err != nil {
+		panic(err)
+	}
+	s.core = core
+	return core
+}
+
+func (s *Server) hostedRuntime() hostedHookRuntime {
+	return hostedHookRuntime{
+		client:            s.client,
+		sessionID:         s.sessionID,
+		agentName:         s.agentName,
+		diagnostic:        s.diagnostic,
+		currentAccessMode: s.currentAccessMode,
+		refreshAccessMode: s.refreshAccessMode,
+	}
+}
 
 func (s *Server) currentAccessMode() backend.HostedAccessMode {
 	s.mu.RLock()
@@ -209,13 +240,8 @@ func (s *Server) ingestEvent(ctx context.Context, req *EvaluateRequest) {
 		s.diagnostic.Printf("sidecar ingest decode: %v\n", err)
 		return
 	}
-	result, err := s.processHostedHookEvent(ctx, event)
-	if err != nil {
+	if _, err := s.runtimeCore().IngestEvent(ctx, event); err != nil {
 		s.diagnostic.Printf("sidecar ingest: %v\n", err)
-		return
-	}
-	if err := s.refreshAccessMode(result.AccessMode); err != nil {
-		s.diagnostic.Printf("sidecar access mode persist: %v\n", err)
 	}
 }
 
@@ -247,7 +273,18 @@ func (s *Server) evaluate(ctx context.Context, req *EvaluateRequest) EvaluateRes
 		s.diagnostic.Printf("sidecar evaluate decode: %v\n", err)
 		return EvaluateResultFromResult(sidecarDecodeFailureResult(req))
 	}
-	return EvaluateResultFromResult(s.evaluateHook(ctx, event))
+	if !event.HookName.CanBlock() {
+		return EvaluateResultFromResult(hook.Result{Decision: hook.DecisionAllow})
+	}
+	result, err := s.runtimeCore().EvaluateHook(ctx, event)
+	if err != nil {
+		s.diagnostic.Printf("sidecar enforce: %v\n", err)
+		return EvaluateResultFromResult(hook.Result{
+			Decision: hook.DecisionDeny,
+			Reason:   "Kontext access policy could not be evaluated.",
+		})
+	}
+	return EvaluateResultFromResult(result)
 }
 
 func sidecarDecodeFailureResult(req *EvaluateRequest) hook.Result {
@@ -264,52 +301,6 @@ func sidecarDecodeFailureResult(req *EvaluateRequest) hook.Result {
 		Decision: hook.DecisionDeny,
 		Reason:   "Kontext hook event could not be decoded.",
 	}
-}
-
-func (s *Server) evaluateHook(ctx context.Context, event hook.Event) hook.Result {
-	if event.HookName != hook.HookPreToolUse {
-		return hook.Result{Decision: hook.DecisionAllow}
-	}
-
-	evalCtx, cancel := context.WithTimeout(ctx, hookEvalTimeout)
-	defer cancel()
-
-	result, err := s.processHostedHookEvent(evalCtx, event)
-	if err != nil {
-		s.diagnostic.Printf("sidecar enforce: %v\n", err)
-		accessMode := s.currentAccessMode()
-		if accessMode != backend.HostedAccessModeEnforce {
-			return hook.Result{
-				Decision: hook.DecisionAllow,
-				Reason:   "Kontext hosted access is not enforcing.",
-				Mode:     string(accessMode),
-			}
-		}
-		return hook.Result{
-			Decision: hook.DecisionDeny,
-			Reason:   "Kontext access policy could not be evaluated.",
-		}
-	}
-	if err := s.refreshAccessMode(result.AccessMode); err != nil {
-		s.diagnostic.Printf("sidecar access mode persist: %v\n", err)
-		if result.AccessMode == backend.HostedAccessModeEnforce {
-			return hook.Result{
-				Decision: hook.DecisionDeny,
-				Reason:   "Kontext access policy mode could not be persisted.",
-				Mode:     string(result.AccessMode),
-			}
-		}
-	}
-
-	accessMode := result.AccessMode
-	if accessMode == "" {
-		accessMode = s.currentAccessMode()
-	}
-	return HookResultFromHostedResult(result, accessMode)
-}
-
-func (s *Server) processHostedHookEvent(ctx context.Context, event hook.Event) (*backend.ProcessHookEventResult, error) {
-	return s.client.ProcessHookEvent(ctx, buildHookEventRequestFromEvent(event))
 }
 
 func buildHookEventRequestFromEvent(event hook.Event) *agentv1.ProcessHookEventRequest {

--- a/internal/sidecar/sidecar.go
+++ b/internal/sidecar/sidecar.go
@@ -120,15 +120,7 @@ func (s *Server) SocketPath() string { return s.socketPath }
 func (s *Server) AccessModePath() string { return s.modePath }
 
 func (s *Server) runtimeCore() *runtimecore.Core {
-	if s.core != nil {
-		return s.core
-	}
-	core, err := runtimecore.New(s.hostedRuntime())
-	if err != nil {
-		panic(err)
-	}
-	s.core = core
-	return core
+	return s.core
 }
 
 func (s *Server) hostedRuntime() hostedHookRuntime {
@@ -279,6 +271,14 @@ func (s *Server) evaluate(ctx context.Context, req *EvaluateRequest) EvaluateRes
 	result, err := s.runtimeCore().EvaluateHook(ctx, event)
 	if err != nil {
 		s.diagnostic.Printf("sidecar enforce: %v\n", err)
+		accessMode := s.currentAccessMode()
+		if accessMode != backend.HostedAccessModeEnforce {
+			return EvaluateResultFromResult(hook.Result{
+				Decision: hook.DecisionAllow,
+				Reason:   "Kontext hosted access is not enforcing.",
+				Mode:     string(accessMode),
+			})
+		}
 		return EvaluateResultFromResult(hook.Result{
 			Decision: hook.DecisionDeny,
 			Reason:   "Kontext access policy could not be evaluated.",

--- a/internal/sidecar/sidecar_test.go
+++ b/internal/sidecar/sidecar_test.go
@@ -20,10 +20,21 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 	"github.com/kontext-security/kontext-cli/internal/hook"
 	"github.com/kontext-security/kontext-cli/internal/hookruntime"
+	"github.com/kontext-security/kontext-cli/internal/runtimecore"
 )
 
 func newTestLogger(buf *bytes.Buffer) diagnostic.Logger {
 	return diagnostic.New(buf, true)
+}
+
+func withRuntimeCore(t *testing.T, s *Server) *Server {
+	t.Helper()
+	core, err := runtimecore.New(s.hostedRuntime())
+	if err != nil {
+		t.Fatalf("runtimecore.New() error = %v", err)
+	}
+	s.core = core
+	return s
 }
 
 func TestHeartbeatDeduplication(t *testing.T) {
@@ -118,14 +129,14 @@ func TestIngestEventRefreshesAccessMode(t *testing.T) {
 	t.Parallel()
 
 	modePath := filepath.Join(t.TempDir(), "access-mode")
-	s := &Server{
+	s := withRuntimeCore(t, &Server{
 		sessionID:  "session-123",
 		agentName:  "claude",
 		modePath:   modePath,
 		accessMode: backend.HostedAccessModeNoPolicy,
 		client:     &stubProcessor{result: &backend.ProcessHookEventResult{AccessMode: backend.HostedAccessModeEnforce}},
 		diagnostic: diagnostic.New(io.Discard, false),
-	}
+	})
 
 	s.ingestEvent(context.Background(), &EvaluateRequest{HookEvent: "PostToolUse"})
 
@@ -216,12 +227,12 @@ func TestEvaluatePreToolUseUsesBackendDecision(t *testing.T) {
 			PolicySetEpoch: "4",
 		},
 	}
-	s := &Server{
+	s := withRuntimeCore(t, &Server{
 		sessionID: "session-123",
 		agentName: "claude",
 		modePath:  filepath.Join(t.TempDir(), "access-mode"),
 		client:    client,
-	}
+	})
 
 	result := s.evaluate(context.Background(), &EvaluateRequest{
 		HookEvent: "PreToolUse",
@@ -246,7 +257,7 @@ func TestEvaluatePreToolUseUsesBackendDecision(t *testing.T) {
 func TestEvaluatePreToolUseAskKeepsRawReasonAndRequestMetadata(t *testing.T) {
 	t.Parallel()
 
-	s := &Server{
+	s := withRuntimeCore(t, &Server{
 		sessionID:  "session-123",
 		agentName:  "claude",
 		modePath:   filepath.Join(t.TempDir(), "access-mode"),
@@ -262,7 +273,7 @@ func TestEvaluatePreToolUseAskKeepsRawReasonAndRequestMetadata(t *testing.T) {
 			},
 		},
 		diagnostic: diagnostic.New(io.Discard, false),
-	}
+	})
 
 	result := s.evaluate(context.Background(), &EvaluateRequest{
 		HookEvent: "PreToolUse",
@@ -309,7 +320,7 @@ func TestEvaluatePreToolUseAllowsBackendBlocksWhenNotEnforcing(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			s := &Server{
+			s := withRuntimeCore(t, &Server{
 				sessionID:  "session-123",
 				agentName:  "claude",
 				modePath:   filepath.Join(t.TempDir(), "access-mode"),
@@ -327,7 +338,7 @@ func TestEvaluatePreToolUseAllowsBackendBlocksWhenNotEnforcing(t *testing.T) {
 					},
 				},
 				diagnostic: diagnostic.New(io.Discard, false),
-			}
+			})
 
 			result := s.evaluate(context.Background(), &EvaluateRequest{
 				HookEvent: "PreToolUse",
@@ -354,7 +365,7 @@ func TestEvaluatePreToolUseAllowsBackendBlocksWhenNotEnforcing(t *testing.T) {
 func TestEvaluatePreToolUseUsesCachedModeWhenBackendOmitsMode(t *testing.T) {
 	t.Parallel()
 
-	s := &Server{
+	s := withRuntimeCore(t, &Server{
 		sessionID:  "session-123",
 		agentName:  "claude",
 		modePath:   filepath.Join(t.TempDir(), "access-mode"),
@@ -369,7 +380,7 @@ func TestEvaluatePreToolUseUsesCachedModeWhenBackendOmitsMode(t *testing.T) {
 			},
 		},
 		diagnostic: diagnostic.New(io.Discard, false),
-	}
+	})
 
 	result := s.evaluate(context.Background(), &EvaluateRequest{
 		HookEvent: "PreToolUse",
@@ -391,13 +402,13 @@ func TestEvaluatePreToolUseUsesCachedModeWhenBackendOmitsMode(t *testing.T) {
 func TestEvaluatePreToolUseFailsClosedOnBackendError(t *testing.T) {
 	t.Parallel()
 
-	s := &Server{
+	s := withRuntimeCore(t, &Server{
 		sessionID:  "session-123",
 		agentName:  "claude",
 		accessMode: backend.HostedAccessModeEnforce,
 		client:     &stubProcessor{err: errors.New("backend down")},
 		diagnostic: diagnostic.New(io.Discard, false),
-	}
+	})
 
 	result := s.evaluate(context.Background(), &EvaluateRequest{HookEvent: "PreToolUse"})
 
@@ -460,13 +471,13 @@ func TestEvaluateAllowsNonblockingHookPayloadDecodeFailure(t *testing.T) {
 func TestEvaluatePreToolUseFailsClosedBeforeClaudeHookDeadline(t *testing.T) {
 	t.Parallel()
 
-	s := &Server{
+	s := withRuntimeCore(t, &Server{
 		sessionID:  "session-123",
 		agentName:  "claude",
 		accessMode: backend.HostedAccessModeEnforce,
 		client:     &stubProcessor{delay: hookEvalTimeout + time.Second},
 		diagnostic: diagnostic.New(io.Discard, false),
-	}
+	})
 
 	start := time.Now()
 	result := s.evaluate(context.Background(), &EvaluateRequest{HookEvent: "PreToolUse"})
@@ -520,13 +531,13 @@ func TestEvaluatePreToolUseFailsClosedWhenEnforceModeCannotPersist(t *testing.T)
 func TestEvaluatePreToolUseFailsOpenWhenNotEnforcing(t *testing.T) {
 	t.Parallel()
 
-	s := &Server{
+	s := withRuntimeCore(t, &Server{
 		sessionID:  "session-123",
 		agentName:  "claude",
 		accessMode: backend.HostedAccessModeNoPolicy,
 		client:     &stubProcessor{err: errors.New("backend down")},
 		diagnostic: diagnostic.New(io.Discard, false),
-	}
+	})
 
 	result := s.evaluate(context.Background(), &EvaluateRequest{HookEvent: "PreToolUse"})
 
@@ -549,14 +560,14 @@ func TestEvaluateRefreshesAccessModeForLaterFailures(t *testing.T) {
 			AccessMode: backend.HostedAccessModeEnforce,
 		},
 	}
-	s := &Server{
+	s := withRuntimeCore(t, &Server{
 		sessionID:  "session-123",
 		agentName:  "claude",
 		modePath:   filepath.Join(t.TempDir(), "access-mode"),
 		accessMode: backend.HostedAccessModeNoPolicy,
 		client:     client,
 		diagnostic: diagnostic.New(io.Discard, false),
-	}
+	})
 
 	first := s.evaluate(context.Background(), &EvaluateRequest{HookEvent: "PreToolUse"})
 	if !first.Allowed {
@@ -581,14 +592,14 @@ func TestEvaluateRefreshesAccessModeBackToFailOpen(t *testing.T) {
 			AccessMode: backend.HostedAccessModeNoPolicy,
 		},
 	}
-	s := &Server{
+	s := withRuntimeCore(t, &Server{
 		sessionID:  "session-123",
 		agentName:  "claude",
 		modePath:   filepath.Join(t.TempDir(), "access-mode"),
 		accessMode: backend.HostedAccessModeEnforce,
 		client:     client,
 		diagnostic: diagnostic.New(io.Discard, false),
-	}
+	})
 
 	first := s.evaluate(context.Background(), &EvaluateRequest{HookEvent: "PreToolUse"})
 	if !first.Allowed {

--- a/internal/sidecar/sidecar_test.go
+++ b/internal/sidecar/sidecar_test.go
@@ -141,6 +141,66 @@ func TestIngestEventRefreshesAccessMode(t *testing.T) {
 	}
 }
 
+func TestNewInitializesRuntimeCore(t *testing.T) {
+	t.Parallel()
+
+	s, err := New(
+		t.TempDir(),
+		&stubProcessor{},
+		"session-123",
+		"claude",
+		backend.HostedAccessModeNoPolicy,
+		diagnostic.New(io.Discard, false),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if s.core == nil {
+		t.Fatal("core = nil, want runtime core initialized")
+	}
+}
+
+func TestEvaluatePreToolUseUsesRuntimeCore(t *testing.T) {
+	t.Parallel()
+
+	client := &stubProcessor{
+		result: &backend.ProcessHookEventResult{
+			Response: &agentv1.ProcessHookEventResponse{
+				Decision: agentv1.Decision_DECISION_DENY,
+				Reason:   "blocked by runtime",
+			},
+			AccessMode: backend.HostedAccessModeEnforce,
+		},
+	}
+	s, err := New(
+		t.TempDir(),
+		client,
+		"session-123",
+		"claude",
+		backend.HostedAccessModeEnforce,
+		diagnostic.New(io.Discard, false),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	result := s.evaluate(context.Background(), &EvaluateRequest{
+		HookEvent: "PreToolUse",
+		ToolName:  "Bash",
+		ToolInput: json.RawMessage(`{"command":"gh repo delete"}`),
+	})
+
+	if result.Allowed {
+		t.Fatal("evaluate().Allowed = true, want false")
+	}
+	if result.Reason != "blocked by runtime" {
+		t.Fatalf("evaluate().Reason = %q, want runtime decision reason", result.Reason)
+	}
+	if client.processCalls != 1 {
+		t.Fatalf("ProcessHookEvent calls = %d, want 1", client.processCalls)
+	}
+}
+
 func TestEvaluatePreToolUseUsesBackendDecision(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- This PR addresses the step 4 in this issue https://github.com/kontext-security/kontext-cli/issues/104
- Introduced runtimecore facade, both Guard server and Hosted sidecar use it

Part of ENG-320