### PR TITLE
refactor(guard): tighten hook boundary typing

### DIFF
--- a/internal/guard/app/server/runtime.go
+++ b/internal/guard/app/server/runtime.go
@@ -55,14 +55,14 @@ func (r guardHookRuntime) EnsureSessionForEvent(ctx context.Context, event hook.
 }
 
 func (r guardHookRuntime) EvaluateHook(ctx context.Context, event hook.Event) (hook.Result, error) {
-	decision, err := r.decideAndRecord(ctx, riskEventFromHookEvent(event))
-	if err != nil {
-		return hook.Result{}, err
-	}
-	return hookResultFromRiskDecision(decision), nil
+	return r.processHook(ctx, event)
 }
 
 func (r guardHookRuntime) IngestEvent(ctx context.Context, event hook.Event) (hook.Result, error) {
+	return r.processHook(ctx, event)
+}
+
+func (r guardHookRuntime) processHook(ctx context.Context, event hook.Event) (hook.Result, error) {
 	decision, err := r.decideAndRecord(ctx, riskEventFromHookEvent(event))
 	if err != nil {
 		return hook.Result{}, err

--- a/internal/guard/app/server/server.go
+++ b/internal/guard/app/server/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
 	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
 	dashboardassets "github.com/kontext-security/kontext-cli/internal/guard/web/assets"
+	"github.com/kontext-security/kontext-cli/internal/hook"
 	"github.com/kontext-security/kontext-cli/internal/runtimecore"
 )
 
@@ -82,23 +83,19 @@ func (s *Server) routes() {
 }
 
 func (s *Server) EvaluateHook(ctx context.Context, event risk.HookEvent) (risk.RiskDecision, error) {
-	result, err := s.core.EvaluateHook(ctx, hookEventFromRiskEvent(event))
-	if err != nil {
-		return risk.RiskDecision{}, err
-	}
-	return riskDecisionFromHookResult(result), nil
+	return s.processWithCore(ctx, event, s.core.EvaluateHook)
 }
 
 func (s *Server) IngestEvent(ctx context.Context, event risk.HookEvent) (risk.RiskDecision, error) {
-	result, err := s.core.IngestEvent(ctx, hookEventFromRiskEvent(event))
-	if err != nil {
-		return risk.RiskDecision{}, err
-	}
-	return riskDecisionFromHookResult(result), nil
+	return s.processWithCore(ctx, event, s.core.IngestEvent)
 }
 
 func (s *Server) ProcessHookEvent(ctx context.Context, event risk.HookEvent) (risk.RiskDecision, error) {
-	result, err := s.core.ProcessHook(ctx, hookEventFromRiskEvent(event))
+	return s.processWithCore(ctx, event, s.core.ProcessHook)
+}
+
+func (s *Server) processWithCore(ctx context.Context, event risk.HookEvent, process func(context.Context, hook.Event) (hook.Result, error)) (risk.RiskDecision, error) {
+	result, err := process(ctx, hookEventFromRiskEvent(event))
 	if err != nil {
 		return risk.RiskDecision{}, err
 	}

--- a/internal/guard/cli/cli.go
+++ b/internal/guard/cli/cli.go
@@ -30,6 +30,10 @@ import (
 const (
 	defaultBaseURL   = "http://" + server.DefaultAddr
 	defaultModelPath = "models/guard/coding-agent-v0.json"
+
+	hooksUsage  = "usage: kontext guard hooks install claude-code | kontext guard hooks uninstall claude-code"
+	tracesUsage = "usage: kontext guard traces inspect"
+	modelUsage  = "usage: kontext guard model info|train"
 )
 
 // Run executes the Kontext command line.
@@ -317,7 +321,7 @@ func hookCommands(raw any) []string {
 
 func runHooks(args []string, out io.Writer) error {
 	if len(args) < 2 || args[1] != "claude-code" {
-		return fmt.Errorf("usage: kontext guard hooks install claude-code | kontext guard hooks uninstall claude-code")
+		return fmt.Errorf(hooksUsage)
 	}
 	switch args[0] {
 	case "install":
@@ -330,11 +334,11 @@ func runHooks(args []string, out io.Writer) error {
 		return installClaudeHooks(out, *socketPath)
 	case "uninstall":
 		if len(args) != 2 {
-			return fmt.Errorf("usage: kontext guard hooks install claude-code | kontext guard hooks uninstall claude-code")
+			return fmt.Errorf(hooksUsage)
 		}
 		return uninstallClaudeHooks(out)
 	default:
-		return fmt.Errorf("usage: kontext guard hooks install claude-code | kontext guard hooks uninstall claude-code")
+		return fmt.Errorf(hooksUsage)
 	}
 }
 
@@ -554,19 +558,19 @@ func runSmokeTest(ctx context.Context, args []string, out io.Writer) error {
 
 func runTraces(ctx context.Context, args []string, out io.Writer) error {
 	if len(args) == 0 {
-		return fmt.Errorf("usage: kontext guard traces inspect")
+		return fmt.Errorf(tracesUsage)
 	}
 	switch args[0] {
 	case "inspect":
 		return runStatus(ctx, args[1:], out)
 	default:
-		return fmt.Errorf("usage: kontext guard traces inspect")
+		return fmt.Errorf(tracesUsage)
 	}
 }
 
 func runModel(args []string, out io.Writer) error {
 	if len(args) == 0 {
-		return fmt.Errorf("usage: kontext guard model info|train")
+		return fmt.Errorf(modelUsage)
 	}
 	switch args[0] {
 	case "info":
@@ -579,7 +583,7 @@ func runModel(args []string, out io.Writer) error {
 	case "train":
 		return runTrainFixtureModel(args[1:], out)
 	default:
-		return fmt.Errorf("usage: kontext guard model info|train")
+		return fmt.Errorf(modelUsage)
 	}
 }
 

--- a/internal/guard/risk/types.go
+++ b/internal/guard/risk/types.go
@@ -3,6 +3,8 @@ package risk
 import (
 	"encoding/json"
 	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/hook"
 )
 
 type HookEvent struct {
@@ -28,12 +30,12 @@ const (
 	EventUnknown                      EventType = "unknown"
 )
 
-type Decision string
+type Decision = hook.Decision
 
 const (
-	DecisionAllow Decision = "allow"
-	DecisionAsk   Decision = "ask"
-	DecisionDeny  Decision = "deny"
+	DecisionAllow = hook.DecisionAllow
+	DecisionAsk   = hook.DecisionAsk
+	DecisionDeny  = hook.DecisionDeny
 )
 
 type RiskEvent struct {

--- a/internal/hookruntime/claude.go
+++ b/internal/hookruntime/claude.go
@@ -1,33 +1,35 @@
 package hookruntime
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/kontext-security/kontext-cli/internal/hook"
 )
 
 type ClaudeHookInput struct {
-	SessionID        string         `json:"session_id"`
-	SessionIDAlt     string         `json:"sessionId"`
-	HookEventName    string         `json:"hook_event_name"`
-	HookEventNameAlt string         `json:"hookEventName"`
-	HookEventLegacy  string         `json:"hook_event"`
-	ToolName         string         `json:"tool_name"`
-	ToolNameAlt      string         `json:"toolName"`
-	ToolInput        map[string]any `json:"tool_input"`
-	ToolInputAlt     map[string]any `json:"toolInput"`
-	ToolResponse     map[string]any `json:"tool_response"`
-	ToolResponseAlt  map[string]any `json:"toolResponse"`
-	ToolUseID        string         `json:"tool_use_id"`
-	ToolUseIDAlt     string         `json:"toolUseId"`
-	ToolUseIDUpper   string         `json:"toolUseID"`
-	CWD              string         `json:"cwd"`
-	PermissionMode   *string        `json:"permission_mode"`
-	DurationMs       *int64         `json:"duration_ms"`
-	Error            *string        `json:"error"`
-	IsInterrupt      *bool          `json:"is_interrupt"`
+	SessionID        string          `json:"session_id"`
+	SessionIDAlt     string          `json:"sessionId"`
+	HookEventName    string          `json:"hook_event_name"`
+	HookEventNameAlt string          `json:"hookEventName"`
+	HookEventLegacy  string          `json:"hook_event"`
+	ToolName         string          `json:"tool_name"`
+	ToolNameAlt      string          `json:"toolName"`
+	ToolInput        json.RawMessage `json:"tool_input"`
+	ToolInputAlt     json.RawMessage `json:"toolInput"`
+	ToolResponse     json.RawMessage `json:"tool_response"`
+	ToolResponseAlt  json.RawMessage `json:"toolResponse"`
+	ToolUseID        string          `json:"tool_use_id"`
+	ToolUseIDAlt     string          `json:"toolUseId"`
+	ToolUseIDUpper   string          `json:"toolUseID"`
+	CWD              string          `json:"cwd"`
+	PermissionMode   *string         `json:"permission_mode"`
+	DurationMs       *int64          `json:"duration_ms"`
+	Error            *string         `json:"error"`
+	IsInterrupt      *bool           `json:"is_interrupt"`
 }
 
 type claudeHookOutput struct {
@@ -36,11 +38,11 @@ type claudeHookOutput struct {
 }
 
 type claudeHookSpecificOutput struct {
-	HookEventName            string         `json:"hookEventName"`
-	PermissionDecision       string         `json:"permissionDecision,omitempty"`
-	PermissionDecisionReason string         `json:"permissionDecisionReason,omitempty"`
-	AdditionalContext        string         `json:"additionalContext,omitempty"`
-	UpdatedInput             map[string]any `json:"updatedInput,omitempty"`
+	HookEventName            string          `json:"hookEventName"`
+	PermissionDecision       string          `json:"permissionDecision,omitempty"`
+	PermissionDecisionReason string          `json:"permissionDecisionReason,omitempty"`
+	AdditionalContext        string          `json:"additionalContext,omitempty"`
+	UpdatedInput             json.RawMessage `json:"updatedInput,omitempty"`
 }
 
 func DecodeClaudeEvent(input []byte, agentName string) (hook.Event, error) {
@@ -52,13 +54,21 @@ func DecodeClaudeEvent(input []byte, agentName string) (hook.Event, error) {
 	if hookName == "" {
 		return hook.Event{}, fmt.Errorf("claude: hook event name missing")
 	}
+	toolInput, err := decodeJSONMapObject(firstRawMessage(h.ToolInput, h.ToolInputAlt))
+	if err != nil {
+		return hook.Event{}, fmt.Errorf("claude: decode tool input: %w", err)
+	}
+	toolResponse, err := decodeJSONMapObject(firstRawMessage(h.ToolResponse, h.ToolResponseAlt))
+	if err != nil {
+		return hook.Event{}, fmt.Errorf("claude: decode tool response: %w", err)
+	}
 	return hook.Event{
 		SessionID:      firstString(h.SessionID, h.SessionIDAlt),
 		Agent:          agentName,
 		HookName:       hook.HookName(hookName),
 		ToolName:       firstString(h.ToolName, h.ToolNameAlt),
-		ToolInput:      firstMap(h.ToolInput, h.ToolInputAlt),
-		ToolResponse:   firstMap(h.ToolResponse, h.ToolResponseAlt),
+		ToolInput:      toolInput,
+		ToolResponse:   toolResponse,
 		ToolUseID:      firstString(h.ToolUseID, h.ToolUseIDAlt, h.ToolUseIDUpper),
 		CWD:            h.CWD,
 		PermissionMode: stringPtrValue(h.PermissionMode),
@@ -77,9 +87,9 @@ func firstString(values ...string) string {
 	return ""
 }
 
-func firstMap(values ...map[string]any) map[string]any {
+func firstRawMessage(values ...json.RawMessage) json.RawMessage {
 	for _, value := range values {
-		if value != nil {
+		if len(value) != 0 {
 			return value
 		}
 	}
@@ -91,22 +101,30 @@ func EncodeClaudeResult(hookEventName string, result hook.Result) ([]byte, error
 		return json.Marshal(claudeHookOutput{SuppressOutput: true})
 	}
 
-	permissionDecision := string(result.Decision)
-	if permissionDecision != string(hook.DecisionAllow) &&
-		permissionDecision != string(hook.DecisionAsk) &&
-		permissionDecision != string(hook.DecisionDeny) {
-		permissionDecision = string(hook.DecisionDeny)
+	permissionDecision := result.Decision
+	switch permissionDecision {
+	case hook.DecisionAllow, hook.DecisionAsk, hook.DecisionDeny:
+	default:
+		permissionDecision = hook.DecisionDeny
 	}
 	reason := result.ClaudeReason()
-	if permissionDecision == "allow" && strings.EqualFold(strings.TrimSpace(reason), "allowed") {
+	if permissionDecision == hook.DecisionAllow && strings.EqualFold(strings.TrimSpace(reason), "allowed") {
 		reason = ""
+	}
+	var updatedInput json.RawMessage
+	if result.UpdatedInput != nil {
+		data, err := json.Marshal(result.UpdatedInput)
+		if err != nil {
+			return nil, fmt.Errorf("claude: encode updated input: %w", err)
+		}
+		updatedInput = data
 	}
 	out := claudeHookOutput{
 		HookSpecificOutput: &claudeHookSpecificOutput{
 			HookEventName:            hookEventName,
-			PermissionDecision:       permissionDecision,
+			PermissionDecision:       string(permissionDecision),
 			PermissionDecisionReason: reason,
-			UpdatedInput:             result.UpdatedInput,
+			UpdatedInput:             updatedInput,
 		},
 		SuppressOutput: result.UpdatedInput != nil,
 	}
@@ -118,4 +136,30 @@ func stringPtrValue(value *string) string {
 		return ""
 	}
 	return *value
+}
+
+func decodeJSONMapObject(raw json.RawMessage) (map[string]any, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil, fmt.Errorf("expected JSON object, got null")
+	}
+
+	var out map[string]any
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&out); err != nil {
+		return nil, err
+	}
+	if out == nil {
+		return nil, fmt.Errorf("expected JSON object")
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("trailing JSON after object")
+		}
+		return nil, err
+	}
+	return out, nil
 }

--- a/internal/hookruntime/claude_test.go
+++ b/internal/hookruntime/claude_test.go
@@ -1,0 +1,67 @@
+package hookruntime
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/hook"
+)
+
+func TestDecodeClaudeEventPreservesLargeJSONNumbers(t *testing.T) {
+	t.Parallel()
+
+	event, err := DecodeClaudeEvent([]byte(`{
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Bash",
+		"tool_use_id": "toolu_123",
+		"cwd": "/tmp",
+		"tool_input": {"id": 9007199254740993}
+	}`), "claude")
+	if err != nil {
+		t.Fatalf("DecodeClaudeEvent() error = %v", err)
+	}
+
+	got, ok := event.ToolInput["id"].(json.Number)
+	if !ok {
+		t.Fatalf("id type = %T, want json.Number", event.ToolInput["id"])
+	}
+	if got.String() != "9007199254740993" {
+		t.Fatalf("id = %s, want exact large number", got.String())
+	}
+}
+
+func TestDecodeClaudeEventRejectsNullToolInput(t *testing.T) {
+	t.Parallel()
+
+	_, err := DecodeClaudeEvent([]byte(`{
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Bash",
+		"tool_use_id": "toolu_123",
+		"cwd": "/tmp",
+		"tool_input": null
+	}`), "claude")
+	if err == nil {
+		t.Fatal("DecodeClaudeEvent() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "decode tool input") {
+		t.Fatalf("DecodeClaudeEvent() error = %v, want tool input decode error", err)
+	}
+}
+
+func TestEncodeClaudeResultFailsOnInvalidUpdatedInput(t *testing.T) {
+	t.Parallel()
+
+	_, err := EncodeClaudeResult("PreToolUse", hook.Result{
+		Decision: hook.DecisionAllow,
+		UpdatedInput: map[string]any{
+			"bad": func() {},
+		},
+	})
+	if err == nil {
+		t.Fatal("EncodeClaudeResult() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "encode updated input") {
+		t.Fatalf("EncodeClaudeResult() error = %v, want updated input encode error", err)
+	}
+}


### PR DESCRIPTION
Summary
This cleans up Guard hook processing by deduping core plumbing, tightening Claude hook JSON boundaries, and unifying decision typing.

Before this, duplicated hook processing lived in `internal/guard/app/server/runtime.go` + `internal/guard/app/server/server.go`, Guard risk redefined `Decision`, and Claude hook payloads decoded `tool_input`/`tool_response` straight into `map[string]any`, which lost numeric fidelity and let non-object JSON slip through.

Now one canonical path handles each boundary:

- Guard server hook processing: `processWithCore(...)`
- Guard runtime hook processing: `processHook(...)`
- Claude hook JSON boundary: decode raw JSON with `UseNumber()` + object-only validation
- Risk decisions: `type risk.Decision = hook.Decision`

Why
This gives Guard a cleaner maintenance path for hook processing:

Claude hook input
-> `internal/hookruntime.DecodeClaudeEvent`
-> `hook.Event` (typed + numeric-safe maps)
-> Guard server/core
-> canonical decision type (`hook.Decision`)

This PR does not broaden behavior beyond the cleanup scope.

What changed
Added/Removed/Consolidated shared hook-processing helpers in Guard server/runtime
Removed duplicated `Decision` type in `internal/guard/risk`
Strengthened Claude hook JSON decoding + added tests for numeric fidelity and invalid updatedInput

Verification
`go test ./...`
