### PR TITLE
refactor(guard): add local model snapshot store

### DIFF
--- a/docs/guard-model-updates.md
+++ b/docs/guard-model-updates.md
@@ -31,6 +31,10 @@ A candidate model should not replace the shipped model unless it improves the ag
 ## Runtime contract
 
 - Model files are local JSON artifacts.
+- Guard activates the configured model into a local snapshot store before
+  loading the in-memory scorer used on the hook hot path.
+- Snapshot metadata records the active model, content hash, activation time, and
+  rollback target.
 - Guard mode must not call a hosted scoring service.
 - Unknown model states must not crash runtime.
 - Deterministic rules remain authoritative for obvious security risk.

--- a/internal/guard/cli/cli.go
+++ b/internal/guard/cli/cli.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/guard/app/server"
 	"github.com/kontext-security/kontext-cli/internal/guard/hookruntime"
 	"github.com/kontext-security/kontext-cli/internal/guard/markov"
+	"github.com/kontext-security/kontext-cli/internal/guard/modelsnapshot"
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
 	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
 	"github.com/kontext-security/kontext-cli/internal/guard/trace"
@@ -116,8 +117,14 @@ func runDaemon(args []string, out io.Writer) error {
 		}
 	}
 	var scorer risk.Scorer = risk.NoopScorer{}
