### PR TITLE
fix: optimize internal/guard/cli hook entry scan

### DIFF
--- a/internal/guard/cli/cli.go
+++ b/internal/guard/cli/cli.go
@@ -484,7 +484,7 @@ func PrintHookStatus(out io.Writer) {
 	hosted := false
 	guard := false
 	for _, raw := range hooks {
-		for _, command := range hookCommands(raw) {
+		walkHookCommands(raw, func(command string) bool {
 			switch {
 			case isGuardHookCommand(command):
 				guard = true
@@ -493,7 +493,8 @@ func PrintHookStatus(out io.Writer) {
 				hosted = true
 				fmt.Fprintf(out, "Claude Code hosted hook: %s\n", command)
 			}
-		}
+			return false
+		})
 	}
 	if guard && hosted {
 		fmt.Fprintln(out, "Claude Code hook mode: conflict (hosted and Guard hooks are both installed)")
@@ -510,12 +511,11 @@ func PrintHookStatus(out io.Writer) {
 	fmt.Fprintln(out, "Claude Code hook mode: no Kontext hook detected")
 }
 
-func hookCommands(raw any) []string {
+func walkHookCommands(raw any, visit func(string) bool) bool {
 	groups, ok := raw.([]any)
 	if !ok {
-		return nil
+		return false
 	}
-	var commands []string
 	for _, group := range groups {
 		groupMap, ok := group.(map[string]any)
 		if !ok {
@@ -531,11 +531,13 @@ func hookCommands(raw any) []string {
 				continue
 			}
 			if command, ok := hookMap["command"].(string); ok {
-				commands = append(commands, command)
+				if visit(command) {
+					return true
+				}
 			}
 		}
 	}
-	return commands
+	return false
 }
 
 func runHooks(args []string, out io.Writer) error {
@@ -698,7 +700,12 @@ func mergeHooks(raw any, hookCommand string) map[string]any {
 }
 
 func isGuardHookEntry(entry any) bool {
-	return isGuardHookCommand(fmt.Sprintf("%v", entry))
+	if command, ok := entry.(string); ok {
+		return isGuardHookCommand(command)
+	}
+	return walkHookCommands([]any{entry}, func(command string) bool {
+		return isGuardHookCommand(command)
+	})
 }
 
 func isGuardHookCommand(command string) bool {

--- a/internal/guard/cli/cli_test.go
+++ b/internal/guard/cli/cli_test.go
@@ -108,6 +108,118 @@ func TestMergeHooksInstallsOnlyToolHooks(t *testing.T) {
 	}
 }
 
+func TestPrintHookStatusReportsConflictForMixedHooks(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	settings := `{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/local/bin/kontext hook --agent claude --mode observe --socket /tmp/kontext.sock"
+          }
+        ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/local/bin/kontext hook --agent claude"
+          }
+        ]
+      }
+    ]
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(settings), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	PrintHookStatus(&out)
+
+	output := out.String()
+	for _, want := range []string{
+		"Claude Code Guard hook: /usr/local/bin/kontext hook --agent claude --mode observe --socket /tmp/kontext.sock",
+		"Claude Code hosted hook: /usr/local/bin/kontext hook --agent claude",
+		"Claude Code hook mode: conflict (hosted and Guard hooks are both installed)",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("PrintHookStatus() output = %q, want %q", output, want)
+		}
+	}
+}
+
+func TestUninstallClaudeHooksRemovesGuardEntriesOnly(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	settings := `{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/local/bin/kontext hook --agent claude --mode observe --socket /tmp/kontext.sock"
+          }
+        ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/local/bin/kontext hook --agent claude"
+          }
+        ]
+      }
+    ]
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(settings), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	if err := uninstallClaudeHooks(&out); err != nil {
+		t.Fatal(err)
+	}
+
+	raw, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var written map[string]any
+	if err := json.Unmarshal(raw, &written); err != nil {
+		t.Fatal(err)
+	}
+	hooks := written["hooks"].(map[string]any)
+	preToolUse := hooks["PreToolUse"].([]any)
+	if len(preToolUse) != 1 {
+		t.Fatalf("remaining PreToolUse entries = %d, want 1", len(preToolUse))
+	}
+	remaining := preToolUse[0].(map[string]any)["hooks"].([]any)[0].(map[string]any)["command"]
+	if remaining != "/usr/local/bin/kontext hook --agent claude" {
+		t.Fatalf("remaining command = %v, want hosted hook", remaining)
+	}
+}
+
 func TestStartRejectsInvalidNumericEnvironment(t *testing.T) {
 	t.Setenv("KONTEXT_THRESHOLD", "high")
 


### PR DESCRIPTION
Summary
This optimizes internal/guard/cli hook inspection by walking Claude hook entries once instead of repeatedly stringifying nested hook objects and building temporary command slices.

Before this, Guard hook detection in internal/guard/cli/cli.go converted whole hook entries to strings during install and uninstall cleanup, and status reporting first collected command slices before classifying them. That added repeated work on every nested hook entry and made the path harder to reason about.

Now direct command traversal is the canonical path:

```go
walkHookCommands(raw, func(command string) bool {
	return isGuardHookCommand(command)
})
```

Why
This gives kontext-cli a cheaper maintenance/runtime path for Claude Code hook management:

Claude settings JSON
-> structured hook command walk
-> Guard/hosted detection and cleanup

This PR does not broaden behavior beyond the optimization scope.

What changed
Optimized Claude hook entry inspection in internal/guard/cli/cli.go
Removed full-entry stringification and temporary command slice allocation during hook inspection
Preserved Guard vs hosted hook detection and uninstall filtering behavior
Updated tests for mixed Guard/hosted status output and Guard-only uninstall cleanup

Verification
go test ./internal/guard/cli
go test ./internal/guard/judge -run 'TestStartLlamaServerHealthCheckAndStop|TestStartLlamaServerEarlyExitDoesNotWaitForStopTimeout' -count=1
go test ./...
go vet ./...
git diff --check
