### PR TITLE
fix: optimize sidecar git remote collection

### DIFF
--- a/internal/sidecar/sidecar.go
+++ b/internal/sidecar/sidecar.go
@@ -320,20 +320,40 @@ func collectGitContext(cwd string) (map[string]any, bool) {
 		git["branch"] = branch
 	}
 
-	remoteNames := strings.Fields(runGit(gitPath, cwd, "remote"))
-	remotes := map[string]string{}
-	for _, name := range remoteNames {
-		remoteURL := strings.TrimSpace(runGit(gitPath, cwd, "remote", "get-url", name))
-		if remoteURL == "" {
-			continue
-		}
-		remotes[name] = sanitizeGitRemoteURL(remoteURL)
-	}
+	remotes := gitRemoteURLs(gitPath, cwd)
 	if len(remotes) > 0 {
 		git["remotes"] = remotes
 	}
 
 	return git, true
+}
+
+func gitRemoteURLs(gitPath, cwd string) map[string]string {
+	output := runGit(gitPath, cwd, "config", "--get-regexp", "^remote\\..*\\.url$")
+	if output == "" {
+		return nil
+	}
+
+	remotes := map[string]string{}
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		key := fields[0]
+		if !strings.HasPrefix(key, "remote.") || !strings.HasSuffix(key, ".url") {
+			continue
+		}
+		name := strings.TrimSuffix(strings.TrimPrefix(key, "remote."), ".url")
+		if name == "" {
+			continue
+		}
+		remotes[name] = sanitizeGitRemoteURL(strings.Join(fields[1:], " "))
+	}
+	if len(remotes) == 0 {
+		return nil
+	}
+	return remotes
 }
 
 func trustedGitPath() (string, bool) {

--- a/internal/sidecar/sidecar_test.go
+++ b/internal/sidecar/sidecar_test.go
@@ -622,6 +622,7 @@ func TestBuildHookEventRequestEnrichesBashPreToolUseWithGitContext(t *testing.T)
 	runTestGit(t, repoDir, "add", "README.md")
 	runTestGit(t, repoDir, "-c", "user.name=Kontext Test", "-c", "user.email=test@example.com", "commit", "-m", "init")
 	runTestGit(t, repoDir, "remote", "add", "origin", "https://token:x-oauth-basic@github.com/kontext-security/kontext-cli.git")
+	runTestGit(t, repoDir, "remote", "add", "backup", "https://oauth2:secret@gitlab.com/kontext-security/kontext-cli.git")
 
 	got := buildHookEventRequestFromEvent(hook.Event{
 		SessionID: "session-123",
@@ -645,8 +646,14 @@ func TestBuildHookEventRequestEnrichesBashPreToolUseWithGitContext(t *testing.T)
 	if remotes["origin"] != "https://github.com/kontext-security/kontext-cli.git" {
 		t.Fatalf("origin remote = %v, want sanitized GitHub URL", remotes["origin"])
 	}
+	if remotes["backup"] != "https://gitlab.com/kontext-security/kontext-cli.git" {
+		t.Fatalf("backup remote = %v, want sanitized GitLab URL", remotes["backup"])
+	}
 	if strings.Contains(string(got.ToolInput), "token") || strings.Contains(string(got.ToolInput), "x-oauth-basic") {
 		t.Fatalf("ToolInput leaked credential-bearing remote: %s", got.ToolInput)
+	}
+	if strings.Contains(string(got.ToolInput), "oauth2:secret") {
+		t.Fatalf("ToolInput leaked backup remote credentials: %s", got.ToolInput)
 	}
 }
 


### PR DESCRIPTION
Summary
This optimizes sidecar Git context enrichment by collecting all remote URLs in one Git config read.

Before this, `internal/sidecar/sidecar.go` ran one `git remote get-url` subprocess per remote after a separate `git remote` scan, which made every enriched Bash pre-tool event pay an avoidable N+1 shell cost.

Now one `git config --get-regexp '^remote\\..*\\.url$'` call is the canonical path:

```go
remotes := gitRemoteURLs(gitPath, cwd)
```

Why
This gives kontext-cli a cheaper runtime path for Bash hook enrichment:

Bash PreToolUse event
-> sidecar Git context collection
-> sanitized remote map in the hosted hook payload

This PR does not broaden behavior beyond the optimization scope.

What changed
Optimized Git remote collection in `internal/sidecar/sidecar.go`
Removed one subprocess per remote during hook payload enrichment
Preserved remote-name mapping and credential sanitization
Updated tests for multiple sanitized remotes in the enriched payload

Verification
gofmt -w internal/sidecar/sidecar.go internal/sidecar/sidecar_test.go
go test ./internal/sidecar
go test ./internal/guard/judge -run 'TestStartLlamaServerHealthCheckAndStop|TestStartLlamaServerEarlyExitDoesNotWaitForStopTimeout' -count=1
go test ./...
go vet ./...
git diff --check
