### PR TITLE
refactor(hook): migrate guard hook command to canonical `--agent`/`--mode` flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ kontext guard start
   │
   ├─ Hooks: generated Claude Code settings.json
   │    │
-  │    ├─ PreToolUse        → kontext guard hook claude-code
-  │    ├─ PostToolUse       → kontext guard hook claude-code
+  │    ├─ PreToolUse        → kontext hook --agent claude --mode observe
+  │    ├─ PostToolUse       → kontext hook --agent claude --mode observe
   │
   ├─ Local daemon: 127.0.0.1:4765
   ├─ Risk engine: deterministic rules + Markov-chain score
@@ -139,8 +139,8 @@ kontext start --agent claude
   ├─ Sidecar: Unix socket server + heartbeat loop
   ├─ Hooks: generated Claude Code settings.json
   │    │
-  │    ├─ PreToolUse        → kontext hook → sidecar → ProcessHookEvent
-  │    ├─ PostToolUse       → kontext hook → sidecar → ProcessHookEvent
+  │    ├─ PreToolUse        → kontext hook --agent claude → sidecar → ProcessHookEvent
+  │    ├─ PostToolUse       → kontext hook --agent claude → sidecar → ProcessHookEvent
   │
   └─ Exit: EndSession → credential expiry + temp file cleanup
 ```

--- a/cmd/kontext/main.go
+++ b/cmd/kontext/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/agent"
 	"github.com/kontext-security/kontext-cli/internal/auth"
 	guardcli "github.com/kontext-security/kontext-cli/internal/guard/cli"
+	guardhookruntime "github.com/kontext-security/kontext-cli/internal/guard/hookruntime"
 	"github.com/kontext-security/kontext-cli/internal/hook"
 	"github.com/kontext-security/kontext-cli/internal/hookcmd"
 	"github.com/kontext-security/kontext-cli/internal/localruntime"
@@ -168,7 +169,11 @@ func newLogoutCmd(clearSession func() error) *cobra.Command {
 }
 
 func hookCmd() *cobra.Command {
-	var agentName string
+	var (
+		agentName  string
+		socketPath string
+		mode       string
+	)
 
 	cmd := &cobra.Command{
 		Use:    "hook",
@@ -181,61 +186,111 @@ func hookCmd() *cobra.Command {
 				os.Exit(2)
 			}
 
-			socketPath := os.Getenv("KONTEXT_SOCKET")
+			resolvedSocketPath := resolveHookSocketPath(socketPath)
+			if mode != "" {
+				hookMode, err := guardhookruntime.ParseMode(mode)
+				if err != nil {
+					return err
+				}
+				adapter := guardhookruntime.AgentAdapter{Agent: a, AgentName: agentName}
+				processor := rootHookProcessor{socketPath: resolvedSocketPath, mode: hookMode}
+				return guardhookruntime.Run(context.Background(), adapter, processor, hookMode, cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr())
+			}
 			hookcmd.Run(a, func(e hook.Event) (hook.Result, error) {
-				return evaluateHookWithSidecar(socketPath, e)
+				return evaluateHookWithSidecar(resolvedSocketPath, e)
 			})
 			return nil
 		},
 	}
 
 	cmd.Flags().StringVar(&agentName, "agent", "claude", "Agent type")
+	cmd.Flags().StringVar(&socketPath, "socket", "", "Unix socket path for local hook runtime")
+	cmd.Flags().StringVar(&mode, "mode", os.Getenv("KONTEXT_MODE"), "hook mode: observe or enforce")
 
 	return cmd
 }
 
-func evaluateHookWithSidecar(socketPath string, event hook.Event) (hook.Result, error) {
-	if socketPath == "" {
-		return sidecarFailureResult(event, "sidecar socket missing"), nil
+type rootHookProcessor struct {
+	socketPath string
+	mode       guardhookruntime.Mode
+}
+
+func (p rootHookProcessor) Process(_ context.Context, event hook.Event) (hook.Result, error) {
+	return evaluateHookWithSidecarForMode(p.socketPath, event, string(p.mode))
+}
+
+func resolveHookSocketPath(flagValue string) string {
+	if flagValue != "" {
+		return flagValue
 	}
-	return evaluateViaSidecar(socketPath, event)
+	if socketPath := os.Getenv("KONTEXT_SOCKET"); socketPath != "" {
+		return socketPath
+	}
+	return localruntime.DefaultSocketPath()
+}
+
+func evaluateHookWithSidecar(socketPath string, event hook.Event) (hook.Result, error) {
+	return evaluateHookWithSidecarForMode(socketPath, event, "")
+}
+
+func evaluateHookWithSidecarForMode(socketPath string, event hook.Event, mode string) (hook.Result, error) {
+	if socketPath == "" {
+		return sidecarFailureResult(event, "sidecar socket missing", mode), nil
+	}
+	return evaluateViaSidecarForMode(socketPath, event, mode)
 }
 
 func evaluateViaSidecar(socketPath string, event hook.Event) (hook.Result, error) {
+	return evaluateViaSidecarForMode(socketPath, event, "")
+}
+
+func evaluateViaSidecarForMode(socketPath string, event hook.Event, mode string) (hook.Result, error) {
 	conn, err := net.DialTimeout("unix", socketPath, 5*time.Second)
 	if err != nil {
-		return sidecarFailureResult(event, "sidecar unreachable"), nil
+		return sidecarFailureResult(event, "sidecar unreachable", mode), nil
 	}
 	defer conn.Close()
 	if err := conn.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
-		return sidecarFailureResult(event, "sidecar deadline error"), nil
+		return sidecarFailureResult(event, "sidecar deadline error", mode), nil
 	}
 
 	req, err := localruntime.EvaluateRequestFromEvent(event)
 	if err != nil {
-		return sidecarFailureResult(event, "sidecar marshal error"), nil
+		return sidecarFailureResult(event, "sidecar marshal error", mode), nil
 	}
 
 	if err := localruntime.WriteMessage(conn, req); err != nil {
-		return sidecarFailureResult(event, "sidecar write error"), nil
+		return sidecarFailureResult(event, "sidecar write error", mode), nil
 	}
 
 	var result localruntime.EvaluateResult
 	if err := localruntime.ReadMessage(conn, &result); err != nil {
-		return sidecarFailureResult(event, "sidecar read error"), nil
+		return sidecarFailureResult(event, "sidecar read error", mode), nil
 	}
 
 	return localruntime.ResultFromEvaluateResult(result), nil
 }
 
-func sidecarFailureResult(event hook.Event, reason string) hook.Result {
+func sidecarFailureResult(event hook.Event, reason, mode string) hook.Result {
 	if event.HookName != hook.HookPreToolUse {
 		return hook.Result{Decision: hook.DecisionAllow, Reason: reason}
+	}
+	if normalizedHookMode(mode) == "enforce" {
+		return hook.Result{Decision: hook.DecisionDeny, Reason: reason, Mode: "enforce"}
 	}
 	if currentHostedAccessMode() == "enforce" {
 		return hook.Result{Decision: hook.DecisionDeny, Reason: reason, Mode: "enforce"}
 	}
 	return hook.Result{Decision: hook.DecisionAllow, Reason: reason}
+}
+
+func normalizedHookMode(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "observe", "enforce":
+		return strings.ToLower(strings.TrimSpace(value))
+	default:
+		return ""
+	}
 }
 
 func currentHostedAccessMode() string {

--- a/cmd/kontext/main_test.go
+++ b/cmd/kontext/main_test.go
@@ -238,6 +238,26 @@ func TestEvaluateHookWithSidecarFailsClosedWhenEnforceSocketMissing(t *testing.T
 	}
 }
 
+func TestEvaluateHookWithSidecarModeFailsClosedWhenEnforceSocketMissing(t *testing.T) {
+	result, err := evaluateHookWithSidecarForMode("", hook.Event{
+		Agent:    "claude",
+		HookName: hook.HookPreToolUse,
+		ToolName: "Bash",
+	}, "enforce")
+	if err != nil {
+		t.Fatalf("evaluateHookWithSidecarForMode() error = %v", err)
+	}
+	if result.Decision != hook.DecisionDeny {
+		t.Fatalf("decision = %q, want DENY", result.Decision)
+	}
+	if result.Mode != "enforce" {
+		t.Fatalf("mode = %q, want enforce", result.Mode)
+	}
+	if result.Reason != "sidecar socket missing" {
+		t.Fatalf("reason = %q, want missing socket", result.Reason)
+	}
+}
+
 func TestEvaluateHookWithSidecarAllowsPostToolUseWhenSocketMissing(t *testing.T) {
 	t.Setenv("KONTEXT_ACCESS_MODE", "enforce")
 

--- a/docs/guard.md
+++ b/docs/guard.md
@@ -43,7 +43,7 @@ Hosted mode owns login, provider connection, short-lived scoped credentials, hos
 
 ```text
 Claude Code
