### PR TITLE
feat(agent): add Hermes shell hook adapter

### DIFF
--- a/cmd/kontext/main.go
+++ b/cmd/kontext/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/update"
 
 	_ "github.com/kontext-security/kontext-cli/internal/agent/claude"
+	_ "github.com/kontext-security/kontext-cli/internal/agent/hermes"
 )
 
 var version = "dev"
@@ -128,7 +129,7 @@ func startCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&agentName, "agent", "claude", "Agent to launch (currently: claude)")
+	cmd.Flags().StringVar(&agentName, "agent", "claude", "Agent to launch (supported: claude, hermes)")
 	cmd.Flags().StringVar(&templateFile, "env-template", ".env.kontext", "Path to env template file for --managed sessions")
 	cmd.Flags().BoolVar(&managed, "managed", false, "Launch with hosted managed credentials and shared traces")
 	cmd.Flags().BoolVar(&verbose, "verbose", false, "Show redacted diagnostic output")
@@ -214,7 +215,7 @@ func hookCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				adapter := guardhookruntime.AgentAdapter{Agent: a, AgentName: agentName}
+				adapter := guardhookruntime.AgentAdapter{Agent: a, AgentName: a.Name()}
 				processor := rootHookProcessor{socketPath: resolvedSocketPath, mode: hookMode}
 				return guardhookruntime.Run(context.Background(), adapter, processor, hookMode, cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr())
 			}

--- a/cmd/kontext/main_test.go
+++ b/cmd/kontext/main_test.go
@@ -3,10 +3,12 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -154,6 +156,38 @@ func TestHookCmdModeDoesNotDefaultFromEnv(t *testing.T) {
 	}
 	if flag.DefValue != "" {
 		t.Fatalf("--mode default = %q, want empty", flag.DefValue)
+	}
+}
+
+func TestHookCmdHermesAliasModeFailsClosedThroughRootHandler(t *testing.T) {
+	cmd := hookCmd()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetIn(strings.NewReader(`{"hook_event_name":"pre_tool_call","tool_name":"terminal","tool_input":{"command":"cat .env"}}`))
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	if err := cmd.Flags().Set("agent", "hermes-agent"); err != nil {
+		t.Fatalf("Set agent error = %v", err)
+	}
+	if err := cmd.Flags().Set("mode", "enforce"); err != nil {
+		t.Fatalf("Set mode error = %v", err)
+	}
+	if err := cmd.Flags().Set("socket", filepath.Join(t.TempDir(), "missing.sock")); err != nil {
+		t.Fatalf("Set socket error = %v", err)
+	}
+
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("RunE() error = %v, stderr = %q", err, stderr.String())
+	}
+	var output map[string]string
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("Unmarshal(stdout) error = %v, stdout = %q", err, stdout.String())
+	}
+	if output["action"] != "block" {
+		t.Fatalf("action = %q, want block; stdout = %q", output["action"], stdout.String())
+	}
+	if output["message"] != "sidecar unreachable" {
+		t.Fatalf("message = %q, want sidecar unreachable", output["message"])
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/oauth2 v0.36.0
 	google.golang.org/protobuf v1.36.11
+	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.50.1
 )
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -10,6 +10,25 @@ type Agent interface {
 	EncodeHookResult(event hook.Event, result hook.Result) ([]byte, error)
 }
 
+type LocalLaunch struct {
+	Env  []string
+	Args []string
+}
+
+type LocalLaunchOptions struct {
+	SessionDir    string
+	KontextBinary string
+	AgentName     string
+	SocketPath    string
+	Mode          string
+	BaseEnv       []string
+	ExtraArgs     []string
+}
+
+type LocalLauncher interface {
+	PrepareLocalLaunch(LocalLaunchOptions) (LocalLaunch, error)
+}
+
 type Aliaser interface {
 	Aliases() []string
 }

