### PR TITLE
feat(guard): connect deterministic policy and judge

### DIFF
--- a/internal/guard/app/server/policy.go
+++ b/internal/guard/app/server/policy.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/kontext-security/kontext-cli/internal/guard/judge"
+	guardpolicy "github.com/kontext-security/kontext-cli/internal/guard/policy"
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
 )
 
@@ -13,9 +14,31 @@ type PolicyProvider interface {
 	DecideHook(context.Context, risk.HookEvent) (risk.RiskDecision, error)
 }
 
+type PolicyConfigProvider interface {
+	ActivePolicyConfig(context.Context) (guardpolicy.Config, error)
+}
+
 type RiskPolicyProvider struct {
-	scorer risk.Scorer
-	judge  judge.Judge
+	scorer       risk.Scorer
+	judge        judge.Judge
+	policyEngine guardpolicy.Engine
+	policyConfig PolicyConfigProvider
+}
+
+type RiskPolicyProviderOptions struct {
+	Scorer               risk.Scorer
+	Judge                judge.Judge
+	PolicyEngine         guardpolicy.Engine
+	PolicyConfig         guardpolicy.Config
+	PolicyConfigProvider PolicyConfigProvider
+}
+
+type staticPolicyConfigProvider struct {
+	config guardpolicy.Config
+}
+
+func (p staticPolicyConfigProvider) ActivePolicyConfig(context.Context) (guardpolicy.Config, error) {
+	return p.config, nil
 }
 
 func NewRiskPolicyProvider(scorer risk.Scorer) RiskPolicyProvider {
@@ -23,10 +46,27 @@ func NewRiskPolicyProvider(scorer risk.Scorer) RiskPolicyProvider {
 }
 
 func NewRiskPolicyProviderWithJudge(scorer risk.Scorer, localJudge judge.Judge) RiskPolicyProvider {
+	return NewRiskPolicyProviderWithOptions(RiskPolicyProviderOptions{
+		Scorer: scorer,
+		Judge:  localJudge,
+	})
+}
+
+func NewRiskPolicyProviderWithOptions(opts RiskPolicyProviderOptions) RiskPolicyProvider {
+	scorer := opts.Scorer
 	if scorer == nil {
 		scorer = risk.NoopScorer{}
 	}
-	return RiskPolicyProvider{scorer: scorer, judge: localJudge}
+	configProvider := opts.PolicyConfigProvider
+	if configProvider == nil {
+		configProvider = staticPolicyConfigProvider{config: opts.PolicyConfig}
+	}
+	return RiskPolicyProvider{
+		scorer:       scorer,
+		judge:        opts.Judge,
+		policyEngine: opts.PolicyEngine,
+		policyConfig: configProvider,
+	}
 }
 
 func (p RiskPolicyProvider) DecideHook(ctx context.Context, event risk.HookEvent) (risk.RiskDecision, error) {
@@ -38,46 +78,63 @@ func (p RiskPolicyProvider) DecideHook(ctx context.Context, event risk.HookEvent
 
 func (p RiskPolicyProvider) decideWithJudge(ctx context.Context, event risk.HookEvent) (risk.RiskDecision, error) {
 	riskEvent := risk.NormalizeHookEvent(event)
-	riskEvent.PolicyVersion = risk.PolicyVersionLaunchV0
+	score, err := p.scorer.Score(riskEvent)
+	if err != nil {
+		return risk.RiskDecision{}, err
+	}
+	riskEvent.RiskScore = score.RiskScore
+	riskEvent.ModelVersion = score.ModelVersion
 
-	if decision := risk.DeterministicDecision(riskEvent); decision.Decision != "" {
-		decision.RiskEvent = riskEvent
-		decision.RiskEvent.Decision = decision.Decision
-		decision.RiskEvent.ReasonCode = decision.ReasonCode
-		decision.RiskEvent.GuardID = decision.GuardID
-		decision.RiskEvent.DecisionStage = "deterministic"
-		decision.RiskEvent.PolicyVersion = risk.PolicyVersionLaunchV0
-		return decision, nil
+	policyResult := p.policyEngine.Evaluate(riskEvent, p.activePolicyConfig(ctx))
+	applyPolicyMetadata(&riskEvent, policyResult)
+	if policyResult.Decision == guardpolicy.DecisionDeny {
+		riskEvent.Decision = risk.DecisionDeny
+		riskEvent.ReasonCode = policyResult.ReasonCode
+		riskEvent.GuardID = policyResult.RuleID
+		riskEvent.DecisionStage = risk.DecisionStageDeterministicDeny
+		return risk.RiskDecision{
+			Decision:     risk.DecisionDeny,
+			Reason:       policyResult.Reason,
+			ReasonCode:   policyResult.ReasonCode,
+			RiskScore:    score.RiskScore,
+			Threshold:    score.Threshold,
+			ModelVersion: score.ModelVersion,
+			GuardID:      policyResult.RuleID,
+			RiskEvent:    riskEvent,
+		}, nil
 	}
 
-	result, err := p.judge.Decide(ctx, judgeInputFromRiskEvent(event, riskEvent))
+	result, err := p.judge.Decide(ctx, judgeInputFromRiskEvent(event, riskEvent, policyResult))
 	if err != nil {
 		failureKind := judge.FailureKind(err)
 		metadata := judgeMetadata(p.judge)
 		riskEvent.Decision = risk.DecisionAllow
 		riskEvent.ReasonCode = "judge_unavailable_allow"
-		riskEvent.DecisionStage = "judge_fail_open"
+		riskEvent.DecisionStage = risk.DecisionStageJudgeFailOpen
 		riskEvent.JudgeRuntime = metadata.Runtime
 		riskEvent.JudgeModel = metadata.Model
 		riskEvent.JudgeFailureKind = failureKind
 		return risk.RiskDecision{
-			Decision:   risk.DecisionAllow,
-			Reason:     "local judge unavailable; allowing by fail-open policy",
-			ReasonCode: "judge_unavailable_allow",
-			RiskEvent:  riskEvent,
+			Decision:     risk.DecisionAllow,
+			Reason:       "local judge unavailable; allowing by fail-open policy",
+			ReasonCode:   "judge_unavailable_allow",
+			RiskScore:    score.RiskScore,
+			Threshold:    score.Threshold,
+			ModelVersion: score.ModelVersion,
+			RiskEvent:    riskEvent,
 		}, nil
 	}
 
 	decision := risk.DecisionAllow
-	reasonCode := "judge_allow"
+	reasonCode := risk.DecisionStageJudgeAllow
 	if result.Output.Decision == judge.DecisionDeny {
 		decision = risk.DecisionDeny
-		reasonCode = "judge_deny"
+		reasonCode = risk.DecisionStageJudgeDeny
 	}
 	duration := result.Metadata.DurationMs
 	riskEvent.Decision = decision
 	riskEvent.ReasonCode = reasonCode
-	riskEvent.DecisionStage = string(reasonCode)
+	riskEvent.DecisionStage = reasonCode
 	riskEvent.GuardID = "local_llm_judge"
 	riskEvent.JudgeRuntime = result.Metadata.Runtime
 	riskEvent.JudgeModel = result.Metadata.Model
@@ -86,15 +143,44 @@ func (p RiskPolicyProvider) decideWithJudge(ctx context.Context, event risk.Hook
 	riskEvent.JudgeCategories = result.Output.Categories
 
 	return risk.RiskDecision{
-		Decision:   decision,
-		Reason:     result.Output.Reason,
-		ReasonCode: reasonCode,
-		GuardID:    "local_llm_judge",
-		RiskEvent:  riskEvent,
+		Decision:     decision,
+		Reason:       result.Output.Reason,
+		ReasonCode:   reasonCode,
+		RiskScore:    score.RiskScore,
+		Threshold:    score.Threshold,
+		ModelVersion: score.ModelVersion,
+		GuardID:      "local_llm_judge",
+		RiskEvent:    riskEvent,
 	}, nil
 }
 
-func judgeInputFromRiskEvent(event risk.HookEvent, riskEvent risk.RiskEvent) judge.Input {
+func (p RiskPolicyProvider) activePolicyConfig(ctx context.Context) guardpolicy.Config {
+	if p.policyConfig == nil {
+		return guardpolicy.DefaultConfig()
+	}
+	config, err := p.policyConfig.ActivePolicyConfig(ctx)
+	if err != nil {
+		return guardpolicy.DefaultConfig()
+	}
+	if err := config.Validate(); err != nil {
+		return guardpolicy.DefaultConfig()
+	}
+	return config
+}
+
+func applyPolicyMetadata(event *risk.RiskEvent, result guardpolicy.Result) {
+	event.PolicyVersion = result.PolicyVersion
+	event.PolicyProfile = string(result.Profile)
+	event.PolicyRulePack = result.RulePack
+	if !result.Matched {
+		return
+	}
+	event.PolicyRuleID = result.RuleID
+	event.PolicyRuleCategory = string(result.Category)
+	event.PolicySignals = result.MatchedSignals
+}
+
+func judgeInputFromRiskEvent(event risk.HookEvent, riskEvent risk.RiskEvent, policyResult guardpolicy.Result) judge.Input {
 	return judge.Input{
 		Agent:     event.Agent,
 		HookEvent: event.HookEventName,
@@ -122,10 +208,18 @@ func judgeInputFromRiskEvent(event risk.HookEvent, riskEvent risk.RiskEvent) jud
 			Signals:            riskEvent.Signals,
 		},
 		DeterministicPolicy: judge.DeterministicContext{
-			Decision:      "allow",
-			PolicyVersion: risk.PolicyVersionLaunchV0,
+			Decision:      string(policyResult.Decision),
+			MatchedRules:  matchedPolicyRules(policyResult),
+			PolicyVersion: policyResult.PolicyVersion,
 		},
 	}
+}
+
+func matchedPolicyRules(result guardpolicy.Result) []string {
+	if !result.Matched || result.RuleID == "" {
+		return nil
+	}
+	return []string{result.RuleID}
 }
 
 func cwdClass(cwd string) string {

--- a/internal/guard/app/server/server.go
+++ b/internal/guard/app/server/server.go
@@ -44,8 +44,10 @@ type ProcessResponse struct {
 }
 
 type Options struct {
-	Scorer risk.Scorer
-	Judge  judge.Judge
+	Scorer               risk.Scorer
+	Judge                judge.Judge
+	PolicyConfig         policy.Config
+	PolicyConfigProvider PolicyConfigProvider
 }
 
 type PolicyProfileResponse struct {
@@ -70,7 +72,23 @@ func NewServer(store *sqlite.Store, scorer risk.Scorer) (*Server, error) {
 }
 
 func NewServerWithOptions(store *sqlite.Store, opts Options) (*Server, error) {
-	return NewServerWithPolicy(store, NewRiskPolicyProviderWithJudge(opts.Scorer, opts.Judge))
+	policyStore, err := openPolicyStoreForSQLite(store)
+	if err != nil {
+		return nil, err
+	}
+	configProvider := opts.PolicyConfigProvider
+	if configProvider == nil {
+		if explicitPolicyConfig(opts.PolicyConfig) {
+			configProvider = staticPolicyConfigProvider{config: opts.PolicyConfig}
+		} else {
+			configProvider = policyStoreConfigProvider{store: policyStore}
+		}
+	}
+	return NewServerWithPolicyConfig(store, NewRiskPolicyProviderWithOptions(RiskPolicyProviderOptions{
+		Scorer:               opts.Scorer,
+		Judge:                opts.Judge,
+		PolicyConfigProvider: configProvider,
+	}), policyStore)
 }
 
 // NewServerWithPolicy creates a Guard server with an injected policy provider.
@@ -85,9 +103,6 @@ func NewServerWithPolicy(store *sqlite.Store, policy PolicyProvider) (*Server, e
 }
 
 func NewServerWithPolicyConfig(store *sqlite.Store, policy PolicyProvider, policyStore *policyconfig.Store) (*Server, error) {
-	if policy == nil {
-		policy = NewRiskPolicyProvider(nil)
-	}
 	if policyStore == nil {
 		var err error
 		policyStore, err = openPolicyStoreForSQLite(store)
@@ -97,6 +112,11 @@ func NewServerWithPolicyConfig(store *sqlite.Store, policy PolicyProvider, polic
 	}
 	if _, err := policyStore.Load(context.Background()); err != nil {
 		return nil, fmt.Errorf("load policy config: %w", err)
+	}
+	if policy == nil {
+		policy = NewRiskPolicyProviderWithOptions(RiskPolicyProviderOptions{
+			PolicyConfigProvider: policyStoreConfigProvider{store: policyStore},
+		})
 	}
 	runtime := newGuardHookRuntime(store, policy)
 	core, err := runtimecore.New(runtime)
@@ -334,6 +354,21 @@ func hasJSONContentType(r *http.Request) bool {
 		return false
 	}
 	return strings.EqualFold(mediaType, jsonContentType)
+}
+
+type policyStoreConfigProvider struct {
+	store *policyconfig.Store
+}
+
+func (p policyStoreConfigProvider) ActivePolicyConfig(context.Context) (policy.Config, error) {
+	if p.store == nil {
+		return policy.DefaultConfig(), nil
+	}
+	return p.store.Current().ToPolicyConfig(), nil
+}
+
+func explicitPolicyConfig(cfg policy.Config) bool {
+	return cfg.Version != "" || cfg.Profile != "" || cfg.RulePack != "" || cfg.NonBypassableRules != nil
 }
 
 func withCORS(next http.Handler) http.Handler {

--- a/internal/guard/app/server/server_test.go
+++ b/internal/guard/app/server/server_test.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -490,7 +492,59 @@ func TestJudgePolicyDeniesFromLocalJudge(t *testing.T) {
 	if decision.Decision != risk.DecisionDeny || decision.ReasonCode != "judge_deny" {
 		t.Fatalf("decision = %+v", decision)
 	}
-	if decision.RiskEvent.JudgeModel != "qwen3-0.6b-q4" || decision.RiskEvent.JudgeRiskLevel != "high" {
+	if decision.RiskEvent.DecisionStage != risk.DecisionStageJudgeDeny || decision.RiskEvent.JudgeModel != "qwen3-0.6b-q4" || decision.RiskEvent.JudgeRiskLevel != "high" {
+		t.Fatalf("risk event = %+v", decision.RiskEvent)
+	}
+}
+
+func TestJudgePolicyAllowsFromLocalJudge(t *testing.T) {
+	store, err := sqlite.OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	localJudge := &recordingJudge{
+		result: judge.Result{
+			Output: judge.Output{
+				Decision:   judge.DecisionAllow,
+				RiskLevel:  judge.RiskLevelLow,
+				Categories: []string{"normal_coding"},
+				Reason:     "Safe local read.",
+			},
+			Metadata: judge.Metadata{
+				Runtime:    "openai-compatible",
+				Model:      "qwen3-0.6b-q4",
+				DurationMs: 8,
+			},
+		},
+	}
+	server, err := NewServerWithOptions(store, Options{Judge: localJudge})
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision, err := server.ProcessHookEvent(context.Background(), risk.HookEvent{
+		SessionID:     "s1",
+		HookEventName: "PreToolUse",
+		Agent:         "claude",
+		ToolName:      "Read",
+		ToolInput:     map[string]any{"file_path": "README.md"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if localJudge.calls != 1 {
+		t.Fatalf("judge calls = %d, want 1", localJudge.calls)
+	}
+	if localJudge.input.NormalizedEvent.Type != string(risk.EventNormalToolCall) {
+		t.Fatalf("judge input = %+v", localJudge.input)
+	}
+	if localJudge.input.DeterministicPolicy.Decision != "allow" || localJudge.input.DeterministicPolicy.PolicyVersion != policy.DefaultPolicyVersion {
+		t.Fatalf("deterministic context = %+v", localJudge.input.DeterministicPolicy)
+	}
+	if decision.Decision != risk.DecisionAllow || decision.ReasonCode != risk.DecisionStageJudgeAllow {
+		t.Fatalf("decision = %+v", decision)
+	}
+	if decision.RiskEvent.DecisionStage != risk.DecisionStageJudgeAllow || decision.RiskEvent.PolicyVersion != policy.DefaultPolicyVersion {
 		t.Fatalf("risk event = %+v", decision.RiskEvent)
 	}
 }
@@ -562,7 +616,7 @@ func TestJudgePolicyFailsOpenWhenJudgeUnavailable(t *testing.T) {
 	if decision.Decision != risk.DecisionAllow || decision.ReasonCode != "judge_unavailable_allow" {
 		t.Fatalf("decision = %+v", decision)
 	}
-	if decision.RiskEvent.JudgeFailureKind != judge.FailureTimeout || decision.RiskEvent.DecisionStage != "judge_fail_open" {
+	if decision.RiskEvent.JudgeFailureKind != judge.FailureTimeout || decision.RiskEvent.DecisionStage != risk.DecisionStageJudgeFailOpen {
 		t.Fatalf("risk event = %+v", decision.RiskEvent)
 	}
 }
@@ -590,8 +644,110 @@ func TestJudgePolicyDeterministicDecisionSkipsJudge(t *testing.T) {
 	if localJudge.calls != 0 {
 		t.Fatalf("judge calls = %d, want 0", localJudge.calls)
 	}
-	if decision.Decision != risk.DecisionDeny || decision.RiskEvent.DecisionStage != "deterministic" {
+	if decision.Decision != risk.DecisionDeny || decision.RiskEvent.DecisionStage != risk.DecisionStageDeterministicDeny {
 		t.Fatalf("decision = %+v", decision)
+	}
+	if decision.RiskEvent.PolicyRuleID != "guard.destructive_persistent_resource.v1" ||
+		decision.RiskEvent.PolicyRuleCategory != string(policy.CategoryDestructivePersistentResource) ||
+		decision.RiskEvent.PolicyVersion != policy.DefaultPolicyVersion {
+		t.Fatalf("policy metadata = %+v", decision.RiskEvent)
+	}
+}
+
+func TestJudgePolicyUsesActiveProfileForDeterministicRules(t *testing.T) {
+	dir := t.TempDir()
+	policyStore, err := policyconfig.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := policyStore.ActivateProfile(context.Background(), policy.ProfileRelaxed); err != nil {
+		t.Fatal(err)
+	}
+	store, err := sqlite.OpenStore(filepath.Join(dir, "guard.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	localJudge := &recordingJudge{
+		result: judge.Result{
+			Output: judge.Output{
+				Decision:   judge.DecisionAllow,
+				RiskLevel:  judge.RiskLevelLow,
+				Categories: []string{"explicit_profile"},
+				Reason:     "Relaxed profile allows this to reach the judge.",
+			},
+			Metadata: judge.Metadata{Runtime: "openai-compatible", Model: "qwen3-0.6b-q4"},
+		},
+	}
+	server, err := NewServerWithOptions(store, Options{Judge: localJudge})
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision, err := server.ProcessHookEvent(context.Background(), risk.HookEvent{
+		SessionID:     "s1",
+		HookEventName: "PreToolUse",
+		ToolName:      "Read",
+		ToolInput:     map[string]any{"file_path": ".env"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if localJudge.calls != 1 {
+		t.Fatalf("judge calls = %d, want 1", localJudge.calls)
+	}
+	if localJudge.input.NormalizedEvent.Type != string(risk.EventCredentialAccess) {
+		t.Fatalf("judge input = %+v", localJudge.input)
+	}
+	if decision.Decision != risk.DecisionAllow || decision.RiskEvent.PolicyProfile != string(policy.ProfileRelaxed) {
+		t.Fatalf("decision = %+v", decision)
+	}
+}
+
+func TestJudgePolicyFallsBackWhenActivePolicyConfigInvalid(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "guard", "policy"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "guard", "policy", "active.json"), []byte(`{"version":"invalid-active-policy","profile":"custom","rulePack":"guard-default","nonBypassableRules":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := sqlite.OpenStore(filepath.Join(dir, "guard.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	localJudge := &recordingJudge{
+		result: judge.Result{
+			Output: judge.Output{
+				Decision:   judge.DecisionAllow,
+				RiskLevel:  judge.RiskLevelLow,
+				Categories: []string{"fallback"},
+				Reason:     "Fallback policy allowed this to reach the judge.",
+			},
+			Metadata: judge.Metadata{Runtime: "openai-compatible", Model: "qwen3-0.6b-q4"},
+		},
+	}
+	server, err := NewServerWithOptions(store, Options{Judge: localJudge})
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision, err := server.ProcessHookEvent(context.Background(), risk.HookEvent{
+		SessionID:     "s1",
+		HookEventName: "PreToolUse",
+		ToolName:      "Read",
+		ToolInput:     map[string]any{"file_path": "README.md"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if localJudge.calls != 1 {
+		t.Fatalf("judge calls = %d, want 1", localJudge.calls)
+	}
+	if localJudge.input.DeterministicPolicy.PolicyVersion != policy.DefaultPolicyVersion {
+		t.Fatalf("deterministic context = %+v", localJudge.input.DeterministicPolicy)
+	}
+	if decision.RiskEvent.PolicyVersion != policy.DefaultPolicyVersion || decision.RiskEvent.PolicyProfile != string(policy.ProfileBalanced) {
+		t.Fatalf("risk event = %+v", decision.RiskEvent)
 	}
 }
 

--- a/internal/guard/judge/http.go
+++ b/internal/guard/judge/http.go
@@ -65,7 +65,7 @@ func NewOpenAICompatibleJudge(opts HTTPOptions) (*OpenAICompatibleJudge, error) 
 	}
 	client := opts.HTTPClient
 	if client == nil {
-		client = http.DefaultClient
+		client = localJudgeHTTPClient()
 	}
 	prompt := opts.Prompt
 	if strings.TrimSpace(prompt) == "" {
@@ -80,6 +80,14 @@ func NewOpenAICompatibleJudge(opts HTTPOptions) (*OpenAICompatibleJudge, error) 
 		prompt:          prompt,
 		disableThinking: opts.DisableThinking || shouldDisableThinking(model),
 	}, nil
+}
+
+func localJudgeHTTPClient() *http.Client {
+	return &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
 }
 
 func (j *OpenAICompatibleJudge) Decide(ctx context.Context, input Input) (Result, error) {

--- a/internal/guard/judge/http_test.go
+++ b/internal/guard/judge/http_test.go
@@ -146,6 +146,35 @@ func TestOpenAICompatibleJudgeClassifiesTimeout(t *testing.T) {
 	}
 }
 
+func TestOpenAICompatibleJudgeDoesNotFollowRedirects(t *testing.T) {
+	redirectTargetCalled := false
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectTargetCalled = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer redirectTarget.Close()
+	redirectSource := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, redirectTarget.URL, http.StatusTemporaryRedirect)
+	}))
+	defer redirectSource.Close()
+
+	localJudge, err := NewOpenAICompatibleJudge(HTTPOptions{
+		BaseURL: redirectSource.URL,
+		Model:   "qwen3-0.6b-q4",
+		Timeout: time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = localJudge.Decide(context.Background(), Input{HookEvent: "PreToolUse"})
+	if FailureKind(err) != FailureUnavailable {
+		t.Fatalf("FailureKind(err) = %q, err=%v", FailureKind(err), err)
+	}
+	if redirectTargetCalled {
+		t.Fatal("judge followed redirect target")
+	}
+}
+
 func TestChatCompletionsEndpointAcceptsV1Base(t *testing.T) {
 	endpoint, err := chatCompletionsEndpoint("http://127.0.0.1:8080/v1")
 	if err != nil {

--- a/internal/guard/judgeruntime/config.go
+++ b/internal/guard/judgeruntime/config.go
@@ -1,0 +1,280 @@
+package judgeruntime
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/guard/judge"
+)
+
+type Config struct {
+	URL            string
+	Model          string
+	Timeout        time.Duration
+	Managed        bool
+	ServerBin      string
+	ModelPath      string
+	HFRepo         string
+	HFFile         string
+	HFRevision     string
+	CacheDir       string
+	Port           int
+	StartupTimeout time.Duration
+}
+
+func ConfigFromEnv(dbPath string, managedDefault bool) (Config, error) {
+	timeout, err := envDuration("KONTEXT_JUDGE_TIMEOUT", judge.DefaultTimeout)
+	if err != nil {
+		return Config{}, err
+	}
+	managed, err := envBoolDefault("KONTEXT_JUDGE_MANAGED", managedDefault)
+	if err != nil {
+		return Config{}, err
+	}
+	if os.Getenv("KONTEXT_JUDGE_MANAGED") == "" && strings.TrimSpace(os.Getenv("KONTEXT_JUDGE_URL")) != "" {
+		managed = false
+	}
+	port, err := envInt("KONTEXT_JUDGE_PORT", judge.DefaultLlamaServerPort)
+	if err != nil {
+		return Config{}, err
+	}
+	startupTimeout, err := envDuration("KONTEXT_JUDGE_STARTUP_TIMEOUT", judge.DefaultLlamaServerStartupTimeout)
+	if err != nil {
+		return Config{}, err
+	}
+	return Config{
+		URL:            os.Getenv("KONTEXT_JUDGE_URL"),
+		Model:          os.Getenv("KONTEXT_JUDGE_MODEL"),
+		Timeout:        timeout,
+		Managed:        managed,
+		ServerBin:      envString("KONTEXT_JUDGE_SERVER_BIN", judge.DefaultLlamaServerBinary),
+		ModelPath:      os.Getenv("KONTEXT_JUDGE_MODEL_PATH"),
+		HFRepo:         os.Getenv("KONTEXT_JUDGE_HF_REPO"),
+		HFFile:         os.Getenv("KONTEXT_JUDGE_HF_FILE"),
+		HFRevision:     os.Getenv("KONTEXT_JUDGE_HF_REVISION"),
+		CacheDir:       ResolvedCacheDir(os.Getenv("KONTEXT_JUDGE_CACHE_DIR"), dbPath),
+		Port:           port,
+		StartupTimeout: startupTimeout,
+	}, nil
+}
+
+func Configure(ctx context.Context, cfg Config) (judge.Judge, func(), string, error) {
+	closeFn := func() {}
+	if cfg.Managed {
+		return configureManaged(ctx, cfg)
+	}
+	if strings.TrimSpace(cfg.URL) == "" && strings.TrimSpace(cfg.Model) == "" {
+		return nil, closeFn, "", nil
+	}
+	if strings.TrimSpace(cfg.URL) == "" || strings.TrimSpace(cfg.Model) == "" {
+		return nil, closeFn, "", fmt.Errorf("--judge-url and --judge-model must be set together")
+	}
+	if err := ValidateLocalURL(cfg.URL); err != nil {
+		return nil, closeFn, "", err
+	}
+	localJudge, err := judge.NewOpenAICompatibleJudge(judge.HTTPOptions{
+		BaseURL: cfg.URL,
+		Model:   cfg.Model,
+		Timeout: cfg.Timeout,
+	})
+	if err != nil {
+		return nil, closeFn, "", err
+	}
+	return localJudge, closeFn, fmt.Sprintf("%s at %s", cfg.Model, cfg.URL), nil
+}
+
+func configureManaged(ctx context.Context, cfg Config) (judge.Judge, func(), string, error) {
+	closeFn := func() {}
+	modelPath := strings.TrimSpace(cfg.ModelPath)
+	modelName := strings.TrimSpace(cfg.Model)
+	if modelPath == "" && LooksLikeGGUFPath(modelName) {
+		modelPath = modelName
+		modelName = ""
+	}
+	hfRepo := strings.TrimSpace(cfg.HFRepo)
+	hfFile := strings.TrimSpace(cfg.HFFile)
+	if modelPath == "" && hfRepo == "" {
+		hfRepo = judge.DefaultLlamaServerHFRepo
+		if hfFile == "" {
+			hfFile = judge.DefaultLlamaServerHFFile
+		}
+	}
+	if modelName == "" {
+		modelName = ManagedModelName(modelPath, hfRepo, hfFile)
+	}
+	host, port, baseURL, err := ManagedListenConfig(cfg.URL, cfg.Port)
+	if err != nil {
+		return nil, closeFn, "", err
+	}
+	server, err := judge.StartLlamaServer(ctx, judge.LlamaServerOptions{
+		BinaryPath:     cfg.ServerBin,
+		ModelPath:      modelPath,
+		HFRepo:         hfRepo,
+		HFFile:         hfFile,
+		HFRevision:     cfg.HFRevision,
+		CacheDir:       cfg.CacheDir,
+		Host:           host,
+		Port:           port,
+		StartupTimeout: cfg.StartupTimeout,
+	})
+	if err != nil {
+		unavailable := judge.UnavailableJudge{
+			Runtime: judge.DefaultLlamaServerRuntime,
+			Model:   modelName,
+			Kind:    judge.FailureUnavailable,
+			Err:     err,
+		}
+		return unavailable, closeFn, fmt.Sprintf("%s unavailable (%v)", modelName, err), nil
+	}
+	closeFn = func() {
+		_ = server.Stop()
+	}
+	localJudge, err := judge.NewOpenAICompatibleJudge(judge.HTTPOptions{
+		BaseURL: baseURL,
+		Model:   modelName,
+		Runtime: judge.DefaultLlamaServerRuntime,
+		Timeout: cfg.Timeout,
+	})
+	if err != nil {
+		closeFn()
+		return nil, func() {}, "", err
+	}
+	return localJudge, closeFn, fmt.Sprintf("%s at %s (%s)", modelName, baseURL, judge.DefaultLlamaServerRuntime), nil
+}
+
+func ManagedListenConfig(rawURL string, port int) (string, int, string, error) {
+	if port <= 0 {
+		port = judge.DefaultLlamaServerPort
+	}
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return judge.DefaultLlamaServerHost, port, managedBaseURL(judge.DefaultLlamaServerHost, port), nil
+	}
+	if err := ValidateLocalURL(rawURL); err != nil {
+		return "", 0, "", err
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", 0, "", fmt.Errorf("parse judge URL: %w", err)
+	}
+	if parsed.Scheme != "http" {
+		return "", 0, "", fmt.Errorf("managed judge URL must use http")
+	}
+	host := parsed.Hostname()
+	if host == "" {
+		return "", 0, "", fmt.Errorf("managed judge URL must include host")
+	}
+	if parsed.Port() != "" {
+		parsedPort, err := strconv.Atoi(parsed.Port())
+		if err != nil || parsedPort <= 0 {
+			return "", 0, "", fmt.Errorf("managed judge URL has invalid port %q", parsed.Port())
+		}
+		port = parsedPort
+	}
+	return host, port, managedBaseURL(host, port), nil
+}
+
+func ValidateLocalURL(value string) error {
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return fmt.Errorf("parse judge URL: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("judge URL must use http or https")
+	}
+	switch strings.ToLower(parsed.Hostname()) {
+	case "localhost", "127.0.0.1", "::1":
+		return nil
+	default:
+		return fmt.Errorf("judge URL must point to localhost")
+	}
+}
+
+func LooksLikeGGUFPath(value string) bool {
+	value = strings.TrimSpace(value)
+	return strings.HasSuffix(strings.ToLower(value), ".gguf") || strings.Contains(value, string(filepath.Separator))
+}
+
+func ManagedModelName(modelPath, hfRepo, hfFile string) string {
+	if strings.TrimSpace(hfRepo) != "" {
+		return strings.TrimSpace(hfRepo)
+	}
+	if strings.TrimSpace(modelPath) != "" {
+		return filepath.Base(modelPath)
+	}
+	if strings.TrimSpace(hfFile) != "" {
+		return strings.TrimSpace(hfFile)
+	}
+	return "local-judge"
+}
+
+func ResolvedCacheDir(cacheDir, dbPath string) string {
+	if strings.TrimSpace(cacheDir) != "" {
+		return cacheDir
+	}
+	return defaultCacheDir(dbPath)
+}
+
+func managedBaseURL(host string, port int) string {
+	return (&url.URL{
+		Scheme: "http",
+		Host:   net.JoinHostPort(host, strconv.Itoa(port)),
+	}).String()
+}
+
+func defaultCacheDir(dbPath string) string {
+	if dbPath != "" {
+		return filepath.Join(filepath.Dir(dbPath), "judge-models")
+	}
+	if dir, err := os.UserCacheDir(); err == nil && dir != "" {
+		return filepath.Join(dir, "kontext", "judge")
+	}
+	return filepath.Join(".", "judge-models")
+}
+
+func envString(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func envBoolDefault(key string, fallback bool) (bool, error) {
+	if value := os.Getenv(key); value != "" {
+		parsed, err := strconv.ParseBool(value)
+		if err != nil {
+			return false, fmt.Errorf("%s must be a boolean: %w", key, err)
+		}
+		return parsed, nil
+	}
+	return fallback, nil
+}
+
+func envInt(key string, fallback int) (int, error) {
+	if value := os.Getenv(key); value != "" {
+		parsed, err := strconv.Atoi(value)
+		if err != nil {
+			return 0, fmt.Errorf("%s must be an integer: %w", key, err)
+		}
+		return parsed, nil
+	}
+	return fallback, nil
+}
+
+func envDuration(key string, fallback time.Duration) (time.Duration, error) {
+	if value := os.Getenv(key); value != "" {
+		parsed, err := time.ParseDuration(value)
+		if err != nil {
+			return 0, fmt.Errorf("%s must be a duration: %w", key, err)
+		}
+		return parsed, nil
+	}
+	return fallback, nil
+}

--- a/internal/guard/judgeruntime/config_test.go
+++ b/internal/guard/judgeruntime/config_test.go
@@ -1,0 +1,34 @@
+package judgeruntime
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestConfigFromEnvDefaultsManagedJudgeOn(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "guard.db")
+
+	cfg, err := ConfigFromEnv(dbPath, true)
+	if err != nil {
+		t.Fatalf("ConfigFromEnv() error = %v", err)
+	}
+	if !cfg.Managed {
+		t.Fatal("Managed = false, want true")
+	}
+	if cfg.CacheDir != filepath.Join(filepath.Dir(dbPath), "judge-models") {
+		t.Fatalf("CacheDir = %q, want db-adjacent judge-models", cfg.CacheDir)
+	}
+}
+
+func TestConfigFromEnvTreatsJudgeURLAsExternalByDefault(t *testing.T) {
+	t.Setenv("KONTEXT_JUDGE_URL", "http://127.0.0.1:18080")
+	t.Setenv("KONTEXT_JUDGE_MODEL", "qwen3")
+
+	cfg, err := ConfigFromEnv(filepath.Join(t.TempDir(), "guard.db"), true)
+	if err != nil {
+		t.Fatalf("ConfigFromEnv() error = %v", err)
+	}
+	if cfg.Managed {
+		t.Fatal("Managed = true, want false for explicit judge URL")
+	}
+}

--- a/internal/guard/risk/types.go
+++ b/internal/guard/risk/types.go
@@ -36,6 +36,13 @@ const (
 	DecisionDeny  Decision = "deny"
 )
 
+const (
+	DecisionStageDeterministicDeny = "deterministic_deny"
+	DecisionStageJudgeAllow        = "judge_allow"
+	DecisionStageJudgeDeny         = "judge_deny"
+	DecisionStageJudgeFailOpen     = "judge_fail_open"
+)
+
 type RiskEvent struct {
 	Type               EventType `json:"type"`
 	Provider           string    `json:"provider,omitempty"`
@@ -60,6 +67,11 @@ type RiskEvent struct {
 	Signals            []string  `json:"signals,omitempty"`
 	DecisionStage      string    `json:"decision_stage,omitempty"`
 	PolicyVersion      string    `json:"policy_version,omitempty"`
+	PolicyProfile      string    `json:"policy_profile,omitempty"`
+	PolicyRulePack     string    `json:"policy_rule_pack,omitempty"`
+	PolicyRuleID       string    `json:"policy_rule_id,omitempty"`
+	PolicyRuleCategory string    `json:"policy_rule_category,omitempty"`
+	PolicySignals      []string  `json:"policy_signals,omitempty"`
 	JudgeRuntime       string    `json:"judge_runtime,omitempty"`
 	JudgeModel         string    `json:"judge_model,omitempty"`
 	JudgeDurationMs    *int64    `json:"judge_duration_ms,omitempty"`

--- a/internal/run/local.go
+++ b/internal/run/local.go
@@ -26,15 +26,17 @@ func StartLocal(ctx context.Context, opts Options) error {
 	}
 	cwd, _ := os.Getwd()
 	host, err := runtimehost.Start(ctx, runtimehost.Options{
-		AgentName:      opts.Agent,
-		CWD:            cwd,
-		DBPath:         os.Getenv("KONTEXT_DB"),
-		ModelPath:      os.Getenv("KONTEXT_MODEL"),
-		DashboardAddr:  os.Getenv("KONTEXT_ADDR"),
-		StartDashboard: true,
-		Mode:           string(mode),
-		Diagnostic:     diagnostics,
-		Out:            os.Stderr,
+		AgentName:           opts.Agent,
+		CWD:                 cwd,
+		DBPath:              os.Getenv("KONTEXT_DB"),
+		ModelPath:           os.Getenv("KONTEXT_MODEL"),
+		DashboardAddr:       os.Getenv("KONTEXT_ADDR"),
+		StartDashboard:      true,
+		JudgeConfigFromEnv:  true,
+		JudgeManagedDefault: true,
+		Mode:                string(mode),
+		Diagnostic:          diagnostics,
+		Out:                 os.Stderr,
 	})
 	if err != nil {
 		return err
@@ -62,6 +64,11 @@ func StartLocal(ctx context.Context, opts Options) error {
 		fmt.Fprintf(os.Stderr, "✓ Dashboard: %s\n", host.DashboardURL)
 	}
 	fmt.Fprintf(os.Stderr, "✓ Risk model: %s\n", host.ActiveModelPath)
+	if host.LocalJudgeStatus != "" {
+		fmt.Fprintf(os.Stderr, "✓ Local judge: %s\n", host.LocalJudgeStatus)
+	} else {
+		fmt.Fprintln(os.Stderr, "✓ Local judge: disabled")
+	}
 	printLocalMode(os.Stderr, string(host.Mode))
 	fmt.Fprintf(os.Stderr, "\nLaunching %s...\n\n", opts.Agent)
 

--- a/internal/runtimehost/host.go
+++ b/internal/runtimehost/host.go
@@ -18,6 +18,8 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 	"github.com/kontext-security/kontext-cli/internal/guard/app/server"
 	guardhookruntime "github.com/kontext-security/kontext-cli/internal/guard/hookruntime"
+	"github.com/kontext-security/kontext-cli/internal/guard/judge"
+	"github.com/kontext-security/kontext-cli/internal/guard/judgeruntime"
 	"github.com/kontext-security/kontext-cli/internal/guard/modelsnapshot"
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
 	"github.com/kontext-security/kontext-cli/internal/localruntime"
@@ -42,6 +44,8 @@ type Options struct {
 	DashboardAddr             string
 	StartDashboard            bool
 	AllowNonLoopbackDashboard bool
+	JudgeConfigFromEnv        bool
+	JudgeManagedDefault       bool
 	Mode                      string
 	Threshold                 float64
 	Horizon                   int
@@ -50,17 +54,19 @@ type Options struct {
 }
 
 type Host struct {
-	SessionID       string
-	SessionDir      string
-	SocketPath      string
-	DBPath          string
-	DashboardURL    string
-	DashboardErr    error
-	ActiveModelPath string
-	Mode            guardhookruntime.Mode
+	SessionID        string
+	SessionDir       string
+	SocketPath       string
+	DBPath           string
+	DashboardURL     string
+	DashboardErr     error
+	ActiveModelPath  string
+	LocalJudgeStatus string
+	Mode             guardhookruntime.Mode
 
 	server           *server.Server
 	closeStore       func() error
+	closeJudge       func()
 	runtimeService   *localruntime.Service
 	dashboardServer  *http.Server
 	sessionOpened    bool
@@ -96,12 +102,30 @@ func Start(ctx context.Context, opts Options) (*Host, error) {
 		return nil, err
 	}
 
-	localServer, closeStore, err := server.OpenDefaultServer(dbPath, scorer)
+	closeJudge := func() {}
+	var localJudge judge.Judge
+	var judgeStatus string
+	if opts.JudgeConfigFromEnv {
+		judgeConfig, err := judgeruntime.ConfigFromEnv(dbPath, opts.JudgeManagedDefault)
+		if err != nil {
+			return nil, err
+		}
+		localJudge, closeJudge, judgeStatus, err = judgeruntime.Configure(ctx, judgeConfig)
+		if err != nil {
+			return nil, err
+		}
+	}
+	localServer, closeStore, err := server.OpenDefaultServerWithOptions(dbPath, server.Options{
+		Scorer: scorer,
+		Judge:  localJudge,
+	})
 	if err != nil {
+		closeJudge()
 		return nil, err
 	}
 	if err := os.Chmod(dbPath, 0o600); err != nil && !errors.Is(err, os.ErrNotExist) {
 		_ = closeStore()
+		closeJudge()
 		return nil, fmt.Errorf("secure runtime database: %w", err)
 	}
 
@@ -111,11 +135,13 @@ func Start(ctx context.Context, opts Options) (*Host, error) {
 	}
 	if err := validateSessionID(sessionID); err != nil {
 		_ = closeStore()
+		closeJudge()
 		return nil, err
 	}
 	sessionDir := filepath.Join("/tmp", "kontext", sessionID)
 	if err := createSessionDir(sessionDir); err != nil {
 		_ = closeStore()
+		closeJudge()
 		return nil, err
 	}
 	socketPath := strings.TrimSpace(opts.SocketPath)
@@ -124,14 +150,16 @@ func Start(ctx context.Context, opts Options) (*Host, error) {
 	}
 
 	host := &Host{
-		SessionID:       sessionID,
-		SessionDir:      sessionDir,
-		SocketPath:      socketPath,
-		DBPath:          dbPath,
-		ActiveModelPath: activeModelPath,
-		Mode:            mode,
-		server:          localServer,
-		closeStore:      closeStore,
+		SessionID:        sessionID,
+		SessionDir:       sessionDir,
+		SocketPath:       socketPath,
+		DBPath:           dbPath,
+		ActiveModelPath:  activeModelPath,
+		LocalJudgeStatus: judgeStatus,
+		Mode:             mode,
+		server:           localServer,
+		closeStore:       closeStore,
+		closeJudge:       closeJudge,
 	}
 
 	runtimeService, err := localruntime.NewService(localruntime.Options{
@@ -220,6 +248,10 @@ func (h *Host) Close(ctx context.Context) error {
 			errs = append(errs, err)
 		}
 		h.closeStore = nil
+	}
+	if h.closeJudge != nil {
+		h.closeJudge()
+		h.closeJudge = nil
 	}
 	if h.SessionDir != "" {
 		if err := os.RemoveAll(h.SessionDir); err != nil {

--- a/internal/runtimehost/host_test.go
+++ b/internal/runtimehost/host_test.go
@@ -3,11 +3,14 @@ package runtimehost
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
+	"github.com/kontext-security/kontext-cli/internal/guard/risk"
 	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
 	"github.com/kontext-security/kontext-cli/internal/hook"
 	"github.com/kontext-security/kontext-cli/internal/localruntime"
@@ -146,6 +149,100 @@ func TestStartPersistsLocalDecisions(t *testing.T) {
 	}
 	if string(events[0].Decision) != string(result.Decision) {
 		t.Fatalf("stored decision = %q, want %q", events[0].Decision, result.Decision)
+	}
+}
+
+func TestStartWiresLocalJudgeFromEnv(t *testing.T) {
+	ctx := context.Background()
+	judgeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Fatalf("judge path = %q, want /v1/chat/completions", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"{\"decision\":\"deny\",\"risk_level\":\"high\",\"categories\":[\"test\"],\"reason\":\"test judge deny\"}"}}]}`))
+	}))
+	defer judgeServer.Close()
+	t.Setenv("KONTEXT_JUDGE_URL", judgeServer.URL)
+	t.Setenv("KONTEXT_JUDGE_MODEL", "test-local-judge")
+
+	dbPath := filepath.Join(t.TempDir(), "guard.db")
+	host, err := Start(ctx, Options{
+		AgentName:          "claude",
+		CWD:                t.TempDir(),
+		DBPath:             dbPath,
+		JudgeConfigFromEnv: true,
+		Diagnostic:         diagnostic.New(nil, false),
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	client := localruntime.NewClient(host.SocketPath)
+	_, err = client.Process(ctx, hook.Event{
+		Agent:    "claude",
+		HookName: hook.HookPreToolUse,
+		ToolName: "Bash",
+		ToolInput: map[string]any{
+			"command": "echo hello",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Process() error = %v", err)
+	}
+	sessionID := host.SessionID
+	if err := host.Close(ctx); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	store, err := sqlite.OpenStore(dbPath)
+	if err != nil {
+		t.Fatalf("OpenStore() error = %v", err)
+	}
+	defer store.Close()
+	events, err := store.Events(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("Events() error = %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events len = %d, want 1", len(events))
+	}
+	if events[0].Decision != risk.DecisionDeny || events[0].RiskEvent.DecisionStage != risk.DecisionStageJudgeDeny {
+		t.Fatalf("stored decision = %q stage = %q, want judge deny", events[0].Decision, events[0].RiskEvent.DecisionStage)
+	}
+	if events[0].RiskEvent.JudgeModel != "test-local-judge" {
+		t.Fatalf("judge model = %q, want test-local-judge", events[0].RiskEvent.JudgeModel)
+	}
+}
+
+func TestStartIgnoresJudgeEnvUnlessEnabled(t *testing.T) {
+	t.Setenv("KONTEXT_JUDGE_TIMEOUT", "not-a-duration")
+
+	host, err := Start(context.Background(), Options{
+		AgentName: "claude",
+		CWD:       t.TempDir(),
+		DBPath:    filepath.Join(t.TempDir(), "guard.db"),
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer host.Close(context.Background())
+}
+
+func TestStartValidatesJudgeEnvWhenEnabled(t *testing.T) {
+	t.Setenv("KONTEXT_JUDGE_TIMEOUT", "not-a-duration")
+
+	host, err := Start(context.Background(), Options{
+		AgentName:          "claude",
+		CWD:                t.TempDir(),
+		DBPath:             filepath.Join(t.TempDir(), "guard.db"),
+		JudgeConfigFromEnv: true,
+	})
+	if err == nil {
+		_ = host.Close(context.Background())
+		t.Fatal("Start() error = nil, want judge env validation error")
+	}
+	if !strings.Contains(err.Error(), "KONTEXT_JUDGE_TIMEOUT") {
+		t.Fatalf("error = %v, want judge timeout error", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- ENG-325: connect Guard PreToolUse decisions into one deterministic-policy-first path, then local LLM judge when deterministic policy allows.
- ENG-356: wire `kontext start` into the local LLM judge path by default for local runtime startup.
- Keep `kontext start` local-first and keep observe mode as the default; enforce still requires explicit `KONTEXT_MODE=enforce`.

## Verification

- [x] `go test ./...`

## Notes

- `kontext start` defaults to a managed local judge configuration. If `llama-server` or the model is unavailable, Guard records judge fail-open metadata rather than blocking by default.
- Setting `KONTEXT_JUDGE_URL` and `KONTEXT_JUDGE_MODEL` points `kontext start` at an already-running OpenAI-compatible local judge.

Linear: ENG-325, ENG-356