### PR TITLE
fix: optimize judge fixture category matching

### DIFF
--- a/internal/guard/judge/fixtures.go
+++ b/internal/guard/judge/fixtures.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"slices"
 	"strings"
 )
 
@@ -78,8 +77,12 @@ func CompareFixtureOutput(output Output, expected FixtureExpected) []string {
 	if output.RiskLevel != expected.RiskLevel {
 		failures = append(failures, fmt.Sprintf("risk_level=%s want=%s", output.RiskLevel, expected.RiskLevel))
 	}
+	outputCategories := make(map[string]struct{}, len(output.Categories))
+	for _, category := range output.Categories {
+		outputCategories[category] = struct{}{}
+	}
 	for _, category := range expected.Categories {
-		if !slices.Contains(output.Categories, category) {
+		if _, ok := outputCategories[category]; !ok {
 			failures = append(failures, fmt.Sprintf("missing category %q", category))
 		}
 	}

--- a/internal/guard/judge/fixtures_test.go
+++ b/internal/guard/judge/fixtures_test.go
@@ -91,6 +91,26 @@ func TestLaunchFixturesMapToJudgeInput(t *testing.T) {
 	}
 }
 
+func TestCompareFixtureOutputMatchesCategoriesWithoutOrderDependency(t *testing.T) {
+	failures := CompareFixtureOutput(
+		Output{
+			Decision:   DecisionDeny,
+			RiskLevel:  RiskLevelHigh,
+			Categories: []string{"production_mutation", "credential_access", "credential_access"},
+			Reason:     "Production credential access is blocked.",
+		},
+		FixtureExpected{
+			Decision:       DecisionDeny,
+			RiskLevel:      RiskLevelHigh,
+			Categories:     []string{"credential_access", "production_mutation"},
+			ReasonContains: []string{"production", "credential"},
+		},
+	)
+	if len(failures) != 0 {
+		t.Fatalf("CompareFixtureOutput() failures = %v, want none", failures)
+	}
+}
+
 func loadLaunchFixtures(t *testing.T) []Fixture {
 	t.Helper()
 	file, err := os.Open("testdata/launch-v0.jsonl")


### PR DESCRIPTION
## Summary

- speed up `CompareFixtureOutput` in `internal/guard/judge/fixtures.go` by indexing output categories once before matching expected categories
- add a focused regression test covering reordered and duplicate output categories

## Why

- `kontext guard judge eval` compares fixture output categories for every evaluated fixture
- the old path scanned `output.Categories` again for each expected category

## What changed

- replace repeated `slices.Contains` checks with a one-pass `map[string]struct{}` lookup
- keep match behavior the same for reordered and duplicate categories

## Verification

- `go test ./internal/guard/judge ./internal/guard/cli`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
