### PR TITLE
refactor: Move kontext start onto shared local runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,11 +136,12 @@ kontext start --agent claude
   ├─ ConnectRPC: CreateSession → governed session in dashboard
   ├─ BootstrapCli: sync managed provider entries into .env.kontext
   ├─ Token exchange: {{kontext:provider}} → short-lived credential
-  ├─ Sidecar: Unix socket server + heartbeat loop
+  ├─ Local runtime: Unix socket service + RuntimeCore
+  ├─ Hosted control plane: access mode + heartbeat loop
   ├─ Hooks: generated Claude Code settings.json
   │    │
-  │    ├─ PreToolUse        → kontext hook --agent claude → sidecar → ProcessHookEvent
-  │    ├─ PostToolUse       → kontext hook --agent claude → sidecar → ProcessHookEvent
+  │    ├─ PreToolUse        → kontext hook --agent claude → local runtime → ProcessHookEvent
+  │    ├─ PostToolUse       → kontext hook --agent claude → local runtime → ProcessHookEvent
   │
   └─ Exit: EndSession → credential expiry + temp file cleanup
 ```

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/backend"
 	"github.com/kontext-security/kontext-cli/internal/credential"
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
+	"github.com/kontext-security/kontext-cli/internal/localruntime"
 	"github.com/kontext-security/kontext-cli/internal/sidecar"
 )
 
@@ -184,7 +185,7 @@ func Start(ctx context.Context, opts Options) error {
 		}
 	}
 
-	// 6. Start sidecar
+	// 6. Start the hosted control plane and shared local runtime.
 	// Use /tmp (not $TMPDIR) with a short ID to keep the Unix socket path
 	// under macOS's 104-byte sun_path limit.
 	sessionDir = filepath.Join("/tmp", "kontext", truncateID(sessionID))
@@ -203,10 +204,27 @@ func Start(ctx context.Context, opts Options) error {
 	if err != nil {
 		return fmt.Errorf("sidecar: %w", err)
 	}
-	if err := sc.Start(ctx); err != nil {
+	if err := sc.StartControlPlane(ctx); err != nil {
 		return fmt.Errorf("sidecar start: %w", err)
 	}
 	defer sc.Stop()
+
+	runtimeService, err := localruntime.NewService(localruntime.Options{
+		SocketPath:  sc.SocketPath(),
+		Core:        sc.RuntimeCore(),
+		SessionID:   sessionID,
+		AgentName:   opts.Agent,
+		AsyncIngest: true,
+		OnFailure:   sc.RuntimeFailureResult,
+		Diagnostic:  diagnostics,
+	})
+	if err != nil {
+		return fmt.Errorf("local runtime: %w", err)
+	}
+	if err := runtimeService.Start(ctx); err != nil {
+		return fmt.Errorf("local runtime start: %w", err)
+	}
+	defer runtimeService.Stop()
 
 	// 7. Generate hook settings
 	kontextBin, _ := os.Executable()

--- a/internal/sidecar/sidecar.go
+++ b/internal/sidecar/sidecar.go
@@ -15,7 +15,6 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/backend"
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 	"github.com/kontext-security/kontext-cli/internal/hook"
-	"github.com/kontext-security/kontext-cli/internal/localruntime"
 	"github.com/kontext-security/kontext-cli/internal/runtimecore"
 )
 
@@ -91,7 +90,6 @@ type Server struct {
 	accessMode backend.HostedAccessMode
 	client     sidecarClient
 	core       *runtimecore.Core
-	local      *localruntime.Service
 	diagnostic diagnostic.Logger
 	cancel     context.CancelFunc
 }
@@ -119,8 +117,12 @@ func (s *Server) SocketPath() string { return s.socketPath }
 
 func (s *Server) AccessModePath() string { return s.modePath }
 
-func (s *Server) runtimeCore() *runtimecore.Core {
+func (s *Server) RuntimeCore() *runtimecore.Core {
 	return s.core
+}
+
+func (s *Server) RuntimeFailureResult(event hook.Event, err error) hook.Result {
+	return s.runtimeFailureResult(event, err)
 }
 
 func (s *Server) hostedRuntime() hostedHookRuntime {
@@ -155,40 +157,26 @@ func (s *Server) refreshAccessMode(mode backend.HostedAccessMode) error {
 	return nil
 }
 
-func (s *Server) Start(ctx context.Context) error {
-	if err := os.WriteFile(s.modePath, []byte(s.currentAccessMode()), 0o600); err != nil {
+func (s *Server) StartControlPlane(ctx context.Context) error {
+	if err := s.writeInitialAccessMode(); err != nil {
 		return err
 	}
+	s.startHeartbeat(ctx)
+	return nil
+}
 
-	local, err := localruntime.NewService(localruntime.Options{
-		SocketPath:  s.socketPath,
-		Core:        s.runtimeCore(),
-		SessionID:   s.sessionID,
-		AgentName:   s.agentName,
-		AsyncIngest: true,
-		OnFailure:   s.runtimeFailureResult,
-		Diagnostic:  s.diagnostic,
-	})
-	if err != nil {
-		return err
-	}
-	if err := local.Start(ctx); err != nil {
-		return err
-	}
-	s.local = local
+func (s *Server) writeInitialAccessMode() error {
+	return os.WriteFile(s.modePath, []byte(s.currentAccessMode()), 0o600)
+}
 
+func (s *Server) startHeartbeat(ctx context.Context) {
 	ctx, s.cancel = context.WithCancel(ctx)
 	go s.heartbeatLoop(ctx)
-
-	return nil
 }
 
 func (s *Server) Stop() {
 	if s.cancel != nil {
 		s.cancel()
-	}
-	if s.local != nil {
-		s.local.Stop()
 	}
 }
 

--- a/internal/sidecar/sidecar_test.go
+++ b/internal/sidecar/sidecar_test.go
@@ -814,7 +814,7 @@ func evaluateServer(t *testing.T, s *Server, req *EvaluateRequest) EvaluateResul
 	if !event.HookName.CanBlock() {
 		return EvaluateResultFromResult(hook.Result{Decision: hook.DecisionAllow})
 	}
-	result, err := s.runtimeCore().EvaluateHook(context.Background(), event)
+	result, err := s.RuntimeCore().EvaluateHook(context.Background(), event)
 	if err != nil {
 		return EvaluateResultFromResult(s.runtimeFailureResult(event, err))
 	}
@@ -828,7 +828,7 @@ func ingestServer(t *testing.T, s *Server, req *EvaluateRequest) {
 	if err != nil {
 		t.Fatalf("EventFromEvaluateRequest() error = %v", err)
 	}
-	if _, err := s.runtimeCore().IngestEvent(context.Background(), event); err != nil {
+	if _, err := s.RuntimeCore().IngestEvent(context.Background(), event); err != nil {
 		t.Fatalf("IngestEvent() error = %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Handles step 10 in https://github.com/kontext-security/kontext-cli/issues/104
- `kontext start` now hosts the same LocalRuntimeService + RuntimeCore boundary used by the converged runtime path. The hosted sidecar remains responsible for control-plane concerns like access mode and heartbeat, while hook traffic goes through the shared local runtime service