### PR TITLE
feat(runtime service): Guard now starts a Unix-socket localruntime.Service alongside the existing HTTP daemon

### DIFF
--- a/internal/guard/app/server/server.go
+++ b/internal/guard/app/server/server.go
@@ -57,6 +57,10 @@ func (s *Server) Handler() http.Handler {
 	return withCORS(s.mux)
 }
 
+func (s *Server) RuntimeCore() *runtimecore.Core {
+	return s.core
+}
+
 func (s *Server) ListenAndServe(addr string) error {
 	httpServer := &http.Server{
 		Addr:              addr,

--- a/internal/guard/cli/cli.go
+++ b/internal/guard/cli/cli.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cli/browser"
 
 	"github.com/kontext-security/kontext-cli/internal/agent"
+	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 	"github.com/kontext-security/kontext-cli/internal/guard/app/hooks/claudecode"
 	"github.com/kontext-security/kontext-cli/internal/guard/app/server"
 	"github.com/kontext-security/kontext-cli/internal/guard/hookruntime"
@@ -27,6 +28,7 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
 	"github.com/kontext-security/kontext-cli/internal/guard/trace"
 	"github.com/kontext-security/kontext-cli/internal/hook"
+	"github.com/kontext-security/kontext-cli/internal/localruntime"
 )
 
 const (
@@ -105,6 +107,7 @@ func runDaemon(args []string, out io.Writer) error {
 	horizon := fs.Int("horizon", defaultHorizon, "Markov-chain risk horizon")
 	skipHookInstall := fs.Bool("skip-hook-install", false, "skip Claude Code hook install")
 	noOpen := fs.Bool("no-open", false, "do not open the local dashboard")
+	socketPath := fs.String("socket", defaultGuardSocketPath(), "Unix socket path for local hook runtime")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -137,7 +140,25 @@ func runDaemon(args []string, out io.Writer) error {
 	defer func() {
 		_ = closeStore()
 	}()
+	if err := ensureGuardSocketDir(*socketPath); err != nil {
+		return err
+	}
+	runtimeService, err := localruntime.NewService(localruntime.Options{
+		SocketPath:  *socketPath,
+		Core:        localServer.RuntimeCore(),
+		AgentName:   "claude",
+		AsyncIngest: true,
+		Diagnostic:  diagnostic.New(out, diagnostic.EnabledFromEnv()),
+	})
+	if err != nil {
+		return err
+	}
+	if err := runtimeService.Start(context.Background()); err != nil {
+		return fmt.Errorf("local runtime start: %w", err)
+	}
+	defer runtimeService.Stop()
 	fmt.Fprintf(out, "Kontext Guard local daemon listening on http://%s\n", *addr)
+	fmt.Fprintf(out, "Hook runtime: unix://%s\n", *socketPath)
 	fmt.Fprintln(out, "Mode: observe (Claude Code runs normally; decisions are recorded as would allow / would ask / would deny).")
 	fmt.Fprintf(out, "Dashboard: http://%s\n", *addr)
 	fmt.Fprintf(out, "Risk model: %s\n", activeModelPath)
@@ -169,6 +190,7 @@ func runHook(ctx context.Context, agentName string, a agent.Agent, args []string
 	fs := flag.NewFlagSet("hook "+a.Name(), flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	baseURL := fs.String("daemon-url", envString("KONTEXT_DAEMON_URL", defaultBaseURL), "local daemon URL")
+	socketPath := fs.String("socket", defaultGuardSocketPath(), "Unix socket path for local hook runtime")
 	mode := fs.String("mode", envString("KONTEXT_MODE", string(hookruntime.ModeObserve)), "hook mode: observe or enforce")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -178,7 +200,12 @@ func runHook(ctx context.Context, agentName string, a agent.Agent, args []string
 		return err
 	}
 	adapter := hookruntime.AgentAdapter{Agent: a, AgentName: agentName}
-	return hookruntime.Run(ctx, adapter, claudecode.NewClient(*baseURL), hookMode, stdin, stdout, stderr)
+	processor := guardHookProcessor{
+		socket:     localruntime.NewClient(*socketPath),
+		fallback:   claudecode.NewClient(*baseURL),
+		diagnostic: diagnostic.New(stderr, diagnostic.EnabledFromEnv()),
+	}
+	return hookruntime.Run(ctx, adapter, processor, hookMode, stdin, stdout, stderr)
 }
 
 func runStatus(ctx context.Context, args []string, out io.Writer) error {

--- a/internal/guard/cli/cli_test.go
+++ b/internal/guard/cli/cli_test.go
@@ -4,9 +4,18 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/diagnostic"
+	"github.com/kontext-security/kontext-cli/internal/hook"
+	"github.com/kontext-security/kontext-cli/internal/localruntime"
+	"github.com/kontext-security/kontext-cli/internal/runtimecore"
 
 	_ "github.com/kontext-security/kontext-cli/internal/agent/claude"
 )
@@ -15,7 +24,11 @@ func TestHookObserveModeFailsOpenForPreToolUse(t *testing.T) {
 	input := strings.NewReader(`{"session_id":"s1","hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{"file_path":"README.md"}}`)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	err := Run(context.Background(), []string{"hook", "claude-code", "--daemon-url", "http://127.0.0.1:1"}, input, &stdout, &stderr)
+	err := Run(context.Background(), []string{
+		"hook", "claude-code",
+		"--socket", missingTestSocket(t),
+		"--daemon-url", "http://127.0.0.1:1",
+	}, input, &stdout, &stderr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,12 +44,76 @@ func TestHookEnforceModeFailsClosedForPreToolUse(t *testing.T) {
 	input := strings.NewReader(`{"session_id":"s1","hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{"file_path":"README.md"}}`)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	err := Run(context.Background(), []string{"hook", "claude-code", "--mode", "enforce", "--daemon-url", "http://127.0.0.1:1"}, input, &stdout, &stderr)
+	err := Run(context.Background(), []string{
+		"hook", "claude-code",
+		"--mode", "enforce",
+		"--socket", missingTestSocket(t),
+		"--daemon-url", "http://127.0.0.1:1",
+	}, input, &stdout, &stderr)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(stdout.String(), `"permissionDecision":"deny"`) {
 		t.Fatalf("stdout = %s", stdout.String())
+	}
+}
+
+func TestHookUsesLocalRuntimeSocketBeforeHTTPFallback(t *testing.T) {
+	runtime := &stubGuardRuntime{
+		result: hook.Result{
+			Decision: hook.DecisionDeny,
+			Reason:   "blocked through socket",
+		},
+	}
+	socketPath := startTestGuardSocket(t, runtime)
+
+	input := strings.NewReader(`{"session_id":"s1","hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{"file_path":"README.md"}}`)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	err := Run(context.Background(), []string{
+		"hook", "claude-code",
+		"--mode", "enforce",
+		"--socket", socketPath,
+		"--daemon-url", "http://127.0.0.1:1",
+	}, input, &stdout, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout.String(), `"permissionDecision":"deny"`) {
+		t.Fatalf("stdout = %s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), `blocked through socket`) {
+		t.Fatalf("stdout = %s", stdout.String())
+	}
+	if got := atomic.LoadInt64(&runtime.evaluateCalls); got != 1 {
+		t.Fatalf("EvaluateHook calls = %d, want 1", got)
+	}
+}
+
+func TestGuardHookProcessorLogsSocketFallbackDiagnostic(t *testing.T) {
+	var stderr bytes.Buffer
+	processor := guardHookProcessor{
+		socket: failingHookProcessor{
+			err: errors.New("dial unix /tmp/kontext.sock: connect: no such file or directory"),
+		},
+		fallback: staticHookProcessor{
+			result: hook.Result{Decision: hook.DecisionAllow},
+		},
+		diagnostic: diagnostic.New(&stderr, true),
+	}
+
+	result, err := processor.Process(context.Background(), hook.Event{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Decision != hook.DecisionAllow {
+		t.Fatalf("decision = %s, want %s", result.Decision, hook.DecisionAllow)
+	}
+	if !strings.Contains(stderr.String(), "falling back to HTTP daemon") {
+		t.Fatalf("stderr = %s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "no such file or directory") {
+		t.Fatalf("stderr = %s", stderr.String())
 	}
 }
 
@@ -53,6 +130,76 @@ func TestHookMalformedInputReturnsFailSafeDecision(t *testing.T) {
 	if !strings.Contains(stderr.String(), "malformed hook input") {
 		t.Fatalf("stderr = %s", stderr.String())
 	}
+}
+
+func startTestGuardSocket(t *testing.T, runtime *stubGuardRuntime) string {
+	t.Helper()
+
+	core, err := runtimecore.New(runtime)
+	if err != nil {
+		t.Fatalf("runtimecore.New() error = %v", err)
+	}
+	dir, err := os.MkdirTemp("/tmp", "kontext-guard-cli-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp() error = %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	socketPath := filepath.Join(dir, "kontext.sock")
+	service, err := localruntime.NewService(localruntime.Options{
+		SocketPath: socketPath,
+		Core:       core,
+		AgentName:  "claude",
+		Diagnostic: diagnostic.New(io.Discard, false),
+	})
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(service.Stop)
+	return socketPath
+}
+
+func missingTestSocket(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("/tmp", "kontext-guard-missing-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp() error = %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return filepath.Join(dir, "missing.sock")
+}
+
+type stubGuardRuntime struct {
+	result        hook.Result
+	evaluateCalls int64
+}
+
+func (s *stubGuardRuntime) EvaluateHook(context.Context, hook.Event) (hook.Result, error) {
+	atomic.AddInt64(&s.evaluateCalls, 1)
+	return s.result, nil
+}
+
+func (s *stubGuardRuntime) IngestEvent(context.Context, hook.Event) (hook.Result, error) {
+	return hook.Result{Decision: hook.DecisionAllow}, nil
+}
+
+type failingHookProcessor struct {
+	err error
+}
+
+func (p failingHookProcessor) Process(context.Context, hook.Event) (hook.Result, error) {
+	return hook.Result{}, p.err
+}
+
+type staticHookProcessor struct {
+	result hook.Result
+}
+
+func (p staticHookProcessor) Process(context.Context, hook.Event) (hook.Result, error) {
+	return p.result, nil
 }
 
 func TestHookMalformedInputFailsClosedInEnforceMode(t *testing.T) {

--- a/internal/guard/cli/hook_processor.go
+++ b/internal/guard/cli/hook_processor.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/kontext-security/kontext-cli/internal/diagnostic"
+	"github.com/kontext-security/kontext-cli/internal/hook"
+)
+
+type hookProcessor interface {
+	Process(context.Context, hook.Event) (hook.Result, error)
+}
+
+type guardHookProcessor struct {
+	socket     hookProcessor
+	fallback   hookProcessor
+	diagnostic diagnostic.Logger
+}
+
+func (p guardHookProcessor) Process(ctx context.Context, event hook.Event) (hook.Result, error) {
+	result, err := p.socket.Process(ctx, event)
+	if err == nil {
+		return result, nil
+	}
+	p.diagnostic.Printf("guard hook socket unavailable; falling back to HTTP daemon: %v\n", err)
+	return p.fallback.Process(ctx, event)
+}

--- a/internal/guard/cli/localruntime.go
+++ b/internal/guard/cli/localruntime.go
@@ -1,0 +1,18 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func defaultGuardSocketPath() string {
+	if path := os.Getenv("KONTEXT_GUARD_SOCKET"); path != "" {
+		return path
+	}
+	return filepath.Join("/tmp", fmt.Sprintf("kontext-guard-%d", os.Getuid()), "kontext.sock")
+}
+
+func ensureGuardSocketDir(socketPath string) error {
+	return os.MkdirAll(filepath.Dir(socketPath), 0o700)
+}

--- a/internal/localruntime/conversions.go
+++ b/internal/localruntime/conversions.go
@@ -13,6 +13,7 @@ import (
 func EvaluateRequestFromEvent(event hook.Event) (EvaluateRequest, error) {
 	req := EvaluateRequest{
 		Type:           "evaluate",
+		SessionID:      event.SessionID,
 		Agent:          event.Agent,
 		HookEvent:      event.HookName.String(),
 		ToolName:       event.ToolName,
@@ -55,6 +56,9 @@ func EventFromEvaluateRequest(sessionID, fallbackAgent string, req *EvaluateRequ
 	agent := req.Agent
 	if agent == "" {
 		agent = fallbackAgent
+	}
+	if sessionID == "" {
+		sessionID = req.SessionID
 	}
 	event := hook.Event{
 		SessionID:      sessionID,

--- a/internal/localruntime/protocol.go
+++ b/internal/localruntime/protocol.go
@@ -10,6 +10,7 @@ import (
 
 type EvaluateRequest struct {
 	Type           string          `json:"type"`
+	SessionID      string          `json:"session_id,omitempty"`
 	Agent          string          `json:"agent"`
 	HookEvent      string          `json:"hook_event"`
 	ToolName       string          `json:"tool_name"`

--- a/internal/localruntime/service_test.go
+++ b/internal/localruntime/service_test.go
@@ -49,8 +49,9 @@ func TestServiceCanAckTelemetryBeforeAsyncIngest(t *testing.T) {
 	client := NewClient(service.SocketPath())
 
 	result, err := client.Process(context.Background(), hook.Event{
-		HookName: hook.HookPostToolUse,
-		ToolName: "Bash",
+		SessionID: "agent-session",
+		HookName:  hook.HookPostToolUse,
+		ToolName:  "Bash",
 	})
 	if err != nil {
 		t.Fatalf("Process() error = %v", err)
@@ -63,6 +64,9 @@ func TestServiceCanAckTelemetryBeforeAsyncIngest(t *testing.T) {
 	case event := <-runtime.ingested:
 		if event.HookName != hook.HookPostToolUse {
 			t.Fatalf("ingested hook = %q, want PostToolUse", event.HookName)
+		}
+		if event.SessionID != "agent-session" {
+			t.Fatalf("ingested session = %q, want agent-session", event.SessionID)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("async ingest did not run")


### PR DESCRIPTION
## Summary

- PR #121 introduced the runtime service and abstracted sidecar owning the unix socket to rntime service owning that. 
- This PR refactors Guard's hook adapter and now it uses this new service instead of HTTP daemon 