### PR TITLE
feat(guard): add policy config store

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sys v0.42.0
 	google.golang.org/protobuf v1.36.11
 	modernc.org/sqlite v1.50.1
 )
@@ -22,7 +23,6 @@ require (
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
-	golang.org/x/sys v0.42.0 // indirect
 	modernc.org/libc v1.72.3 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/internal/guard/policyconfig/config.go
+++ b/internal/guard/policyconfig/config.go
@@ -1,0 +1,99 @@
+package policyconfig
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/kontext-security/kontext-cli/internal/guard/policy"
+)
+
+const (
+	fileMode = 0o600
+	dirMode  = 0o755
+)
+
+type Config struct {
+	Version            string         `json:"version"`
+	Profile            policy.Profile `json:"profile"`
+	RulePack           string         `json:"rulePack"`
+	NonBypassableRules *bool          `json:"nonBypassableRules"`
+}
+
+func DefaultConfig() Config {
+	nonBypassableRules := true
+	return Config{
+		Version:            policy.DefaultPolicyVersion,
+		Profile:            policy.ProfileBalanced,
+		RulePack:           policy.DefaultRulePackID,
+		NonBypassableRules: &nonBypassableRules,
+	}
+}
+
+func cloneConfig(cfg Config) Config {
+	if cfg.NonBypassableRules != nil {
+		nonBypassableRules := *cfg.NonBypassableRules
+		cfg.NonBypassableRules = &nonBypassableRules
+	}
+	return cfg
+}
+
+func decodeConfig(data []byte) (Config, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+
+	var cfg Config
+	if err := decoder.Decode(&cfg); err != nil {
+		return Config{}, ValidationError{Reason: err.Error()}
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return Config{}, ValidationError{Reason: "unexpected trailing JSON value"}
+	}
+	if err := validateConfig(cfg); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}
+
+func validateConfig(cfg Config) error {
+	if cfg.Version != policy.DefaultPolicyVersion {
+		return ValidationError{Reason: fmt.Sprintf("version must be %q", policy.DefaultPolicyVersion)}
+	}
+	switch cfg.Profile {
+	case policy.ProfileRelaxed, policy.ProfileBalanced, policy.ProfileStrict:
+	default:
+		return ValidationError{Reason: fmt.Sprintf("unknown profile %q", cfg.Profile)}
+	}
+	if cfg.RulePack != policy.DefaultRulePackID {
+		return ValidationError{Reason: fmt.Sprintf("unknown rule pack %q", cfg.RulePack)}
+	}
+	if cfg.NonBypassableRules == nil {
+		return ValidationError{Reason: "nonBypassableRules is required"}
+	}
+	if !*cfg.NonBypassableRules {
+		return ValidationError{Reason: "nonBypassableRules must be true"}
+	}
+	return nil
+}
+
+func encodeConfig(cfg Config) ([]byte, error) {
+	if err := validateConfig(cfg); err != nil {
+		return nil, err
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
+func toPolicyConfig(cfg Config) policy.Config {
+	return policy.Config{
+		Version:            cfg.Version,
+		Profile:            cfg.Profile,
+		RulePack:           cfg.RulePack,
+		NonBypassableRules: cfg.NonBypassableRules,
+	}
+}

--- a/internal/guard/policyconfig/errors.go
+++ b/internal/guard/policyconfig/errors.go
@@ -1,0 +1,14 @@
+package policyconfig
+
+import "fmt"
+
+type ValidationError struct {
+	Reason string
+}
+
+func (e ValidationError) Error() string {
+	if e.Reason == "" {
+		return "invalid policy config"
+	}
+	return fmt.Sprintf("invalid policy config: %s", e.Reason)
+}

--- a/internal/guard/policyconfig/filelock_unix.go
+++ b/internal/guard/policyconfig/filelock_unix.go
@@ -1,0 +1,37 @@
+//go:build !windows
+
+package policyconfig
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func lockFileAt(ctx context.Context, path string) (func(), error) {
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, fileMode)
+		if err != nil {
+			return nil, err
+		}
+		if err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+			_ = file.Close()
+			if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
+				if err := waitForLockRetry(ctx); err != nil {
+					return nil, err
+				}
+				continue
+			}
+			return nil, err
+		}
+		return func() {
+			_ = unix.Flock(int(file.Fd()), unix.LOCK_UN)
+			_ = file.Close()
+		}, nil
+	}
+}

--- a/internal/guard/policyconfig/filelock_windows.go
+++ b/internal/guard/policyconfig/filelock_windows.go
@@ -1,0 +1,46 @@
+//go:build windows
+
+package policyconfig
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockFileAt(ctx context.Context, path string) (func(), error) {
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, fileMode)
+		if err != nil {
+			return nil, err
+		}
+		var overlapped windows.Overlapped
+		err = windows.LockFileEx(
+			windows.Handle(file.Fd()),
+			windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+			0,
+			1,
+			0,
+			&overlapped,
+		)
+		if err != nil {
+			_ = file.Close()
+			if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+				if err := waitForLockRetry(ctx); err != nil {
+					return nil, err
+				}
+				continue
+			}
+			return nil, err
+		}
+		return func() {
+			_ = windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, &overlapped)
+			_ = file.Close()
+		}, nil
+	}
+}