--- a/internal/agent/hermes/hermes.go
+++ b/internal/agent/hermes/hermes.go
@@ -1,0 +1,259 @@
+package hermes
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/kontext-security/kontext-cli/internal/agent"
+	"github.com/kontext-security/kontext-cli/internal/hook"
+)
+
+func init() {
+	agent.Register(&Hermes{})
+}
+
+type Hermes struct{}
+
+func (h *Hermes) Name() string { return "hermes" }
+
+func (h *Hermes) Aliases() []string { return []string{"hermes-agent"} }
+
+func (h *Hermes) DecodeHookInput(input []byte) (hook.Event, error) {
+	return DecodeEvent(input)
+}
+
+func (h *Hermes) EncodeHookResult(event hook.Event, result hook.Result) ([]byte, error) {
+	return EncodeResult(event, result)
+}
+
+type HookInput struct {
+	HookEventName      string         `json:"hook_event_name"`
+	HookEventNameCamel string         `json:"hookEventName"`
+	ToolName           string         `json:"tool_name"`
+	ToolNameCamel      string         `json:"toolName"`
+	ToolInput          map[string]any `json:"tool_input"`
+	ToolInputCamel     map[string]any `json:"toolInput"`
+	SessionID          string         `json:"session_id"`
+	SessionIDCamel     string         `json:"sessionId"`
+	CWD                string         `json:"cwd"`
+	Extra              map[string]any `json:"extra"`
+	ToolCallID         string         `json:"tool_call_id"`
+	ToolUseID          string         `json:"tool_use_id"`
+	ToolUseIDCamel     string         `json:"toolUseID"`
+	DurationMs         any            `json:"duration_ms"`
+	DurationMsCamel    any            `json:"durationMs"`
+	Error              any            `json:"error"`
+	IsInterrupt        any            `json:"is_interrupt"`
+	IsInterruptCamel   any            `json:"isInterrupt"`
+	Result             any            `json:"result"`
+}
+
+type hookOutput struct {
+	Action  string `json:"action,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+func DecodeEvent(input []byte) (hook.Event, error) {
+	var h HookInput
+	if err := json.Unmarshal(input, &h); err != nil {
+		return hook.Event{}, fmt.Errorf("hermes: decode hook input: %w", err)
+	}
+	hookEventName := firstNonEmpty(h.HookEventName, h.HookEventNameCamel)
+	hookName, ok := mapHookName(hookEventName)
+	if !ok {
+		if strings.TrimSpace(hookEventName) == "" {
+			return hook.Event{}, fmt.Errorf("hermes: hook event name missing")
+		}
+		return hook.Event{}, fmt.Errorf("hermes: unsupported hook event %q", hookEventName)
+	}
+
+	metadata := h.metadata()
+	event := hook.Event{
+		SessionID:    firstNonEmpty(h.SessionID, h.SessionIDCamel),
+		Agent:        "hermes",
+		HookName:     hookName,
+		ToolName:     normalizeToolName(firstNonEmpty(h.ToolName, h.ToolNameCamel)),
+		ToolInput:    firstMap(h.ToolInput, h.ToolInputCamel),
+		ToolUseID:    stringFromExtra(metadata, "tool_call_id", "tool_use_id", "toolUseID"),
+		CWD:          h.CWD,
+		ToolResponse: toolResponseFromExtra(metadata),
+	}
+	if duration, ok := int64FromExtra(metadata, "duration_ms", "durationMs"); ok {
+		event.DurationMs = &duration
+	}
+	if errText := stringFromExtra(metadata, "error"); errText != "" {
+		event.Error = errText
+	}
+	if interrupted, ok := boolFromExtra(metadata, "is_interrupt", "isInterrupt"); ok {
+		event.IsInterrupt = &interrupted
+	}
+	return event, nil
+}
+
+func (h HookInput) metadata() map[string]any {
+	metadata := map[string]any{}
+	for key, value := range h.Extra {
+		metadata[key] = value
+	}
+	for key, value := range map[string]any{
+		"tool_call_id": h.ToolCallID,
+		"tool_use_id":  h.ToolUseID,
+		"toolUseID":    h.ToolUseIDCamel,
+		"duration_ms":  h.DurationMs,
+		"durationMs":   h.DurationMsCamel,
+		"error":        h.Error,
+		"is_interrupt": h.IsInterrupt,
+		"isInterrupt":  h.IsInterruptCamel,
+		"result":       h.Result,
+	} {
+		if isZeroMetadataValue(value) {
+			continue
+		}
+		metadata[key] = value
+	}
+	return metadata
+}
+
+func EncodeResult(event hook.Event, result hook.Result) ([]byte, error) {
+	if !event.HookName.CanBlock() || !result.Blocking() {
+		return []byte("{}"), nil
+	}
+
+	return json.Marshal(hookOutput{
+		Action:  "block",
+		Message: blockMessage(result),
+	})
+}
+
+func mapHookName(value string) (hook.HookName, bool) {
+	switch strings.ToLower(strings.ReplaceAll(strings.TrimSpace(value), "_", "")) {
+	case "pretoolcall":
+		return hook.HookPreToolUse, true
+	case "posttoolcall":
+		return hook.HookPostToolUse, true
+	default:
+		return "", false
+	}
+}
+
+func normalizeToolName(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "terminal", "shell", "bash":
+		return "Bash"
+	case "read_file", "read":
+		return "Read"
+	case "write_file", "write":
+		return "Write"
+	case "patch", "edit", "edit_file":
+		return "Edit"
+	default:
+		return value
+	}
+}
+
+func toolResponseFromExtra(extra map[string]any) map[string]any {
+	if extra == nil {
+		return nil
+	}
+	if result, ok := extra["result"]; ok {
+		return map[string]any{"result": result}
+	}
+	return nil
+}
+
+func blockMessage(result hook.Result) string {
+	if reason := result.ClaudeReason(); strings.TrimSpace(reason) != "" {
+		return reason
+	}
+	return "Blocked by Kontext access policy."
+}
+
+func stringFromExtra(extra map[string]any, keys ...string) string {
+	if extra == nil {
+		return ""
+	}
+	for _, key := range keys {
+		value, ok := extra[key]
+		if !ok {
+			continue
+		}
+		switch typed := value.(type) {
+		case string:
+			return typed
+		case json.Number:
+			return typed.String()
+		}
+	}
+	return ""
+}
+
+func int64FromExtra(extra map[string]any, keys ...string) (int64, bool) {
+	if extra == nil {
+		return 0, false
+	}
+	for _, key := range keys {
+		value, ok := extra[key]
+		if !ok {
+			continue
+		}
+		switch typed := value.(type) {
+		case float64:
+			return int64(typed), true
+		case json.Number:
+			parsed, err := typed.Int64()
+			return parsed, err == nil
+		case int64:
+			return typed, true
+		case int:
+			return int64(typed), true
+		default:
+			return 0, false
+		}
+	}
+	return 0, false
+}
+
+func boolFromExtra(extra map[string]any, keys ...string) (bool, bool) {
+	if extra == nil {
+		return false, false
+	}
+	for _, key := range keys {
+		value, ok := extra[key]
+		if !ok {
+			continue
+		}
+		typed, ok := value.(bool)
+		return typed, ok
+	}
+	return false, false
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func firstMap(values ...map[string]any) map[string]any {
+	for _, value := range values {
+		if value != nil {
+			return value
+		}
+	}
+	return nil
+}
+
+func isZeroMetadataValue(value any) bool {
+	switch typed := value.(type) {
+	case nil:
+		return true
+	case string:
+		return typed == ""
+	default:
+		return false
+	}
+}

--- a/internal/agent/hermes/hermes_test.go
+++ b/internal/agent/hermes/hermes_test.go
@@ -1,0 +1,231 @@
+package hermes
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/hook"
+)
+
+func TestDecodePreToolCall(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`{
+		"hook_event_name": "pre_tool_call",
+		"tool_name": "terminal",
+		"tool_input": {"command": "cat .env"},
+		"session_id": "sess_123",
+		"cwd": "/tmp/project",
+		"extra": {"tool_call_id": "call_123"}
+	}`)
+
+	event, err := DecodeEvent(input)
+	if err != nil {
+		t.Fatalf("DecodeEvent() error = %v", err)
+	}
+	if event.Agent != "hermes" ||
+		event.HookName != hook.HookPreToolUse ||
+		event.ToolName != "Bash" ||
+		event.SessionID != "sess_123" ||
+		event.ToolUseID != "call_123" ||
+		event.CWD != "/tmp/project" {
+		t.Fatalf("event = %+v, want normalized Hermes pre-tool event", event)
+	}
+	if event.ToolInput["command"] != "cat .env" {
+		t.Fatalf("tool input = %+v, want command", event.ToolInput)
+	}
+}
+
+func TestDecodePostToolCallPreservesResultMetadata(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`{
+		"hook_event_name": "post_tool_call",
+		"tool_name": "read_file",
+		"tool_input": {"path": "README.md"},
+		"session_id": "sess_123",
+		"cwd": "/tmp/project",
+		"extra": {
+			"tool_call_id": "call_123",
+			"result": "{\"ok\":true}",
+			"duration_ms": 42,
+			"error": "command failed",
+			"is_interrupt": false
+		}
+	}`)
+
+	event, err := DecodeEvent(input)
+	if err != nil {
+		t.Fatalf("DecodeEvent() error = %v", err)
+	}
+	if event.HookName != hook.HookPostToolUse || event.ToolName != "Read" {
+		t.Fatalf("event = %+v, want normalized post-tool event", event)
+	}
+	if got := event.ToolResponse["result"]; got != `{"ok":true}` {
+		t.Fatalf("ToolResponse[result] = %#v, want raw result", got)
+	}
+	if event.DurationMs == nil || *event.DurationMs != 42 {
+		t.Fatalf("DurationMs = %v, want 42", event.DurationMs)
+	}
+	if event.Error != "command failed" {
+		t.Fatalf("Error = %q, want command failed", event.Error)
+	}
+	if event.IsInterrupt == nil || *event.IsInterrupt {
+		t.Fatalf("IsInterrupt = %v, want explicit false", event.IsInterrupt)
+	}
+}
+
+func TestDecodeAcceptsCamelCaseAndTopLevelMetadata(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`{
+		"hookEventName": "postToolCall",
+		"toolName": "write_file",
+		"toolInput": {"path": "README.md", "content": "hello"},
+		"sessionId": "sess_123",
+		"cwd": "/tmp/project",
+		"toolUseID": "call_123",
+		"result": "wrote file",
+		"durationMs": 7,
+		"error": "write warning",
+		"isInterrupt": true
+	}`)
+
+	event, err := DecodeEvent(input)
+	if err != nil {
+		t.Fatalf("DecodeEvent() error = %v", err)
+	}
+	if event.HookName != hook.HookPostToolUse ||
+		event.ToolName != "Write" ||
+		event.SessionID != "sess_123" ||
+		event.ToolUseID != "call_123" ||
+		event.CWD != "/tmp/project" {
+		t.Fatalf("event = %+v, want camelCase Hermes event metadata", event)
+	}
+	if event.ToolInput["content"] != "hello" {
+		t.Fatalf("ToolInput = %+v, want camelCase tool input", event.ToolInput)
+	}
+	if got := event.ToolResponse["result"]; got != "wrote file" {
+		t.Fatalf("ToolResponse[result] = %#v, want top-level result", got)
+	}
+	if event.DurationMs == nil || *event.DurationMs != 7 {
+		t.Fatalf("DurationMs = %v, want 7", event.DurationMs)
+	}
+	if event.Error != "write warning" {
+		t.Fatalf("Error = %q, want write warning", event.Error)
+	}
+	if event.IsInterrupt == nil || !*event.IsInterrupt {
+		t.Fatalf("IsInterrupt = %v, want explicit true", event.IsInterrupt)
+	}
+}
+
+func TestDecodeRejectsUnsupportedHook(t *testing.T) {
+	t.Parallel()
+
+	_, err := DecodeEvent([]byte(`{"hook_event_name":"pre_llm_call"}`))
+	if err == nil {
+		t.Fatal("DecodeEvent() error = nil, want unsupported hook error")
+	}
+	if !strings.Contains(err.Error(), "unsupported hook event") {
+		t.Fatalf("DecodeEvent() error = %v, want unsupported hook event", err)
+	}
+}
+
+func TestDecodeRejectsMissingHookName(t *testing.T) {
+	t.Parallel()
+
+	_, err := DecodeEvent([]byte(`{"tool_name":"terminal"}`))
+	if err == nil {
+		t.Fatal("DecodeEvent() error = nil, want missing hook event name")
+	}
+	if !strings.Contains(err.Error(), "hook event name missing") {
+		t.Fatalf("DecodeEvent() error = %v, want missing hook event name", err)
+	}
+}
+
+func TestEncodeAllowsWithNoopOutput(t *testing.T) {
+	t.Parallel()
+
+	out, err := EncodeResult(
+		hook.Event{HookName: hook.HookPreToolUse},
+		hook.Result{Decision: hook.DecisionAllow, Reason: "allowed"},
+	)
+	if err != nil {
+		t.Fatalf("EncodeResult() error = %v", err)
+	}
+	if string(out) != "{}" {
+		t.Fatalf("EncodeResult() = %s, want empty Hermes response", out)
+	}
+}
+
+func TestEncodeBlocksDenyAndAsk(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		result     hook.Result
+		wantReason string
+	}{
+		{
+			name:       "deny",
+			result:     hook.Result{Decision: hook.DecisionDeny, Reason: "blocked by policy"},
+			wantReason: "blocked by policy",
+		},
+		{
+			name:       "ask",
+			result:     hook.Result{Decision: hook.DecisionAsk, Reason: "approval required", RequestID: "req-123"},
+			wantReason: "approval required Request ID: req-123",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			out, err := EncodeResult(hook.Event{HookName: hook.HookPreToolUse}, tt.result)
+			if err != nil {
+				t.Fatalf("EncodeResult() error = %v", err)
+			}
+			var got hookOutput
+			if err := json.Unmarshal(out, &got); err != nil {
+				t.Fatalf("Unmarshal(%s) error = %v", out, err)
+			}
+			if got.Action != "block" || got.Message != tt.wantReason {
+				t.Fatalf("output = %+v, want block with reason %q", got, tt.wantReason)
+			}
+		})
+	}
+}
+
+func TestEncodeDoesNotBlockNonBlockingHooks(t *testing.T) {
+	t.Parallel()
+
+	out, err := EncodeResult(
+		hook.Event{HookName: hook.HookPostToolUse},
+		hook.Result{Decision: hook.DecisionDeny, Reason: "telemetry only"},
+	)
+	if err != nil {
+		t.Fatalf("EncodeResult() error = %v", err)
+	}
+	if string(out) != "{}" {
+		t.Fatalf("EncodeResult() = %s, want empty Hermes response", out)
+	}
+}
+
+func TestNormalizeToolName(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"terminal":   "Bash",
+		"shell":      "Bash",
+		"read_file":  "Read",
+		"write_file": "Write",
+		"patch":      "Edit",
+		"web_search": "web_search",
+	}
+	for input, want := range cases {
+		if got := normalizeToolName(input); got != want {
+			t.Fatalf("normalizeToolName(%q) = %q, want %q", input, got, want)
+		}
+	}
+}

--- a/internal/agent/hermes/launch.go
+++ b/internal/agent/hermes/launch.go
@@ -1,0 +1,261 @@
+package hermes
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/agent"
+	"gopkg.in/yaml.v3"
+)
+
+const localHookTimeoutSeconds = 20
+
+type hermesSource struct {
+	Home string
+	Root string
+}
+
+type shellHookAllowlist struct {
+	Approvals []shellHookApproval `json:"approvals"`
+}
+
+type shellHookApproval struct {
+	Event      string `json:"event"`
+	Command    string `json:"command"`
+	ApprovedAt string `json:"approved_at"`
+}
+
+func (h *Hermes) PrepareLocalLaunch(opts agent.LocalLaunchOptions) (agent.LocalLaunch, error) {
+	source := resolveHermesSource()
+	hermesHome, err := generateLocalHermesHome(opts.SessionDir, source, opts.KontextBinary, opts.AgentName, opts.SocketPath, opts.Mode)
+	if err != nil {
+		return agent.LocalLaunch{}, fmt.Errorf("generate Hermes runtime config: %w", err)
+	}
+
+	env := append([]string{}, opts.BaseEnv...)
+	env = append(env, "HERMES_HOME="+hermesHome)
+	return agent.LocalLaunch{Env: env, Args: append([]string{}, opts.ExtraArgs...)}, nil
+}
+
+func generateLocalHermesHome(sessionDir string, source hermesSource, kontextBinary, agentName, socketPath, mode string) (string, error) {
+	hermesRoot := filepath.Join(sessionDir, "hermes")
+	hermesHome := filepath.Join(hermesRoot, "profiles", "kontext")
+	if err := os.MkdirAll(hermesHome, 0o700); err != nil {
+		return "", fmt.Errorf("create temporary Hermes home: %w", err)
+	}
+
+	if err := snapshotHermesState(source, hermesRoot, hermesHome); err != nil {
+		return "", err
+	}
+
+	hookCmd := hookCommand(kontextBinary, agentName, socketPath, mode)
+	if err := writeHermesConfig(filepath.Join(source.Home, "config.yaml"), filepath.Join(hermesHome, "config.yaml"), hookCmd); err != nil {
+		return "", err
+	}
+	if err := writeHermesHookAllowlist(filepath.Join(hermesHome, "shell-hooks-allowlist.json"), hookCmd); err != nil {
+		return "", err
+	}
+
+	return hermesHome, nil
+}
+
+func resolveHermesSource() hermesSource {
+	if envHome := strings.TrimSpace(os.Getenv("HERMES_HOME")); envHome != "" {
+		return hermesSource{Home: envHome, Root: hermesRootForHome(envHome)}
+	}
+
+	root := filepath.Join(os.Getenv("HOME"), ".hermes")
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		root = filepath.Join(home, ".hermes")
+	}
+	if profile := activeHermesProfile(root); profile != "" {
+		return hermesSource{Home: filepath.Join(root, "profiles", profile), Root: root}
+	}
+	return hermesSource{Home: root, Root: root}
+}
+
+func hermesRootForHome(home string) string {
+	if filepath.Base(filepath.Dir(home)) == "profiles" {
+		return filepath.Dir(filepath.Dir(home))
+	}
+	return home
+}
+
+func activeHermesProfile(root string) string {
+	data, err := os.ReadFile(filepath.Join(root, "active_profile"))
+	if err != nil {
+		return ""
+	}
+	profile := strings.TrimSpace(string(data))
+	if profile == "" || profile == "default" {
+		return ""
+	}
+	return profile
+}
+
+func snapshotHermesState(source hermesSource, targetRoot, targetHome string) error {
+	if source.Root != "" && source.Root != source.Home {
+		if err := copySnapshotFile(source.Root, targetRoot, "auth.json"); err != nil {
+			return err
+		}
+		if err := copySnapshotDir(filepath.Join(source.Root, "auth"), filepath.Join(targetRoot, "auth")); err != nil {
+			return err
+		}
+	}
+	for _, name := range []string{".env", "auth.json"} {
+		if err := copySnapshotFile(source.Home, targetHome, name); err != nil {
+			return err
+		}
+	}
+	return copySnapshotDir(filepath.Join(source.Home, "auth"), filepath.Join(targetHome, "auth"))
+}
+
+func copySnapshotFile(sourceDir, targetDir, name string) error {
+	sourcePath := filepath.Join(sourceDir, name)
+	info, err := os.Lstat(sourcePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("inspect Hermes file %s: %w", sourcePath, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil
+	}
+	return copyRegularFile(sourcePath, filepath.Join(targetDir, name))
+}
+
+func copySnapshotDir(sourceDir, targetDir string) error {
+	info, err := os.Lstat(sourceDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("inspect Hermes directory %s: %w", sourceDir, err)
+	}
+	if !info.IsDir() {
+		return nil
+	}
+	if err := os.MkdirAll(targetDir, 0o700); err != nil {
+		return fmt.Errorf("create Hermes snapshot directory %s: %w", targetDir, err)
+	}
+	entries, err := os.ReadDir(sourceDir)
+	if err != nil {
+		return fmt.Errorf("read Hermes directory %s: %w", sourceDir, err)
+	}
+	for _, entry := range entries {
+		sourcePath := filepath.Join(sourceDir, entry.Name())
+		targetPath := filepath.Join(targetDir, entry.Name())
+		info, err := entry.Info()
+		if err != nil {
+			return fmt.Errorf("inspect Hermes entry %s: %w", sourcePath, err)
+		}
+		switch {
+		case info.IsDir():
+			if err := copySnapshotDir(sourcePath, targetPath); err != nil {
+				return err
+			}
+		case info.Mode().IsRegular():
+			if err := copyRegularFile(sourcePath, targetPath); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func copyRegularFile(sourcePath, targetPath string) error {
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return fmt.Errorf("open Hermes file %s: %w", sourcePath, err)
+	}
+	defer source.Close()
+
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o700); err != nil {
+		return fmt.Errorf("create Hermes file directory %s: %w", filepath.Dir(targetPath), err)
+	}
+	target, err := os.OpenFile(targetPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("create Hermes snapshot file %s: %w", targetPath, err)
+	}
+	defer target.Close()
+
+	if _, err := io.Copy(target, source); err != nil {
+		return fmt.Errorf("copy Hermes file %s: %w", sourcePath, err)
+	}
+	return nil
+}
+
+func writeHermesConfig(sourcePath, targetPath, hookCmd string) error {
+	config := map[string]any{}
+	data, err := os.ReadFile(sourcePath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read Hermes config: %w", err)
+	}
+	if len(strings.TrimSpace(string(data))) > 0 {
+		if err := yaml.Unmarshal(data, &config); err != nil {
+			return fmt.Errorf("parse Hermes config: %w", err)
+		}
+		if config == nil {
+			config = map[string]any{}
+		}
+	}
+
+	config["hooks"] = map[string]any{
+		"pre_tool_call":  []any{hermesHookEntry(hookCmd)},
+		"post_tool_call": []any{hermesHookEntry(hookCmd)},
+	}
+
+	out, err := yaml.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("marshal Hermes config: %w", err)
+	}
+	if err := os.WriteFile(targetPath, out, 0o600); err != nil {
+		return fmt.Errorf("write Hermes config: %w", err)
+	}
+	return nil
+}
+
+func writeHermesHookAllowlist(targetPath, hookCmd string) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	allowlist := shellHookAllowlist{
+		Approvals: []shellHookApproval{
+			{Event: "pre_tool_call", Command: hookCmd, ApprovedAt: now},
+			{Event: "post_tool_call", Command: hookCmd, ApprovedAt: now},
+		},
+	}
+	data, err := json.MarshalIndent(allowlist, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal Hermes hook allowlist: %w", err)
+	}
+	if err := os.WriteFile(targetPath, data, 0o600); err != nil {
+		return fmt.Errorf("write Hermes hook allowlist: %w", err)
+	}
+	return nil
+}
+
+func hookCommand(kontextBinary, agentName, socketPath, mode string) string {
+	return fmt.Sprintf(
+		"%s hook --agent %s --mode %s --socket %s",
+		shellQuote(kontextBinary),
+		shellQuote(agentName),
+		shellQuote(mode),
+		shellQuote(socketPath),
+	)
+}
+
+func hermesHookEntry(hookCmd string) map[string]any {
+	return map[string]any{
+		"command": hookCmd,
+		"timeout": localHookTimeoutSeconds,
+	}
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+}

--- a/internal/agent/hermes/launch_test.go
+++ b/internal/agent/hermes/launch_test.go
@@ -1,0 +1,201 @@
+package hermes
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/agent"
+	"gopkg.in/yaml.v3"
+)
+
+func TestPrepareLocalLaunchUsesTemporaryProfileHome(t *testing.T) {
+	home := t.TempDir()
+	sourceHome := filepath.Join(home, ".hermes")
+	if err := os.MkdirAll(sourceHome, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceHome, "config.yaml"), []byte("model: test-model\nhooks:\n  pre_tool_call:\n    - command: existing-hook\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceHome, ".env"), []byte("ANTHROPIC_API_KEY=test\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("HERMES_HOME", sourceHome)
+
+	launch, err := (&Hermes{}).PrepareLocalLaunch(agent.LocalLaunchOptions{
+		SessionDir:    filepath.Join(home, "session"),
+		KontextBinary: "/usr/local/bin/kontext",
+		AgentName:     "hermes",
+		SocketPath:    "/tmp/kontext.sock",
+		Mode:          "observe",
+		BaseEnv:       []string{"PATH=/usr/bin"},
+		ExtraArgs:     []string{"--help"},
+	})
+	if err != nil {
+		t.Fatalf("PrepareLocalLaunch() error = %v", err)
+	}
+	if !reflect.DeepEqual(launch.Args, []string{"--help"}) {
+		t.Fatalf("launch args = %v, want [--help]", launch.Args)
+	}
+	hermesHome := envValue(launch.Env, "HERMES_HOME")
+	if hermesHome == "" {
+		t.Fatal("launch env missing HERMES_HOME")
+	}
+	if filepath.Base(filepath.Dir(hermesHome)) != "profiles" {
+		t.Fatalf("HERMES_HOME = %q, parent must be named profiles", hermesHome)
+	}
+	if hermesHome == sourceHome {
+		t.Fatal("PrepareLocalLaunch reused source HERMES_HOME, want temporary session home")
+	}
+	if _, err := os.Lstat(filepath.Join(hermesHome, ".env")); err != nil {
+		t.Fatalf("snapshot .env missing: %v", err)
+	}
+
+	config := readHermesConfig(t, filepath.Join(hermesHome, "config.yaml"))
+	if got := config["model"]; got != "test-model" {
+		t.Fatalf("model = %v, want preserved test-model", got)
+	}
+	hooks := config["hooks"].(map[string]any)
+	preHooks := hooks["pre_tool_call"].([]any)
+	postHooks := hooks["post_tool_call"].([]any)
+	if len(preHooks) != 1 {
+		t.Fatalf("pre_tool_call hooks len = %d, want only Kontext hook", len(preHooks))
+	}
+	if len(postHooks) != 1 {
+		t.Fatalf("post_tool_call hooks len = %d, want only Kontext hook", len(postHooks))
+	}
+	wantCommand := `'/usr/local/bin/kontext' hook --agent 'hermes' --mode 'observe' --socket '/tmp/kontext.sock'`
+	if got := preHooks[0].(map[string]any)["command"]; got != wantCommand {
+		t.Fatalf("pre hook command = %q, want %q", got, wantCommand)
+	}
+	if got := postHooks[0].(map[string]any)["command"]; got != wantCommand {
+		t.Fatalf("post hook command = %q, want %q", got, wantCommand)
+	}
+
+	allowlist := readAllowlist(t, filepath.Join(hermesHome, "shell-hooks-allowlist.json"))
+	if len(allowlist.Approvals) != 2 {
+		t.Fatalf("allowlist approvals len = %d, want 2", len(allowlist.Approvals))
+	}
+	for _, approval := range allowlist.Approvals {
+		if approval.Command != wantCommand {
+			t.Fatalf("allowlist command = %q, want %q", approval.Command, wantCommand)
+		}
+		if approval.Event != "pre_tool_call" && approval.Event != "post_tool_call" {
+			t.Fatalf("allowlist event = %q, want Kontext hook event", approval.Event)
+		}
+	}
+}
+
+func TestResolveHermesSourceHonorsExplicitHomeBeforeActiveProfile(t *testing.T) {
+	home := t.TempDir()
+	explicitHome := filepath.Join(home, "custom-hermes")
+	defaultProfile := filepath.Join(home, ".hermes", "profiles", "work")
+	if err := os.MkdirAll(explicitHome, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(defaultProfile, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".hermes", "active_profile"), []byte("work\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("HERMES_HOME", explicitHome)
+
+	source := resolveHermesSource()
+	if source.Home != explicitHome {
+		t.Fatalf("source home = %q, want explicit HERMES_HOME %q", source.Home, explicitHome)
+	}
+	if source.Root != explicitHome {
+		t.Fatalf("source root = %q, want explicit root %q", source.Root, explicitHome)
+	}
+}
+
+func TestGenerateLocalHermesHomeCopiesAuthSnapshotWithoutSymlinks(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	sourceRoot := filepath.Join(root, "source")
+	sourceHome := filepath.Join(sourceRoot, "profiles", "work")
+	if err := os.MkdirAll(filepath.Join(sourceHome, "auth"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceHome, "config.yaml"), []byte("model: test-model\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceRoot, "auth.json"), []byte(`{"root":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceHome, "auth.json"), []byte(`{"profile":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceHome, "auth", "google_oauth.json"), []byte(`{"token":"test"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceHome, "SOUL.md"), []byte("persona"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	hermesHome, err := generateLocalHermesHome(filepath.Join(root, "session"), hermesSource{Home: sourceHome, Root: sourceRoot}, "/usr/local/bin/kontext", "hermes", "/tmp/kontext.sock", "observe")
+	if err != nil {
+		t.Fatalf("generateLocalHermesHome() error = %v", err)
+	}
+	hermesRoot := filepath.Dir(filepath.Dir(hermesHome))
+	for _, path := range []string{
+		filepath.Join(hermesRoot, "auth.json"),
+		filepath.Join(hermesHome, "auth.json"),
+		filepath.Join(hermesHome, "auth", "google_oauth.json"),
+	} {
+		info, err := os.Lstat(path)
+		if err != nil {
+			t.Fatalf("snapshot path %s missing: %v", path, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			t.Fatalf("snapshot path %s is symlink, want copied file", path)
+		}
+	}
+	if _, err := os.Lstat(filepath.Join(hermesHome, "SOUL.md")); !os.IsNotExist(err) {
+		t.Fatalf("SOUL.md snapshot err = %v, want not copied", err)
+	}
+}
+
+func readHermesConfig(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", path, err)
+	}
+	var config map[string]any
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		t.Fatalf("Unmarshal(%s) error = %v", path, err)
+	}
+	return config
+}
+
+func readAllowlist(t *testing.T, path string) shellHookAllowlist {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", path, err)
+	}
+	var allowlist shellHookAllowlist
+	if err := json.Unmarshal(data, &allowlist); err != nil {
+		t.Fatalf("Unmarshal(%s) error = %v", path, err)
+	}
+	return allowlist
+}
+
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	for i := len(env) - 1; i >= 0; i-- {
+		if strings.HasPrefix(env[i], prefix) {
+			return strings.TrimPrefix(env[i], prefix)
+		}
+	}
+	return ""
+}

