### PR TITLE
feat(runtime service): Introduce runtime service and make existing Unix socket more generic

### DIFF
--- a/cmd/kontext/main.go
+++ b/cmd/kontext/main.go
@@ -17,8 +17,8 @@ import (
 	guardcli "github.com/kontext-security/kontext-cli/internal/guard/cli"
 	"github.com/kontext-security/kontext-cli/internal/hook"
 	"github.com/kontext-security/kontext-cli/internal/hookcmd"
+	"github.com/kontext-security/kontext-cli/internal/localruntime"
 	"github.com/kontext-security/kontext-cli/internal/run"
-	"github.com/kontext-security/kontext-cli/internal/sidecar"
 	"github.com/kontext-security/kontext-cli/internal/update"
 
 	_ "github.com/kontext-security/kontext-cli/internal/agent/claude"
@@ -211,21 +211,21 @@ func evaluateViaSidecar(socketPath string, event hook.Event) (hook.Result, error
 		return sidecarFailureResult(event, "sidecar deadline error"), nil
 	}
 
-	req, err := sidecar.EvaluateRequestFromEvent(event)
+	req, err := localruntime.EvaluateRequestFromEvent(event)
 	if err != nil {
 		return sidecarFailureResult(event, "sidecar marshal error"), nil
 	}
 
-	if err := sidecar.WriteMessage(conn, req); err != nil {
+	if err := localruntime.WriteMessage(conn, req); err != nil {
 		return sidecarFailureResult(event, "sidecar write error"), nil
 	}
 
-	var result sidecar.EvaluateResult
-	if err := sidecar.ReadMessage(conn, &result); err != nil {
+	var result localruntime.EvaluateResult
+	if err := localruntime.ReadMessage(conn, &result); err != nil {
 		return sidecarFailureResult(event, "sidecar read error"), nil
 	}
 
-	return sidecar.ResultFromEvaluateResult(result), nil
+	return localruntime.ResultFromEvaluateResult(result), nil
 }
 
 func sidecarFailureResult(event hook.Event, reason string) hook.Result {

--- a/internal/localruntime/client.go
+++ b/internal/localruntime/client.go
@@ -1,0 +1,48 @@
+package localruntime
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/hook"
+)
+
+type Client struct {
+	SocketPath string
+	Timeout    time.Duration
+}
+
+func NewClient(socketPath string) Client {
+	return Client{SocketPath: socketPath, Timeout: 10 * time.Second}
+}
+
+func (c Client) Process(ctx context.Context, event hook.Event) (hook.Result, error) {
+	timeout := c.Timeout
+	if timeout == 0 {
+		timeout = 10 * time.Second
+	}
+	dialer := net.Dialer{Timeout: timeout}
+	conn, err := dialer.DialContext(ctx, "unix", c.SocketPath)
+	if err != nil {
+		return hook.Result{}, err
+	}
+	defer conn.Close()
+	if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
+		return hook.Result{}, err
+	}
+
+	req, err := EvaluateRequestFromEvent(event)
+	if err != nil {
+		return hook.Result{}, err
+	}
+	if err := WriteMessage(conn, req); err != nil {
+		return hook.Result{}, err
+	}
+
+	var result EvaluateResult
+	if err := ReadMessage(conn, &result); err != nil {
+		return hook.Result{}, err
+	}
+	return ResultFromEvaluateResult(result), nil
+}

--- a/internal/localruntime/conversions.go
+++ b/internal/localruntime/conversions.go
@@ -1,0 +1,148 @@
+package localruntime
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/kontext-security/kontext-cli/internal/hook"
+)
+
+func EvaluateRequestFromEvent(event hook.Event) (EvaluateRequest, error) {
+	req := EvaluateRequest{
+		Type:           "evaluate",
+		Agent:          event.Agent,
+		HookEvent:      event.HookName.String(),
+		ToolName:       event.ToolName,
+		ToolUseID:      event.ToolUseID,
+		CWD:            event.CWD,
+		PermissionMode: event.PermissionMode,
+		DurationMs:     event.DurationMs,
+		Error:          event.Error,
+		IsInterrupt:    event.IsInterrupt,
+	}
+
+	if event.ToolInput != nil {
+		data, err := marshalMap(event.ToolInput)
+		if err != nil {
+			return EvaluateRequest{}, fmt.Errorf("marshal tool input: %w", err)
+		}
+		req.ToolInput = data
+	}
+	if event.ToolResponse != nil {
+		data, err := marshalMap(event.ToolResponse)
+		if err != nil {
+			return EvaluateRequest{}, fmt.Errorf("marshal tool response: %w", err)
+		}
+		req.ToolResponse = data
+	}
+	return req, nil
+}
+
+func EventFromEvaluateRequest(sessionID, fallbackAgent string, req *EvaluateRequest) (hook.Event, error) {
+	if req == nil {
+		return hook.Event{}, errors.New("evaluate request missing")
+	}
+	if req.HookEvent == "" {
+		return hook.Event{}, errors.New("hook event missing")
+	}
+	hookName, ok := normalizeHookName(req.HookEvent)
+	if !ok {
+		return hook.Event{}, fmt.Errorf("unknown hook event %q", req.HookEvent)
+	}
+	agent := req.Agent
+	if agent == "" {
+		agent = fallbackAgent
+	}
+	event := hook.Event{
+		SessionID:      sessionID,
+		Agent:          agent,
+		HookName:       hookName,
+		ToolName:       req.ToolName,
+		ToolUseID:      req.ToolUseID,
+		CWD:            req.CWD,
+		PermissionMode: req.PermissionMode,
+		DurationMs:     req.DurationMs,
+		Error:          req.Error,
+		IsInterrupt:    req.IsInterrupt,
+	}
+
+	var err error
+	event.ToolInput, err = rawMap(req.ToolInput)
+	if err != nil {
+		return hook.Event{}, fmt.Errorf("decode tool input: %w", err)
+	}
+	event.ToolResponse, err = rawMap(req.ToolResponse)
+	if err != nil {
+		return hook.Event{}, fmt.Errorf("decode tool response: %w", err)
+	}
+	return event, nil
+}
+
+func EvaluateResultFromResult(result hook.Result) EvaluateResult {
+	return EvaluateResult{
+		Type:         "result",
+		Decision:     string(result.Decision),
+		Allowed:      result.Allowed(),
+		Reason:       result.Reason,
+		ReasonCode:   result.ReasonCode,
+		RequestID:    result.RequestID,
+		Mode:         result.Mode,
+		Epoch:        result.Epoch,
+		UpdatedInput: result.UpdatedInput,
+	}
+}
+
+func ResultFromEvaluateResult(result EvaluateResult) hook.Result {
+	decision, ok := hook.NormalizeDecision(result.Decision)
+	if !ok {
+		decision = resultFromBool(result.Allowed).Decision
+	}
+	return hook.Result{
+		Decision:     decision,
+		Reason:       result.Reason,
+		ReasonCode:   result.ReasonCode,
+		RequestID:    result.RequestID,
+		Mode:         result.Mode,
+		Epoch:        result.Epoch,
+		UpdatedInput: result.UpdatedInput,
+	}
+}
+
+func resultFromBool(allowed bool) hook.Result {
+	if allowed {
+		return hook.Result{Decision: hook.DecisionAllow}
+	}
+	return hook.Result{Decision: hook.DecisionDeny}
+}
+
+func marshalMap(value map[string]any) (json.RawMessage, error) {
+	if value == nil {
+		return nil, nil
+	}
+	return json.Marshal(value)
+}
+
+func rawMap(data json.RawMessage) (map[string]any, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var value map[string]any
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+func normalizeHookName(value string) (hook.HookName, bool) {
+	switch hookName := hook.HookName(strings.TrimSpace(value)); hookName {
+	case hook.HookPreToolUse, hook.HookPostToolUse, hook.HookPostToolUseFailed, hook.HookUserPromptSubmit:
+		return hookName, true
+	default:
+		return "", false
+	}
+}

--- a/internal/localruntime/protocol.go
+++ b/internal/localruntime/protocol.go
@@ -1,0 +1,70 @@
+package localruntime
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+)
+
+type EvaluateRequest struct {
+	Type           string          `json:"type"`
+	Agent          string          `json:"agent"`
+	HookEvent      string          `json:"hook_event"`
+	ToolName       string          `json:"tool_name"`
+	ToolInput      json.RawMessage `json:"tool_input,omitempty"`
+	ToolResponse   json.RawMessage `json:"tool_response,omitempty"`
+	ToolUseID      string          `json:"tool_use_id"`
+	CWD            string          `json:"cwd"`
+	PermissionMode string          `json:"permission_mode,omitempty"`
+	DurationMs     *int64          `json:"duration_ms,omitempty"`
+	Error          string          `json:"error,omitempty"`
+	IsInterrupt    *bool           `json:"is_interrupt,omitempty"`
+}
+
+type EvaluateResult struct {
+	Type         string         `json:"type"`
+	Decision     string         `json:"decision,omitempty"`
+	Allowed      bool           `json:"allowed"`
+	Reason       string         `json:"reason"`
+	ReasonCode   string         `json:"reason_code,omitempty"`
+	RequestID    string         `json:"request_id,omitempty"`
+	Mode         string         `json:"mode,omitempty"`
+	Epoch        string         `json:"epoch,omitempty"`
+	UpdatedInput map[string]any `json:"updated_input,omitempty"`
+}
+
+func WriteMessage(conn net.Conn, v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+
+	length := uint32(len(data))
+	if err := binary.Write(conn, binary.BigEndian, length); err != nil {
+		return fmt.Errorf("write length: %w", err)
+	}
+	if _, err := conn.Write(data); err != nil {
+		return fmt.Errorf("write payload: %w", err)
+	}
+	return nil
+}
+
+func ReadMessage(conn net.Conn, v any) error {
+	var length uint32
+	if err := binary.Read(conn, binary.BigEndian, &length); err != nil {
+		return fmt.Errorf("read length: %w", err)
+	}
+
+	if length > 10*1024*1024 {
+		return fmt.Errorf("message too large: %d bytes", length)
+	}
+
+	data := make([]byte, length)
+	if _, err := io.ReadFull(conn, data); err != nil {
+		return fmt.Errorf("read payload: %w", err)
+	}
+
+	return json.Unmarshal(data, v)
+}

