### PR TITLE
feat: manage local judge runtime

### DIFF
--- a/docs/guard.md
+++ b/docs/guard.md
@@ -71,6 +71,33 @@ kontext guard start \
   --judge-model qwen3-0.6b-q4
 ```
 
+Guard can also manage `llama-server` itself. This downloads the selected GGUF into the Kontext model cache when it is missing, starts `llama-server` on loopback, waits for `/v1/models`, and shuts the child process down with Guard:
+
+```bash
+kontext guard start --judge-managed
+```
+
+Use `--judge-port` or a loopback `--judge-url` such as `http://127.0.0.1:18081` to choose a different managed `llama-server` port.
+
+The managed default is `Qwen/Qwen3-0.6B-GGUF` with `Qwen3-0.6B-Q8_0.gguf`. Override it with either a local model path:
+
+```bash
+kontext guard start \
+  --judge-managed \
+  --judge-model-path ~/.config/kontext/judge-models/qwen.gguf
+```
+
+Or a specific Hugging Face GGUF:
+
+```bash
+kontext guard start \
+  --judge-managed \
+  --judge-hf-repo Qwen/Qwen3-0.6B-GGUF \
+  --judge-hf-file Qwen3-0.6B-Q8_0.gguf
+```
+
+Use `--judge-hf-revision` when the GGUF is on a Hugging Face branch, tag, commit, or ref other than `main`.
+
 The judge receives a small redacted JSON input with tool metadata, normalized risk fields, deterministic policy context, and no full conversation history. It must return structured JSON with `decision` set to `allow` or `deny`. `ask` is not part of the judge contract.
 
 Judge failures are fail-open for launch. If the local runtime is unavailable, times out, or returns invalid JSON, Guard records `judge_unavailable_allow` plus high-level metadata and allows the tool call. Judge URLs must point at localhost.