--- a/internal/guard/policyconfig/snapshot.go
+++ b/internal/guard/policyconfig/snapshot.go
@@ -1,0 +1,74 @@
+package policyconfig
+
+import (
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/guard/policy"
+)
+
+type Source string
+
+const (
+	SourceActiveFile    Source = "active-file"
+	SourceDefault       Source = "default"
+	SourceLastKnownGood Source = "last-known-good"
+)
+
+type Status string
+
+const (
+	StatusOK               Status = "ok"
+	StatusDefaultedMissing Status = "defaulted_missing"
+	StatusRecoveredLKG     Status = "recovered_lkg"
+	StatusDefaultedInvalid Status = "defaulted_invalid"
+)
+
+type Snapshot struct {
+	Config Config
+
+	ConfigDigest string
+	ActivationID string
+	Source       Source
+	Status       Status
+	LoadedAt     time.Time
+
+	PolicyVersion   string
+	RulePack        string
+	RulePackVersion string
+}
+
+type DecisionMetadata struct {
+	ConfigDigest       string `json:"config_digest"`
+	ActivationID       string `json:"activation_id"`
+	ConfigSource       string `json:"config_source"`
+	ConfigStatus       string `json:"config_status"`
+	PolicyVersion      string `json:"policy_version"`
+	RulePack           string `json:"rule_pack"`
+	RulePackVersion    string `json:"rule_pack_version"`
+	Profile            string `json:"profile"`
+	NonBypassableRules bool   `json:"non_bypassable_rules"`
+}
+
+func cloneSnapshot(snapshot Snapshot) Snapshot {
+	snapshot.Config = cloneConfig(snapshot.Config)
+	return snapshot
+}
+
+func (s Snapshot) ToPolicyConfig() policy.Config {
+	return toPolicyConfig(cloneConfig(s.Config))
+}
+
+func (s Snapshot) DecisionMetadata() DecisionMetadata {
+	nonBypassableRules := s.Config.NonBypassableRules != nil && *s.Config.NonBypassableRules
+	return DecisionMetadata{
+		ConfigDigest:       s.ConfigDigest,
+		ActivationID:       s.ActivationID,
+		ConfigSource:       string(s.Source),
+		ConfigStatus:       string(s.Status),
+		PolicyVersion:      s.PolicyVersion,
+		RulePack:           s.RulePack,
+		RulePackVersion:    s.RulePackVersion,
+		Profile:            string(s.Config.Profile),
+		NonBypassableRules: nonBypassableRules,
+	}
+}

