### PR TITLE
refactor: unify session lifecycle

### DIFF
--- a/internal/guard/app/server/runtime.go
+++ b/internal/guard/app/server/runtime.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
 	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
 	"github.com/kontext-security/kontext-cli/internal/hook"
+	"github.com/kontext-security/kontext-cli/internal/runtimecore"
 )
 
 type guardHookRuntime struct {
@@ -17,6 +18,40 @@ type guardHookRuntime struct {
 
 func newGuardHookRuntime(store *sqlite.Store, policy PolicyProvider) guardHookRuntime {
 	return guardHookRuntime{store: store, policy: policy}
+}
+
+func (r guardHookRuntime) OpenSession(ctx context.Context, session runtimecore.Session) (runtimecore.Session, error) {
+	source := string(session.Source)
+	if source == "" {
+		source = string(runtimecore.SessionSourceDaemonObserved)
+	}
+	record, err := r.store.OpenSession(ctx, session.ID, session.Agent, session.CWD, source, session.ExternalID)
+	if err != nil {
+		return runtimecore.Session{}, err
+	}
+	return runtimecore.Session{
+		ID:         record.ID,
+		Agent:      record.Agent,
+		CWD:        record.CWD,
+		Source:     runtimecore.SessionSource(record.Source),
+		ExternalID: record.ExternalID,
+	}, nil
+}
+
+func (r guardHookRuntime) CloseSession(ctx context.Context, sessionID string) error {
+	return r.store.CloseSession(ctx, sessionID)
+}
+
+func (r guardHookRuntime) EnsureSessionForEvent(ctx context.Context, event hook.Event) (hook.Event, error) {
+	session, err := r.store.EnsureObservedSession(ctx, event.SessionID, event.Agent, event.CWD)
+	if err != nil {
+		return hook.Event{}, err
+	}
+	event.SessionID = session.ID
+	if event.Agent == "" {
+		event.Agent = session.Agent
+	}
+	return event, nil
 }
 
 func (r guardHookRuntime) EvaluateHook(ctx context.Context, event hook.Event) (hook.Result, error) {

--- a/internal/guard/app/server/server_test.go
+++ b/internal/guard/app/server/server_test.go
@@ -120,6 +120,80 @@ func TestProcessHookEventUsesPolicyProvider(t *testing.T) {
 	}
 }
 
+func TestProcessHookEventEnsuresDaemonObservedSession(t *testing.T) {
+	store, err := sqlite.OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	server := newTestServer(t, store, risk.NoopScorer{})
+
+	if _, err := server.ProcessHookEvent(context.Background(), risk.HookEvent{
+		HookEventName: "PreToolUse",
+		Agent:         "claude",
+		ToolName:      "Read",
+		ToolInput:     map[string]any{"file_path": "README.md"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	session, err := store.Session(context.Background(), "local")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.Source != "daemon_observed" || session.Status != "open" || session.Agent != "claude" {
+		t.Fatalf("session = %+v, want daemon-observed local session", session)
+	}
+	events, err := store.Events(context.Background(), "local")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0].SessionID != "local" {
+		t.Fatalf("events = %+v, want one local event", events)
+	}
+}
+
+func TestProcessHookEventPreservesClosedWrapperOwnedSession(t *testing.T) {
+	store, err := sqlite.OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	server := newTestServer(t, store, risk.NoopScorer{})
+
+	if _, err := store.OpenSession(context.Background(), "session-123", "claude", "/tmp/project", "wrapper_owned", "backend-123"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CloseSession(context.Background(), "session-123"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := server.ProcessHookEvent(context.Background(), risk.HookEvent{
+		SessionID:     "session-123",
+		HookEventName: "PreToolUse",
+		Agent:         "claude",
+		ToolName:      "Read",
+		ToolInput:     map[string]any{"file_path": "README.md"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	session, err := store.Session(context.Background(), "session-123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.Source != "wrapper_owned" || session.Status != "closed" || session.ClosedAt == nil {
+		t.Fatalf("session = %+v, want closed wrapper-owned session", session)
+	}
+	events, err := store.Events(context.Background(), "session-123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events = %+v, want one event", events)
+	}
+}
+
 func TestProcessHookEventPreservesRiskMetadata(t *testing.T) {
 	store, err := sqlite.OpenStore(t.TempDir() + "/guard.db")
 	if err != nil {

--- a/internal/guard/store/sqlite/store.go
+++ b/internal/guard/store/sqlite/store.go
@@ -50,6 +50,18 @@ type SessionSummary struct {
 	LatestAt  time.Time `json:"latest_at"`
 }
 
+type SessionRecord struct {
+	ID         string     `json:"id"`
+	Agent      string     `json:"agent,omitempty"`
+	CWD        string     `json:"cwd,omitempty"`
+	Source     string     `json:"source,omitempty"`
+	Status     string     `json:"status,omitempty"`
+	ExternalID string     `json:"external_id,omitempty"`
+	CreatedAt  time.Time  `json:"created_at"`
+	UpdatedAt  time.Time  `json:"updated_at"`
+	ClosedAt   *time.Time `json:"closed_at,omitempty"`
+}
+
 func OpenStore(path string) (*Store, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return nil, err
@@ -74,12 +86,16 @@ func (s *Store) Close() error {
 func (s *Store) migrate(ctx context.Context) error {
 	_, err := s.db.ExecContext(ctx, `
 create table if not exists agent_sessions (
-  id text primary key,
-  agent text,
-  cwd text,
-  created_at text not null,
-  updated_at text not null
-);
+	  id text primary key,
+	  agent text,
+	  cwd text,
+	  source text not null default 'daemon_observed',
+	  status text not null default 'open',
+	  external_id text,
+	  closed_at text,
+	  created_at text not null,
+	  updated_at text not null
+	);
 
 create table if not exists risk_decisions (
   id text primary key,
@@ -99,16 +115,121 @@ create table if not exists risk_decisions (
 
 create index if not exists idx_risk_decisions_session_created
 on risk_decisions(session_id, created_at);
-`)
+	`)
+	if err != nil {
+		return err
+	}
+	for _, column := range []struct {
+		name string
+		def  string
+	}{
+		{name: "source", def: "text not null default 'daemon_observed'"},
+		{name: "status", def: "text not null default 'open'"},
+		{name: "external_id", def: "text"},
+		{name: "closed_at", def: "text"},
+	} {
+		if err := s.ensureColumn(ctx, "agent_sessions", column.name, column.def); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Store) ensureColumn(ctx context.Context, table, name, def string) error {
+	rows, err := s.db.QueryContext(ctx, "pragma table_info("+table+")")
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid int
+		var columnName, columnType string
+		var notNull int
+		var defaultValue sql.NullString
+		var pk int
+		if err := rows.Scan(&cid, &columnName, &columnType, &notNull, &defaultValue, &pk); err != nil {
+			return err
+		}
+		if columnName == name {
+			return rows.Err()
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	_, err = s.db.ExecContext(ctx, fmt.Sprintf("alter table %s add column %s %s", table, name, def))
 	return err
+}
+
+func (s *Store) OpenSession(ctx context.Context, sessionID, agent, cwd, source, externalID string) (SessionRecord, error) {
+	now := time.Now().UTC()
+	sessionID = normalizeSessionID(sessionID)
+	if source == "" {
+		source = "daemon_observed"
+	}
+	_, err := s.db.ExecContext(ctx, `
+insert into agent_sessions(id, agent, cwd, source, status, external_id, closed_at, created_at, updated_at)
+values(?, ?, ?, ?, 'open', ?, null, ?, ?)
+on conflict(id) do update set
+  agent = coalesce(nullif(excluded.agent, ''), agent_sessions.agent),
+  cwd = coalesce(nullif(excluded.cwd, ''), agent_sessions.cwd),
+  source = case
+    when excluded.source = 'wrapper_owned' then excluded.source
+    when agent_sessions.source = 'wrapper_owned' then agent_sessions.source
+    else coalesce(nullif(excluded.source, ''), agent_sessions.source)
+  end,
+  status = 'open',
+  external_id = coalesce(nullif(excluded.external_id, ''), agent_sessions.external_id),
+  closed_at = null,
+  updated_at = excluded.updated_at
+	`, sessionID, agent, cwd, source, externalID, now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano))
+	if err != nil {
+		return SessionRecord{}, err
+	}
+	return s.Session(ctx, sessionID)
+}
+
+func (s *Store) EnsureObservedSession(ctx context.Context, sessionID, agent, cwd string) (SessionRecord, error) {
+	now := time.Now().UTC()
+	sessionID = normalizeSessionID(sessionID)
+	_, err := s.db.ExecContext(ctx, `
+insert into agent_sessions(id, agent, cwd, source, status, created_at, updated_at)
+values(?, ?, ?, 'daemon_observed', 'open', ?, ?)
+on conflict(id) do update set
+  agent = coalesce(nullif(excluded.agent, ''), agent_sessions.agent),
+  cwd = coalesce(nullif(excluded.cwd, ''), agent_sessions.cwd),
+  updated_at = excluded.updated_at
+	`, sessionID, agent, cwd, now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano))
+	if err != nil {
+		return SessionRecord{}, err
+	}
+	return s.Session(ctx, sessionID)
+}
+
+func (s *Store) CloseSession(ctx context.Context, sessionID string) error {
+	sessionID = normalizeSessionID(sessionID)
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	_, err := s.db.ExecContext(ctx, `
+update agent_sessions
+set status = 'closed', closed_at = ?, updated_at = ?
+where id = ?
+	`, now, now, sessionID)
+	return err
+}
+
+func (s *Store) Session(ctx context.Context, sessionID string) (SessionRecord, error) {
+	row := s.db.QueryRowContext(ctx, `
+select id, coalesce(agent, ''), coalesce(cwd, ''), source, status, coalesce(external_id, ''),
+  created_at, updated_at, closed_at
+from agent_sessions
+where id = ?
+	`, sessionID)
+	return scanSession(row)
 }
 
 func (s *Store) SaveDecision(ctx context.Context, event risk.HookEvent, decision risk.RiskDecision) (DecisionRecord, error) {
 	now := time.Now().UTC()
-	sessionID := event.SessionID
-	if sessionID == "" {
-		sessionID = "local"
-	}
+	sessionID := normalizeSessionID(event.SessionID)
 	id := "evt_" + uuid.NewString()
 	riskEventJSON, err := json.Marshal(decision.RiskEvent)
 	if err != nil {
@@ -122,10 +243,13 @@ func (s *Store) SaveDecision(ctx context.Context, event risk.HookEvent, decision
 		_ = tx.Rollback()
 	}()
 	_, err = tx.ExecContext(ctx, `
-insert into agent_sessions(id, agent, cwd, created_at, updated_at)
-values(?, ?, ?, ?, ?)
-on conflict(id) do update set agent = excluded.agent, cwd = excluded.cwd, updated_at = excluded.updated_at
-`, sessionID, event.Agent, event.CWD, now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano))
+insert into agent_sessions(id, agent, cwd, source, status, created_at, updated_at)
+values(?, ?, ?, 'daemon_observed', 'open', ?, ?)
+on conflict(id) do update set
+  agent = coalesce(nullif(excluded.agent, ''), agent_sessions.agent),
+  cwd = coalesce(nullif(excluded.cwd, ''), agent_sessions.cwd),
+  updated_at = excluded.updated_at
+	`, sessionID, event.Agent, event.CWD, now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano))
 	if err != nil {
 		return DecisionRecord{}, err
 	}
@@ -285,6 +409,43 @@ func scanDecision(scanner interface{ Scan(...any) error }) (DecisionRecord, erro
 	return record, nil
 }
 
+func scanSession(scanner interface{ Scan(...any) error }) (SessionRecord, error) {
+	var record SessionRecord
+	var created, updated string
+	var closed sql.NullString
+	if err := scanner.Scan(
+		&record.ID,
+		&record.Agent,
+		&record.CWD,
+		&record.Source,
+		&record.Status,
+		&record.ExternalID,
+		&created,
+		&updated,
+		&closed,
+	); err != nil {
+		return SessionRecord{}, err
+	}
+	createdAt, err := parseStoredTime("session created_at", created)
+	if err != nil {
+		return SessionRecord{}, err
+	}
+	updatedAt, err := parseStoredTime("session updated_at", updated)
+	if err != nil {
+		return SessionRecord{}, err
+	}
+	record.CreatedAt = createdAt
+	record.UpdatedAt = updatedAt
+	if closed.Valid && closed.String != "" {
+		closedAt, err := parseStoredTime("session closed_at", closed.String)
+		if err != nil {
+			return SessionRecord{}, err
+		}
+		record.ClosedAt = &closedAt
+	}
+	return record, nil
+}
+
 func parseStoredTime(label, value string) (time.Time, error) {
 	parsed, err := time.Parse(time.RFC3339Nano, value)
 	if err != nil {
@@ -298,4 +459,11 @@ func nullableFloat(value *float64) any {
 		return nil
 	}
 	return *value
+}
+
+func normalizeSessionID(sessionID string) string {
+	if sessionID == "" {
+		return "local"
+	}
+	return sessionID
 }

--- a/internal/guard/store/sqlite/store_test.go
+++ b/internal/guard/store/sqlite/store_test.go
@@ -96,6 +96,107 @@ func TestSaveDecisionGeneratesUniqueIDsConcurrently(t *testing.T) {
 	}
 }
 
+func TestOpenAndCloseSessionRecordsLifecycle(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	opened, err := store.OpenSession(context.Background(), "session-123", "claude", "/tmp/project", "wrapper_owned", "backend-123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opened.ID != "session-123" ||
+		opened.Agent != "claude" ||
+		opened.CWD != "/tmp/project" ||
+		opened.Source != "wrapper_owned" ||
+		opened.Status != "open" ||
+		opened.ExternalID != "backend-123" ||
+		opened.ClosedAt != nil {
+		t.Fatalf("opened session = %+v", opened)
+	}
+
+	if err := store.CloseSession(context.Background(), "session-123"); err != nil {
+		t.Fatal(err)
+	}
+	closed, err := store.Session(context.Background(), "session-123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if closed.Status != "closed" || closed.ClosedAt == nil {
+		t.Fatalf("closed session = %+v, want closed with closed_at", closed)
+	}
+}
+
+func TestCloseSessionNormalizesEmptySessionID(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	if _, err := store.OpenSession(context.Background(), "", "claude", "/tmp/project", "daemon_observed", ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CloseSession(context.Background(), ""); err != nil {
+		t.Fatal(err)
+	}
+
+	closed, err := store.Session(context.Background(), "local")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if closed.Status != "closed" || closed.ClosedAt == nil {
+		t.Fatalf("closed session = %+v, want normalized local session closed", closed)
+	}
+}
+
+func TestOpenSessionDoesNotDowngradeWrapperOwnedSource(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	if _, err := store.OpenSession(context.Background(), "session-123", "claude", "/tmp/project", "wrapper_owned", "backend-123"); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := store.OpenSession(context.Background(), "session-123", "", "", "daemon_observed", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reopened.Source != "wrapper_owned" || reopened.ExternalID != "backend-123" {
+		t.Fatalf("reopened session = %+v, want wrapper-owned source preserved", reopened)
+	}
+}
+
+func TestEnsureObservedSessionPreservesExistingLifecycle(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	if _, err := store.OpenSession(context.Background(), "session-123", "claude", "/tmp/project", "wrapper_owned", "backend-123"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CloseSession(context.Background(), "session-123"); err != nil {
+		t.Fatal(err)
+	}
+
+	observed, err := store.EnsureObservedSession(context.Background(), "session-123", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observed.Source != "wrapper_owned" ||
+		observed.Status != "closed" ||
+		observed.ExternalID != "backend-123" ||
+		observed.ClosedAt == nil {
+		t.Fatalf("observed session = %+v, want existing wrapper-owned closed session", observed)
+	}
+}
+
 func TestSessionsRejectsInvalidStoredTimestamp(t *testing.T) {
 	store, err := OpenStore(t.TempDir() + "/guard.db")
 	if err != nil {

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/credential"
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 	"github.com/kontext-security/kontext-cli/internal/localruntime"
+	"github.com/kontext-security/kontext-cli/internal/runtimecore"
 	"github.com/kontext-security/kontext-cli/internal/sidecar"
 )
 
@@ -208,6 +209,18 @@ func Start(ctx context.Context, opts Options) error {
 		return fmt.Errorf("sidecar start: %w", err)
 	}
 	defer sc.Stop()
+	if _, err := sc.RuntimeCore().OpenSession(ctx, runtimecore.Session{
+		ID:         sessionID,
+		Agent:      opts.Agent,
+		CWD:        cwd,
+		Source:     runtimecore.SessionSourceWrapperOwned,
+		ExternalID: sessionID,
+	}); err != nil {
+		return fmt.Errorf("open runtime session: %w", err)
+	}
+	defer func() {
+		_ = sc.RuntimeCore().CloseSession(context.Background(), sessionID)
+	}()
 
 	runtimeService, err := localruntime.NewService(localruntime.Options{
 		SocketPath:  sc.SocketPath(),

--- a/internal/runtimecore/core.go
+++ b/internal/runtimecore/core.go
@@ -13,19 +13,71 @@ type HookRuntime interface {
 	IngestEvent(context.Context, hook.Event) (hook.Result, error)
 }
 
+type SessionSource string
+
+const (
+	SessionSourceWrapperOwned   SessionSource = "wrapper_owned"
+	SessionSourceDaemonObserved SessionSource = "daemon_observed"
+)
+
+type Session struct {
+	ID         string
+	Agent      string
+	CWD        string
+	Source     SessionSource
+	ExternalID string
+}
+
+type SessionRuntime interface {
+	OpenSession(context.Context, Session) (Session, error)
+	CloseSession(context.Context, string) error
+	EnsureSessionForEvent(context.Context, hook.Event) (hook.Event, error)
+}
+
 type Core struct {
-	runtime HookRuntime
+	runtime  HookRuntime
+	sessions SessionRuntime
 }
 
 func New(runtime HookRuntime) (*Core, error) {
 	if runtime == nil {
 		return nil, errors.New("runtime core requires hook runtime")
 	}
-	return &Core{runtime: runtime}, nil
+	core := &Core{runtime: runtime}
+	if sessions, ok := runtime.(SessionRuntime); ok {
+		core.sessions = sessions
+	}
+	return core, nil
+}
+
+func (c *Core) OpenSession(ctx context.Context, session Session) (Session, error) {
+	if c.sessions == nil {
+		return Session{}, errors.New("runtime core does not support session lifecycle")
+	}
+	return c.sessions.OpenSession(ctx, session)
+}
+
+func (c *Core) CloseSession(ctx context.Context, sessionID string) error {
+	if c.sessions == nil {
+		return errors.New("runtime core does not support session lifecycle")
+	}
+	return c.sessions.CloseSession(ctx, sessionID)
+}
+
+func (c *Core) EnsureSessionForEvent(ctx context.Context, event hook.Event) (hook.Event, error) {
+	if c.sessions == nil {
+		return event, nil
+	}
+	return c.sessions.EnsureSessionForEvent(ctx, event)
 }
 
 func (c *Core) EvaluateHook(ctx context.Context, event hook.Event) (hook.Result, error) {
 	if err := ValidateEvaluateHook(event); err != nil {
+		return hook.Result{}, err
+	}
+	var err error
+	event, err = c.EnsureSessionForEvent(ctx, event)
+	if err != nil {
 		return hook.Result{}, err
 	}
 	return c.runtime.EvaluateHook(ctx, event)
@@ -47,6 +99,11 @@ func (c *Core) IngestEvent(ctx context.Context, event hook.Event) (hook.Result, 
 	}
 	if event.HookName.CanBlock() {
 		return hook.Result{}, fmt.Errorf("hook event %q must be evaluated for enforcement", event.HookName)
+	}
+	var err error
+	event, err = c.EnsureSessionForEvent(ctx, event)
+	if err != nil {
+		return hook.Result{}, err
 	}
 	return c.runtime.IngestEvent(ctx, event)
 }

--- a/internal/runtimecore/core_test.go
+++ b/internal/runtimecore/core_test.go
@@ -54,6 +54,58 @@ func TestProcessHookRoutesByBlockingCapability(t *testing.T) {
 	}
 }
 
+func TestProcessHookEnsuresSessionBeforeEvaluation(t *testing.T) {
+	runtime := &recordingSessionRuntime{
+		recordingRuntime: recordingRuntime{
+			evaluateResult: hook.Result{Decision: hook.DecisionAllow, Reason: "ok"},
+		},
+	}
+	core, err := New(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := core.ProcessHook(context.Background(), hook.Event{
+		HookName: hook.HookPreToolUse,
+		Agent:    "claude",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if runtime.ensureCalls != 1 {
+		t.Fatalf("EnsureSessionForEvent calls = %d, want 1", runtime.ensureCalls)
+	}
+	if runtime.lastEvaluateEvent.SessionID != "resolved-session" {
+		t.Fatalf("evaluated session = %q, want resolved-session", runtime.lastEvaluateEvent.SessionID)
+	}
+}
+
+func TestOpenAndCloseSessionDelegateToRuntime(t *testing.T) {
+	runtime := &recordingSessionRuntime{}
+	core, err := New(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	session, err := core.OpenSession(context.Background(), Session{
+		ID:     "session-123",
+		Agent:  "claude",
+		Source: SessionSourceWrapperOwned,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.ID != "session-123" || runtime.openCalls != 1 {
+		t.Fatalf("OpenSession() = %+v calls=%d", session, runtime.openCalls)
+	}
+	if err := core.CloseSession(context.Background(), "session-123"); err != nil {
+		t.Fatal(err)
+	}
+	if runtime.closeCalls != 1 || runtime.closedSessionID != "session-123" {
+		t.Fatalf("CloseSession calls=%d session=%q", runtime.closeCalls, runtime.closedSessionID)
+	}
+}
+
 func TestNewRejectsMissingRuntime(t *testing.T) {
 	if _, err := New(nil); err == nil {
 		t.Fatal("New(nil) error = nil, want error")
@@ -61,15 +113,17 @@ func TestNewRejectsMissingRuntime(t *testing.T) {
 }
 
 type recordingRuntime struct {
-	evaluateCalls  int
-	ingestCalls    int
-	evaluateResult hook.Result
-	ingestResult   hook.Result
-	err            error
+	evaluateCalls     int
+	ingestCalls       int
+	evaluateResult    hook.Result
+	ingestResult      hook.Result
+	err               error
+	lastEvaluateEvent hook.Event
 }
 
-func (r *recordingRuntime) EvaluateHook(context.Context, hook.Event) (hook.Result, error) {
+func (r *recordingRuntime) EvaluateHook(_ context.Context, event hook.Event) (hook.Result, error) {
 	r.evaluateCalls++
+	r.lastEvaluateEvent = event
 	if r.err != nil {
 		return hook.Result{}, r.err
 	}
@@ -91,3 +145,30 @@ func (r *recordingRuntime) IngestEvent(context.Context, hook.Event) (hook.Result
 }
 
 var _ HookRuntime = (*recordingRuntime)(nil)
+
+type recordingSessionRuntime struct {
+	recordingRuntime
+	openCalls       int
+	closeCalls      int
+	ensureCalls     int
+	closedSessionID string
+}
+
+func (r *recordingSessionRuntime) OpenSession(_ context.Context, session Session) (Session, error) {
+	r.openCalls++
+	return session, nil
+}
+
+func (r *recordingSessionRuntime) CloseSession(_ context.Context, sessionID string) error {
+	r.closeCalls++
+	r.closedSessionID = sessionID
+	return nil
+}
+
+func (r *recordingSessionRuntime) EnsureSessionForEvent(_ context.Context, event hook.Event) (hook.Event, error) {
+	r.ensureCalls++
+	event.SessionID = "resolved-session"
+	return event, nil
+}
+
+var _ SessionRuntime = (*recordingSessionRuntime)(nil)

--- a/internal/sidecar/runtime.go
+++ b/internal/sidecar/runtime.go
@@ -6,13 +6,43 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/backend"
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 	"github.com/kontext-security/kontext-cli/internal/hook"
+	"github.com/kontext-security/kontext-cli/internal/runtimecore"
 )
 
 type hostedHookRuntime struct {
+	sessionID         string
+	agentName         string
 	policy            hostedPolicyProvider
 	diagnostic        diagnostic.Logger
 	currentAccessMode func() backend.HostedAccessMode
 	refreshAccessMode func(backend.HostedAccessMode) error
+}
+
+func (r hostedHookRuntime) OpenSession(_ context.Context, session runtimecore.Session) (runtimecore.Session, error) {
+	// Hosted session lifecycle is currently represented by the sidecar session ID.
+	// Backend persistence will be wired in by the hosted session API.
+	if session.ID == "" {
+		session.ID = r.sessionID
+	}
+	if session.Agent == "" {
+		session.Agent = r.agentName
+	}
+	if session.Source == "" {
+		session.Source = runtimecore.SessionSourceWrapperOwned
+	}
+	if session.ExternalID == "" {
+		session.ExternalID = session.ID
+	}
+	return session, nil
+}
+
+func (r hostedHookRuntime) CloseSession(context.Context, string) error {
+	// Hosted session close is a placeholder until the backend exposes lifecycle persistence.
+	return nil
+}
+
+func (r hostedHookRuntime) EnsureSessionForEvent(_ context.Context, event hook.Event) (hook.Event, error) {
+	return withHostedSession(event, r.sessionID, r.agentName), nil
 }
 
 func (r hostedHookRuntime) EvaluateHook(ctx context.Context, event hook.Event) (hook.Result, error) {

--- a/internal/sidecar/sidecar.go
+++ b/internal/sidecar/sidecar.go
@@ -127,6 +127,8 @@ func (s *Server) RuntimeFailureResult(event hook.Event, err error) hook.Result {
 
 func (s *Server) hostedRuntime() hostedHookRuntime {
 	return hostedHookRuntime{
+		sessionID: s.sessionID,
+		agentName: s.agentName,
 		policy: backendPolicyProvider{
 			client:    s.client,
 			sessionID: s.sessionID,


### PR DESCRIPTION
## Summary

- handling the step 12 in https://github.com/kontext-security/kontext-cli/issues/104
- `kontext start `now explicitly opens/closes a wrapper-owned runtime session around the shared local runtime