### PR TITLE
feat: add local guard judge contract

### DIFF
--- a/docs/guard.md
+++ b/docs/guard.md
@@ -47,7 +47,7 @@ Claude Code
   -> local runtime Unix socket
   -> RuntimeCore
   -> deterministic risk rules
-  -> Markov-chain risk model
+  -> optional local LLM judge or Markov-chain risk model
   -> local SQLite
   -> local dashboard + notifications
 ```
@@ -60,6 +60,20 @@ Guard uses two layers:
 2. A local Markov-chain risk model for sequence context in coding-agent workflows.
 
 The shipped model is a JSON artifact under `models/guard/`. Lab is the private pipeline that ingests datasets and local traces, evaluates candidate models, and produces improved JSON files. Accepted model files are committed back to this repo by PR.
+
+## Local judge
+
+Guard can optionally call a localhost OpenAI-compatible judge, such as `llama-server`, after deterministic rules allow a blocking tool call:
+
+```bash
+kontext guard start \
+  --judge-url http://127.0.0.1:8080 \
+  --judge-model qwen3-0.6b-q4
+```
+
+The judge receives a small redacted JSON input with tool metadata, normalized risk fields, deterministic policy context, and no full conversation history. It must return structured JSON with `decision` set to `allow` or `deny`. `ask` is not part of the judge contract.
+
+Judge failures are fail-open for launch. If the local runtime is unavailable, times out, or returns invalid JSON, Guard records `judge_unavailable_allow` plus high-level metadata and allows the tool call. Judge URLs must point at localhost.
 
 ## Public/private boundary
 

--- a/internal/guard/app/server/policy.go
+++ b/internal/guard/app/server/policy.go
@@ -2,7 +2,10 @@ package server
 
 import (
 	"context"
+	"path/filepath"
+	"strings"
 
+	"github.com/kontext-security/kontext-cli/internal/guard/judge"
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
 )
 
@@ -12,15 +15,134 @@ type PolicyProvider interface {
 
 type RiskPolicyProvider struct {
 	scorer risk.Scorer
+	judge  judge.Judge
 }
 
 func NewRiskPolicyProvider(scorer risk.Scorer) RiskPolicyProvider {
+	return NewRiskPolicyProviderWithJudge(scorer, nil)
+}
+
+func NewRiskPolicyProviderWithJudge(scorer risk.Scorer, localJudge judge.Judge) RiskPolicyProvider {
 	if scorer == nil {
 		scorer = risk.NoopScorer{}
 	}
-	return RiskPolicyProvider{scorer: scorer}
+	return RiskPolicyProvider{scorer: scorer, judge: localJudge}
 }
 
-func (p RiskPolicyProvider) DecideHook(_ context.Context, event risk.HookEvent) (risk.RiskDecision, error) {
+func (p RiskPolicyProvider) DecideHook(ctx context.Context, event risk.HookEvent) (risk.RiskDecision, error) {
+	if p.judge != nil && event.HookEventName == "PreToolUse" {
+		return p.decideWithJudge(ctx, event)
+	}
 	return risk.DecideRisk(event, p.scorer)
+}
+
+func (p RiskPolicyProvider) decideWithJudge(ctx context.Context, event risk.HookEvent) (risk.RiskDecision, error) {
+	riskEvent := risk.NormalizeHookEvent(event)
+	riskEvent.PolicyVersion = risk.PolicyVersionLaunchV0
+
+	if decision := risk.DeterministicDecision(riskEvent); decision.Decision != "" {
+		decision.RiskEvent = riskEvent
+		decision.RiskEvent.Decision = decision.Decision
+		decision.RiskEvent.ReasonCode = decision.ReasonCode
+		decision.RiskEvent.GuardID = decision.GuardID
+		decision.RiskEvent.DecisionStage = "deterministic"
+		decision.RiskEvent.PolicyVersion = risk.PolicyVersionLaunchV0
+		return decision, nil
+	}
+
+	result, err := p.judge.Decide(ctx, judgeInputFromRiskEvent(event, riskEvent))
+	if err != nil {
+		failureKind := judge.FailureKind(err)
+		metadata := judgeMetadata(p.judge)
+		riskEvent.Decision = risk.DecisionAllow
+		riskEvent.ReasonCode = "judge_unavailable_allow"
+		riskEvent.DecisionStage = "judge_fail_open"
+		riskEvent.JudgeRuntime = metadata.Runtime
+		riskEvent.JudgeModel = metadata.Model
+		riskEvent.JudgeFailureKind = failureKind
+		return risk.RiskDecision{
+			Decision:   risk.DecisionAllow,
+			Reason:     "local judge unavailable; allowing by fail-open policy",
+			ReasonCode: "judge_unavailable_allow",
+			RiskEvent:  riskEvent,
+		}, nil
+	}
+
+	decision := risk.DecisionAllow
+	reasonCode := "judge_allow"
+	if result.Output.Decision == judge.DecisionDeny {
+		decision = risk.DecisionDeny
+		reasonCode = "judge_deny"
+	}
+	duration := result.Metadata.DurationMs
+	riskEvent.Decision = decision
+	riskEvent.ReasonCode = reasonCode
+	riskEvent.DecisionStage = string(reasonCode)
+	riskEvent.GuardID = "local_llm_judge"
+	riskEvent.JudgeRuntime = result.Metadata.Runtime
+	riskEvent.JudgeModel = result.Metadata.Model
+	riskEvent.JudgeDurationMs = &duration
+	riskEvent.JudgeRiskLevel = string(result.Output.RiskLevel)
+	riskEvent.JudgeCategories = result.Output.Categories
+
+	return risk.RiskDecision{
+		Decision:   decision,
+		Reason:     result.Output.Reason,
+		ReasonCode: reasonCode,
+		GuardID:    "local_llm_judge",
+		RiskEvent:  riskEvent,
+	}, nil
+}
+
+func judgeInputFromRiskEvent(event risk.HookEvent, riskEvent risk.RiskEvent) judge.Input {
+	return judge.Input{
+		Agent:     event.Agent,
+		HookEvent: event.HookEventName,
+		ToolName:  event.ToolName,
+		CWDClass:  cwdClass(event.CWD),
+		ToolInput: judge.ToolInput{
+			CommandRedacted: riskEvent.CommandSummary,
+			PathRedacted:    riskEvent.PathClass,
+			RequestSummary:  riskEvent.RequestSummary,
+		},
+		NormalizedEvent: judge.NormalizedEvent{
+			Type:               string(riskEvent.Type),
+			Provider:           riskEvent.Provider,
+			ProviderCategory:   riskEvent.ProviderCategory,
+			Operation:          riskEvent.Operation,
+			OperationClass:     riskEvent.OperationClass,
+			ResourceClass:      riskEvent.ResourceClass,
+			Environment:        riskEvent.Environment,
+			CredentialObserved: riskEvent.CredentialObserved,
+			DirectAPICall:      riskEvent.DirectAPICall,
+			ExplicitUserIntent: riskEvent.ExplicitUserIntent,
+			PathClass:          riskEvent.PathClass,
+			CommandSummary:     riskEvent.CommandSummary,
+			RequestSummary:     riskEvent.RequestSummary,
+			Signals:            riskEvent.Signals,
+		},
+		DeterministicPolicy: judge.DeterministicContext{
+			Decision:      "allow",
+			PolicyVersion: risk.PolicyVersionLaunchV0,
+		},
+	}
+}
+
+func cwdClass(cwd string) string {
+	cwd = strings.TrimSpace(cwd)
+	if cwd == "" {
+		return "unknown"
+	}
+	base := strings.ToLower(filepath.Base(cwd))
+	if base == "" || base == "." || base == string(filepath.Separator) {
+		return "unknown"
+	}
+	return "project"
+}
+
+func judgeMetadata(localJudge judge.Judge) judge.Metadata {
+	if provider, ok := localJudge.(judge.MetadataProvider); ok {
+		return provider.Metadata()
+	}
+	return judge.Metadata{}
 }

--- a/internal/guard/app/server/server.go
+++ b/internal/guard/app/server/server.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kontext-security/kontext-cli/internal/guard/judge"
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
 	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
 	dashboardassets "github.com/kontext-security/kontext-cli/internal/guard/web/assets"
@@ -32,8 +33,17 @@ type ProcessResponse struct {
 	EventID    string        `json:"event_id"`
 }
 
+type Options struct {
+	Scorer risk.Scorer
+	Judge  judge.Judge
+}
+
 func NewServer(store *sqlite.Store, scorer risk.Scorer) (*Server, error) {
-	return NewServerWithPolicy(store, NewRiskPolicyProvider(scorer))
+	return NewServerWithOptions(store, Options{Scorer: scorer})
+}
+
+func NewServerWithOptions(store *sqlite.Store, opts Options) (*Server, error) {
+	return NewServerWithPolicy(store, NewRiskPolicyProviderWithJudge(opts.Scorer, opts.Judge))
 }
 
 // NewServerWithPolicy creates a Guard server with an injected policy provider.
@@ -219,11 +229,15 @@ func withCORS(next http.Handler) http.Handler {
 }
 
 func OpenDefaultServer(dbPath string, scorer risk.Scorer) (*Server, func() error, error) {
+	return OpenDefaultServerWithOptions(dbPath, Options{Scorer: scorer})
+}
+
+func OpenDefaultServerWithOptions(dbPath string, opts Options) (*Server, func() error, error) {
 	store, err := sqlite.OpenStore(dbPath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("open store: %w", err)
 	}
-	server, err := NewServer(store, scorer)
+	server, err := NewServerWithOptions(store, opts)
 	if err != nil {
 		_ = store.Close()
 		return nil, nil, err

--- a/internal/guard/app/server/server_test.go
+++ b/internal/guard/app/server/server_test.go
@@ -3,8 +3,10 @@ package server
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
+	"github.com/kontext-security/kontext-cli/internal/guard/judge"
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
 	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
 )
@@ -239,6 +241,156 @@ func TestProcessHookEventPreservesRiskMetadata(t *testing.T) {
 	}
 }
 
+func TestJudgePolicyDeniesFromLocalJudge(t *testing.T) {
+	store, err := sqlite.OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	localJudge := &recordingJudge{
+		result: judge.Result{
+			Output: judge.Output{
+				Decision:   judge.DecisionDeny,
+				RiskLevel:  judge.RiskLevelHigh,
+				Categories: []string{"destructive_operation"},
+				Reason:     "Risky operation.",
+			},
+			Metadata: judge.Metadata{
+				Runtime:    "openai-compatible",
+				Model:      "qwen3-0.6b-q4",
+				DurationMs: 12,
+			},
+		},
+	}
+	server, err := NewServerWithOptions(store, Options{Judge: localJudge})
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision, err := server.ProcessHookEvent(context.Background(), risk.HookEvent{
+		SessionID:     "s1",
+		HookEventName: "PreToolUse",
+		Agent:         "claude",
+		ToolName:      "Bash",
+		ToolInput:     map[string]any{"command": "python scripts/deploy.py --dry-run"},
+		CWD:           "/tmp/project",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if localJudge.calls != 1 {
+		t.Fatalf("judge calls = %d, want 1", localJudge.calls)
+	}
+	if localJudge.input.Agent != "claude" || localJudge.input.CWDClass != "project" {
+		t.Fatalf("judge input = %+v", localJudge.input)
+	}
+	if decision.Decision != risk.DecisionDeny || decision.ReasonCode != "judge_deny" {
+		t.Fatalf("decision = %+v", decision)
+	}
+	if decision.RiskEvent.JudgeModel != "qwen3-0.6b-q4" || decision.RiskEvent.JudgeRiskLevel != "high" {
+		t.Fatalf("risk event = %+v", decision.RiskEvent)
+	}
+}
+
+func TestJudgePolicyRedactsCredentialValuesFromJudgeInput(t *testing.T) {
+	store, err := sqlite.OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	localJudge := &recordingJudge{
+		result: judge.Result{
+			Output: judge.Output{
+				Decision:   judge.DecisionAllow,
+				RiskLevel:  judge.RiskLevelLow,
+				Categories: []string{"normal_coding"},
+				Reason:     "Safe.",
+			},
+			Metadata: judge.Metadata{Runtime: "openai-compatible", Model: "qwen3-0.6b-q4"},
+		},
+	}
+	server, err := NewServerWithOptions(store, Options{Judge: localJudge})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = server.ProcessHookEvent(context.Background(), risk.HookEvent{
+		SessionID:     "s1",
+		HookEventName: "PreToolUse",
+		Agent:         "claude",
+		ToolName:      "Bash",
+		ToolInput:     map[string]any{"command": `echo API_TOKEN=real-secret-123`},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if localJudge.calls != 1 {
+		t.Fatalf("judge calls = %d, want 1", localJudge.calls)
+	}
+	got := localJudge.input.ToolInput.CommandRedacted + " " + localJudge.input.ToolInput.RequestSummary + " " + localJudge.input.NormalizedEvent.CommandSummary + " " + localJudge.input.NormalizedEvent.RequestSummary
+	if strings.Contains(got, "real-secret-123") {
+		t.Fatalf("judge input leaked credential value: %+v", localJudge.input)
+	}
+	if !strings.Contains(got, "[redacted-credential]") {
+		t.Fatalf("judge input missing redaction marker: %+v", localJudge.input)
+	}
+}
+
+func TestJudgePolicyFailsOpenWhenJudgeUnavailable(t *testing.T) {
+	store, err := sqlite.OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	server, err := NewServerWithOptions(store, Options{
+		Judge: &recordingJudge{err: judge.Error{Kind: judge.FailureTimeout, Err: context.DeadlineExceeded}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision, err := server.ProcessHookEvent(context.Background(), risk.HookEvent{
+		SessionID:     "s1",
+		HookEventName: "PreToolUse",
+		ToolName:      "Bash",
+		ToolInput:     map[string]any{"command": "python scripts/deploy.py --dry-run"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Decision != risk.DecisionAllow || decision.ReasonCode != "judge_unavailable_allow" {
+		t.Fatalf("decision = %+v", decision)
+	}
+	if decision.RiskEvent.JudgeFailureKind != judge.FailureTimeout || decision.RiskEvent.DecisionStage != "judge_fail_open" {
+		t.Fatalf("risk event = %+v", decision.RiskEvent)
+	}
+}
+
+func TestJudgePolicyDeterministicDecisionSkipsJudge(t *testing.T) {
+	store, err := sqlite.OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	localJudge := &recordingJudge{}
+	server, err := NewServerWithOptions(store, Options{Judge: localJudge})
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision, err := server.ProcessHookEvent(context.Background(), risk.HookEvent{
+		SessionID:     "s1",
+		HookEventName: "PreToolUse",
+		ToolName:      "Bash",
+		ToolInput:     map[string]any{"command": "drop database"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if localJudge.calls != 0 {
+		t.Fatalf("judge calls = %d, want 0", localJudge.calls)
+	}
+	if decision.Decision != risk.DecisionDeny || decision.RiskEvent.DecisionStage != "deterministic" {
+		t.Fatalf("decision = %+v", decision)
+	}
+}
+
 func TestEvaluateHookRejectsTelemetryEvents(t *testing.T) {
 	store, err := sqlite.OpenStore(t.TempDir() + "/guard.db")
 	if err != nil {
@@ -329,6 +481,22 @@ type recordingPolicy struct {
 	called   bool
 	decision risk.RiskDecision
 	err      error
+}
+
+type recordingJudge struct {
+	calls  int
+	input  judge.Input
+	result judge.Result
+	err    error
+}
+
+func (j *recordingJudge) Decide(_ context.Context, input judge.Input) (judge.Result, error) {
+	j.calls++
+	j.input = input
+	if j.err != nil {
+		return judge.Result{}, j.err
+	}
+	return j.result, nil
 }
 
 func (p *recordingPolicy) DecideHook(_ context.Context, _ risk.HookEvent) (risk.RiskDecision, error) {

--- a/internal/guard/cli/cli.go
+++ b/internal/guard/cli/cli.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 	"github.com/kontext-security/kontext-cli/internal/guard/app/server"
+	"github.com/kontext-security/kontext-cli/internal/guard/judge"
 	"github.com/kontext-security/kontext-cli/internal/guard/markov"
 	"github.com/kontext-security/kontext-cli/internal/guard/modelsnapshot"
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
@@ -91,6 +93,10 @@ func runDaemon(args []string, out io.Writer) error {
 	if err != nil {
 		return err
 	}
+	defaultJudgeTimeout, err := envDuration("KONTEXT_JUDGE_TIMEOUT", judge.DefaultTimeout)
+	if err != nil {
+		return err
+	}
 	fs := flag.NewFlagSet("start", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	addr := fs.String("addr", envString("KONTEXT_ADDR", server.DefaultAddr), "listen address")
@@ -101,6 +107,9 @@ func runDaemon(args []string, out io.Writer) error {
 	skipHookInstall := fs.Bool("skip-hook-install", false, "skip Claude Code hook install")
 	noOpen := fs.Bool("no-open", false, "do not open the local dashboard")
 	socketPath := fs.String("socket", defaultGuardSocketPath(), "Unix socket path for local hook runtime")
+	judgeURL := fs.String("judge-url", envString("KONTEXT_JUDGE_URL", ""), "OpenAI-compatible local judge base URL, for example http://127.0.0.1:8080")
+	judgeModel := fs.String("judge-model", envString("KONTEXT_JUDGE_MODEL", ""), "local judge model name")
+	judgeTimeout := fs.Duration("judge-timeout", defaultJudgeTimeout, "local judge timeout")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -126,7 +135,27 @@ func runDaemon(args []string, out io.Writer) error {
 		}
 		scorer = loaded
 	}
-	localServer, closeStore, err := server.OpenDefaultServer(*dbPath, scorer)
+	var localJudge judge.Judge
+	if strings.TrimSpace(*judgeURL) != "" || strings.TrimSpace(*judgeModel) != "" {
+		if strings.TrimSpace(*judgeURL) == "" || strings.TrimSpace(*judgeModel) == "" {
+			return fmt.Errorf("--judge-url and --judge-model must be set together")
+		}
+		if err := validateLocalJudgeURL(*judgeURL); err != nil {
+			return err
+		}
+		localJudge, err = judge.NewOpenAICompatibleJudge(judge.HTTPOptions{
+			BaseURL: *judgeURL,
+			Model:   *judgeModel,
+			Timeout: *judgeTimeout,
+		})
+		if err != nil {
+			return err
+		}
+	}
+	localServer, closeStore, err := server.OpenDefaultServerWithOptions(*dbPath, server.Options{
+		Scorer: scorer,
+		Judge:  localJudge,
+	})
 	if err != nil {
 		return err
 	}
@@ -155,6 +184,11 @@ func runDaemon(args []string, out io.Writer) error {
 	fmt.Fprintln(out, "Mode: observe (Claude Code runs normally; decisions are recorded as would allow / would ask / would deny).")
 	fmt.Fprintf(out, "Dashboard: http://%s\n", *addr)
 	fmt.Fprintf(out, "Risk model: %s\n", activeModelPath)
+	if localJudge != nil {
+		fmt.Fprintf(out, "Local judge: %s at %s\n", *judgeModel, *judgeURL)
+	} else {
+		fmt.Fprintln(out, "Local judge: disabled")
+	}
 	if !*noOpen {
 		_ = browser.OpenURL("http://" + *addr)
 	}
@@ -661,6 +695,33 @@ func envFloat(key string, fallback float64) (float64, error) {
 		return parsed, nil
 	}
 	return fallback, nil
+}
+
+func envDuration(key string, fallback time.Duration) (time.Duration, error) {
+	if value := os.Getenv(key); value != "" {
+		parsed, err := time.ParseDuration(value)
+		if err != nil {
+			return 0, fmt.Errorf("%s must be a duration: %w", key, err)
+		}
+		return parsed, nil
+	}
+	return fallback, nil
+}
+
+func validateLocalJudgeURL(value string) error {
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return fmt.Errorf("parse judge URL: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("judge URL must use http or https")
+	}
+	switch strings.ToLower(parsed.Hostname()) {
+	case "localhost", "127.0.0.1", "::1":
+		return nil
+	default:
+		return fmt.Errorf("judge URL must point to localhost")
+	}
 }
 
 func defaultDBPath() string {

--- a/internal/guard/cli/cli_test.go
+++ b/internal/guard/cli/cli_test.go
@@ -115,3 +115,15 @@ func TestStartRejectsInvalidNumericEnvironment(t *testing.T) {
 		t.Fatalf("err = %v", err)
 	}
 }
+
+func TestValidateLocalJudgeURLRejectsHostedURL(t *testing.T) {
+	if err := validateLocalJudgeURL("https://api.example.com/v1"); err == nil {
+		t.Fatal("validateLocalJudgeURL() error = nil, want hosted URL rejection")
+	}
+}
+
+func TestValidateLocalJudgeURLAllowsLoopback(t *testing.T) {
+	if err := validateLocalJudgeURL("http://127.0.0.1:8080"); err != nil {
+		t.Fatalf("validateLocalJudgeURL() error = %v", err)
+	}
+}

--- a/internal/guard/judge/http.go
+++ b/internal/guard/judge/http.go
@@ -1,0 +1,219 @@
+package judge
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultTimeout = 2 * time.Second
+	DefaultRuntime = "openai-compatible"
+)
+
+//go:embed prompts/launch-v0.md
+var defaultPrompt string
+
+type HTTPOptions struct {
+	BaseURL    string
+	Model      string
+	Timeout    time.Duration
+	HTTPClient *http.Client
+	Prompt     string
+}
+
+type OpenAICompatibleJudge struct {
+	endpoint   string
+	model      string
+	timeout    time.Duration
+	httpClient *http.Client
+	prompt     string
+}
+
+func NewOpenAICompatibleJudge(opts HTTPOptions) (*OpenAICompatibleJudge, error) {
+	baseURL := strings.TrimSpace(opts.BaseURL)
+	if baseURL == "" {
+		return nil, errors.New("judge base URL is required")
+	}
+	endpoint, err := chatCompletionsEndpoint(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	model := strings.TrimSpace(opts.Model)
+	if model == "" {
+		return nil, errors.New("judge model is required")
+	}
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
+	client := opts.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	prompt := opts.Prompt
+	if strings.TrimSpace(prompt) == "" {
+		prompt = defaultPrompt
+	}
+	return &OpenAICompatibleJudge{
+		endpoint:   endpoint,
+		model:      model,
+		timeout:    timeout,
+		httpClient: client,
+		prompt:     prompt,
+	}, nil
+}
+
+func (j *OpenAICompatibleJudge) Decide(ctx context.Context, input Input) (Result, error) {
+	if j == nil {
+		return Result{}, Error{Kind: FailureUnavailable, Err: errors.New("judge is nil")}
+	}
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(ctx, j.timeout)
+	defer cancel()
+
+	payload, err := j.requestBody(input)
+	if err != nil {
+		return Result{}, Error{Kind: FailureUnavailable, Err: err}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, j.endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return Result{}, Error{Kind: FailureUnavailable, Err: err}
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := j.httpClient.Do(req)
+	if err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return Result{}, Error{Kind: FailureTimeout, Err: err}
+		}
+		return Result{}, Error{Kind: FailureUnavailable, Err: err}
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return Result{}, Error{Kind: FailureUnavailable, Err: fmt.Errorf("judge returned %s", resp.Status)}
+	}
+
+	var decoded openAIChatResponse
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		return Result{}, Error{Kind: FailureInvalidOutput, Err: err}
+	}
+	content := strings.TrimSpace(decoded.firstContent())
+	output, err := ParseOutput(content)
+	if err != nil {
+		return Result{}, Error{Kind: FailureInvalidOutput, Err: err}
+	}
+	return Result{
+		Output:   output,
+		Metadata: j.metadata(time.Since(start).Milliseconds()),
+	}, nil
+}
+
+func (j *OpenAICompatibleJudge) Metadata() Metadata {
+	if j == nil {
+		return Metadata{}
+	}
+	return j.metadata(0)
+}
+
+func (j *OpenAICompatibleJudge) metadata(durationMs int64) Metadata {
+	return Metadata{
+		Runtime:    DefaultRuntime,
+		Model:      j.model,
+		DurationMs: durationMs,
+	}
+}
+
+func (j *OpenAICompatibleJudge) requestBody(input Input) ([]byte, error) {
+	inputJSON, err := json.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("marshal judge input: %w", err)
+	}
+	request := openAIChatRequest{
+		Model: j.model,
+		Messages: []openAIMessage{
+			{Role: "system", Content: j.prompt},
+			{Role: "user", Content: string(inputJSON)},
+		},
+		Temperature:    0,
+		MaxTokens:      256,
+		ResponseFormat: map[string]string{"type": "json_object"},
+	}
+	return json.Marshal(request)
+}
+
+func ParseOutput(content string) (Output, error) {
+	if strings.TrimSpace(content) == "" {
+		return Output{}, errors.New("empty judge output")
+	}
+	var output Output
+	decoder := json.NewDecoder(strings.NewReader(content))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&output); err != nil {
+		return Output{}, err
+	}
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		return Output{}, errors.New("trailing data after judge output")
+	}
+	if err := ValidateOutput(output); err != nil {
+		return Output{}, err
+	}
+	return output, nil
+}
+
+func chatCompletionsEndpoint(baseURL string) (string, error) {
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("parse judge URL: %w", err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("judge URL must include scheme and host")
+	}
+	path := strings.TrimRight(parsed.Path, "/")
+	switch {
+	case strings.HasSuffix(path, "/chat/completions"):
+		return parsed.String(), nil
+	case strings.HasSuffix(path, "/v1"):
+		parsed.Path = path + "/chat/completions"
+	default:
+		parsed.Path = path + "/v1/chat/completions"
+	}
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String(), nil
+}
+
+type openAIChatRequest struct {
+	Model          string            `json:"model"`
+	Messages       []openAIMessage   `json:"messages"`
+	Temperature    float64           `json:"temperature"`
+	MaxTokens      int               `json:"max_tokens"`
+	ResponseFormat map[string]string `json:"response_format,omitempty"`
+}
+
+type openAIMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type openAIChatResponse struct {
+	Choices []struct {
+		Message openAIMessage `json:"message"`
+	} `json:"choices"`
+}
+
+func (r openAIChatResponse) firstContent() string {
+	if len(r.Choices) == 0 {
+		return ""
+	}
+	return r.Choices[0].Message.Content
+}

--- a/internal/guard/judge/http_test.go
+++ b/internal/guard/judge/http_test.go
@@ -1,0 +1,97 @@
+package judge
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestParseOutputValidatesDecisionSchema(t *testing.T) {
+	output, err := ParseOutput(`{"decision":"deny","risk_level":"high","categories":["production_mutation"],"reason":"Deletes production data."}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if output.Decision != DecisionDeny || output.RiskLevel != RiskLevelHigh {
+		t.Fatalf("output = %+v", output)
+	}
+}
+
+func TestParseOutputRejectsAsk(t *testing.T) {
+	_, err := ParseOutput(`{"decision":"ask","risk_level":"medium","categories":["review"],"reason":"Needs review."}`)
+	if err == nil {
+		t.Fatal("ParseOutput() error = nil, want invalid decision")
+	}
+}
+
+func TestOpenAICompatibleJudgeCallsChatCompletions(t *testing.T) {
+	var request openAIChatRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Fatalf("path = %q, want /v1/chat/completions", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatal(err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"{\"decision\":\"allow\",\"risk_level\":\"low\",\"categories\":[\"normal_coding\"],\"reason\":\"Reads a project file.\"}"}}]}`))
+	}))
+	defer server.Close()
+
+	judge, err := NewOpenAICompatibleJudge(HTTPOptions{
+		BaseURL: server.URL,
+		Model:   "qwen3-0.6b-q4",
+		Timeout: time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := judge.Decide(context.Background(), Input{
+		HookEvent: "PreToolUse",
+		ToolName:  "Read",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if request.Model != "qwen3-0.6b-q4" || len(request.Messages) != 2 {
+		t.Fatalf("request = %+v", request)
+	}
+	if request.MaxTokens != 256 {
+		t.Fatalf("max tokens = %d, want 256", request.MaxTokens)
+	}
+	if result.Output.Decision != DecisionAllow || result.Metadata.Model != "qwen3-0.6b-q4" {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestOpenAICompatibleJudgeClassifiesTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+	}))
+	defer server.Close()
+
+	judge, err := NewOpenAICompatibleJudge(HTTPOptions{
+		BaseURL: server.URL,
+		Model:   "qwen3-0.6b-q4",
+		Timeout: time.Nanosecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = judge.Decide(context.Background(), Input{HookEvent: "PreToolUse"})
+	if FailureKind(err) != FailureTimeout {
+		t.Fatalf("FailureKind(err) = %q, err=%v", FailureKind(err), err)
+	}
+}
+
+func TestChatCompletionsEndpointAcceptsV1Base(t *testing.T) {
+	endpoint, err := chatCompletionsEndpoint("http://127.0.0.1:8080/v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if endpoint != "http://127.0.0.1:8080/v1/chat/completions" {
+		t.Fatalf("endpoint = %q", endpoint)
+	}
+}

--- a/internal/guard/judge/prompts/launch-v0.md
+++ b/internal/guard/judge/prompts/launch-v0.md
@@ -1,0 +1,21 @@
+/no_think
+
+You are the Kontext Guard local judge.
+
+Classify one normalized coding-agent tool call. Return only JSON matching this shape:
+
+{
+  "decision": "allow" | "deny",
+  "risk_level": "low" | "medium" | "high",
+  "categories": ["short_snake_case_category"],
+  "reason": "short human-readable reason"
+}
+
+Rules:
+
+- Deny destructive operations against production or persistent resources unless explicit user intent is present.
+- Deny credential exfiltration, credential dumping, or direct infrastructure API calls that include credential material.
+- Allow ordinary coding, reading project files, local tests, formatting, and source-control inspection.
+- Do not ask for approval. Use only allow or deny.
+- Keep the reason under 160 characters.
+- Do not include markdown, prose, or fields outside the JSON object.

--- a/internal/guard/judge/types.go
+++ b/internal/guard/judge/types.go
@@ -1,0 +1,147 @@
+package judge
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type Decision string
+
+const (
+	DecisionAllow Decision = "allow"
+	DecisionDeny  Decision = "deny"
+)
+
+type RiskLevel string
+
+const (
+	RiskLevelLow    RiskLevel = "low"
+	RiskLevelMedium RiskLevel = "medium"
+	RiskLevelHigh   RiskLevel = "high"
+)
+
+type Input struct {
+	Agent               string               `json:"agent,omitempty"`
+	HookEvent           string               `json:"hook_event"`
+	ToolName            string               `json:"tool_name,omitempty"`
+	CWDClass            string               `json:"cwd_class,omitempty"`
+	ToolInput           ToolInput            `json:"tool_input"`
+	NormalizedEvent     NormalizedEvent      `json:"normalized_event"`
+	DeterministicPolicy DeterministicContext `json:"deterministic_policy"`
+}
+
+type ToolInput struct {
+	CommandRedacted string `json:"command_redacted,omitempty"`
+	PathRedacted    string `json:"path_redacted,omitempty"`
+	RequestSummary  string `json:"request_summary,omitempty"`
+}
+
+type NormalizedEvent struct {
+	Type               string   `json:"type"`
+	Provider           string   `json:"provider,omitempty"`
+	ProviderCategory   string   `json:"provider_category,omitempty"`
+	Operation          string   `json:"operation,omitempty"`
+	OperationClass     string   `json:"operation_class,omitempty"`
+	ResourceClass      string   `json:"resource_class,omitempty"`
+	Environment        string   `json:"environment,omitempty"`
+	CredentialObserved bool     `json:"credential_observed"`
+	DirectAPICall      bool     `json:"direct_api_call"`
+	ExplicitUserIntent bool     `json:"explicit_user_intent"`
+	PathClass          string   `json:"path_class,omitempty"`
+	CommandSummary     string   `json:"command_summary,omitempty"`
+	RequestSummary     string   `json:"request_summary,omitempty"`
+	Signals            []string `json:"signals,omitempty"`
+}
+
+type DeterministicContext struct {
+	Decision      string   `json:"decision"`
+	MatchedRules  []string `json:"matched_rules,omitempty"`
+	PolicyVersion string   `json:"policy_version"`
+}
+
+type Output struct {
+	Decision   Decision  `json:"decision"`
+	RiskLevel  RiskLevel `json:"risk_level"`
+	Categories []string  `json:"categories"`
+	Reason     string    `json:"reason"`
+}
+
+type Metadata struct {
+	Runtime     string
+	Model       string
+	DurationMs  int64
+	FailureKind string
+}
+
+type Result struct {
+	Output   Output
+	Metadata Metadata
+}
+
+type Judge interface {
+	Decide(context.Context, Input) (Result, error)
+}
+
+type MetadataProvider interface {
+	Metadata() Metadata
+}
+
+const (
+	FailureUnavailable   = "unavailable"
+	FailureTimeout       = "timeout"
+	FailureInvalidOutput = "invalid_output"
+)
+
+type Error struct {
+	Kind string
+	Err  error
+}
+
+func (e Error) Error() string {
+	if e.Err == nil {
+		return e.Kind
+	}
+	return fmt.Sprintf("%s: %v", e.Kind, e.Err)
+}
+
+func (e Error) Unwrap() error {
+	return e.Err
+}
+
+func FailureKind(err error) string {
+	if err == nil {
+		return ""
+	}
+	var judgeErr Error
+	if errors.As(err, &judgeErr) && judgeErr.Kind != "" {
+		return judgeErr.Kind
+	}
+	return FailureUnavailable
+}
+
+func ValidateOutput(output Output) error {
+	switch output.Decision {
+	case DecisionAllow, DecisionDeny:
+	default:
+		return fmt.Errorf("invalid decision %q", output.Decision)
+	}
+	switch output.RiskLevel {
+	case RiskLevelLow, RiskLevelMedium, RiskLevelHigh:
+	default:
+		return fmt.Errorf("invalid risk_level %q", output.RiskLevel)
+	}
+	if strings.TrimSpace(output.Reason) == "" {
+		return errors.New("reason is required")
+	}
+	if len(output.Categories) > 12 {
+		return errors.New("too many categories")
+	}
+	for _, category := range output.Categories {
+		if strings.TrimSpace(category) == "" {
+			return errors.New("empty category")
+		}
+	}
+	return nil
+}

--- a/internal/guard/risk/decision.go
+++ b/internal/guard/risk/decision.go
@@ -1,10 +1,13 @@
 package risk
 
+const PolicyVersionLaunchV0 = "guard-launch-v0"
+
 func DecideRisk(event HookEvent, scorer Scorer) (RiskDecision, error) {
 	if scorer == nil {
 		scorer = NoopScorer{}
 	}
 	riskEvent := NormalizeHookEvent(event)
+	riskEvent.PolicyVersion = PolicyVersionLaunchV0
 	score, err := scorer.Score(riskEvent)
 	if err != nil {
 		return RiskDecision{}, err
@@ -14,6 +17,7 @@ func DecideRisk(event HookEvent, scorer Scorer) (RiskDecision, error) {
 	if event.HookEventName != "PreToolUse" {
 		riskEvent.Decision = DecisionAllow
 		riskEvent.ReasonCode = "async_telemetry"
+		riskEvent.DecisionStage = "async_telemetry"
 		return RiskDecision{
 			Decision:     DecisionAllow,
 			Reason:       "async telemetry event recorded",
@@ -50,7 +54,22 @@ func DecideRisk(event HookEvent, scorer Scorer) (RiskDecision, error) {
 	decision.RiskEvent.GuardID = decision.GuardID
 	decision.RiskEvent.RiskScore = decision.RiskScore
 	decision.RiskEvent.ModelVersion = decision.ModelVersion
+	decision.RiskEvent.PolicyVersion = PolicyVersionLaunchV0
+	if decision.RiskEvent.DecisionStage == "" {
+		switch {
+		case decision.ReasonCode == "model_risk_threshold":
+			decision.RiskEvent.DecisionStage = "model"
+		case decision.GuardID != "":
+			decision.RiskEvent.DecisionStage = "deterministic"
+		default:
+			decision.RiskEvent.DecisionStage = "policy_allow"
+		}
+	}
 	return decision, nil
+}
+
+func DeterministicDecision(event RiskEvent) RiskDecision {
+	return guardDecision(event)
 }
 
 func modelCanEscalate(event RiskEvent) bool {

--- a/internal/guard/risk/normalizer.go
+++ b/internal/guard/risk/normalizer.go
@@ -7,7 +7,10 @@ import (
 	"strings"
 )
 
-var credentialShape = regexp.MustCompile(`(?i)(authorization\s*:|bearer\s+[a-z0-9._~+/=-]+|api[_-]?key\s*[=:]|secret\s*[=:]|token\s*[=:])`)
+var credentialAssignment = regexp.MustCompile(`(?i)\b([a-z0-9_]*(?:api[_-]?key|token|secret|access[_-]?key)[a-z0-9_]*|api[_-]?key|token|secret)\s*=\s*("[^"]*"|'[^']*'|[^\s;&|]+)`)
+var credentialHeader = regexp.MustCompile(`(?i)(authorization\s*:\s*)(bearer\s+)?("[^"]*"|'[^']*'|[^\s;&|]+)`)
+var credentialBearer = regexp.MustCompile(`(?i)\bbearer\s+("[^"]*"|'[^']*'|[a-z0-9._~+/=-]+)`)
+var credentialShape = regexp.MustCompile(`(?i)(authorization\s*:|api[_-]?key\s*[=:]|secret\s*[=:]|token\s*[=:])`)
 var credentialReference = regexp.MustCompile(`(?i)(authorization\s*:|bearer\s+[a-z0-9._~+/=-]+|api[_-]?key\s*[=:]|secret\s*[=:]|token\s*[=:]|\$[A-Z0-9_]*(TOKEN|SECRET|API_KEY|ACCESS_KEY)[A-Z0-9_]*)`)
 var destructiveWord = regexp.MustCompile(`(?i)\b(delete|destroy|drop|truncate|wipe)\b`)
 var resourceWord = regexp.MustCompile(`(?i)\b(database|volume|backup|bucket|project|repo|repository|branch|deployment|namespace|secret)\b`)