--- a/internal/guard/policyconfig/store.go
+++ b/internal/guard/policyconfig/store.go
@@ -1,0 +1,296 @@
+package policyconfig
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/guard/policy"
+)
+
+type clockFunc func() time.Time
+
+type Option func(*Store)
+
+type Store struct {
+	root   string
+	clock  clockFunc
+	write  func(path string, data []byte, perm os.FileMode) error
+	locker func(context.Context) (func(), error)
+
+	mu      sync.RWMutex
+	current Snapshot
+}
+
+func WithClock(clock clockFunc) Option {
+	return func(s *Store) {
+		if clock != nil {
+			s.clock = clock
+		}
+	}
+}
+
+func withWriter(write func(path string, data []byte, perm os.FileMode) error) Option {
+	return func(s *Store) {
+		if write != nil {
+			s.write = write
+		}
+	}
+}
+
+func withLocker(locker func(context.Context) (func(), error)) Option {
+	return func(s *Store) {
+		if locker != nil {
+			s.locker = locker
+		}
+	}
+}
+
+func Open(dir string, opts ...Option) (*Store, error) {
+	if dir == "" {
+		return nil, fmt.Errorf("policy config directory is required")
+	}
+	store := &Store{
+		root:  dir,
+		clock: func() time.Time { return time.Now().UTC() },
+		write: writeFileAtomic,
+	}
+	store.locker = store.lockFile
+	for _, opt := range opts {
+		opt(store)
+	}
+	return store, nil
+}
+
+func (s *Store) Load(ctx context.Context) (Snapshot, error) {
+	unlockStore, err := s.lockStore(ctx)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	defer unlockStore()
+	unlockFile, err := s.locker(ctx)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	defer unlockFile()
+
+	active, err := s.readConfig(s.activePath())
+	if err == nil {
+		data, err := encodeConfig(active)
+		if err != nil {
+			return Snapshot{}, err
+		}
+		if err := s.write(s.lastKnownGoodPath(), data, fileMode); err != nil {
+			return Snapshot{}, err
+		}
+		snapshot, err := s.snapshot(active, SourceActiveFile, StatusOK)
+		if err != nil {
+			return Snapshot{}, err
+		}
+		s.current = cloneSnapshot(snapshot)
+		return cloneSnapshot(snapshot), nil
+	}
+	activeMissing := errors.Is(err, os.ErrNotExist)
+	activeInvalid := isValidationError(err)
+	if !activeMissing && !activeInvalid {
+		return Snapshot{}, err
+	}
+
+	lkg, lkgErr := s.readConfig(s.lastKnownGoodPath())
+	if lkgErr == nil {
+		if activeMissing {
+			return s.activateRecovered(lkg, SourceLastKnownGood, StatusDefaultedMissing)
+		}
+		return s.activateRecovered(lkg, SourceLastKnownGood, StatusRecoveredLKG)
+	}
+	if lkgErr != nil && !errors.Is(lkgErr, os.ErrNotExist) && !isValidationError(lkgErr) {
+		return Snapshot{}, lkgErr
+	}
+	if activeMissing {
+		return s.activateRecovered(DefaultConfig(), SourceDefault, StatusDefaultedMissing)
+	}
+	return s.activateRecovered(DefaultConfig(), SourceDefault, StatusDefaultedInvalid)
+}
+
+func (s *Store) Current() Snapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return cloneSnapshot(s.current)
+}
+
+func (s *Store) Activate(ctx context.Context, candidate Config) (Snapshot, error) {
+	unlockStore, err := s.lockStore(ctx)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	defer unlockStore()
+	unlockFile, err := s.locker(ctx)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	defer unlockFile()
+
+	data, err := encodeConfig(candidate)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	snapshot, err := s.snapshot(candidate, SourceActiveFile, StatusOK)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	if err := s.write(s.lastKnownGoodPath(), data, fileMode); err != nil {
+		return Snapshot{}, err
+	}
+	if err := s.write(s.activePath(), data, fileMode); err != nil {
+		return Snapshot{}, err
+	}
+	s.current = cloneSnapshot(snapshot)
+	return cloneSnapshot(snapshot), nil
+}
+
+func (s *Store) ActivateProfile(ctx context.Context, profile policy.Profile) (Snapshot, error) {
+	cfg := DefaultConfig()
+	cfg.Profile = profile
+	return s.Activate(ctx, cfg)
+}
+
+func (s *Store) activateRecovered(cfg Config, source Source, status Status) (Snapshot, error) {
+	data, err := encodeConfig(cfg)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	snapshot, err := s.snapshot(cfg, source, status)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	if err := s.write(s.lastKnownGoodPath(), data, fileMode); err != nil {
+		return Snapshot{}, err
+	}
+	if err := s.write(s.activePath(), data, fileMode); err != nil {
+		return Snapshot{}, err
+	}
+	s.current = cloneSnapshot(snapshot)
+	return cloneSnapshot(snapshot), nil
+}
+
+func (s *Store) readConfig(path string) (Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Config{}, err
+	}
+	return decodeConfig(data)
+}
+
+func (s *Store) snapshot(cfg Config, source Source, status Status) (Snapshot, error) {
+	cfg = cloneConfig(cfg)
+	pack := policy.DefaultRulePack()
+	digest, err := configDigest(cfg)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	now := s.clock()
+	return Snapshot{
+		Config:          cfg,
+		ConfigDigest:    digest,
+		ActivationID:    digest[:12],
+		Source:          source,
+		Status:          status,
+		LoadedAt:        now,
+		PolicyVersion:   cfg.Version,
+		RulePack:        cfg.RulePack,
+		RulePackVersion: pack.Version,
+	}, nil
+}
+
+func (s *Store) activePath() string {
+	return filepath.Join(s.root, "guard", "policy", "active.json")
+}
+
+func (s *Store) lastKnownGoodPath() string {
+	return filepath.Join(s.root, "guard", "policy", "last-known-good.json")
+}
+
+func (s *Store) lockPath() string {
+	return filepath.Join(s.root, "guard", "policy", ".lock")
+}
+
+func (s *Store) lockStore(ctx context.Context) (func(), error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	for {
+		if s.mu.TryLock() {
+			return s.mu.Unlock, nil
+		}
+		if err := waitForLockRetry(ctx); err != nil {
+			return nil, err
+		}
+	}
+}
+
+func (s *Store) lockFile(ctx context.Context) (func(), error) {
+	path := s.lockPath()
+	if err := os.MkdirAll(filepath.Dir(path), dirMode); err != nil {
+		return nil, err
+	}
+	return lockFileAt(ctx, path)
+}
+
+func waitForLockRetry(ctx context.Context) error {
+	timer := time.NewTimer(25 * time.Millisecond)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func configDigest(cfg Config) (string, error) {
+	data, err := encodeConfig(cfg)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func isValidationError(err error) bool {
+	var validationErr ValidationError
+	return errors.As(err, &validationErr)
+}
+
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), dirMode); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/internal/guard/policyconfig/store_test.go
+++ b/internal/guard/policyconfig/store_test.go
@@ -1,0 +1,778 @@
+package policyconfig
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/guard/policy"
+)
+
+func TestLoadMissingConfigMaterializesDefault(t *testing.T) {
+	store := newTestStore(t)
+
+	snapshot, err := store.Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if snapshot.Source != SourceDefault || snapshot.Status != StatusDefaultedMissing {
+		t.Fatalf("snapshot source/status = %s/%s", snapshot.Source, snapshot.Status)
+	}
+	if snapshot.Config.Profile != policy.ProfileBalanced {
+		t.Fatalf("profile = %q, want balanced", snapshot.Config.Profile)
+	}
+	assertFileExists(t, filepath.Join(store.root, "guard", "policy", "active.json"))
+	assertFileExists(t, filepath.Join(store.root, "guard", "policy", "last-known-good.json"))
+	if got := store.Current(); got.ConfigDigest != snapshot.ConfigDigest {
+		t.Fatalf("Current() digest = %q, want %q", got.ConfigDigest, snapshot.ConfigDigest)
+	}
+}
+
+func TestLoadMissingActiveRecoversFromLastKnownGood(t *testing.T) {
+	store := newTestStore(t)
+	activated, err := store.ActivateProfile(context.Background(), policy.ProfileStrict)
+	if err != nil {
+		t.Fatalf("ActivateProfile() error = %v", err)
+	}
+	if err := os.Remove(store.activePath()); err != nil {
+		t.Fatalf("Remove(active) error = %v", err)
+	}
+
+	reopened := newStoreAt(t, store.root)
+	snapshot, err := reopened.Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if snapshot.Source != SourceLastKnownGood || snapshot.Status != StatusDefaultedMissing {
+		t.Fatalf("source/status = %s/%s, want lkg/defaulted_missing", snapshot.Source, snapshot.Status)
+	}
+	if snapshot.Config.Profile != policy.ProfileStrict {
+		t.Fatalf("profile = %q, want strict", snapshot.Config.Profile)
+	}
+	if snapshot.ConfigDigest != activated.ConfigDigest {
+		t.Fatalf("digest = %q, want %q", snapshot.ConfigDigest, activated.ConfigDigest)
+	}
+	if cfg := readConfigFile(t, reopened.activePath()); cfg.Profile != policy.ProfileStrict {
+		t.Fatalf("active profile = %q, want strict", cfg.Profile)
+	}
+	if cfg := readConfigFile(t, reopened.lastKnownGoodPath()); cfg.Profile != policy.ProfileStrict {
+		t.Fatalf("LKG profile = %q, want strict", cfg.Profile)
+	}
+}
+
+func TestLoadValidActiveRefreshesLastKnownGood(t *testing.T) {
+	store := newTestStore(t)
+	if _, err := store.ActivateProfile(context.Background(), policy.ProfileBalanced); err != nil {
+		t.Fatalf("ActivateProfile(balanced) error = %v", err)
+	}
+
+	strict := DefaultConfig()
+	strict.Profile = policy.ProfileStrict
+	strictData, err := encodeConfig(strict)
+	if err != nil {
+		t.Fatalf("encodeConfig(strict) error = %v", err)
+	}
+	if err := os.WriteFile(store.activePath(), strictData, fileMode); err != nil {
+		t.Fatalf("WriteFile(active) error = %v", err)
+	}
+
+	reopened := newStoreAt(t, store.root)
+	snapshot, err := reopened.Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if snapshot.Config.Profile != policy.ProfileStrict {
+		t.Fatalf("profile = %q, want strict", snapshot.Config.Profile)
+	}
+	if cfg := readConfigFile(t, reopened.lastKnownGoodPath()); cfg.Profile != policy.ProfileStrict {
+		t.Fatalf("LKG profile = %q, want strict", cfg.Profile)
+	}
+}
+
+func TestLoadRejectsUnknownFields(t *testing.T) {
+	store := newTestStore(t)
+	writeActive(t, store, `{
+  "version": "guard-policy-v1",
+  "profile": "balanced",
+  "rulePack": "guard-default",
+  "nonBypassableRules": true,
+  "rules": []
+}`)
+
+	snapshot, err := store.Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if snapshot.Status != StatusDefaultedInvalid {
+		t.Fatalf("status = %s, want %s", snapshot.Status, StatusDefaultedInvalid)
+	}
+}
+
+func TestActivateInvalidLeavesCurrentAndDiskUnchanged(t *testing.T) {
+	store := newTestStore(t)
+	initial, err := store.Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	before := readActive(t, store)
+
+	cfg := DefaultConfig()
+	cfg.Profile = "unknown"
+	_, err = store.Activate(context.Background(), cfg)
+	var validationErr ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("Activate() error = %T %v, want ValidationError", err, err)
+	}
+	if got := store.Current(); got.ConfigDigest != initial.ConfigDigest {
+		t.Fatalf("Current() changed after invalid activate")
+	}
+	if after := readActive(t, store); after != before {
+		t.Fatalf("active file changed after invalid activate")
+	}
+}
+
+func TestActivateFailureWritingLKGLeavesActiveAndMemoryUnchanged(t *testing.T) {
+	root := t.TempDir()
+	store := newStoreAt(t, root)
+	initial, err := store.ActivateProfile(context.Background(), policy.ProfileBalanced)
+	if err != nil {
+		t.Fatalf("ActivateProfile(initial) error = %v", err)
+	}
+	beforeActive := readActive(t, store)
+
+	writeErr := errors.New("write lkg failed")
+	failingStore := newStoreAt(t, root, withWriter(func(path string, data []byte, perm os.FileMode) error {
+		if filepath.Base(path) == "last-known-good.json" {
+			return writeErr
+		}
+		return writeFileAtomic(path, data, perm)
+	}))
+	seedCurrent(failingStore, initial)
+
+	_, err = failingStore.ActivateProfile(context.Background(), policy.ProfileStrict)
+	if !errors.Is(err, writeErr) {
+		t.Fatalf("ActivateProfile() error = %v, want %v", err, writeErr)
+	}
+	if got := readActive(t, failingStore); got != beforeActive {
+		t.Fatalf("active file changed after LKG write failure")
+	}
+	if got := failingStore.Current(); got.ConfigDigest != initial.ConfigDigest {
+		t.Fatalf("Current() changed after LKG write failure")
+	}
+	reopened := newStoreAt(t, root)
+	loaded, err := reopened.Load(context.Background())
+	if err != nil {
+		t.Fatalf("reopened Load() error = %v", err)
+	}
+	if loaded.Config.Profile != policy.ProfileBalanced {
+		t.Fatalf("reopened profile = %q, want balanced", loaded.Config.Profile)
+	}
+}
+
+func TestActivateFailureWritingActiveLeavesNewConfigRecoverableFromLKG(t *testing.T) {
+	root := t.TempDir()
+	store := newStoreAt(t, root)
+	initial, err := store.ActivateProfile(context.Background(), policy.ProfileBalanced)
+	if err != nil {
+		t.Fatalf("ActivateProfile(initial) error = %v", err)
+	}
+	beforeActive := readActive(t, store)
+
+	writeErr := errors.New("write active failed")
+	failingStore := newStoreAt(t, root, withWriter(func(path string, data []byte, perm os.FileMode) error {
+		if filepath.Base(path) == "active.json" {
+			return writeErr
+		}
+		return writeFileAtomic(path, data, perm)
+	}))
+	seedCurrent(failingStore, initial)
+
+	_, err = failingStore.ActivateProfile(context.Background(), policy.ProfileStrict)
+	if !errors.Is(err, writeErr) {
+		t.Fatalf("ActivateProfile() error = %v, want %v", err, writeErr)
+	}
+	if got := readActive(t, failingStore); got != beforeActive {
+		t.Fatalf("active file changed after active write failure")
+	}
+	if got := failingStore.Current(); got.ConfigDigest != initial.ConfigDigest {
+		t.Fatalf("Current() changed after active write failure")
+	}
+
+	writeActive(t, failingStore, `{"version":`)
+	reopened := newStoreAt(t, root)
+	loaded, err := reopened.Load(context.Background())
+	if err != nil {
+		t.Fatalf("reopened Load() error = %v", err)
+	}
+	if loaded.Config.Profile != policy.ProfileStrict {
+		t.Fatalf("reopened profile = %q, want strict from LKG recovery", loaded.Config.Profile)
+	}
+	if loaded.Status != StatusRecoveredLKG {
+		t.Fatalf("reopened status = %s, want %s", loaded.Status, StatusRecoveredLKG)
+	}
+}
+
+func TestConcurrentActivateSerializesDiskWrites(t *testing.T) {
+	root := t.TempDir()
+	firstLKGWritten := make(chan struct{})
+	secondStarted := make(chan struct{})
+	allowFirstActive := make(chan struct{})
+	interleaved := make(chan string, 1)
+
+	var writeMu sync.Mutex
+	lkgWrites := 0
+	firstPendingActive := false
+	store := newStoreAt(t, root, withWriter(func(path string, data []byte, perm os.FileMode) error {
+		profile := "unknown"
+		if strings.Contains(string(data), `"profile": "strict"`) {
+			profile = "strict"
+		} else if strings.Contains(string(data), `"profile": "relaxed"`) {
+			profile = "relaxed"
+		}
+
+		writeMu.Lock()
+		isFirstLKG := filepath.Base(path) == "last-known-good.json" && lkgWrites == 0
+		if firstPendingActive && profile == "relaxed" {
+			select {
+			case interleaved <- filepath.Base(path) + ":" + profile:
+			default:
+			}
+		}
+		if filepath.Base(path) == "last-known-good.json" {
+			lkgWrites++
+		}
+		writeMu.Unlock()
+		if isFirstLKG {
+			if err := writeFileAtomic(path, data, perm); err != nil {
+				return err
+			}
+			writeMu.Lock()
+			firstPendingActive = true
+			writeMu.Unlock()
+			close(firstLKGWritten)
+			<-secondStarted
+			close(allowFirstActive)
+			writeMu.Lock()
+			firstPendingActive = false
+			writeMu.Unlock()
+			return nil
+		}
+		return writeFileAtomic(path, data, perm)
+	}))
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := store.ActivateProfile(context.Background(), policy.ProfileStrict)
+		firstDone <- err
+	}()
+	<-firstLKGWritten
+
+	secondDone := make(chan error, 1)
+	go func() {
+		close(secondStarted)
+		_, err := store.ActivateProfile(context.Background(), policy.ProfileRelaxed)
+		secondDone <- err
+	}()
+
+	<-allowFirstActive
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first ActivateProfile() error = %v", err)
+	}
+	if err := <-secondDone; err != nil {
+		t.Fatalf("second ActivateProfile() error = %v", err)
+	}
+	select {
+	case got := <-interleaved:
+		t.Fatalf("second activation wrote before first completed: %s", got)
+	default:
+	}
+	if got := store.Current().Config.Profile; got != policy.ProfileRelaxed {
+		t.Fatalf("Current() profile = %q, want relaxed", got)
+	}
+	if cfg := readConfigFile(t, store.activePath()); cfg.Profile != policy.ProfileRelaxed {
+		t.Fatalf("active profile = %q, want relaxed", cfg.Profile)
+	}
+	if cfg := readConfigFile(t, store.lastKnownGoodPath()); cfg.Profile != policy.ProfileRelaxed {
+		t.Fatalf("LKG profile = %q, want relaxed", cfg.Profile)
+	}
+}
+
+func TestConcurrentStoreInstancesSerializeDiskWrites(t *testing.T) {
+	root := t.TempDir()
+	lockToken := make(chan struct{}, 1)
+	lockToken <- struct{}{}
+	lockAttempts := make(chan string, 10)
+	firstLKGWritten := make(chan struct{})
+	secondLockAttempted := make(chan struct{})
+	allowFirstActive := make(chan struct{})
+	interleaved := make(chan string, 1)
+
+	locker := func(name string) func(context.Context) (func(), error) {
+		return func(context.Context) (func(), error) {
+			lockAttempts <- name
+			<-lockToken
+			return func() {
+				lockToken <- struct{}{}
+			}, nil
+		}
+	}
+
+	var writeMu sync.Mutex
+	firstPendingActive := false
+	writer := func(path string, data []byte, perm os.FileMode) error {
+		profile := "unknown"
+		if strings.Contains(string(data), `"profile": "strict"`) {
+			profile = "strict"
+		} else if strings.Contains(string(data), `"profile": "relaxed"`) {
+			profile = "relaxed"
+		}
+
+		writeMu.Lock()
+		if firstPendingActive && profile == "relaxed" {
+			select {
+			case interleaved <- filepath.Base(path) + ":" + profile:
+			default:
+			}
+		}
+		writeMu.Unlock()
+
+		isFirstLKG := filepath.Base(path) == "last-known-good.json" && profile == "strict"
+		if isFirstLKG {
+			if err := writeFileAtomic(path, data, perm); err != nil {
+				return err
+			}
+			writeMu.Lock()
+			firstPendingActive = true
+			writeMu.Unlock()
+			close(firstLKGWritten)
+			<-secondLockAttempted
+			close(allowFirstActive)
+			writeMu.Lock()
+			firstPendingActive = false
+			writeMu.Unlock()
+			return nil
+		}
+		return writeFileAtomic(path, data, perm)
+	}
+
+	firstStore := newStoreAt(t, root, withLocker(locker("first")), withWriter(writer))
+	secondStore := newStoreAt(t, root, withLocker(locker("second")), withWriter(writer))
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := firstStore.ActivateProfile(context.Background(), policy.ProfileStrict)
+		firstDone <- err
+	}()
+	<-firstLKGWritten
+
+	secondDone := make(chan error, 1)
+	go func() {
+		_, err := secondStore.ActivateProfile(context.Background(), policy.ProfileRelaxed)
+		secondDone <- err
+	}()
+
+	for {
+		if got := waitString(t, lockAttempts); got == "second" {
+			close(secondLockAttempted)
+			break
+		}
+	}
+	<-allowFirstActive
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first ActivateProfile() error = %v", err)
+	}
+	if err := <-secondDone; err != nil {
+		t.Fatalf("second ActivateProfile() error = %v", err)
+	}
+	select {
+	case got := <-interleaved:
+		t.Fatalf("second store wrote before first completed: %s", got)
+	default:
+	}
+	if got := secondStore.Current().Config.Profile; got != policy.ProfileRelaxed {
+		t.Fatalf("Current() profile = %q, want relaxed", got)
+	}
+	if cfg := readConfigFile(t, secondStore.activePath()); cfg.Profile != policy.ProfileRelaxed {
+		t.Fatalf("active profile = %q, want relaxed", cfg.Profile)
+	}
+	if cfg := readConfigFile(t, secondStore.lastKnownGoodPath()); cfg.Profile != policy.ProfileRelaxed {
+		t.Fatalf("LKG profile = %q, want relaxed", cfg.Profile)
+	}
+}
+
+func TestLoadRespectsCancellationWhileWaitingForPolicyLock(t *testing.T) {
+	store := newStoreAt(t, t.TempDir(), withLocker(func(ctx context.Context) (func(), error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}))
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	_, err := store.Load(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Load() error = %v, want %v", err, context.DeadlineExceeded)
+	}
+}
+
+func TestActivateRespectsCancellationWhileWaitingForPolicyLock(t *testing.T) {
+	store := newStoreAt(t, t.TempDir(), withLocker(func(ctx context.Context) (func(), error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}))
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	_, err := store.ActivateProfile(ctx, policy.ProfileStrict)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("ActivateProfile() error = %v, want %v", err, context.DeadlineExceeded)
+	}
+}
+
+func TestActivateProfileUpdatesDiskAndMemory(t *testing.T) {
+	store := newTestStore(t)
+	if _, err := store.Load(context.Background()); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	snapshot, err := store.ActivateProfile(context.Background(), policy.ProfileStrict)
+	if err != nil {
+		t.Fatalf("ActivateProfile() error = %v", err)
+	}
+	if snapshot.Config.Profile != policy.ProfileStrict {
+		t.Fatalf("profile = %q, want strict", snapshot.Config.Profile)
+	}
+	if store.Current().Config.Profile != policy.ProfileStrict {
+		t.Fatalf("Current() profile = %q, want strict", store.Current().Config.Profile)
+	}
+	reopened := newStoreAt(t, store.root)
+	loaded, err := reopened.Load(context.Background())
+	if err != nil {
+		t.Fatalf("reopened Load() error = %v", err)
+	}
+	if loaded.Config.Profile != policy.ProfileStrict {
+		t.Fatalf("reopened profile = %q, want strict", loaded.Config.Profile)
+	}
+	if loaded.ActivationID != snapshot.ActivationID {
+		t.Fatalf("reopened activation ID = %q, want %q", loaded.ActivationID, snapshot.ActivationID)
+	}
+}
+
+func TestActivateDoesNotKeepCallerConfigPointer(t *testing.T) {
+	store := newTestStore(t)
+	nonBypassableRules := true
+	cfg := Config{
+		Version:            policy.DefaultPolicyVersion,
+		Profile:            policy.ProfileStrict,
+		RulePack:           policy.DefaultRulePackID,
+		NonBypassableRules: &nonBypassableRules,
+	}
+
+	snapshot, err := store.Activate(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Activate() error = %v", err)
+	}
+	nonBypassableRules = false
+
+	if !*snapshot.Config.NonBypassableRules {
+		t.Fatalf("returned snapshot shares caller config pointer")
+	}
+	if !*store.Current().Config.NonBypassableRules {
+		t.Fatalf("Current() shares caller config pointer")
+	}
+}
+
+func TestCurrentDoesNotExposeStoredConfigPointer(t *testing.T) {
+	store := newTestStore(t)
+	if _, err := store.Load(context.Background()); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	snapshot := store.Current()
+	*snapshot.Config.NonBypassableRules = false
+
+	if !*store.Current().Config.NonBypassableRules {
+		t.Fatalf("Current() exposed mutable stored config pointer")
+	}
+}
+
+func TestLoadRecoversFromLastKnownGood(t *testing.T) {
+	store := newTestStore(t)
+	if _, err := store.ActivateProfile(context.Background(), policy.ProfileStrict); err != nil {
+		t.Fatalf("ActivateProfile() error = %v", err)
+	}
+	writeActive(t, store, `{"version":`)
+
+	reopened := newStoreAt(t, store.root)
+	snapshot, err := reopened.Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if snapshot.Status != StatusRecoveredLKG || snapshot.Source != SourceLastKnownGood {
+		t.Fatalf("source/status = %s/%s, want lkg/recovered", snapshot.Source, snapshot.Status)
+	}
+	if snapshot.Config.Profile != policy.ProfileStrict {
+		t.Fatalf("profile = %q, want strict", snapshot.Config.Profile)
+	}
+}
+
+func TestLoadFallsBackToDefaultWhenActiveAndLKGInvalid(t *testing.T) {
+	store := newTestStore(t)
+	writeActive(t, store, `{"version":`)
+	writeLKG(t, store, `{
+  "version": "guard-policy-v1",
+  "profile": "balanced",
+  "rulePack": "guard-default",
+  "nonBypassableRules": false
+}`)
+
+	snapshot, err := store.Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if snapshot.Status != StatusDefaultedInvalid {
+		t.Fatalf("status = %s, want %s", snapshot.Status, StatusDefaultedInvalid)
+	}
+	if snapshot.Config.Profile != policy.ProfileBalanced {
+		t.Fatalf("profile = %q, want balanced", snapshot.Config.Profile)
+	}
+}
+
+func TestValidationRejectsBadProfilesRulePacksAndBypassableRules(t *testing.T) {
+	tests := []struct {
+		name   string
+		config string
+	}{
+		{
+			name: "unknown profile",
+			config: `{
+  "version": "guard-policy-v1",
+  "profile": "aggressive",
+  "rulePack": "guard-default",
+  "nonBypassableRules": true
+}`,
+		},
+		{
+			name: "unknown rule pack",
+			config: `{
+  "version": "guard-policy-v1",
+  "profile": "balanced",
+  "rulePack": "custom",
+  "nonBypassableRules": true
+}`,
+		},
+		{
+			name: "missing nonBypassableRules",
+			config: `{
+  "version": "guard-policy-v1",
+  "profile": "balanced",
+  "rulePack": "guard-default"
+}`,
+		},
+		{
+			name: "false nonBypassableRules",
+			config: `{
+  "version": "guard-policy-v1",
+  "profile": "balanced",
+  "rulePack": "guard-default",
+  "nonBypassableRules": false
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := decodeConfig([]byte(tt.config)); !isValidationError(err) {
+				t.Fatalf("decodeConfig() error = %T %v, want ValidationError", err, err)
+			}
+		})
+	}
+}
+
+func TestDigestStableForSameConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	got := mustConfigDigest(t, cfg)
+	want := mustConfigDigest(t, cfg)
+	if got != want {
+		t.Fatalf("digest = %q, want %q", got, want)
+	}
+	cfg.Profile = policy.ProfileStrict
+	got = mustConfigDigest(t, DefaultConfig())
+	want = mustConfigDigest(t, cfg)
+	if got == want {
+		t.Fatalf("digest did not change after profile changed")
+	}
+}
+
+func TestDigestReturnsValidationError(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Profile = "invalid"
+	if _, err := configDigest(cfg); !isValidationError(err) {
+		t.Fatalf("configDigest() error = %T %v, want ValidationError", err, err)
+	}
+}
+
+func TestWrittenFilesAreUserOnly(t *testing.T) {
+	store := newTestStore(t)
+	if _, err := store.Load(context.Background()); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	assertFileMode(t, store.activePath(), fileMode)
+	assertFileMode(t, store.lastKnownGoodPath(), fileMode)
+
+	if _, err := store.ActivateProfile(context.Background(), policy.ProfileStrict); err != nil {
+		t.Fatalf("ActivateProfile() error = %v", err)
+	}
+	assertFileMode(t, store.activePath(), fileMode)
+	assertFileMode(t, store.lastKnownGoodPath(), fileMode)
+}
+
+func TestCurrentSupportsConcurrentReads(t *testing.T) {
+	store := newTestStore(t)
+	if _, err := store.Load(context.Background()); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				if got := store.Current(); got.ConfigDigest == "" {
+					t.Errorf("Current() returned empty digest")
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestSnapshotConvertsToPolicyConfigAndMetadata(t *testing.T) {
+	store := newTestStore(t)
+	snapshot, err := store.ActivateProfile(context.Background(), policy.ProfileRelaxed)
+	if err != nil {
+		t.Fatalf("ActivateProfile() error = %v", err)
+	}
+
+	engineConfig := snapshot.ToPolicyConfig()
+	if engineConfig.Profile != policy.ProfileRelaxed || engineConfig.RulePack != policy.DefaultRulePackID {
+		t.Fatalf("ToPolicyConfig() = %#v", engineConfig)
+	}
+	metadata := snapshot.DecisionMetadata()
+	if metadata.PolicyVersion != policy.DefaultPolicyVersion || metadata.RulePackVersion != "v1" {
+		t.Fatalf("DecisionMetadata() = %#v", metadata)
+	}
+	if metadata.ConfigSource != string(SourceActiveFile) || metadata.ConfigStatus != string(StatusOK) {
+		t.Fatalf("DecisionMetadata() source/status = %s/%s", metadata.ConfigSource, metadata.ConfigStatus)
+	}
+	if !metadata.NonBypassableRules {
+		t.Fatalf("DecisionMetadata() NonBypassableRules = false, want true")
+	}
+}
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	return newStoreAt(t, t.TempDir())
+}
+
+func newStoreAt(t *testing.T, root string, opts ...Option) *Store {
+	t.Helper()
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	opts = append([]Option{WithClock(func() time.Time { return now })}, opts...)
+	store, err := Open(root, opts...)
+	if err != nil {
+		t.Fatalf("Open(%s) error = %v", root, err)
+	}
+	return store
+}
+
+func writeActive(t *testing.T, store *Store, data string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(store.activePath()), dirMode); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(store.activePath(), []byte(data), fileMode); err != nil {
+		t.Fatalf("WriteFile(active) error = %v", err)
+	}
+}
+
+func writeLKG(t *testing.T, store *Store, data string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(store.lastKnownGoodPath()), dirMode); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(store.lastKnownGoodPath(), []byte(data), fileMode); err != nil {
+		t.Fatalf("WriteFile(lkg) error = %v", err)
+	}
+}
+
+func readActive(t *testing.T, store *Store) string {
+	t.Helper()
+	data, err := os.ReadFile(store.activePath())
+	if err != nil {
+		t.Fatalf("ReadFile(active) error = %v", err)
+	}
+	return string(data)
+}
+
+func readConfigFile(t *testing.T, path string) Config {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", path, err)
+	}
+	cfg, err := decodeConfig(data)
+	if err != nil {
+		t.Fatalf("decodeConfig(%s) error = %v", path, err)
+	}
+	return cfg
+}
+
+func mustConfigDigest(t *testing.T, cfg Config) string {
+	t.Helper()
+	digest, err := configDigest(cfg)
+	if err != nil {
+		t.Fatalf("configDigest() error = %v", err)
+	}
+	return digest
+}
+
+func waitString(t *testing.T, ch <-chan string) string {
+	t.Helper()
+	select {
+	case value := <-ch:
+		return value
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for channel value")
+		return ""
+	}
+}
+
+func seedCurrent(store *Store, snapshot Snapshot) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	store.current = cloneSnapshot(snapshot)
+}
+
+func assertFileExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("Stat(%s) error = %v", path, err)
+	}
+}
+
+func assertFileMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(%s) error = %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("mode(%s) = %o, want %o", path, got, want)
+	}
+}


### PR DESCRIPTION
## Summary

This adds the local deterministic policy config store for ENG-339 in the Local Guard LLM Judge launch.

ENG-338 created the deterministic policy engine in `internal/guard/policy`, but there was still no durable local source of truth for which profile should be active on a machine.

Now the active policy config is isolated in `internal/guard/policyconfig`:

```go
snapshot := store.Current()
config := snapshot.ToPolicyConfig()
```

It loads a small JSON config for the active profile and rule pack, validates it strictly, materializes the safe `balanced` default when missing, and recovers from invalid active config through last-known-good.

## Why

This gives ENG-325 and ENG-340 a clean shared seam:

```text
policy config store
-> active profile snapshot
-> deterministic policy engine config
-> runtime decision path / dashboard strictness control
```

This PR does not wire the running Guard decision path or build dashboard UI. ENG-325 owns runtime orchestration, and ENG-340 owns the dashboard selector.

## What changed

- Added `internal/guard/policyconfig`
- Added strict JSON loading for `guard/policy/active.json`
- Added first-run default materialization to `balanced`
- Added last-known-good recovery with `guard/policy/last-known-good.json`
- Added atomic config activation and `ActivateProfile`
- Added immutable in-memory snapshots through `Current()`
- Added conversion from active snapshot to `policy.Config`
- Added decision metadata for ENG-328 diagnostics
- Added tests for validation, recovery, activation, digest stability, and concurrent reads

## Verification

- `go test ./internal/guard/policyconfig ./internal/guard/policy`
- `go test ./...`