+	activeModelPath := *modelPath
 	if *modelPath != "" {
-		loaded, err := risk.LoadMarkovScorer(*modelPath, *threshold, *horizon)
+		snapshot, err := modelsnapshot.NewWithValidator(defaultModelSnapshotDir(*dbPath), risk.ValidateMarkovModel).ActivateFromFile(*modelPath)
+		if err != nil {
+			return err
+		}
+		activeModelPath = snapshot.Path
+		loaded, err := risk.LoadMarkovScorer(activeModelPath, *threshold, *horizon)
 		if err != nil {
 			return err
 		}
@@ -133,7 +140,7 @@ func runDaemon(args []string, out io.Writer) error {
 	fmt.Fprintf(out, "Kontext Guard local daemon listening on http://%s\n", *addr)
 	fmt.Fprintln(out, "Mode: observe (Claude Code runs normally; decisions are recorded as would allow / would ask / would deny).")
 	fmt.Fprintf(out, "Dashboard: http://%s\n", *addr)
-	fmt.Fprintf(out, "Risk model: %s\n", *modelPath)
+	fmt.Fprintf(out, "Risk model: %s\n", activeModelPath)
 	if !*noOpen {
 		_ = browser.OpenURL("http://" + *addr)
 	}
@@ -659,6 +666,13 @@ func defaultDBPath() string {
 		return filepath.Join(home, ".kontext", "guard.db")
 	}
 	return "kontext-guard.db"
+}
+
+func defaultModelSnapshotDir(dbPath string) string {
+	if dbPath != "" {
+		return filepath.Join(filepath.Dir(dbPath), "models")
+	}
+	return filepath.Join(".", "models")
 }
 
 func selfPath() string {

--- a/internal/guard/modelsnapshot/store.go
+++ b/internal/guard/modelsnapshot/store.go
@@ -1,0 +1,211 @@
+package modelsnapshot
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/guard/markov"
+)
+
+var ErrNoActiveSnapshot = errors.New("no active model snapshot")
+
+type Snapshot struct {
+	ID          string    `json:"id"`
+	SourcePath  string    `json:"source_path"`
+	Path        string    `json:"path"`
+	SHA256      string    `json:"sha256"`
+	CreatedAt   time.Time `json:"created_at"`
+	ActivatedAt time.Time `json:"activated_at"`
+	PreviousID  string    `json:"previous_id,omitempty"`
+}
+
+type Store struct {
+	root     string
+	validate func(*markov.Model) error
+}
+
+func New(root string) *Store {
+	return &Store{root: root}
+}
+
+func NewWithValidator(root string, validate func(*markov.Model) error) *Store {
+	return &Store{root: root, validate: validate}
+}
+
+func (s *Store) ActivateFromFile(path string) (Snapshot, error) {
+	if strings.TrimSpace(path) == "" {
+		return Snapshot{}, fmt.Errorf("model path is required")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	model, err := markov.ReadModelJSON(bytes.NewReader(data))
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("validate model snapshot: %w", err)
+	}
+	if s.validate != nil {
+		if err := s.validate(model); err != nil {
+			return Snapshot{}, fmt.Errorf("validate model snapshot: %w", err)
+		}
+	}
+
+	sum := sha256.Sum256(data)
+	hash := hex.EncodeToString(sum[:])
+	active, activeErr := s.Active()
+	if activeErr == nil && active.SHA256 == hash {
+		return active, nil
+	} else if activeErr != nil && !errors.Is(activeErr, ErrNoActiveSnapshot) {
+		return Snapshot{}, activeErr
+	}
+
+	now := time.Now().UTC()
+	previousID := ""
+	if activeErr == nil {
+		previousID = active.ID
+	}
+
+	id := now.Format("20060102T150405.000000000Z") + "-" + hash[:12]
+	snapshotDir := filepath.Join(s.root, "snapshots")
+	if err := os.MkdirAll(snapshotDir, 0o755); err != nil {
+		return Snapshot{}, err
+	}
+	modelPath := filepath.Join(snapshotDir, id+".json")
+	if err := writeFileAtomic(modelPath, data, 0o644); err != nil {
+		return Snapshot{}, err
+	}
+	snapshot := Snapshot{
+		ID:          id,
+		SourcePath:  path,
+		Path:        modelPath,
+		SHA256:      hash,
+		CreatedAt:   now,
+		ActivatedAt: now,
+		PreviousID:  previousID,
+	}
+	if err := s.writeSnapshot(snapshot); err != nil {
+		return Snapshot{}, err
+	}
+	if err := s.writeActive(snapshot); err != nil {
+		return Snapshot{}, err
+	}
+	return snapshot, nil
+}
+
+func (s *Store) Active() (Snapshot, error) {
+	data, err := os.ReadFile(s.activePath())
+	if errors.Is(err, os.ErrNotExist) {
+		return Snapshot{}, ErrNoActiveSnapshot
+	}
+	if err != nil {
+		return Snapshot{}, err
+	}
+	var snapshot Snapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return Snapshot{}, err
+	}
+	if snapshot.ID == "" || snapshot.Path == "" {
+		return Snapshot{}, fmt.Errorf("active model snapshot is invalid")
+	}
+	return snapshot, nil
+}
+
+func (s *Store) Rollback() (Snapshot, error) {
+	active, err := s.Active()
+	if err != nil {
+		return Snapshot{}, err
+	}
+	if active.PreviousID == "" {
+		return Snapshot{}, fmt.Errorf("active model snapshot has no rollback target")
+	}
+	previous, err := s.readSnapshot(active.PreviousID)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	previous.PreviousID = active.ID
+	previous.ActivatedAt = time.Now().UTC()
+	if err := s.writeSnapshot(previous); err != nil {
+		return Snapshot{}, err
+	}
+	if err := s.writeActive(previous); err != nil {
+		return Snapshot{}, err
+	}
+	return previous, nil
+}
+
+func (s *Store) writeSnapshot(snapshot Snapshot) error {
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return writeFileAtomic(s.snapshotMetadataPath(snapshot.ID), data, 0o644)
+}
+
+func (s *Store) readSnapshot(id string) (Snapshot, error) {
+	data, err := os.ReadFile(s.snapshotMetadataPath(id))
+	if err != nil {
+		return Snapshot{}, err
+	}
+	var snapshot Snapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return Snapshot{}, err
+	}
+	if snapshot.ID == "" || snapshot.Path == "" {
+		return Snapshot{}, fmt.Errorf("model snapshot %q is invalid", id)
+	}
+	return snapshot, nil
+}
+
+func (s *Store) writeActive(snapshot Snapshot) error {
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return writeFileAtomic(s.activePath(), data, 0o644)
+}
+
+func (s *Store) activePath() string {
+	return filepath.Join(s.root, "active.json")
+}
+
+func (s *Store) snapshotMetadataPath(id string) string {
+	return filepath.Join(s.root, "snapshots", id+".metadata.json")
+}
+
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/internal/guard/modelsnapshot/store_test.go
+++ b/internal/guard/modelsnapshot/store_test.go
@@ -1,0 +1,159 @@
+package modelsnapshot
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/guard/markov"
+	"github.com/kontext-security/kontext-cli/internal/guard/trace"
+)
+
+func TestActivateFromFilePersistsActiveSnapshot(t *testing.T) {
+	source := writeModel(t, t.TempDir(), "model.json", "v1")
+	store := New(t.TempDir())
+
+	snapshot, err := store.ActivateFromFile(source)
+	if err != nil {
+		t.Fatalf("ActivateFromFile() error = %v", err)
+	}
+	if snapshot.ID == "" || snapshot.Path == "" || snapshot.SHA256 == "" {
+		t.Fatalf("snapshot missing metadata: %+v", snapshot)
+	}
+	if snapshot.SourcePath != source {
+		t.Fatalf("SourcePath = %q, want %q", snapshot.SourcePath, source)
+	}
+	if _, err := os.Stat(snapshot.Path); err != nil {
+		t.Fatalf("snapshot model file: %v", err)
+	}
+	active, err := store.Active()
+	if err != nil {
+		t.Fatalf("Active() error = %v", err)
+	}
+	if active.ID != snapshot.ID || active.Path != snapshot.Path {
+		t.Fatalf("active = %+v, want snapshot %+v", active, snapshot)
+	}
+}
+
+func TestActivateFromFileReusesActiveSnapshotForSameModel(t *testing.T) {
+	source := writeModel(t, t.TempDir(), "model.json", "v1")
+	store := New(t.TempDir())
+
+	first, err := store.ActivateFromFile(source)
+	if err != nil {
+		t.Fatalf("first ActivateFromFile() error = %v", err)
+	}
+	second, err := store.ActivateFromFile(source)
+	if err != nil {
+		t.Fatalf("second ActivateFromFile() error = %v", err)
+	}
+	if second.ID != first.ID {
+		t.Fatalf("second ID = %q, want reused active ID %q", second.ID, first.ID)
+	}
+}
+
+func TestRollbackActivatesPreviousSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	store := New(t.TempDir())
+	firstSource := writeModel(t, dir, "model-v1.json", "v1")
+	secondSource := writeModel(t, dir, "model-v2.json", "v2")
+
+	first, err := store.ActivateFromFile(firstSource)
+	if err != nil {
+		t.Fatalf("first ActivateFromFile() error = %v", err)
+	}
+	second, err := store.ActivateFromFile(secondSource)
+	if err != nil {
+		t.Fatalf("second ActivateFromFile() error = %v", err)
+	}
+	if second.PreviousID != first.ID {
+		t.Fatalf("PreviousID = %q, want %q", second.PreviousID, first.ID)
+	}
+	rolledBack, err := store.Rollback()
+	if err != nil {
+		t.Fatalf("Rollback() error = %v", err)
+	}
+	if rolledBack.ID != first.ID {
+		t.Fatalf("rolledBack ID = %q, want %q", rolledBack.ID, first.ID)
+	}
+	active, err := store.Active()
+	if err != nil {
+		t.Fatalf("Active() error = %v", err)
+	}
+	if active.ID != first.ID || active.PreviousID != second.ID {
+		t.Fatalf("active after rollback = %+v, want first with previous second", active)
+	}
+	persisted, err := store.readSnapshot(first.ID)
+	if err != nil {
+		t.Fatalf("readSnapshot() error = %v", err)
+	}
+	if persisted.ID != first.ID || persisted.PreviousID != second.ID {
+		t.Fatalf("persisted snapshot after rollback = %+v, want first with previous second", persisted)
+	}
+	if !persisted.ActivatedAt.Equal(rolledBack.ActivatedAt) {
+		t.Fatalf("persisted ActivatedAt = %s, want returned rollback activation time %s", persisted.ActivatedAt, rolledBack.ActivatedAt)
+	}
+}
+
+func TestActiveReturnsNoActiveSnapshot(t *testing.T) {
+	_, err := New(t.TempDir()).Active()
+	if !errors.Is(err, ErrNoActiveSnapshot) {
+		t.Fatalf("Active() error = %v, want ErrNoActiveSnapshot", err)
+	}
+}
+
+func TestActivateFromFileRejectsInvalidModel(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "invalid.json")
+	if err := os.WriteFile(path, []byte(`{"states":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := New(t.TempDir()).ActivateFromFile(path); err == nil {
+		t.Fatal("ActivateFromFile() error = nil, want invalid model error")
+	}
+}
+
+func TestActivateFromFileRejectsValidatorError(t *testing.T) {
+	source := writeModel(t, t.TempDir(), "model.json", "v1")
+	store := NewWithValidator(t.TempDir(), func(*markov.Model) error {
+		return errors.New("unsupported abstraction")
+	})
+
+	if _, err := store.ActivateFromFile(source); err == nil {
+		t.Fatal("ActivateFromFile() error = nil, want validator error")
+	}
+	if _, err := store.Active(); !errors.Is(err, ErrNoActiveSnapshot) {
+		t.Fatalf("Active() error = %v, want ErrNoActiveSnapshot", err)
+	}
+}
+
+func writeModel(t *testing.T, dir, name, version string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	metadata, err := json.Marshal(map[string]string{"abstraction_version": trace.RiskAbstractionVersion, "version": version})
+	if err != nil {
+		t.Fatal(err)
+	}
+	model := markov.Model{
+		States: []string{"safe"},
+		StateIndex: map[string]int{
+			"safe": 0,
+		},
+		TransitionProbs: map[int]map[int]float64{
+			0: {0: 1},
+		},
+		Metadata: map[string]json.RawMessage{
+			"abstraction_version": metadata,
+		},
+	}
+	data, err := json.Marshal(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/internal/guard/risk/scorer.go
+++ b/internal/guard/risk/scorer.go
@@ -44,6 +44,11 @@ func LoadMarkovScorer(path string, threshold float64, horizon int) (*MarkovScore
 	}, nil
 }
 
+func ValidateMarkovModel(model *markov.Model) error {
+	_, _, err := abstractionFromModel(model)
+	return err
+}
+
 func (s *MarkovScorer) Score(event RiskEvent) (ScoreResult, error) {
 	if s == nil || s.Model == nil {
 		return ScoreResult{}, fmt.Errorf("markov scorer model is nil")


### PR DESCRIPTION
## Summary

- Handling step 7 in https://github.com/kontext-security/kontext-cli/issues/104
- Introduced local model snapshot store as an abstraction fo fallback, model versionining etc. 
- Added interfaces that can later store hosted policy snapshots when backend support exists.