@@ -279,6 +282,9 @@ func summarizeRequest(toolName, path, command string) string {
 }
 
 func redact(value string) string {
+	value = credentialAssignment.ReplaceAllString(value, "$1=[redacted-credential]")
+	value = credentialHeader.ReplaceAllString(value, "${1}${2}[redacted-credential]")
+	value = credentialBearer.ReplaceAllString(value, "Bearer [redacted-credential]")
 	value = credentialShape.ReplaceAllString(value, "[redacted-credential]")
 	if len(value) > 240 {
 		return value[:240] + "..."

--- a/internal/guard/risk/risk_test.go
+++ b/internal/guard/risk/risk_test.go
@@ -3,6 +3,7 @@ package risk
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/kontext-security/kontext-cli/internal/guard/markov"
@@ -108,6 +109,18 @@ func TestNormalizeDirectProviderAPIStillSeesAuthorizationHeader(t *testing.T) {
 	}
 	if !event.CredentialObserved {
 		t.Fatal("credential material was not observed")
+	}
+}
+
+func TestNormalizeRedactsCredentialValuesFromSummaries(t *testing.T) {
+	event := NormalizeHookEvent(HookEvent{ToolName: "Bash", ToolInput: map[string]any{"command": `API_TOKEN=real-secret-123 curl https://api.cloudflare.com -H "Authorization: Bearer abc123"`}})
+	for _, value := range []string{event.CommandSummary, event.RequestSummary} {
+		if strings.Contains(value, "real-secret-123") || strings.Contains(value, "abc123") {
+			t.Fatalf("summary leaked credential value: %q", value)
+		}
+		if !strings.Contains(value, "[redacted-credential]") {
+			t.Fatalf("summary did not include redaction marker: %q", value)
+		}
 	}
 }
 

--- a/internal/guard/risk/types.go
+++ b/internal/guard/risk/types.go
@@ -58,6 +58,14 @@ type RiskEvent struct {
 	RiskScore          *float64  `json:"risk_score,omitempty"`
 	Confidence         float64   `json:"confidence,omitempty"`
 	Signals            []string  `json:"signals,omitempty"`
+	DecisionStage      string    `json:"decision_stage,omitempty"`
+	PolicyVersion      string    `json:"policy_version,omitempty"`
+	JudgeRuntime       string    `json:"judge_runtime,omitempty"`
+	JudgeModel         string    `json:"judge_model,omitempty"`
+	JudgeDurationMs    *int64    `json:"judge_duration_ms,omitempty"`
+	JudgeFailureKind   string    `json:"judge_failure_kind,omitempty"`
+	JudgeRiskLevel     string    `json:"judge_risk_level,omitempty"`
+	JudgeCategories    []string  `json:"judge_categories,omitempty"`
 }
 
 type RiskDecision struct {


### PR DESCRIPTION
## Summary

Adds the local Guard judge contract and opt-in localhost OpenAI-compatible judge adapter. Defines strict `allow|deny` JSON output validation, fail-open behavior for timeout/unavailable/invalid output, high-level judge diagnostics, and Guard flags for `--judge-url`, `--judge-model`, and `--judge-timeout`.

## Verification

- [x] `go test ./...`