--- a/internal/run/local.go
+++ b/internal/run/local.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/kontext-security/kontext-cli/internal/agent"
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 	"github.com/kontext-security/kontext-cli/internal/runtimehost"
 )
@@ -14,11 +15,11 @@ func StartLocal(ctx context.Context, opts Options) error {
 	diagnostics := diagnostic.New(os.Stderr, opts.Verbose || diagnostic.EnabledFromEnv())
 	diagnostics.Printf("start local: agent=%s\n", opts.Agent)
 
-	agentPath, err := preflightAgent(opts.Agent)
+	preflight, err := preflightAgent(opts.Agent)
 	if err != nil {
 		return err
 	}
-	diagnostics.Printf("agent preflight: %s -> %s\n", opts.Agent, agentPath)
+	diagnostics.Printf("agent preflight: %s -> %s\n", preflight.Name, preflight.BinaryPath)
 
 	mode, err := runtimehost.ResolveMode(os.Getenv("KONTEXT_MODE"))
 	if err != nil {
@@ -26,7 +27,7 @@ func StartLocal(ctx context.Context, opts Options) error {
 	}
 	cwd, _ := os.Getwd()
 	host, err := runtimehost.Start(ctx, runtimehost.Options{
-		AgentName:      opts.Agent,
+		AgentName:      preflight.Name,
 		CWD:            cwd,
 		DBPath:         os.Getenv("KONTEXT_DB"),
 		ModelPath:      os.Getenv("KONTEXT_MODEL"),
@@ -47,12 +48,21 @@ func StartLocal(ctx context.Context, opts Options) error {
 	if err != nil {
 		return fmt.Errorf("resolve kontext executable: %w", err)
 	}
-	settingsPath, err := GenerateLocalSettings(host.SessionDir, kontextBin, opts.Agent, host.SocketPath, string(host.Mode))
+
+	launch, err := prepareLocalAgentLaunch(preflight.Agent, agent.LocalLaunchOptions{
+		SessionDir:    host.SessionDir,
+		KontextBinary: kontextBin,
+		AgentName:     preflight.Name,
+		SocketPath:    host.SocketPath,
+		Mode:          string(host.Mode),
+		BaseEnv:       os.Environ(),
+		ExtraArgs:     opts.Args,
+	})
 	if err != nil {
-		return fmt.Errorf("generate settings: %w", err)
+		return err
 	}
 
-	env := append(os.Environ(), "KONTEXT_RUN=1")
+	env := append(launch.Env, "KONTEXT_RUN=1")
 	env = append(env, "KONTEXT_SOCKET="+host.SocketPath)
 	env = append(env, "KONTEXT_SESSION_ID="+host.SessionID)
 	env = append(env, "KONTEXT_MODE="+string(host.Mode))
@@ -63,9 +73,28 @@ func StartLocal(ctx context.Context, opts Options) error {
 	}
 	fmt.Fprintf(os.Stderr, "✓ Risk model: %s\n", host.ActiveModelPath)
 	printLocalMode(os.Stderr, string(host.Mode))
-	fmt.Fprintf(os.Stderr, "\nLaunching %s...\n\n", opts.Agent)
+	fmt.Fprintf(os.Stderr, "\nLaunching %s...\n\n", preflight.Name)
 
-	return launchAgentWithSettings(ctx, opts.Agent, agentPath, env, opts.Args, settingsPath)
+	return launchAgent(ctx, preflight.Name, preflight.BinaryPath, env, launch.Args)
+}
+
+func prepareLocalAgentLaunch(a agent.Agent, opts agent.LocalLaunchOptions) (agent.LocalLaunch, error) {
+	opts.BaseEnv = append([]string{}, opts.BaseEnv...)
+	opts.ExtraArgs = filterArgs(opts.ExtraArgs)
+
+	if launcher, ok := a.(agent.LocalLauncher); ok {
+		return launcher.PrepareLocalLaunch(opts)
+	}
+	if a.Name() != "claude" {
+		return agent.LocalLaunch{}, fmt.Errorf("local launch unsupported for agent %q", a.Name())
+	}
+
+	settingsPath, err := GenerateLocalSettings(opts.SessionDir, opts.KontextBinary, a.Name(), opts.SocketPath, opts.Mode)
+	if err != nil {
+		return agent.LocalLaunch{}, fmt.Errorf("generate Claude settings: %w", err)
+	}
+	args := append([]string{"--settings", settingsPath}, opts.ExtraArgs...)
+	return agent.LocalLaunch{Env: opts.BaseEnv, Args: args}, nil
 }
 
 func printLocalMode(out *os.File, mode string) {

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -56,11 +56,20 @@ func StartManaged(ctx context.Context, opts Options) error {
 	diagnostics := diagnostic.New(os.Stderr, opts.Verbose || diagnostic.EnabledFromEnv())
 	diagnostics.Printf("start managed: agent=%s env_template=%s\n", opts.Agent, opts.TemplateFile)
 
-	agentPath, err := preflightAgent(opts.Agent)
+	a, err := resolveAgent(opts.Agent)
 	if err != nil {
 		return err
 	}
-	diagnostics.Printf("agent preflight: %s -> %s\n", opts.Agent, agentPath)
+	agentName := a.Name()
+	if agentName != "claude" {
+		return fmt.Errorf("managed sessions currently support Claude Code only; use `kontext start --agent %s` for local mode", agentName)
+	}
+
+	agentPath, err := findAgentExecutable(opts.Agent, a)
+	if err != nil {
+		return err
+	}
+	diagnostics.Printf("agent preflight: %s -> %s\n", agentName, agentPath)
 
 	// 1. Auth
 	session, err := ensureSession(ctx, opts.IssuerURL, opts.ClientID)
@@ -86,7 +95,7 @@ func StartManaged(ctx context.Context, opts Options) error {
 	cwd, _ := os.Getwd()
 	createResp, err := client.CreateSession(ctx, &agentv1.CreateSessionRequest{
 		UserId:   identityKey,
-		Agent:    opts.Agent,
+		Agent:    agentName,
 		Hostname: hostname,
 		Cwd:      cwd,
 		ClientInfo: map[string]string{
@@ -209,7 +218,7 @@ func StartManaged(ctx context.Context, opts Options) error {
 		sessionDir,
 		client,
 		sessionID,
-		opts.Agent,
+		agentName,
 		bootstrapResult.AccessMode,
 		diagnostics,
 	)
@@ -222,7 +231,7 @@ func StartManaged(ctx context.Context, opts Options) error {
 	defer sc.Stop()
 	if _, err := sc.RuntimeCore().OpenSession(ctx, runtimecore.Session{
 		ID:         sessionID,
-		Agent:      opts.Agent,
+		Agent:      agentName,
 		CWD:        cwd,
 		Source:     runtimecore.SessionSourceWrapperOwned,
 		ExternalID: sessionID,
@@ -237,7 +246,7 @@ func StartManaged(ctx context.Context, opts Options) error {
 		SocketPath:  sc.SocketPath(),
 		Core:        sc.RuntimeCore(),
 		SessionID:   sessionID,
-		AgentName:   opts.Agent,
+		AgentName:   agentName,
 		AsyncIngest: true,
 		OnFailure:   sc.RuntimeFailureResult,
 		Diagnostic:  diagnostics,
@@ -255,12 +264,12 @@ func StartManaged(ctx context.Context, opts Options) error {
 	if err != nil {
 		return fmt.Errorf("resolve kontext executable: %w", err)
 	}
-	settingsPath, err := GenerateSettings(sessionDir, kontextBin, opts.Agent)
+	settingsPath, err := GenerateSettings(sessionDir, kontextBin, agentName)
 	if err != nil {
 		return fmt.Errorf("generate settings: %w", err)
 	}
 	if bootstrapResult.AccessMode == backend.HostedAccessModeEnforce {
-		if err := VerifyBlockingHookSettings(settingsPath, kontextBin, opts.Agent); err != nil {
+		if err := VerifyBlockingHookSettings(settingsPath, kontextBin, agentName); err != nil {
 			return fmt.Errorf("verify enforce hook settings: %w", err)
 		}
 	}
@@ -273,8 +282,8 @@ func StartManaged(ctx context.Context, opts Options) error {
 	env = append(env, "KONTEXT_ACCESS_MODE_PATH="+sc.AccessModePath())
 
 	// 9. Launch agent with hooks
-	fmt.Fprintf(os.Stderr, "\nLaunching %s...\n\n", opts.Agent)
-	agentErr := launchAgentWithSettings(ctx, opts.Agent, agentPath, env, opts.Args, settingsPath)
+	fmt.Fprintf(os.Stderr, "\nLaunching %s...\n\n", agentName)
+	agentErr := launchAgentWithSettings(ctx, agentName, agentPath, env, opts.Args, settingsPath)
 
 	return agentErr
 }
@@ -1032,11 +1041,56 @@ func shouldRefreshSession(session *auth.Session, forceRefresh bool, now time.Tim
 	return forceRefresh || !now.Before(session.ExpiresAt.Add(-proactiveRefreshWindow))
 }
 
-func preflightAgent(agentName string) (string, error) {
-	if _, ok := agent.Get(agentName); !ok {
-		return "", fmt.Errorf("unsupported agent %q (supported: %s)", agentName, strings.Join(supportedAgents(), ", "))
+type agentPreflight struct {
+	Agent      agent.Agent
+	Name       string
+	BinaryPath string
+}
+
+func resolveAgent(agentName string) (agent.Agent, error) {
+	a, ok := agent.Get(agentName)
+	if !ok {
+		return nil, fmt.Errorf("unsupported agent %q (supported: %s)", agentName, strings.Join(supportedAgents(), ", "))
 	}
-	return findExecutable(agentName, os.Getenv("PATH"))
+	return a, nil
+}
+
+func preflightAgent(agentName string) (agentPreflight, error) {
+	a, err := resolveAgent(agentName)
+	if err != nil {
+		return agentPreflight{}, err
+	}
+	binaryPath, err := findAgentExecutable(agentName, a)
+	if err != nil {
+		return agentPreflight{}, err
+	}
+	return agentPreflight{Agent: a, Name: a.Name(), BinaryPath: binaryPath}, nil
+}
+
+func findAgentExecutable(requestedName string, a agent.Agent) (string, error) {
+	pathEnv := os.Getenv("PATH")
+	path, err := findExecutable(requestedName, pathEnv)
+	if err == nil {
+		return path, nil
+	}
+	if strings.Contains(requestedName, string(os.PathSeparator)) {
+		return "", err
+	}
+
+	names := []string{a.Name()}
+	if aliaser, ok := a.(agent.Aliaser); ok {
+		names = append(names, aliaser.Aliases()...)
+	}
+	for _, name := range names {
+		if name == requestedName {
+			continue
+		}
+		path, candidateErr := findExecutable(name, pathEnv)
+		if candidateErr == nil {
+			return path, nil
+		}
+	}
+	return "", err
 }
 
 func findExecutable(agentName, pathEnv string) (string, error) {
@@ -1093,13 +1147,16 @@ func validateExecutable(agentName, path string) (string, error) {
 	return path, nil
 }
 
-func launchAgentWithSettings(_ context.Context, agentName, binaryPath string, env, extraArgs []string, settingsPath string) error {
+func launchAgentWithSettings(ctx context.Context, agentName, binaryPath string, env, extraArgs []string, settingsPath string) error {
 	var args []string
 	if settingsPath != "" {
 		args = append(args, "--settings", settingsPath)
 	}
 	args = append(args, filterArgs(extraArgs)...)
+	return launchAgent(ctx, agentName, binaryPath, env, args)
+}
 
+func launchAgent(_ context.Context, agentName, binaryPath string, env, args []string) error {
 	cmd := exec.Command(binaryPath, args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/auth"
 	"github.com/kontext-security/kontext-cli/internal/credential"
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
+
+	_ "github.com/kontext-security/kontext-cli/internal/agent/hermes"
 )
 
 func TestFilterArgs(t *testing.T) {
@@ -130,6 +132,27 @@ func TestFindExecutableDistinguishesMissing(t *testing.T) {
 	}
 }
 
+func TestFindAgentExecutableFallsBackToAliasForCanonicalName(t *testing.T) {
+	dir := t.TempDir()
+	aliasPath := filepath.Join(dir, "hermes-agent")
+	if err := os.WriteFile(aliasPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+
+	a, err := resolveAgent("hermes")
+	if err != nil {
+		t.Fatalf("resolveAgent() error = %v", err)
+	}
+	got, err := findAgentExecutable("hermes", a)
+	if err != nil {
+		t.Fatalf("findAgentExecutable() error = %v", err)
+	}
+	if got != aliasPath {
+		t.Fatalf("findAgentExecutable() = %q, want alias path %q", got, aliasPath)
+	}
+}
+
 func TestCredentialFailureSummaryHidesRawDetails(t *testing.T) {
 	t.Parallel()
 
@@ -218,6 +241,80 @@ func TestLaunchAgentWithSettingsReturnsAgentExitError(t *testing.T) {
 	}
 	if exitErr.ExitCode() != 42 {
 		t.Fatalf("ExitCode() = %d, want 42", exitErr.ExitCode())
+	}
+}
+
+func TestStartManagedRejectsHermes(t *testing.T) {
+	t.Parallel()
+
+	err := StartManaged(context.Background(), Options{Agent: "hermes"})
+	if err == nil {
+		t.Fatal("StartManaged() error = nil, want unsupported Hermes error")
+	}
+	if !strings.Contains(err.Error(), "managed sessions currently support Claude Code only") {
+		t.Fatalf("StartManaged() error = %q, want managed unsupported message", err.Error())
+	}
+}
+
+func TestStartLocalLaunchesHermesWithGeneratedHookHome(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script launch test is POSIX-specific")
+	}
+
+	root := t.TempDir()
+	binDir := filepath.Join(root, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	recordPath := filepath.Join(root, "hermes-launch.env")
+	fakeHermes := filepath.Join(binDir, "hermes")
+	script := `#!/bin/sh
+set -eu
+{
+  printf 'argv=%s\n' "$*"
+  printf 'HERMES_HOME=%s\n' "${HERMES_HOME:-}"
+} > "$KONTEXT_TEST_RECORD"
+`
+	if err := os.WriteFile(fakeHermes, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	sourceHome := filepath.Join(root, ".hermes")
+	if err := os.MkdirAll(sourceHome, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceHome, "config.yaml"), []byte("model: test-model\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("HOME", root)
+	t.Setenv("HERMES_HOME", sourceHome)
+	t.Setenv("KONTEXT_DB", filepath.Join(root, "runtime.db"))
+	t.Setenv("KONTEXT_ADDR", "127.0.0.1:0")
+	t.Setenv("KONTEXT_TEST_RECORD", recordPath)
+
+	err := StartLocal(context.Background(), Options{
+		Agent: "hermes-agent",
+		Args:  []string{"--settings", "ignored.json", "--print", "hello"},
+	})
+	if err != nil {
+		t.Fatalf("StartLocal() error = %v", err)
+	}
+
+	record := readKeyValueFile(t, recordPath)
+	if got := record["argv"]; got != "--print hello" {
+		t.Fatalf("fake Hermes argv = %q, want filtered passthrough args", got)
+	}
+	hermesHome := record["HERMES_HOME"]
+	if hermesHome == "" {
+		t.Fatal("fake Hermes did not receive HERMES_HOME")
+	}
+	if hermesHome == sourceHome {
+		t.Fatal("fake Hermes received source HERMES_HOME, want generated session home")
+	}
+	if filepath.Base(filepath.Dir(hermesHome)) != "profiles" {
+		t.Fatalf("HERMES_HOME = %q, parent must be profiles", hermesHome)
 	}
 }
 
@@ -1265,6 +1362,22 @@ func TestVerifyBlockingHookSettingsRequiresPreToolUseCommand(t *testing.T) {
 type recordingCredentialProvider struct {
 	resolve func(context.Context, credential.Entry) (credential.Resolved, error)
 	connect func(context.Context, bool, loginFunc) (string, error)
+}
+
+func readKeyValueFile(t *testing.T, path string) map[string]string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", path, err)
+	}
+	values := map[string]string{}
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		key, value, ok := strings.Cut(line, "=")
+		if ok {
+			values[key] = value
+		}
+	}
+	return values
 }
 
 func (p recordingCredentialProvider) ResolveCredential(ctx context.Context, entry credential.Entry) (credential.Resolved, error) {


### PR DESCRIPTION
## Summary

Adds beta Hermes Agent support for local Kontext sessions.

- Register a Hermes agent adapter for Hermes shell-hook JSON, including `pre_tool_call` and `post_tool_call` decoding, tool-name normalization, and Hermes block/no-op result encoding.
- Support `kontext start --agent hermes` and the `hermes-agent` alias for local sessions while keeping managed sessions Claude-only.
- Generate a per-session temporary Hermes profile home with Kontext `pre_tool_call` / `post_tool_call` shell hooks and a narrow temporary allowlist, without editing the user's real `~/.hermes/config.yaml`.
- Resolve canonical agent names consistently so runtime records, hook handling, and executable lookup behave correctly for aliases.

Known limitations for this first Hermes path:

- Hermes shell hooks do not support native Kontext approval prompts, so `ask` is represented as a block in enforce mode.
- Hermes shell hooks do not support `updatedInput` rewrites.
- If Hermes cannot run the hook subprocess, Hermes logs and continues; fail-closed behavior applies only when the Kontext hook process runs and returns a valid block result.

## Verification

- [x] `go test ./internal/agent/hermes ./internal/run ./cmd/kontext`
- [x] `go test ./internal/agent/... ./internal/hookruntime ./internal/hookcmd ./internal/guard/hookruntime ./internal/localruntime ./internal/run ./cmd/kontext ./internal/guard/cli`
- [x] Built a temporary `kontext` binary and smoke-tested `kontext start --agent hermes-agent -- hooks list` against local Hermes; generated hooks were shown as allowed.

## Release notes

- [x] Adds beta local Hermes Agent support through `kontext start --agent hermes`.