--- a/internal/guard/cli/cli.go
+++ b/internal/guard/cli/cli.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -42,7 +43,7 @@ func Run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 	}
 	switch args[0] {
 	case "start", "daemon":
-		return runDaemon(args[1:], stdout)
+		return runDaemon(ctx, args[1:], stdout)
 	case "stop":
 		fmt.Fprintln(stdout, "Stop the foreground `kontext guard start` process with Ctrl-C.")
 		return nil
@@ -87,7 +88,7 @@ func usage(out io.Writer) {
 	fmt.Fprintln(out, "  judge eval                    Evaluate local judge fixtures")
 }
 
-func runDaemon(args []string, out io.Writer) error {
+func runDaemon(ctx context.Context, args []string, out io.Writer) error {
 	defaultThreshold, err := envFloat("KONTEXT_THRESHOLD", 0.5)
 	if err != nil {
 		return err
@@ -97,6 +98,18 @@ func runDaemon(args []string, out io.Writer) error {
 		return err
 	}
 	defaultJudgeTimeout, err := envDuration("KONTEXT_JUDGE_TIMEOUT", judge.DefaultTimeout)
+	if err != nil {
+		return err
+	}
+	defaultJudgeManaged, err := envBool("KONTEXT_JUDGE_MANAGED", false)
+	if err != nil {
+		return err
+	}
+	defaultJudgePort, err := envInt("KONTEXT_JUDGE_PORT", judge.DefaultLlamaServerPort)
+	if err != nil {
+		return err
+	}
+	defaultJudgeStartupTimeout, err := envDuration("KONTEXT_JUDGE_STARTUP_TIMEOUT", judge.DefaultLlamaServerStartupTimeout)
 	if err != nil {
 		return err
 	}
@@ -111,8 +124,17 @@ func runDaemon(args []string, out io.Writer) error {
 	noOpen := fs.Bool("no-open", false, "do not open the local dashboard")
 	socketPath := fs.String("socket", defaultGuardSocketPath(), "Unix socket path for local hook runtime")
 	judgeURL := fs.String("judge-url", envString("KONTEXT_JUDGE_URL", ""), "OpenAI-compatible local judge base URL, for example http://127.0.0.1:8080")
-	judgeModel := fs.String("judge-model", envString("KONTEXT_JUDGE_MODEL", ""), "local judge model name")
+	judgeModel := fs.String("judge-model", envString("KONTEXT_JUDGE_MODEL", ""), "local judge model name; with --judge-managed this may be a local GGUF path")
 	judgeTimeout := fs.Duration("judge-timeout", defaultJudgeTimeout, "local judge timeout")
+	judgeManaged := fs.Bool("judge-managed", defaultJudgeManaged, "start and health-check a managed llama-server child process")
+	judgeServerBin := fs.String("judge-server-bin", envString("KONTEXT_JUDGE_SERVER_BIN", judge.DefaultLlamaServerBinary), "llama-server binary path")
+	judgeModelPath := fs.String("judge-model-path", envString("KONTEXT_JUDGE_MODEL_PATH", ""), "local GGUF model path for managed llama-server")
+	judgeHFRepo := fs.String("judge-hf-repo", envString("KONTEXT_JUDGE_HF_REPO", ""), "Hugging Face GGUF repo to cache for managed llama-server")
+	judgeHFFile := fs.String("judge-hf-file", envString("KONTEXT_JUDGE_HF_FILE", ""), "Hugging Face GGUF filename to cache for managed llama-server")
+	judgeHFRevision := fs.String("judge-hf-revision", envString("KONTEXT_JUDGE_HF_REVISION", ""), "Hugging Face revision, branch, or tag to cache for managed llama-server")
+	judgeCacheDir := fs.String("judge-cache-dir", envString("KONTEXT_JUDGE_CACHE_DIR", ""), "directory for cached GGUF judge models")
+	judgePort := fs.Int("judge-port", defaultJudgePort, "managed llama-server port")
+	judgeStartupTimeout := fs.Duration("judge-startup-timeout", defaultJudgeStartupTimeout, "managed llama-server startup timeout")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -138,23 +160,24 @@ func runDaemon(args []string, out io.Writer) error {
 		}
 		scorer = loaded
 	}
-	var localJudge judge.Judge
-	if strings.TrimSpace(*judgeURL) != "" || strings.TrimSpace(*judgeModel) != "" {
-		if strings.TrimSpace(*judgeURL) == "" || strings.TrimSpace(*judgeModel) == "" {
-			return fmt.Errorf("--judge-url and --judge-model must be set together")
-		}
-		if err := validateLocalJudgeURL(*judgeURL); err != nil {
-			return err
-		}
-		localJudge, err = judge.NewOpenAICompatibleJudge(judge.HTTPOptions{
-			BaseURL: *judgeURL,
-			Model:   *judgeModel,
-			Timeout: *judgeTimeout,
-		})
-		if err != nil {
-			return err
-		}
+	localJudge, closeJudge, judgeStatus, err := configureLocalJudge(ctx, localJudgeConfig{
+		URL:            *judgeURL,
+		Model:          *judgeModel,
+		Timeout:        *judgeTimeout,
+		Managed:        *judgeManaged,
+		ServerBin:      *judgeServerBin,
+		ModelPath:      *judgeModelPath,
+		HFRepo:         *judgeHFRepo,
+		HFFile:         *judgeHFFile,
+		HFRevision:     *judgeHFRevision,
+		CacheDir:       resolvedJudgeCacheDir(*judgeCacheDir, *dbPath),
+		Port:           *judgePort,
+		StartupTimeout: *judgeStartupTimeout,
+	})
+	if err != nil {
+		return err
 	}
+	defer closeJudge()
 	localServer, closeStore, err := server.OpenDefaultServerWithOptions(*dbPath, server.Options{
 		Scorer: scorer,
 		Judge:  localJudge,
@@ -188,7 +211,7 @@ func runDaemon(args []string, out io.Writer) error {
 	fmt.Fprintf(out, "Dashboard: http://%s\n", *addr)
 	fmt.Fprintf(out, "Risk model: %s\n", activeModelPath)
 	if localJudge != nil {
-		fmt.Fprintf(out, "Local judge: %s at %s\n", *judgeModel, *judgeURL)
+		fmt.Fprintf(out, "Local judge: %s\n", judgeStatus)
 	} else {
 		fmt.Fprintln(out, "Local judge: disabled")
 	}
@@ -196,6 +219,169 @@ func runDaemon(args []string, out io.Writer) error {
 		_ = browser.OpenURL("http://" + *addr)
 	}
 	return localServer.ListenAndServe(*addr)
+}
+
+type localJudgeConfig struct {
+	URL            string
+	Model          string
+	Timeout        time.Duration
+	Managed        bool
+	ServerBin      string
+	ModelPath      string
+	HFRepo         string
+	HFFile         string
+	HFRevision     string
+	CacheDir       string
+	Port           int
+	StartupTimeout time.Duration
+}
+
+func configureLocalJudge(ctx context.Context, cfg localJudgeConfig) (judge.Judge, func(), string, error) {
+	closeFn := func() {}
+	if cfg.Managed {
+		return configureManagedJudge(ctx, cfg)
+	}
+	if strings.TrimSpace(cfg.URL) == "" && strings.TrimSpace(cfg.Model) == "" {
+		return nil, closeFn, "", nil
+	}
+	if strings.TrimSpace(cfg.URL) == "" || strings.TrimSpace(cfg.Model) == "" {
+		return nil, closeFn, "", fmt.Errorf("--judge-url and --judge-model must be set together")
+	}
+	if err := validateLocalJudgeURL(cfg.URL); err != nil {
+		return nil, closeFn, "", err
+	}
+	localJudge, err := judge.NewOpenAICompatibleJudge(judge.HTTPOptions{
+		BaseURL: cfg.URL,
+		Model:   cfg.Model,
+		Timeout: cfg.Timeout,
+	})
+	if err != nil {
+		return nil, closeFn, "", err
+	}
+	return localJudge, closeFn, fmt.Sprintf("%s at %s", cfg.Model, cfg.URL), nil
+}
+
+func configureManagedJudge(ctx context.Context, cfg localJudgeConfig) (judge.Judge, func(), string, error) {
+	closeFn := func() {}
+	modelPath := strings.TrimSpace(cfg.ModelPath)
+	modelName := strings.TrimSpace(cfg.Model)
+	if modelPath == "" && looksLikeGGUFPath(modelName) {
+		modelPath = modelName
+		modelName = ""
+	}
+	hfRepo := strings.TrimSpace(cfg.HFRepo)
+	hfFile := strings.TrimSpace(cfg.HFFile)
+	if modelPath == "" && hfRepo == "" {
+		hfRepo = judge.DefaultLlamaServerHFRepo
+		if hfFile == "" {
+			hfFile = judge.DefaultLlamaServerHFFile
+		}
+	}
+	if modelName == "" {
+		modelName = managedJudgeModelName(modelPath, hfRepo, hfFile)
+	}
+	host, port, baseURL, err := managedJudgeListenConfig(cfg.URL, cfg.Port)
+	if err != nil {
+		return nil, closeFn, "", err
+	}
+	server, err := judge.StartLlamaServer(ctx, judge.LlamaServerOptions{
+		BinaryPath:     cfg.ServerBin,
+		ModelPath:      modelPath,
+		HFRepo:         hfRepo,
+		HFFile:         hfFile,
+		HFRevision:     cfg.HFRevision,
+		CacheDir:       cfg.CacheDir,
+		Host:           host,
+		Port:           port,
+		StartupTimeout: cfg.StartupTimeout,
+	})
+	if err != nil {
+		unavailable := judge.UnavailableJudge{
+			Runtime: judge.DefaultLlamaServerRuntime,
+			Model:   modelName,
+			Kind:    judge.FailureUnavailable,
+			Err:     err,
+		}
+		return unavailable, closeFn, fmt.Sprintf("%s unavailable (%v)", modelName, err), nil
+	}
+	closeFn = func() {
+		_ = server.Stop()
+	}
+	localJudge, err := judge.NewOpenAICompatibleJudge(judge.HTTPOptions{
+		BaseURL: baseURL,
+		Model:   modelName,
+		Runtime: judge.DefaultLlamaServerRuntime,
+		Timeout: cfg.Timeout,
+	})
+	if err != nil {
+		closeFn()
+		return nil, func() {}, "", err
+	}
+	return localJudge, closeFn, fmt.Sprintf("%s at %s (%s)", modelName, baseURL, judge.DefaultLlamaServerRuntime), nil
+}
+
+func managedJudgeListenConfig(rawURL string, port int) (string, int, string, error) {
+	if port <= 0 {
+		port = judge.DefaultLlamaServerPort
+	}
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return judge.DefaultLlamaServerHost, port, managedJudgeBaseURL(judge.DefaultLlamaServerHost, port), nil
+	}
+	if err := validateLocalJudgeURL(rawURL); err != nil {
+		return "", 0, "", err
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", 0, "", fmt.Errorf("parse judge URL: %w", err)
+	}
+	if parsed.Scheme != "http" {
+		return "", 0, "", fmt.Errorf("managed judge URL must use http")
+	}
+	host := parsed.Hostname()
+	if host == "" {
+		return "", 0, "", fmt.Errorf("managed judge URL must include host")
+	}
+	if parsed.Port() != "" {
+		parsedPort, err := strconv.Atoi(parsed.Port())
+		if err != nil || parsedPort <= 0 {
+			return "", 0, "", fmt.Errorf("managed judge URL has invalid port %q", parsed.Port())
+		}
+		port = parsedPort
+	}
+	return host, port, managedJudgeBaseURL(host, port), nil
+}
+
+func managedJudgeBaseURL(host string, port int) string {
+	return (&url.URL{
+		Scheme: "http",
+		Host:   net.JoinHostPort(host, strconv.Itoa(port)),
+	}).String()
+}
+
+func looksLikeGGUFPath(value string) bool {
+	value = strings.TrimSpace(value)
+	return strings.HasSuffix(strings.ToLower(value), ".gguf") || strings.Contains(value, string(filepath.Separator))
+}
+
+func managedJudgeModelName(modelPath, hfRepo, hfFile string) string {
+	if strings.TrimSpace(hfRepo) != "" {
+		return strings.TrimSpace(hfRepo)
+	}
+	if strings.TrimSpace(modelPath) != "" {
+		return filepath.Base(modelPath)
+	}
+	if strings.TrimSpace(hfFile) != "" {
+		return strings.TrimSpace(hfFile)
+	}
+	return "local-judge"
+}
+
+func resolvedJudgeCacheDir(cacheDir, dbPath string) string {
+	if strings.TrimSpace(cacheDir) != "" {
+		return cacheDir
+	}
+	return defaultJudgeCacheDir(dbPath)
 }
 
 func verifyClaudeCode() error {
@@ -772,6 +958,17 @@ func envInt(key string, fallback int) (int, error) {
 	return fallback, nil
 }
 
+func envBool(key string, fallback bool) (bool, error) {
+	if value := os.Getenv(key); value != "" {
+		parsed, err := strconv.ParseBool(value)
+		if err != nil {
+			return false, fmt.Errorf("%s must be a boolean: %w", key, err)
+		}
+		return parsed, nil
+	}
+	return fallback, nil
+}
+
 func envFloat(key string, fallback float64) (float64, error) {
 	if value := os.Getenv(key); value != "" {
 		parsed, err := strconv.ParseFloat(value, 64)
@@ -825,6 +1022,16 @@ func defaultModelSnapshotDir(dbPath string) string {
 		return filepath.Join(filepath.Dir(dbPath), "models")
 	}
 	return filepath.Join(".", "models")
+}
+
+func defaultJudgeCacheDir(dbPath string) string {
+	if dbPath != "" {
+		return filepath.Join(filepath.Dir(dbPath), "judge-models")
+	}
+	if dir, err := os.UserCacheDir(); err == nil && dir != "" {
+		return filepath.Join(dir, "kontext", "judge")
+	}
+	return filepath.Join(".", "judge-models")
 }
 
 func selfPath() string {

--- a/internal/guard/cli/cli_test.go
+++ b/internal/guard/cli/cli_test.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/guard/judge"
 )
 
 func TestGuardHookCompatibilityCommandIsRetired(t *testing.T) {
@@ -214,5 +216,93 @@ func TestJudgeEvalChecksExpectedRiskCategoriesAndReason(t *testing.T) {
 		if !strings.Contains(output, want) {
 			t.Fatalf("stdout = %s, want %q", output, want)
 		}
+	}
+}
+
+func TestConfigureManagedJudgeFailsOpenWhenModelMissing(t *testing.T) {
+	localJudge, closeJudge, status, err := configureLocalJudge(context.Background(), localJudgeConfig{
+		Managed:   true,
+		ModelPath: filepath.Join(t.TempDir(), "missing.gguf"),
+		Model:     "qwen",
+		Port:      18082,
+	})
+	defer closeJudge()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if localJudge == nil {
+		t.Fatal("localJudge = nil, want unavailable judge")
+	}
+	if !strings.Contains(status, "unavailable") {
+		t.Fatalf("status = %q, want unavailable", status)
+	}
+	_, err = localJudge.Decide(context.Background(), judge.Input{HookEvent: "PreToolUse"})
+	if judge.FailureKind(err) != judge.FailureUnavailable {
+		t.Fatalf("FailureKind(err) = %q, want unavailable", judge.FailureKind(err))
+	}
+}
+
+func TestConfigureManagedJudgeUsesJudgeModelAsGGUFPath(t *testing.T) {
+	modelPath := filepath.Join(t.TempDir(), "qwen.gguf")
+	localJudge, closeJudge, status, err := configureLocalJudge(context.Background(), localJudgeConfig{
+		Managed: true,
+		Model:   modelPath,
+		Port:    18083,
+	})
+	defer closeJudge()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if localJudge == nil {
+		t.Fatal("localJudge = nil, want unavailable judge")
+	}
+	if !strings.Contains(status, "qwen.gguf") {
+		t.Fatalf("status = %q, want model basename", status)
+	}
+}
+
+func TestResolvedJudgeCacheDirUsesParsedDBPath(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "custom", "guard.db")
+	got := resolvedJudgeCacheDir("", dbPath)
+	want := filepath.Join(filepath.Dir(dbPath), "judge-models")
+	if got != want {
+		t.Fatalf("cache dir = %q, want %q", got, want)
+	}
+}
+
+func TestResolvedJudgeCacheDirPrefersExplicitValue(t *testing.T) {
+	got := resolvedJudgeCacheDir("/explicit/cache", filepath.Join(t.TempDir(), "guard.db"))
+	if got != "/explicit/cache" {
+		t.Fatalf("cache dir = %q, want explicit cache", got)
+	}
+}
+
+func TestManagedJudgeListenConfigDefaultsToJudgePort(t *testing.T) {
+	host, port, baseURL, err := managedJudgeListenConfig("", 18081)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if host != judge.DefaultLlamaServerHost || port != 18081 || baseURL != "http://127.0.0.1:18081" {
+		t.Fatalf("host=%q port=%d baseURL=%q", host, port, baseURL)
+	}
+}
+
+func TestManagedJudgeListenConfigAppliesJudgeURLPort(t *testing.T) {
+	host, port, baseURL, err := managedJudgeListenConfig("http://localhost:18082/v1", 18081)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if host != "localhost" || port != 18082 || baseURL != "http://localhost:18082" {
+		t.Fatalf("host=%q port=%d baseURL=%q", host, port, baseURL)
+	}
+}
+
+func TestManagedJudgeListenConfigRejectsHTTPS(t *testing.T) {
+	_, _, _, err := managedJudgeListenConfig("https://127.0.0.1:18082", 18081)
+	if err == nil {
+		t.Fatal("managedJudgeListenConfig() error = nil, want HTTPS rejection")
+	}
+	if !strings.Contains(err.Error(), "managed judge URL must use http") {
+		t.Fatalf("err = %v, want managed http error", err)
 	}
 }

--- a/internal/guard/judge/http.go
+++ b/internal/guard/judge/http.go
@@ -25,6 +25,7 @@ var defaultPrompt string
 type HTTPOptions struct {
 	BaseURL         string
 	Model           string
+	Runtime         string
 	Timeout         time.Duration
 	HTTPClient      *http.Client
 	Prompt          string
@@ -34,6 +35,7 @@ type HTTPOptions struct {
 type OpenAICompatibleJudge struct {
 	endpoint        string
 	model           string
+	runtime         string
 	timeout         time.Duration
 	httpClient      *http.Client
 	prompt          string
@@ -53,6 +55,10 @@ func NewOpenAICompatibleJudge(opts HTTPOptions) (*OpenAICompatibleJudge, error) 
 	if model == "" {
 		return nil, errors.New("judge model is required")
 	}
+	runtime := strings.TrimSpace(opts.Runtime)
+	if runtime == "" {
+		runtime = DefaultRuntime
+	}
 	timeout := opts.Timeout
 	if timeout <= 0 {
 		timeout = DefaultTimeout
@@ -68,6 +74,7 @@ func NewOpenAICompatibleJudge(opts HTTPOptions) (*OpenAICompatibleJudge, error) 
 	return &OpenAICompatibleJudge{
 		endpoint:        endpoint,
 		model:           model,
+		runtime:         runtime,
 		timeout:         timeout,
 		httpClient:      client,
 		prompt:          prompt,
@@ -129,7 +136,7 @@ func (j *OpenAICompatibleJudge) Metadata() Metadata {
 
 func (j *OpenAICompatibleJudge) metadata(durationMs int64) Metadata {
 	return Metadata{
-		Runtime:    DefaultRuntime,
+		Runtime:    j.runtime,
 		Model:      j.model,
 		DurationMs: durationMs,
 	}

--- a/internal/guard/judge/http_test.go
+++ b/internal/guard/judge/http_test.go
@@ -44,6 +44,7 @@ func TestOpenAICompatibleJudgeCallsChatCompletions(t *testing.T) {
 	judge, err := NewOpenAICompatibleJudge(HTTPOptions{
 		BaseURL: server.URL,
 		Model:   "qwen3-0.6b-q4",
+		Runtime: "llama-server",
 		Timeout: time.Second,
 	})
 	if err != nil {
@@ -65,7 +66,7 @@ func TestOpenAICompatibleJudgeCallsChatCompletions(t *testing.T) {
 	if request.MaxTokens != 256 {
 		t.Fatalf("max tokens = %d, want 256", request.MaxTokens)
 	}
-	if result.Output.Decision != DecisionAllow || result.Metadata.Model != "qwen3-0.6b-q4" {
+	if result.Output.Decision != DecisionAllow || result.Metadata.Model != "qwen3-0.6b-q4" || result.Metadata.Runtime != "llama-server" {
 		t.Fatalf("result = %+v", result)
 	}
 }

--- a/internal/guard/judge/llama_server.go
+++ b/internal/guard/judge/llama_server.go
@@ -1,0 +1,344 @@
+package judge
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultLlamaServerRuntime         = "llama-server"
+	DefaultLlamaServerBinary          = "llama-server"
+	DefaultLlamaServerHost            = "127.0.0.1"
+	DefaultLlamaServerPort            = 18080
+	DefaultLlamaServerStartupTimeout  = 30 * time.Second
+	DefaultLlamaServerHFRepo          = "Qwen/Qwen3-0.6B-GGUF"
+	DefaultLlamaServerHFFile          = "Qwen3-0.6B-Q8_0.gguf"
+	DefaultLlamaServerHFRevision      = "main"
+	DefaultLlamaServerDownloadTimeout = 10 * time.Minute
+)
+
+type LlamaServerOptions struct {
+	BinaryPath     string
+	ModelPath      string
+	HFRepo         string
+	HFFile         string
+	HFRevision     string
+	CacheDir       string
+	Host           string
+	Port           int
+	StartupTimeout time.Duration
+	HTTPClient     *http.Client
+	Stdout         io.Writer
+	Stderr         io.Writer
+}
+
+type LlamaServer struct {
+	baseURL string
+	cancel  context.CancelFunc
+	wait    chan error
+	cmd     *exec.Cmd
+}
+
+func StartLlamaServer(ctx context.Context, opts LlamaServerOptions) (*LlamaServer, error) {
+	opts = normalizeLlamaServerOptions(opts)
+	binaryPath, err := exec.LookPath(opts.BinaryPath)
+	if err != nil {
+		return nil, fmt.Errorf("find %s: %w", opts.BinaryPath, err)
+	}
+	if err := ensureLlamaServerPortAvailable(opts.Host, opts.Port); err != nil {
+		return nil, err
+	}
+	modelPath, err := ResolveLlamaServerModel(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := os.Stat(modelPath); err != nil {
+		return nil, fmt.Errorf("stat judge model %q: %w", modelPath, err)
+	}
+
+	childCtx, cancel := context.WithCancel(ctx)
+	args := BuildLlamaServerArgs(LlamaServerOptions{
+		ModelPath: modelPath,
+		Host:      opts.Host,
+		Port:      opts.Port,
+	})
+	cmd := exec.CommandContext(childCtx, binaryPath, args...)
+	cmd.Stdout = opts.Stdout
+	cmd.Stderr = opts.Stderr
+	if cmd.Stdout == nil {
+		cmd.Stdout = io.Discard
+	}
+	if cmd.Stderr == nil {
+		cmd.Stderr = io.Discard
+	}
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, fmt.Errorf("start %s: %w", opts.BinaryPath, err)
+	}
+
+	server := &LlamaServer{
+		baseURL: llamaServerBaseURL(opts.Host, opts.Port),
+		cancel:  cancel,
+		wait:    make(chan error, 1),
+		cmd:     cmd,
+	}
+	go func() {
+		server.wait <- cmd.Wait()
+	}()
+	if err := server.waitHealthy(ctx, opts); err != nil {
+		_ = server.Stop()
+		return nil, err
+	}
+	return server, nil
+}
+
+func ensureLlamaServerPortAvailable(host string, port int) error {
+	listener, err := net.Listen("tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	if err != nil {
+		return fmt.Errorf("llama-server port %s:%d is unavailable: %w", host, port, err)
+	}
+	return listener.Close()
+}
+
+func llamaServerBaseURL(host string, port int) string {
+	return (&url.URL{
+		Scheme: "http",
+		Host:   net.JoinHostPort(host, strconv.Itoa(port)),
+	}).String()
+}
+
+func ResolveLlamaServerModel(ctx context.Context, opts LlamaServerOptions) (string, error) {
+	opts = normalizeLlamaServerOptions(opts)
+	modelPath := strings.TrimSpace(opts.ModelPath)
+	if modelPath != "" {
+		return modelPath, nil
+	}
+	repo := strings.TrimSpace(opts.HFRepo)
+	file := strings.TrimSpace(opts.HFFile)
+	revision := strings.TrimSpace(opts.HFRevision)
+	if repo == "" || file == "" {
+		return "", errors.New("judge model path or Hugging Face repo/file is required")
+	}
+	cachedPath, err := CachedHFModelPath(opts.CacheDir, repo, revision, file)
+	if err != nil {
+		return "", err
+	}
+	if _, err := os.Stat(cachedPath); err == nil {
+		return cachedPath, nil
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
+	if err := downloadHFModel(ctx, opts.HTTPClient, repo, revision, file, cachedPath); err != nil {
+		return "", err
+	}
+	return cachedPath, nil
+}
+
+func BuildLlamaServerArgs(opts LlamaServerOptions) []string {
+	opts = normalizeLlamaServerOptions(opts)
+	return []string{
+		"--model", strings.TrimSpace(opts.ModelPath),
+		"--host", opts.Host,
+		"--port", strconv.Itoa(opts.Port),
+	}
+}
+
+func CachedHFModelPath(cacheDir, repo, revision, file string) (string, error) {
+	cacheDir = strings.TrimSpace(cacheDir)
+	if cacheDir == "" {
+		cacheDir = defaultJudgeCacheDir()
+	}
+	repo = strings.TrimSpace(repo)
+	revision = strings.TrimSpace(revision)
+	if revision == "" {
+		revision = DefaultLlamaServerHFRevision
+	}
+	file = strings.TrimSpace(file)
+	if repo == "" || file == "" {
+		return "", errors.New("Hugging Face repo and file are required")
+	}
+	if strings.Contains(repo, "..") {
+		return "", fmt.Errorf("invalid Hugging Face repo %q", repo)
+	}
+	if strings.Contains(revision, "..") {
+		return "", fmt.Errorf("invalid Hugging Face revision %q", revision)
+	}
+	cleanRevision := filepath.Clean(revision)
+	if filepath.IsAbs(cleanRevision) || cleanRevision == "." || strings.HasPrefix(cleanRevision, ".."+string(filepath.Separator)) || cleanRevision == ".." {
+		return "", fmt.Errorf("invalid Hugging Face revision %q", revision)
+	}
+	cleanFile := filepath.Clean(file)
+	if filepath.IsAbs(cleanFile) || cleanFile == "." || strings.HasPrefix(cleanFile, ".."+string(filepath.Separator)) || cleanFile == ".." {
+		return "", fmt.Errorf("invalid Hugging Face file %q", file)
+	}
+	repoParts := strings.Split(repo, "/")
+	parts := append([]string{cacheDir, "huggingface"}, repoParts...)
+	parts = append(parts, cleanRevision)
+	parts = append(parts, cleanFile)
+	return filepath.Join(parts...), nil
+}
+
+func (s *LlamaServer) BaseURL() string {
+	if s == nil {
+		return ""
+	}
+	return s.baseURL
+}
+
+func (s *LlamaServer) Stop() error {
+	if s == nil {
+		return nil
+	}
+	s.cancel()
+	select {
+	case err := <-s.wait:
+		if err == nil {
+			return nil
+		}
+		if errors.Is(err, context.Canceled) {
+			return nil
+		}
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return nil
+		}
+		return err
+	case <-time.After(3 * time.Second):
+		if s.cmd != nil && s.cmd.Process != nil {
+			_ = s.cmd.Process.Kill()
+		}
+		return errors.New("timed out stopping llama-server")
+	}
+}
+
+func (s *LlamaServer) waitHealthy(ctx context.Context, opts LlamaServerOptions) error {
+	timeout := opts.StartupTimeout
+	if timeout <= 0 {
+		timeout = DefaultLlamaServerStartupTimeout
+	}
+	client := opts.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 500 * time.Millisecond}
+	}
+	healthCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case err := <-s.wait:
+			s.wait <- err
+			if err == nil {
+				return errors.New("llama-server exited before becoming healthy")
+			}
+			return fmt.Errorf("llama-server exited before becoming healthy: %w", err)
+		default:
+		}
+		req, err := http.NewRequestWithContext(healthCtx, http.MethodGet, s.baseURL+"/v1/models", nil)
+		if err == nil {
+			resp, err := client.Do(req)
+			if err == nil {
+				_ = resp.Body.Close()
+				if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+					return nil
+				}
+			}
+		}
+		select {
+		case <-healthCtx.Done():
+			return fmt.Errorf("llama-server health check timed out after %s", timeout)
+		case <-ticker.C:
+		}
+	}
+}
+
+func normalizeLlamaServerOptions(opts LlamaServerOptions) LlamaServerOptions {
+	if strings.TrimSpace(opts.BinaryPath) == "" {
+		opts.BinaryPath = DefaultLlamaServerBinary
+	}
+	if strings.TrimSpace(opts.Host) == "" {
+		opts.Host = DefaultLlamaServerHost
+	}
+	if opts.Port <= 0 {
+		opts.Port = DefaultLlamaServerPort
+	}
+	if strings.TrimSpace(opts.HFRevision) == "" {
+		opts.HFRevision = DefaultLlamaServerHFRevision
+	}
+	if opts.StartupTimeout <= 0 {
+		opts.StartupTimeout = DefaultLlamaServerStartupTimeout
+	}
+	return opts
+}
+
+func downloadHFModel(ctx context.Context, client *http.Client, repo, revision, file, targetPath string) error {
+	if client == nil {
+		client = &http.Client{Timeout: DefaultLlamaServerDownloadTimeout}
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, hfResolveURL(repo, revision, file), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", "kontext-guard")
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("download judge model: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("download judge model returned %s", resp.Status)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(targetPath), filepath.Base(targetPath)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := io.Copy(tmp, resp.Body); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, targetPath)
+}
+
+func hfResolveURL(repo, revision, file string) string {
+	if strings.TrimSpace(revision) == "" {
+		revision = DefaultLlamaServerHFRevision
+	}
+	return "https://huggingface.co/" + escapePath(repo) + "/resolve/" + escapePath(revision) + "/" + escapePath(file)
+}
+
+func escapePath(value string) string {
+	parts := strings.Split(value, "/")
+	for i, part := range parts {
+		parts[i] = url.PathEscape(part)
+	}
+	return strings.Join(parts, "/")
+}
+
+func defaultJudgeCacheDir() string {
+	if dir, err := os.UserCacheDir(); err == nil && dir != "" {
+		return filepath.Join(dir, "kontext", "judge")
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".kontext", "judge")
+	}
+	return filepath.Join(".", ".kontext", "judge")
+}

--- a/internal/guard/judge/llama_server_test.go
+++ b/internal/guard/judge/llama_server_test.go
@@ -1,0 +1,336 @@
+package judge
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildLlamaServerArgsUsesLocalModel(t *testing.T) {
+	got := BuildLlamaServerArgs(LlamaServerOptions{
+		ModelPath: "/models/qwen.gguf",
+		Host:      "127.0.0.1",
+		Port:      18081,
+	})
+	want := []string{"--model", "/models/qwen.gguf", "--host", "127.0.0.1", "--port", "18081"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args = %#v, want %#v", got, want)
+	}
+}
+
+func TestStartLlamaServerMissingBinary(t *testing.T) {
+	modelPath := writeTestModel(t)
+	_, err := StartLlamaServer(context.Background(), LlamaServerOptions{
+		BinaryPath: "kontext-missing-llama-server",
+		ModelPath:  modelPath,
+	})
+	if err == nil {
+		t.Fatal("StartLlamaServer() error = nil, want missing binary error")
+	}
+	if !strings.Contains(err.Error(), "find kontext-missing-llama-server") {
+		t.Fatalf("err = %v, want missing binary", err)
+	}
+}
+
+func TestStartLlamaServerMissingBinaryDoesNotDownloadModel(t *testing.T) {
+	downloaded := false
+	_, err := StartLlamaServer(context.Background(), LlamaServerOptions{
+		BinaryPath: "kontext-missing-llama-server",
+		CacheDir:   t.TempDir(),
+		HFRepo:     "Qwen/Qwen3-0.6B-GGUF",
+		HFFile:     "Qwen3-0.6B-Q8_0.gguf",
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			downloaded = true
+			return http.DefaultTransport.RoundTrip(req)
+		})},
+	})
+	if err == nil {
+		t.Fatal("StartLlamaServer() error = nil, want missing binary error")
+	}
+	if downloaded {
+		t.Fatal("model download started before checking llama-server binary")
+	}
+}
+
+func TestStartLlamaServerRejectsOccupiedPort(t *testing.T) {
+	modelPath := writeTestModel(t)
+	binaryPath := writeFakeLlamaServer(t)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	_, err = StartLlamaServer(context.Background(), LlamaServerOptions{
+		BinaryPath: binaryPath,
+		ModelPath:  modelPath,
+		Port:       port,
+	})
+	if err == nil {
+		t.Fatal("StartLlamaServer() error = nil, want occupied port rejection")
+	}
+	if !strings.Contains(err.Error(), "llama-server port 127.0.0.1:") {
+		t.Fatalf("err = %v, want occupied port error", err)
+	}
+}
+
+func TestStartLlamaServerHealthCheckAndStop(t *testing.T) {
+	modelPath := writeTestModel(t)
+	binaryPath := writeFakeLlamaServer(t)
+	port := freeTCPPort(t)
+	server, err := StartLlamaServer(context.Background(), LlamaServerOptions{
+		BinaryPath:     binaryPath,
+		ModelPath:      modelPath,
+		Port:           port,
+		StartupTimeout: 2 * time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if server.BaseURL() != "http://127.0.0.1:"+strconv.Itoa(port) {
+		t.Fatalf("BaseURL() = %q", server.BaseURL())
+	}
+	if err := server.Stop(); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+}
+
+func TestStartLlamaServerEarlyExitDoesNotWaitForStopTimeout(t *testing.T) {
+	modelPath := writeTestModel(t)
+	binaryPath := writeFakeExitingLlamaServer(t)
+	start := time.Now()
+	_, err := StartLlamaServer(context.Background(), LlamaServerOptions{
+		BinaryPath:     binaryPath,
+		ModelPath:      modelPath,
+		Port:           freeTCPPort(t),
+		StartupTimeout: 2 * time.Second,
+	})
+	if err == nil {
+		t.Fatal("StartLlamaServer() error = nil, want early exit error")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("early exit took %s, want less than 1s", elapsed)
+	}
+}
+
+func TestCachedHFModelPathRejectsTraversal(t *testing.T) {
+	if _, err := CachedHFModelPath(t.TempDir(), "Qwen/Qwen3-0.6B-GGUF", "main", "../model.gguf"); err == nil {
+		t.Fatal("CachedHFModelPath() error = nil, want traversal rejection")
+	}
+}
+
+func TestCachedHFModelPathIncludesRevision(t *testing.T) {
+	got, err := CachedHFModelPath("/cache", "Qwen/Qwen3-0.6B-GGUF", "refs/pr/1", "Qwen3-0.6B-Q8_0.gguf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join("/cache", "huggingface", "Qwen", "Qwen3-0.6B-GGUF", "refs/pr/1", "Qwen3-0.6B-Q8_0.gguf")
+	if got != want {
+		t.Fatalf("path = %q, want %q", got, want)
+	}
+}
+
+func TestResolveLlamaServerModelUsesCachedFile(t *testing.T) {
+	cacheDir := t.TempDir()
+	want, err := CachedHFModelPath(cacheDir, "Qwen/Qwen3-0.6B-GGUF", "main", "Qwen3-0.6B-Q8_0.gguf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(want), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(want, []byte("gguf"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ResolveLlamaServerModel(context.Background(), LlamaServerOptions{
+		CacheDir: cacheDir,
+		HFRepo:   "Qwen/Qwen3-0.6B-GGUF",
+		HFFile:   "Qwen3-0.6B-Q8_0.gguf",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("model path = %q, want %q", got, want)
+	}
+}
+
+func TestResolveLlamaServerModelDownloadsToCache(t *testing.T) {
+	cacheDir := t.TempDir()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/Qwen/Qwen3-0.6B-GGUF/resolve/main/Qwen3-0.6B-Q8_0.gguf" {
+			t.Fatalf("download path = %q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte("gguf"))
+	}))
+	defer server.Close()
+	target, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ResolveLlamaServerModel(context.Background(), LlamaServerOptions{
+		CacheDir:   cacheDir,
+		HFRepo:     "Qwen/Qwen3-0.6B-GGUF",
+		HFFile:     "Qwen3-0.6B-Q8_0.gguf",
+		HFRevision: "main",
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			rewritten := req.Clone(req.Context())
+			rewritten.URL.Scheme = target.Scheme
+			rewritten.URL.Host = target.Host
+			return http.DefaultTransport.RoundTrip(rewritten)
+		})},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	bytes, err := os.ReadFile(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(bytes) != "gguf" {
+		t.Fatalf("cached bytes = %q, want gguf", bytes)
+	}
+}
+
+func TestResolveLlamaServerModelDownloadsCustomRevision(t *testing.T) {
+	cacheDir := t.TempDir()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/Qwen/Qwen3-0.6B-GGUF/resolve/refs/pr/1/Qwen3-0.6B-Q8_0.gguf" {
+			t.Fatalf("download path = %q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte("gguf"))
+	}))
+	defer server.Close()
+	target, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ResolveLlamaServerModel(context.Background(), LlamaServerOptions{
+		CacheDir:   cacheDir,
+		HFRepo:     "Qwen/Qwen3-0.6B-GGUF",
+		HFFile:     "Qwen3-0.6B-Q8_0.gguf",
+		HFRevision: "refs/pr/1",
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			rewritten := req.Clone(req.Context())
+			rewritten.URL.Scheme = target.Scheme
+			rewritten.URL.Host = target.Host
+			return http.DefaultTransport.RoundTrip(rewritten)
+		})},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, filepath.Join("Qwen3-0.6B-GGUF", "refs/pr/1", "Qwen3-0.6B-Q8_0.gguf")) {
+		t.Fatalf("cached path = %q, want revision included", got)
+	}
+}
+
+func TestUnavailableJudgeFailsWithMetadata(t *testing.T) {
+	localJudge := UnavailableJudge{Runtime: DefaultLlamaServerRuntime, Model: "qwen", Err: os.ErrNotExist}
+	_, err := localJudge.Decide(context.Background(), Input{HookEvent: "PreToolUse"})
+	if FailureKind(err) != FailureUnavailable {
+		t.Fatalf("FailureKind(err) = %q, want unavailable", FailureKind(err))
+	}
+	if metadata := localJudge.Metadata(); metadata.Runtime != DefaultLlamaServerRuntime || metadata.Model != "qwen" {
+		t.Fatalf("metadata = %+v", metadata)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestFakeLlamaServerProcess(t *testing.T) {
+	if os.Getenv("KONTEXT_FAKE_LLAMA_SERVER") != "1" {
+		return
+	}
+	args := os.Args
+	port := ""
+	for i, arg := range args {
+		if arg == "--" && i+1 < len(args) {
+			port = args[i+1]
+			break
+		}
+	}
+	if port == "" {
+		os.Exit(2)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/models", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[{"id":"fake"}]}`))
+	})
+	if err := http.ListenAndServe("127.0.0.1:"+port, mux); err != nil {
+		os.Exit(1)
+	}
+}
+
+func writeTestModel(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "model.gguf")
+	if err := os.WriteFile(path, []byte("gguf"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func writeFakeLlamaServer(t *testing.T) string {
+	t.Helper()
+	testBinary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "llama-server")
+	script := `#!/bin/sh
+port=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--port" ]; then
+    shift
+    port="$1"
+  fi
+  shift
+done
+KONTEXT_FAKE_LLAMA_SERVER=1 exec ` + shellQuote(testBinary) + ` -test.run=TestFakeLlamaServerProcess -- "$port"
+`
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func writeFakeExitingLlamaServer(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "llama-server")
+	script := "#!/bin/sh\nexit 42\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func freeTCPPort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	return listener.Addr().(*net.TCPAddr).Port
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
+}

--- a/internal/guard/judge/unavailable.go
+++ b/internal/guard/judge/unavailable.go
@@ -1,0 +1,33 @@
+package judge
+
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+type UnavailableJudge struct {
+	Runtime string
+	Model   string
+	Kind    string
+	Err     error
+}
+
+func (j UnavailableJudge) Decide(context.Context, Input) (Result, error) {
+	kind := strings.TrimSpace(j.Kind)
+	if kind == "" {
+		kind = FailureUnavailable
+	}
+	err := j.Err
+	if err == nil {
+		err = errors.New("judge unavailable")
+	}
+	return Result{}, Error{Kind: kind, Err: err}
+}
+
+func (j UnavailableJudge) Metadata() Metadata {
+	return Metadata{
+		Runtime: strings.TrimSpace(j.Runtime),
+		Model:   strings.TrimSpace(j.Model),
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `kontext guard start --judge-managed` to start and health-check a managed `llama-server` sidecar.
- Caches/downloads the selected GGUF model under the Kontext judge model cache, with Qwen3 0.6B Q8 as the launch default.
- Preserves fail-open behavior with runtime/model/failure metadata when the binary, model, or sidecar is unavailable.
- Documents managed and external judge startup paths.

## Verification

- [x] `go test ./...`
- [ ] real local smoke test with installed `llama-server`

## Linear

- ENG-345