--- a/internal/localruntime/service.go
+++ b/internal/localruntime/service.go
@@ -1,0 +1,180 @@
+package localruntime
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/diagnostic"
+	"github.com/kontext-security/kontext-cli/internal/hook"
+	"github.com/kontext-security/kontext-cli/internal/runtimecore"
+)
+
+const hookConnDeadline = 10 * time.Second
+
+type Service struct {
+	socketPath  string
+	listener    net.Listener
+	core        *runtimecore.Core
+	sessionID   string
+	agentName   string
+	asyncIngest bool
+	onFailure   func(hook.Event, error) hook.Result
+	diagnostic  diagnostic.Logger
+	cancel      context.CancelFunc
+}
+
+type Options struct {
+	SocketPath  string
+	Core        *runtimecore.Core
+	SessionID   string
+	AgentName   string
+	AsyncIngest bool
+	OnFailure   func(hook.Event, error) hook.Result
+	Diagnostic  diagnostic.Logger
+}
+
+func NewService(opts Options) (*Service, error) {
+	if opts.SocketPath == "" {
+		return nil, errors.New("local runtime service requires socket path")
+	}
+	if opts.Core == nil {
+		return nil, errors.New("local runtime service requires runtime core")
+	}
+	return &Service{
+		socketPath:  opts.SocketPath,
+		core:        opts.Core,
+		sessionID:   opts.SessionID,
+		agentName:   opts.AgentName,
+		asyncIngest: opts.AsyncIngest,
+		onFailure:   opts.OnFailure,
+		diagnostic:  opts.Diagnostic,
+	}, nil
+}
+
+func (s *Service) SocketPath() string { return s.socketPath }
+
+func (s *Service) Start(ctx context.Context) error {
+	os.Remove(s.socketPath)
+	ln, err := net.Listen("unix", s.socketPath)
+	if err != nil {
+		return err
+	}
+	s.listener = ln
+
+	ctx, s.cancel = context.WithCancel(ctx)
+	go s.acceptLoop(ctx)
+	return nil
+}
+
+func (s *Service) Stop() {
+	if s.cancel != nil {
+		s.cancel()
+	}
+	if s.listener != nil {
+		s.listener.Close()
+	}
+	os.Remove(s.socketPath)
+}
+
+func (s *Service) acceptLoop(ctx context.Context) {
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				s.diagnostic.Printf("local runtime accept: %v\n", err)
+				return
+			}
+		}
+		go s.handleConn(ctx, conn)
+	}
+}
+
+func (s *Service) handleConn(ctx context.Context, conn net.Conn) {
+	defer conn.Close()
+	if err := conn.SetDeadline(time.Now().Add(hookConnDeadline)); err != nil {
+		s.diagnostic.Printf("local runtime deadline: %v\n", err)
+		return
+	}
+
+	var req EvaluateRequest
+	if err := ReadMessage(conn, &req); err != nil {
+		s.diagnostic.Printf("local runtime read: %v\n", err)
+		return
+	}
+
+	result := s.process(ctx, &req)
+	if err := WriteMessage(conn, result); err != nil {
+		s.diagnostic.Printf("local runtime write: %v\n", err)
+		return
+	}
+
+	if s.asyncIngest && req.HookEvent != hook.HookPreToolUse.String() {
+		go s.ingestEvent(ctx, &req)
+	}
+}
+
+func (s *Service) ingestEvent(ctx context.Context, req *EvaluateRequest) {
+	event, err := EventFromEvaluateRequest(s.sessionID, s.agentName, req)
+	if err != nil {
+		s.diagnostic.Printf("local runtime ingest decode: %v\n", err)
+		return
+	}
+	if _, err := s.core.IngestEvent(ctx, event); err != nil {
+		s.diagnostic.Printf("local runtime ingest: %v\n", err)
+	}
+}
+
+func (s *Service) process(ctx context.Context, req *EvaluateRequest) EvaluateResult {
+	event, err := EventFromEvaluateRequest(s.sessionID, s.agentName, req)
+	if err != nil {
+		s.diagnostic.Printf("local runtime decode: %v\n", err)
+		return EvaluateResultFromResult(decodeFailureResult(req))
+	}
+	if s.asyncIngest && !event.HookName.CanBlock() {
+		return EvaluateResultFromResult(hook.Result{Decision: hook.DecisionAllow})
+	}
+	result, err := s.core.ProcessHook(ctx, event)
+	if err != nil {
+		s.diagnostic.Printf("local runtime process: %v\n", err)
+		if s.onFailure != nil {
+			return EvaluateResultFromResult(s.onFailure(event, err))
+		}
+		return EvaluateResultFromResult(processFailureResult(event))
+	}
+	return EvaluateResultFromResult(result)
+}
+
+func decodeFailureResult(req *EvaluateRequest) hook.Result {
+	if req != nil {
+		hookName, ok := normalizeHookName(req.HookEvent)
+		if ok && !hookName.CanBlock() {
+			return hook.Result{
+				Decision: hook.DecisionAllow,
+				Reason:   "Kontext hook event could not be decoded.",
+			}
+		}
+	}
+	return hook.Result{
+		Decision: hook.DecisionDeny,
+		Reason:   "Kontext hook event could not be decoded.",
+	}
+}
+
+func processFailureResult(event hook.Event) hook.Result {
+	if !event.HookName.CanBlock() {
+		return hook.Result{
+			Decision: hook.DecisionAllow,
+			Reason:   "Kontext hook event could not be ingested.",
+		}
+	}
+	return hook.Result{
+		Decision: hook.DecisionDeny,
+		Reason:   "Kontext access policy could not be evaluated.",
+	}
+}