-  -> kontext guard hook claude-code
+  -> kontext hook --agent claude --mode observe
   -> local daemon
   -> deterministic risk rules
   -> Markov-chain risk model

--- a/internal/guard/cli/cli.go
+++ b/internal/guard/cli/cli.go
@@ -115,7 +115,7 @@ func runDaemon(args []string, out io.Writer) error {
 		if err := verifyClaudeCode(); err != nil {
 			return err
 		}
-		if err := installClaudeHooks(out); err != nil {
+		if err := installClaudeHooks(out, *socketPath); err != nil {
 			return err
 		}
 	}
@@ -356,20 +356,29 @@ func hookCommands(raw any) []string {
 }
 
 func runHooks(args []string, out io.Writer) error {
-	if len(args) != 2 || args[1] != "claude-code" {
+	if len(args) < 2 || args[1] != "claude-code" {
 		return fmt.Errorf("usage: kontext guard hooks install claude-code | kontext guard hooks uninstall claude-code")
 	}
 	switch args[0] {
 	case "install":
-		return installClaudeHooks(out)
+		fs := flag.NewFlagSet("hooks install claude-code", flag.ContinueOnError)
+		fs.SetOutput(io.Discard)
+		socketPath := fs.String("socket", defaultGuardSocketPath(), "Unix socket path for local hook runtime")
+		if err := fs.Parse(args[2:]); err != nil {
+			return err
+		}
+		return installClaudeHooks(out, *socketPath)
 	case "uninstall":
+		if len(args) != 2 {
+			return fmt.Errorf("usage: kontext guard hooks install claude-code | kontext guard hooks uninstall claude-code")
+		}
 		return uninstallClaudeHooks(out)
 	default:
 		return fmt.Errorf("usage: kontext guard hooks install claude-code | kontext guard hooks uninstall claude-code")
 	}
 }
 
-func installClaudeHooks(out io.Writer) error {
+func installClaudeHooks(out io.Writer, socketPath string) error {
 	settingsPath, settings, err := readClaudeSettings()
 	if err != nil {
 		return err
@@ -377,7 +386,7 @@ func installClaudeHooks(out io.Writer) error {
 	if err := backupFile(settingsPath, "kontext-guard"); err != nil {
 		return err
 	}
-	hookCommand := installedHookCommand()
+	hookCommand := installedHookCommand(socketPath)
 	settings["hooks"] = mergeHooks(settings["hooks"], hookCommand)
 	if err := writeJSONFile(settingsPath, settings); err != nil {
 		return err
@@ -512,7 +521,7 @@ func isGuardHookEntry(entry any) bool {
 func isGuardHookCommand(command string) bool {
 	normalized := strings.ReplaceAll(command, "'", "")
 	return strings.Contains(normalized, "kontext guard hook claude-code") ||
-		(strings.Contains(normalized, "kontext hook --agent claude") && strings.Contains(normalized, "--mode observe"))
+		(strings.Contains(normalized, "kontext hook --agent claude") && strings.Contains(normalized, "--mode"))
 }
 
 func runSmokeTest(ctx context.Context, args []string, out io.Writer) error {
@@ -714,19 +723,26 @@ func selfPath() string {
 	return "kontext"
 }
 
-func installedHookCommand() string {
+func installedHookCommand(socketPath string) string {
 	if command := os.Getenv("KONTEXT_GUARD_HOOK_COMMAND"); strings.TrimSpace(command) != "" {
 		return command
+	}
+	if strings.TrimSpace(socketPath) == "" {
+		socketPath = defaultGuardSocketPath()
 	}
 	path := selfPath()
 	if strings.Contains(path, "go-build") {
 		if cwd, err := os.Getwd(); err == nil {
 			if _, statErr := os.Stat(filepath.Join(cwd, "cmd", "kontext")); statErr == nil {
-				return fmt.Sprintf("cd %s && go run ./cmd/kontext hook --agent claude --mode observe", shellQuote(cwd))
+				return fmt.Sprintf("cd %s && %s", shellQuote(cwd), installedHookInvocation("go run ./cmd/kontext", socketPath))
 			}
 		}
 	}
-	return fmt.Sprintf("%s hook --agent claude --mode observe", shellQuote(path))
+	return installedHookInvocation(shellQuote(path), socketPath)
+}
+
+func installedHookInvocation(launcher, socketPath string) string {
+	return fmt.Sprintf("%s hook --agent claude --mode \"${KONTEXT_MODE:-observe}\" --socket %s", launcher, shellQuote(socketPath))
 }
 
 func shellQuote(value string) string {

--- a/internal/guard/cli/cli.go
+++ b/internal/guard/cli/cli.go
@@ -83,7 +83,7 @@ func usage(out io.Writer) {
 	fmt.Fprintln(out, "  doctor                        Check local daemon health")
 	fmt.Fprintln(out, "  hooks install claude-code     Install Claude Code hooks")
 	fmt.Fprintln(out, "  hooks uninstall claude-code   Remove Claude Code hooks")
-	fmt.Fprintln(out, "  hook claude-code              Runtime hook adapter")
+	fmt.Fprintln(out, "  hook claude-code              Runtime hook adapter compatibility alias")
 	fmt.Fprintln(out, "  traces inspect                Inspect local trace summary")
 	fmt.Fprintln(out, "  model info                    Print baseline model info")
 	fmt.Fprintln(out, "  model train                   Train a local fixture model")
@@ -303,7 +303,7 @@ func PrintHookStatus(out io.Writer) {
 	for _, raw := range hooks {
 		for _, command := range hookCommands(raw) {
 			switch {
-			case strings.Contains(command, "kontext guard hook claude-code"):
+			case isGuardHookCommand(command):
 				guard = true
 				fmt.Fprintf(out, "Claude Code Guard hook: %s\n", command)
 			case strings.Contains(command, "kontext hook"):
@@ -506,8 +506,13 @@ func mergeHooks(raw any, hookCommand string) map[string]any {
 }
 
 func isGuardHookEntry(entry any) bool {
-	text := fmt.Sprintf("%v", entry)
-	return strings.Contains(text, "kontext guard hook claude-code")
+	return isGuardHookCommand(fmt.Sprintf("%v", entry))
+}
+
+func isGuardHookCommand(command string) bool {
+	normalized := strings.ReplaceAll(command, "'", "")
+	return strings.Contains(normalized, "kontext guard hook claude-code") ||
+		(strings.Contains(normalized, "kontext hook --agent claude") && strings.Contains(normalized, "--mode observe"))
 }
 
 func runSmokeTest(ctx context.Context, args []string, out io.Writer) error {
@@ -717,11 +722,11 @@ func installedHookCommand() string {
 	if strings.Contains(path, "go-build") {
 		if cwd, err := os.Getwd(); err == nil {
 			if _, statErr := os.Stat(filepath.Join(cwd, "cmd", "kontext")); statErr == nil {
-				return fmt.Sprintf("cd %s && go run ./cmd/kontext guard hook claude-code", shellQuote(cwd))
+				return fmt.Sprintf("cd %s && go run ./cmd/kontext hook --agent claude --mode observe", shellQuote(cwd))
 			}
 		}
 	}
-	return fmt.Sprintf("%s guard hook claude-code", shellQuote(path))
+	return fmt.Sprintf("%s hook --agent claude --mode observe", shellQuote(path))
 }
 
 func shellQuote(value string) string {

--- a/internal/guard/cli/cli_test.go
+++ b/internal/guard/cli/cli_test.go
@@ -217,7 +217,7 @@ func TestHookMalformedInputFailsClosedInEnforceMode(t *testing.T) {
 func TestInstalledHookCommandUsesStableLauncherOverride(t *testing.T) {
 	t.Setenv("KONTEXT_GUARD_HOOK_COMMAND", "'/usr/local/bin/kontext' guard hook claude-code")
 
-	got := installedHookCommand()
+	got := installedHookCommand("/tmp/kontext-custom.sock")
 	if strings.Contains(got, "go-build") {
 		t.Fatalf("hook command should not use transient Go build cache path: %s", got)
 	}
@@ -229,16 +229,25 @@ func TestInstalledHookCommandUsesStableLauncherOverride(t *testing.T) {
 func TestInstalledHookCommandUsesCanonicalRootHookHandler(t *testing.T) {
 	t.Setenv("KONTEXT_GUARD_HOOK_COMMAND", "")
 
-	got := installedHookCommand()
+	got := installedHookCommand("/tmp/kontext-custom.sock")
 	if strings.Contains(got, "guard hook claude-code") {
 		t.Fatalf("hook command used legacy Guard handler: %s", got)
 	}
-	if !strings.Contains(got, "hook --agent claude --mode observe") {
+	if !strings.Contains(got, "hook --agent claude") {
 		t.Fatalf("hook command did not use canonical root handler: %s", got)
+	}
+	if !strings.Contains(got, `--mode "${KONTEXT_MODE:-observe}"`) {
+		t.Fatalf("hook command did not leave mode overridable through KONTEXT_MODE: %s", got)
+	}
+	if strings.Contains(got, "--mode observe") {
+		t.Fatalf("hook command hardcoded observe mode: %s", got)
+	}
+	if !strings.Contains(got, "--socket ") || !strings.Contains(got, "/tmp/kontext-custom.sock") {
+		t.Fatalf("hook command did not carry custom socket path: %s", got)
 	}
 }
 
-func TestIsGuardHookCommandRecognizesLegacyAndCanonicalObserveHooks(t *testing.T) {
+func TestIsGuardHookCommandRecognizesLegacyAndCanonicalGuardHooks(t *testing.T) {
 	t.Parallel()
 
 	for _, command := range []string{
@@ -247,6 +256,7 @@ func TestIsGuardHookCommandRecognizesLegacyAndCanonicalObserveHooks(t *testing.T
 		"/usr/local/bin/kontext hook --agent claude --mode observe",
 		"'/usr/local/bin/kontext' hook --agent claude --mode observe",
 		"cd '/repo' && go run ./cmd/kontext hook --agent claude --mode observe",
+		`/usr/local/bin/kontext hook --agent claude --mode "${KONTEXT_MODE:-observe}" --socket /tmp/kontext-custom.sock`,
 	} {
 		if !isGuardHookCommand(command) {
 			t.Fatalf("isGuardHookCommand(%q) = false, want true", command)

--- a/internal/guard/cli/cli_test.go
+++ b/internal/guard/cli/cli_test.go
@@ -226,6 +226,37 @@ func TestInstalledHookCommandUsesStableLauncherOverride(t *testing.T) {
 	}
 }
 
+func TestInstalledHookCommandUsesCanonicalRootHookHandler(t *testing.T) {
+	t.Setenv("KONTEXT_GUARD_HOOK_COMMAND", "")
+
+	got := installedHookCommand()
+	if strings.Contains(got, "guard hook claude-code") {
+		t.Fatalf("hook command used legacy Guard handler: %s", got)
+	}
+	if !strings.Contains(got, "hook --agent claude --mode observe") {
+		t.Fatalf("hook command did not use canonical root handler: %s", got)
+	}
+}
+
+func TestIsGuardHookCommandRecognizesLegacyAndCanonicalObserveHooks(t *testing.T) {
+	t.Parallel()
+
+	for _, command := range []string{
+		"/usr/local/bin/kontext guard hook claude-code",
+		"'/usr/local/bin/kontext' guard hook claude-code",
+		"/usr/local/bin/kontext hook --agent claude --mode observe",
+		"'/usr/local/bin/kontext' hook --agent claude --mode observe",
+		"cd '/repo' && go run ./cmd/kontext hook --agent claude --mode observe",
+	} {
+		if !isGuardHookCommand(command) {
+			t.Fatalf("isGuardHookCommand(%q) = false, want true", command)
+		}
+	}
+	if isGuardHookCommand("/usr/local/bin/kontext hook --agent claude") {
+		t.Fatal("hosted/pass-through hook should not be classified as Guard observe hook")
+	}
+}
+
 func TestMergeHooksInstallsOnlyToolHooks(t *testing.T) {
 	t.Parallel()
 

--- a/internal/guard/cli/localruntime.go
+++ b/internal/guard/cli/localruntime.go
@@ -1,18 +1,13 @@
 package cli
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
+	"github.com/kontext-security/kontext-cli/internal/localruntime"
 )
 
 func defaultGuardSocketPath() string {
-	if path := os.Getenv("KONTEXT_GUARD_SOCKET"); path != "" {
-		return path
-	}
-	return filepath.Join("/tmp", fmt.Sprintf("kontext-guard-%d", os.Getuid()), "kontext.sock")
+	return localruntime.DefaultSocketPath()
 }
 
 func ensureGuardSocketDir(socketPath string) error {
-	return os.MkdirAll(filepath.Dir(socketPath), 0o700)
+	return localruntime.EnsureSocketDir(socketPath)
 }

--- a/internal/localruntime/socket.go
+++ b/internal/localruntime/socket.go
@@ -1,0 +1,18 @@
+package localruntime
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func DefaultSocketPath() string {
+	if path := os.Getenv("KONTEXT_GUARD_SOCKET"); path != "" {
+		return path
+	}
+	return filepath.Join("/tmp", fmt.Sprintf("kontext-guard-%d", os.Getuid()), "kontext.sock")
+}
+
+func EnsureSocketDir(socketPath string) error {
+	return os.MkdirAll(filepath.Dir(socketPath), 0o700)
+}


### PR DESCRIPTION
## Summary

- This PR handels thestep 9 in https://github.com/kontext-security/kontext-cli/issues/104
- Implemented by making kontext hook --agent claude the canonical hook handler for Guard installs, while keeping kontext guard hook claude-code as a compatibility alias. It now supports Guard observe/enforce mode and default Guard socket discovery.