--- a/internal/localruntime/service_test.go
+++ b/internal/localruntime/service_test.go
@@ -1,0 +1,205 @@
+package localruntime
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/diagnostic"
+	"github.com/kontext-security/kontext-cli/internal/hook"
+	"github.com/kontext-security/kontext-cli/internal/runtimecore"
+)
+
+func TestServiceEvaluatesBlockingHook(t *testing.T) {
+	t.Parallel()
+
+	runtime := &stubRuntime{
+		evaluateResult: hook.Result{
+			Decision: hook.DecisionDeny,
+			Reason:   "blocked by runtime",
+		},
+	}
+	service := newTestService(t, runtime, false)
+	client := NewClient(service.SocketPath())
+
+	result, err := client.Process(context.Background(), hook.Event{
+		HookName: hook.HookPreToolUse,
+		ToolName: "Bash",
+	})
+	if err != nil {
+		t.Fatalf("Process() error = %v", err)
+	}
+	if result.Decision != hook.DecisionDeny || result.Reason != "blocked by runtime" {
+		t.Fatalf("Process() = %+v, want runtime deny result", result)
+	}
+	if got := runtime.evaluateCalls.Load(); got != 1 {
+		t.Fatalf("EvaluateHook calls = %d, want 1", got)
+	}
+}
+
+func TestServiceCanAckTelemetryBeforeAsyncIngest(t *testing.T) {
+	t.Parallel()
+
+	runtime := &stubRuntime{ingested: make(chan hook.Event, 1)}
+	service := newTestService(t, runtime, true)
+	client := NewClient(service.SocketPath())
+
+	result, err := client.Process(context.Background(), hook.Event{
+		HookName: hook.HookPostToolUse,
+		ToolName: "Bash",
+	})
+	if err != nil {
+		t.Fatalf("Process() error = %v", err)
+	}
+	if result.Decision != hook.DecisionAllow {
+		t.Fatalf("Process().Decision = %q, want allow", result.Decision)
+	}
+
+	select {
+	case event := <-runtime.ingested:
+		if event.HookName != hook.HookPostToolUse {
+			t.Fatalf("ingested hook = %q, want PostToolUse", event.HookName)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("async ingest did not run")
+	}
+}
+
+func TestServiceUsesCustomFailureResult(t *testing.T) {
+	t.Parallel()
+
+	runtime := &stubRuntime{evaluateErr: context.DeadlineExceeded}
+	core, err := runtimecore.New(runtime)
+	if err != nil {
+		t.Fatalf("runtimecore.New() error = %v", err)
+	}
+	result := newTestServiceWithOptions(t, Options{
+		Core: core,
+		OnFailure: func(event hook.Event, err error) hook.Result {
+			if event.HookName != hook.HookPreToolUse || err == nil {
+				t.Fatalf("failure callback event=%+v err=%v", event, err)
+			}
+			return hook.Result{
+				Decision: hook.DecisionAllow,
+				Reason:   "custom fail-open",
+			}
+		},
+	})
+	client := NewClient(result.SocketPath())
+
+	got, err := client.Process(context.Background(), hook.Event{HookName: hook.HookPreToolUse})
+	if err != nil {
+		t.Fatalf("Process() error = %v", err)
+	}
+	if got.Decision != hook.DecisionAllow || got.Reason != "custom fail-open" {
+		t.Fatalf("Process() = %+v, want custom fail-open result", got)
+	}
+}
+
+func TestServiceFailsClosedWhenBlockingHookPayloadCannotDecode(t *testing.T) {
+	t.Parallel()
+
+	service := newTestService(t, &stubRuntime{}, false)
+	result := service.process(context.Background(), &EvaluateRequest{
+		HookEvent: "PreToolUse",
+		ToolInput: []byte(`{`),
+	})
+
+	if result.Allowed {
+		t.Fatal("result.Allowed = true, want false")
+	}
+	if result.Decision != string(hook.DecisionDeny) {
+		t.Fatalf("result.Decision = %q, want deny", result.Decision)
+	}
+}
+
+func TestServiceAllowsNonblockingHookPayloadDecodeFailure(t *testing.T) {
+	t.Parallel()
+
+	service := newTestService(t, &stubRuntime{}, true)
+	result := service.process(context.Background(), &EvaluateRequest{
+		HookEvent: "PostToolUse",
+		ToolInput: []byte(`{`),
+	})
+
+	if !result.Allowed {
+		t.Fatal("result.Allowed = false, want true")
+	}
+	if result.Decision != string(hook.DecisionAllow) {
+		t.Fatalf("result.Decision = %q, want allow", result.Decision)
+	}
+}
+
+func newTestService(t *testing.T, runtime *stubRuntime, asyncIngest bool) *Service {
+	t.Helper()
+
+	core, err := runtimecore.New(runtime)
+	if err != nil {
+		t.Fatalf("runtimecore.New() error = %v", err)
+	}
+	return newTestServiceWithOptions(t, Options{
+		Core:        core,
+		AgentName:   "claude",
+		AsyncIngest: asyncIngest,
+		Diagnostic:  diagnostic.New(io.Discard, false),
+	})
+}
+
+func newTestServiceWithOptions(t *testing.T, opts Options) *Service {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("/tmp", "kontext-runtime-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp() error = %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	opts.SocketPath = filepath.Join(dir, "kontext.sock")
+	if opts.AgentName == "" {
+		opts.AgentName = "claude"
+	}
+	if !opts.Diagnostic.Enabled() {
+		opts.Diagnostic = diagnostic.New(io.Discard, false)
+	}
+	service, err := NewService(Options{
+		SocketPath:  opts.SocketPath,
+		Core:        opts.Core,
+		SessionID:   opts.SessionID,
+		AgentName:   opts.AgentName,
+		AsyncIngest: opts.AsyncIngest,
+		OnFailure:   opts.OnFailure,
+		Diagnostic:  opts.Diagnostic,
+	})
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(service.Stop)
+	return service
+}
+
+type stubRuntime struct {
+	evaluateResult hook.Result
+	evaluateErr    error
+	ingested       chan hook.Event
+	evaluateCalls  atomic.Int32
+	ingestCalls    atomic.Int32
+}
+
+func (s *stubRuntime) EvaluateHook(_ context.Context, _ hook.Event) (hook.Result, error) {
+	s.evaluateCalls.Add(1)
+	return s.evaluateResult, s.evaluateErr
+}
+
+func (s *stubRuntime) IngestEvent(_ context.Context, event hook.Event) (hook.Result, error) {
+	s.ingestCalls.Add(1)
+	if s.ingested != nil {
+		s.ingested <- event
+	}
+	return hook.Result{Decision: hook.DecisionAllow}, nil
+}

--- a/internal/sidecar/conversions.go
+++ b/internal/sidecar/conversions.go
@@ -1,123 +1,29 @@
 package sidecar
 
 import (
-	"bytes"
 	"encoding/json"
-	"errors"
-	"fmt"
 	"strings"
 
 	agentv1 "github.com/kontext-security/kontext-cli/gen/kontext/agent/v1"
 	"github.com/kontext-security/kontext-cli/internal/backend"
 	"github.com/kontext-security/kontext-cli/internal/hook"
+	"github.com/kontext-security/kontext-cli/internal/localruntime"
 )
 
 func EvaluateRequestFromEvent(event hook.Event) (EvaluateRequest, error) {
-	req := EvaluateRequest{
-		Type:           "evaluate",
-		Agent:          event.Agent,
-		HookEvent:      event.HookName.String(),
-		ToolName:       event.ToolName,
-		ToolUseID:      event.ToolUseID,
-		CWD:            event.CWD,
-		PermissionMode: event.PermissionMode,
-		DurationMs:     event.DurationMs,
-		Error:          event.Error,
-		IsInterrupt:    event.IsInterrupt,
-	}
-
-	if event.ToolInput != nil {
-		data, err := marshalMap(event.ToolInput)
-		if err != nil {
-			return EvaluateRequest{}, fmt.Errorf("marshal tool input: %w", err)
-		}
-		req.ToolInput = data
-	}
-	if event.ToolResponse != nil {
-		data, err := marshalMap(event.ToolResponse)
-		if err != nil {
-			return EvaluateRequest{}, fmt.Errorf("marshal tool response: %w", err)
-		}
-		req.ToolResponse = data
-	}
-	return req, nil
+	return localruntime.EvaluateRequestFromEvent(event)
 }
 
 func EventFromEvaluateRequest(sessionID, fallbackAgent string, req *EvaluateRequest) (hook.Event, error) {
-	if req == nil {
-		return hook.Event{}, errors.New("evaluate request missing")
-	}
-	if req.HookEvent == "" {
-		return hook.Event{}, errors.New("hook event missing")
-	}
-	hookName, ok := normalizeHookName(req.HookEvent)
-	if !ok {
-		return hook.Event{}, fmt.Errorf("unknown hook event %q", req.HookEvent)
-	}
-	agent := req.Agent
-	if agent == "" {
-		agent = fallbackAgent
-	}
-	event := hook.Event{
-		SessionID:      sessionID,
-		Agent:          agent,
-		HookName:       hookName,
-		ToolName:       req.ToolName,
-		ToolUseID:      req.ToolUseID,
-		CWD:            req.CWD,
-		PermissionMode: req.PermissionMode,
-		DurationMs:     req.DurationMs,
-		Error:          req.Error,
-		IsInterrupt:    req.IsInterrupt,
-	}
-
-	var err error
-	event.ToolInput, err = rawMap(req.ToolInput)
-	if err != nil {
-		return hook.Event{}, fmt.Errorf("decode tool input: %w", err)
-	}
-	event.ToolResponse, err = rawMap(req.ToolResponse)
-	if err != nil {
-		return hook.Event{}, fmt.Errorf("decode tool response: %w", err)
-	}
-	return event, nil
+	return localruntime.EventFromEvaluateRequest(sessionID, fallbackAgent, req)
 }
 
 func EvaluateResultFromResult(result hook.Result) EvaluateResult {
-	return EvaluateResult{
-		Type:         "result",
-		Decision:     string(result.Decision),
-		Allowed:      result.Allowed(),
-		Reason:       result.Reason,
-		ReasonCode:   result.ReasonCode,
-		RequestID:    result.RequestID,
-		Mode:         result.Mode,
-		Epoch:        result.Epoch,
-		UpdatedInput: result.UpdatedInput,
-	}
+	return localruntime.EvaluateResultFromResult(result)
 }
 
 func ResultFromEvaluateResult(result EvaluateResult) hook.Result {
-	decision, ok := hook.NormalizeDecision(result.Decision)
-	if !ok {
-		decision = resultFromBool(result.Allowed).Decision
-	}
-	return hook.Result{
-		Decision:     decision,
-		Reason:       result.Reason,
-		ReasonCode:   result.ReasonCode,
-		RequestID:    result.RequestID,
-		Mode:         result.Mode,
-		Epoch:        result.Epoch,
-		UpdatedInput: result.UpdatedInput,
-	}
-}
-
-func resultFromBool(allowed bool) hook.Result {
-	if allowed {
-		return hook.Result{Decision: hook.DecisionAllow}
-	}
-	return hook.Result{Decision: hook.DecisionDeny}
+	return localruntime.ResultFromEvaluateResult(result)
 }
 
 func HookResultFromHostedResult(result *backend.ProcessHookEventResult, accessMode backend.HostedAccessMode) hook.Result {
@@ -158,19 +64,6 @@ func marshalMap(value map[string]any) (json.RawMessage, error) {
 		return nil, nil
 	}
 	return json.Marshal(value)
-}
-
-func rawMap(data json.RawMessage) (map[string]any, error) {
-	if len(data) == 0 {
-		return nil, nil
-	}
-	var value map[string]any
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.UseNumber()
-	if err := decoder.Decode(&value); err != nil {
-		return nil, err
-	}
-	return value, nil
 }
 
 func normalizeHookName(value string) (hook.HookName, bool) {

--- a/internal/sidecar/protocol.go
+++ b/internal/sidecar/protocol.go
@@ -1,70 +1,18 @@
 package sidecar
 
 import (
-	"encoding/binary"
-	"encoding/json"
-	"fmt"
-	"io"
 	"net"
+
+	"github.com/kontext-security/kontext-cli/internal/localruntime"
 )
 
-type EvaluateRequest struct {
-	Type           string          `json:"type"`
-	Agent          string          `json:"agent"`
-	HookEvent      string          `json:"hook_event"`
-	ToolName       string          `json:"tool_name"`
-	ToolInput      json.RawMessage `json:"tool_input,omitempty"`
-	ToolResponse   json.RawMessage `json:"tool_response,omitempty"`
-	ToolUseID      string          `json:"tool_use_id"`
-	CWD            string          `json:"cwd"`
-	PermissionMode string          `json:"permission_mode,omitempty"`
-	DurationMs     *int64          `json:"duration_ms,omitempty"`
-	Error          string          `json:"error,omitempty"`
-	IsInterrupt    *bool           `json:"is_interrupt,omitempty"`
-}
-
-type EvaluateResult struct {
-	Type         string         `json:"type"`
-	Decision     string         `json:"decision,omitempty"`
-	Allowed      bool           `json:"allowed"`
-	Reason       string         `json:"reason"`
-	ReasonCode   string         `json:"reason_code,omitempty"`
-	RequestID    string         `json:"request_id,omitempty"`
-	Mode         string         `json:"mode,omitempty"`
-	Epoch        string         `json:"epoch,omitempty"`
-	UpdatedInput map[string]any `json:"updated_input,omitempty"`
-}
+type EvaluateRequest = localruntime.EvaluateRequest
+type EvaluateResult = localruntime.EvaluateResult
 
 func WriteMessage(conn net.Conn, v any) error {
-	data, err := json.Marshal(v)
-	if err != nil {
-		return fmt.Errorf("marshal: %w", err)
-	}
-
-	length := uint32(len(data))
-	if err := binary.Write(conn, binary.BigEndian, length); err != nil {
-		return fmt.Errorf("write length: %w", err)
-	}
-	if _, err := conn.Write(data); err != nil {
-		return fmt.Errorf("write payload: %w", err)
-	}
-	return nil
+	return localruntime.WriteMessage(conn, v)
 }
 
 func ReadMessage(conn net.Conn, v any) error {
-	var length uint32
-	if err := binary.Read(conn, binary.BigEndian, &length); err != nil {
-		return fmt.Errorf("read length: %w", err)
-	}
-
-	if length > 10*1024*1024 {
-		return fmt.Errorf("message too large: %d bytes", length)
-	}
-
-	data := make([]byte, length)
-	if _, err := io.ReadFull(conn, data); err != nil {
-		return fmt.Errorf("read payload: %w", err)
-	}
-
-	return json.Unmarshal(data, v)
+	return localruntime.ReadMessage(conn, v)
 }

--- a/internal/sidecar/sidecar.go
+++ b/internal/sidecar/sidecar.go
@@ -3,7 +3,6 @@ package sidecar
 import (
 	"context"
 	"encoding/json"
-	"net"
 	"net/url"
 	"os"
 	"os/exec"
@@ -16,6 +15,7 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/backend"
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 	"github.com/kontext-security/kontext-cli/internal/hook"
+	"github.com/kontext-security/kontext-cli/internal/localruntime"
 	"github.com/kontext-security/kontext-cli/internal/runtimecore"
 )
 
@@ -85,13 +85,13 @@ func (h *heartbeatState) record(now time.Time, err error, logf func(string, ...a
 type Server struct {
 	socketPath string
 	modePath   string
-	listener   net.Listener
 	sessionID  string
 	agentName  string
 	mu         sync.RWMutex
 	accessMode backend.HostedAccessMode
 	client     sidecarClient
 	core       *runtimecore.Core
+	local      *localruntime.Service
 	diagnostic diagnostic.Logger
 	cancel     context.CancelFunc
 }
@@ -156,19 +156,28 @@ func (s *Server) refreshAccessMode(mode backend.HostedAccessMode) error {
 }
 
 func (s *Server) Start(ctx context.Context) error {
-	os.Remove(s.socketPath)
 	if err := os.WriteFile(s.modePath, []byte(s.currentAccessMode()), 0o600); err != nil {
 		return err
 	}
 
-	ln, err := net.Listen("unix", s.socketPath)
+	local, err := localruntime.NewService(localruntime.Options{
+		SocketPath:  s.socketPath,
+		Core:        s.runtimeCore(),
+		SessionID:   s.sessionID,
+		AgentName:   s.agentName,
+		AsyncIngest: true,
+		OnFailure:   s.runtimeFailureResult,
+		Diagnostic:  s.diagnostic,
+	})
 	if err != nil {
 		return err
 	}
-	s.listener = ln
+	if err := local.Start(ctx); err != nil {
+		return err
+	}
+	s.local = local
 
 	ctx, s.cancel = context.WithCancel(ctx)
-	go s.acceptLoop(ctx)
 	go s.heartbeatLoop(ctx)
 
 	return nil
@@ -178,64 +187,8 @@ func (s *Server) Stop() {
 	if s.cancel != nil {
 		s.cancel()
 	}
-	if s.listener != nil {
-		s.listener.Close()
-	}
-	os.Remove(s.socketPath)
-}
-
-func (s *Server) acceptLoop(ctx context.Context) {
-	for {
-		conn, err := s.listener.Accept()
-		if err != nil {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-				if ne, ok := err.(net.Error); ok && ne.Temporary() {
-					s.diagnostic.Printf("sidecar accept temporary error: %v\n", err)
-					continue
-				}
-				s.diagnostic.Printf("sidecar accept: %v\n", err)
-				return
-			}
-		}
-		go s.handleConn(ctx, conn)
-	}
-}
-
-func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
-	defer conn.Close()
-	if err := conn.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
-		s.diagnostic.Printf("sidecar deadline: %v\n", err)
-		return
-	}
-
-	var req EvaluateRequest
-	if err := ReadMessage(conn, &req); err != nil {
-		s.diagnostic.Printf("sidecar read: %v\n", err)
-		return
-	}
-
-	result := s.evaluate(ctx, &req)
-	if err := WriteMessage(conn, result); err != nil {
-		s.diagnostic.Printf("sidecar write: %v\n", err)
-		return
-	}
-
-	if req.HookEvent != "PreToolUse" {
-		go s.ingestEvent(ctx, &req)
-	}
-}
-
-func (s *Server) ingestEvent(ctx context.Context, req *EvaluateRequest) {
-	event, err := EventFromEvaluateRequest(s.sessionID, s.agentName, req)
-	if err != nil {
-		s.diagnostic.Printf("sidecar ingest decode: %v\n", err)
-		return
-	}
-	if _, err := s.runtimeCore().IngestEvent(ctx, event); err != nil {
-		s.diagnostic.Printf("sidecar ingest: %v\n", err)
+	if s.local != nil {
+		s.local.Stop()
 	}
 }
 
@@ -261,47 +214,24 @@ func (s *Server) heartbeatLoop(ctx context.Context) {
 	}
 }
 
-func (s *Server) evaluate(ctx context.Context, req *EvaluateRequest) EvaluateResult {
-	event, err := EventFromEvaluateRequest(s.sessionID, s.agentName, req)
-	if err != nil {
-		s.diagnostic.Printf("sidecar evaluate decode: %v\n", err)
-		return EvaluateResultFromResult(sidecarDecodeFailureResult(req))
-	}
+func (s *Server) runtimeFailureResult(event hook.Event, _ error) hook.Result {
 	if !event.HookName.CanBlock() {
-		return EvaluateResultFromResult(hook.Result{Decision: hook.DecisionAllow})
-	}
-	result, err := s.runtimeCore().EvaluateHook(ctx, event)
-	if err != nil {
-		s.diagnostic.Printf("sidecar enforce: %v\n", err)
-		accessMode := s.currentAccessMode()
-		if accessMode != backend.HostedAccessModeEnforce {
-			return EvaluateResultFromResult(hook.Result{
-				Decision: hook.DecisionAllow,
-				Reason:   "Kontext hosted access is not enforcing.",
-				Mode:     string(accessMode),
-			})
+		return hook.Result{
+			Decision: hook.DecisionAllow,
+			Reason:   "Kontext hook event could not be ingested.",
 		}
-		return EvaluateResultFromResult(hook.Result{
-			Decision: hook.DecisionDeny,
-			Reason:   "Kontext access policy could not be evaluated.",
-		})
 	}
-	return EvaluateResultFromResult(result)
-}
-
-func sidecarDecodeFailureResult(req *EvaluateRequest) hook.Result {
-	if req != nil {
-		hookName, ok := normalizeHookName(req.HookEvent)
-		if ok && !hookName.CanBlock() {
-			return hook.Result{
-				Decision: hook.DecisionAllow,
-				Reason:   "Kontext hook event could not be decoded.",
-			}
+	accessMode := s.currentAccessMode()
+	if accessMode != backend.HostedAccessModeEnforce {
+		return hook.Result{
+			Decision: hook.DecisionAllow,
+			Reason:   "Kontext hosted access is not enforcing.",
+			Mode:     string(accessMode),
 		}
 	}
 	return hook.Result{
 		Decision: hook.DecisionDeny,
-		Reason:   "Kontext hook event could not be decoded.",
+		Reason:   "Kontext access policy could not be evaluated.",
 	}
 }
 

--- a/internal/sidecar/sidecar_test.go
+++ b/internal/sidecar/sidecar_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -102,29 +101,6 @@ func TestHeartbeatBackoffIntervalCalculation(t *testing.T) {
 	}
 }
 
-func TestAcceptLoopReturnsOnListenerError(t *testing.T) {
-	t.Parallel()
-
-	ln := &stubListener{acceptErr: errors.New("accept failed")}
-	s := &Server{listener: ln}
-
-	done := make(chan struct{})
-	go func() {
-		s.acceptLoop(context.Background())
-		close(done)
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("acceptLoop did not return after listener error")
-	}
-
-	if got := ln.accepts; got != 1 {
-		t.Fatalf("Accept() calls = %d, want 1", got)
-	}
-}
-
 func TestIngestEventRefreshesAccessMode(t *testing.T) {
 	t.Parallel()
 
@@ -138,7 +114,7 @@ func TestIngestEventRefreshesAccessMode(t *testing.T) {
 		diagnostic: diagnostic.New(io.Discard, false),
 	})
 
-	s.ingestEvent(context.Background(), &EvaluateRequest{HookEvent: "PostToolUse"})
+	ingestServer(t, s, &EvaluateRequest{HookEvent: "PostToolUse"})
 
 	if got := s.currentAccessMode(); got != backend.HostedAccessModeEnforce {
 		t.Fatalf("currentAccessMode() = %q, want enforce", got)
@@ -195,7 +171,7 @@ func TestEvaluatePreToolUseUsesRuntimeCore(t *testing.T) {
 		t.Fatalf("New() error = %v", err)
 	}
 
-	result := s.evaluate(context.Background(), &EvaluateRequest{
+	result := evaluateServer(t, s, &EvaluateRequest{
 		HookEvent: "PreToolUse",
 		ToolName:  "Bash",
 		ToolInput: json.RawMessage(`{"command":"gh repo delete"}`),
@@ -234,7 +210,7 @@ func TestEvaluatePreToolUseUsesBackendDecision(t *testing.T) {
 		client:    client,
 	})
 
-	result := s.evaluate(context.Background(), &EvaluateRequest{
+	result := evaluateServer(t, s, &EvaluateRequest{
 		HookEvent: "PreToolUse",
 		ToolName:  "Bash",
 		ToolInput: json.RawMessage(`{"command":"gh repo delete"}`),
@@ -275,7 +251,7 @@ func TestEvaluatePreToolUseAskKeepsRawReasonAndRequestMetadata(t *testing.T) {
 		diagnostic: diagnostic.New(io.Discard, false),
 	})
 
-	result := s.evaluate(context.Background(), &EvaluateRequest{
+	result := evaluateServer(t, s, &EvaluateRequest{
 		HookEvent: "PreToolUse",
 		ToolName:  "Bash",
 		ToolInput: json.RawMessage(`{"command":"gh pr merge 92"}`),
@@ -340,7 +316,7 @@ func TestEvaluatePreToolUseAllowsBackendBlocksWhenNotEnforcing(t *testing.T) {
 				diagnostic: diagnostic.New(io.Discard, false),
 			})
 
-			result := s.evaluate(context.Background(), &EvaluateRequest{
+			result := evaluateServer(t, s, &EvaluateRequest{
 				HookEvent: "PreToolUse",
 				ToolName:  "Bash",
 				ToolInput: json.RawMessage(`{"command":"gh pr merge 92"}`),
@@ -382,7 +358,7 @@ func TestEvaluatePreToolUseUsesCachedModeWhenBackendOmitsMode(t *testing.T) {
 		diagnostic: diagnostic.New(io.Discard, false),
 	})
 
-	result := s.evaluate(context.Background(), &EvaluateRequest{
+	result := evaluateServer(t, s, &EvaluateRequest{
 		HookEvent: "PreToolUse",
 		ToolName:  "Bash",
 		ToolInput: json.RawMessage(`{"command":"gh repo delete"}`),
@@ -410,61 +386,13 @@ func TestEvaluatePreToolUseFailsClosedOnBackendError(t *testing.T) {
 		diagnostic: diagnostic.New(io.Discard, false),
 	})
 
-	result := s.evaluate(context.Background(), &EvaluateRequest{HookEvent: "PreToolUse"})
+	result := evaluateServer(t, s, &EvaluateRequest{HookEvent: "PreToolUse"})
 
 	if result.Allowed {
 		t.Fatal("evaluate().Allowed = true, want false")
 	}
 	if result.Reason == "" {
 		t.Fatal("evaluate().Reason = empty, want failure reason")
-	}
-}
-
-func TestEvaluateFailsClosedWhenBlockingHookPayloadCannotDecode(t *testing.T) {
-	t.Parallel()
-
-	s := &Server{
-		sessionID:  "session-123",
-		agentName:  "claude",
-		accessMode: backend.HostedAccessModeEnforce,
-		client:     &stubProcessor{},
-		diagnostic: diagnostic.New(io.Discard, false),
-	}
-
-	result := s.evaluate(context.Background(), &EvaluateRequest{
-		HookEvent: "PreToolUse",
-		ToolInput: json.RawMessage(`{`),
-	})
-
-	if result.Allowed {
-		t.Fatal("evaluate().Allowed = true, want false")
-	}
-	if result.Decision != string(hook.DecisionDeny) {
-		t.Fatalf("evaluate().Decision = %q, want deny", result.Decision)
-	}
-}
-
-func TestEvaluateAllowsNonblockingHookPayloadDecodeFailure(t *testing.T) {
-	t.Parallel()
-
-	s := &Server{
-		sessionID:  "session-123",
-		agentName:  "claude",
-		accessMode: backend.HostedAccessModeEnforce,
-		client:     &stubProcessor{},
-		diagnostic: diagnostic.New(io.Discard, false),
-	}
-
-	result := s.evaluate(context.Background(), &EvaluateRequest{
-		HookEvent: "PostToolUse",
-		ToolInput: json.RawMessage(`{`),
-	})
-
-	if !result.Allowed {
-		t.Fatal("evaluate().Allowed = false, want true")
-	}
-	if result.Decision != string(hook.DecisionAllow) {
-		t.Fatalf("evaluate().Decision = %q, want allow", result.Decision)
 	}
 }
 
@@ -480,7 +408,7 @@ func TestEvaluatePreToolUseFailsClosedBeforeClaudeHookDeadline(t *testing.T) {
 	})
 
 	start := time.Now()
-	result := s.evaluate(context.Background(), &EvaluateRequest{HookEvent: "PreToolUse"})
+	result := evaluateServer(t, s, &EvaluateRequest{HookEvent: "PreToolUse"})
 
 	if result.Allowed {
 		t.Fatal("evaluate().Allowed = true, want false")
@@ -514,7 +442,7 @@ func TestEvaluatePreToolUseFailsClosedWhenEnforceModeCannotPersist(t *testing.T)
 		t.Fatalf("New() error = %v", err)
 	}
 
-	result := s.evaluate(context.Background(), &EvaluateRequest{
+	result := evaluateServer(t, s, &EvaluateRequest{
 		HookEvent: "PreToolUse",
 		ToolName:  "Bash",
 		ToolInput: json.RawMessage(`{"command":"gh pr view 92"}`),
@@ -539,7 +467,7 @@ func TestEvaluatePreToolUseFailsOpenWhenNotEnforcing(t *testing.T) {
 		diagnostic: diagnostic.New(io.Discard, false),
 	})
 
-	result := s.evaluate(context.Background(), &EvaluateRequest{HookEvent: "PreToolUse"})
+	result := evaluateServer(t, s, &EvaluateRequest{HookEvent: "PreToolUse"})
 
 	if !result.Allowed {
 		t.Fatal("evaluate().Allowed = false, want true")
@@ -569,13 +497,13 @@ func TestEvaluateRefreshesAccessModeForLaterFailures(t *testing.T) {
 		diagnostic: diagnostic.New(io.Discard, false),
 	})
 
-	first := s.evaluate(context.Background(), &EvaluateRequest{HookEvent: "PreToolUse"})
+	first := evaluateServer(t, s, &EvaluateRequest{HookEvent: "PreToolUse"})
 	if !first.Allowed {
 		t.Fatal("first evaluate().Allowed = false, want true")
 	}
 
 	client.err = errors.New("backend down")
-	second := s.evaluate(context.Background(), &EvaluateRequest{HookEvent: "PreToolUse"})
+	second := evaluateServer(t, s, &EvaluateRequest{HookEvent: "PreToolUse"})
 	if second.Allowed {
 		t.Fatal("second evaluate().Allowed = true, want enforce-mode fail closed")
 	}
@@ -601,13 +529,13 @@ func TestEvaluateRefreshesAccessModeBackToFailOpen(t *testing.T) {
 		diagnostic: diagnostic.New(io.Discard, false),
 	})
 
-	first := s.evaluate(context.Background(), &EvaluateRequest{HookEvent: "PreToolUse"})
+	first := evaluateServer(t, s, &EvaluateRequest{HookEvent: "PreToolUse"})
 	if !first.Allowed {
 		t.Fatal("first evaluate().Allowed = false, want true")
 	}
 
 	client.err = errors.New("backend down")
-	second := s.evaluate(context.Background(), &EvaluateRequest{HookEvent: "PreToolUse"})
+	second := evaluateServer(t, s, &EvaluateRequest{HookEvent: "PreToolUse"})
 	if !second.Allowed {
 		t.Fatal("second evaluate().Allowed = false, want no-policy fail open")
 	}
@@ -621,7 +549,7 @@ func TestEvaluateNonPreToolUseDoesNotCallBackend(t *testing.T) {
 
 	client := &stubProcessor{}
 	s := &Server{client: client}
-	result := s.evaluate(context.Background(), &EvaluateRequest{HookEvent: "PostToolUse"})
+	result := evaluateServer(t, s, &EvaluateRequest{HookEvent: "PostToolUse"})
 
 	if !result.Allowed {
 		t.Fatal("evaluate().Allowed = false, want true")
@@ -876,25 +804,34 @@ func assertJSONEqual(t *testing.T, got, want []byte) {
 	}
 }
 
-type stubListener struct {
-	accepts   int
-	acceptErr error
+func evaluateServer(t *testing.T, s *Server, req *EvaluateRequest) EvaluateResult {
+	t.Helper()
+
+	event, err := EventFromEvaluateRequest(s.sessionID, s.agentName, req)
+	if err != nil {
+		t.Fatalf("EventFromEvaluateRequest() error = %v", err)
+	}
+	if !event.HookName.CanBlock() {
+		return EvaluateResultFromResult(hook.Result{Decision: hook.DecisionAllow})
+	}
+	result, err := s.runtimeCore().EvaluateHook(context.Background(), event)
+	if err != nil {
+		return EvaluateResultFromResult(s.runtimeFailureResult(event, err))
+	}
+	return EvaluateResultFromResult(result)
 }
 
-func (l *stubListener) Accept() (net.Conn, error) {
-	l.accepts++
-	return nil, l.acceptErr
+func ingestServer(t *testing.T, s *Server, req *EvaluateRequest) {
+	t.Helper()
+
+	event, err := EventFromEvaluateRequest(s.sessionID, s.agentName, req)
+	if err != nil {
+		t.Fatalf("EventFromEvaluateRequest() error = %v", err)
+	}
+	if _, err := s.runtimeCore().IngestEvent(context.Background(), event); err != nil {
+		t.Fatalf("IngestEvent() error = %v", err)
+	}
 }
-
-func (l *stubListener) Close() error { return nil }
-
-func (l *stubListener) Addr() net.Addr { return stubAddr("stub") }
-
-type stubAddr string
-
-func (a stubAddr) Network() string { return string(a) }
-
-func (a stubAddr) String() string { return string(a) }
 
 type stubProcessor struct {
 	result       *backend.ProcessHookEventResult


### PR DESCRIPTION
## Summary

- Handling step 8 in https://github.com/kontext-security/kontext-cli/issues/104
- Curently sidecar is the hook transport owner in "hosted" cersion with Unix sockets and HTTP daemon is the owner for "guard" version. This PR introduces runtime service