### PR TITLE
feat(managed): add managed config contract

### DIFF
--- a/internal/managedconfig/config.go
+++ b/internal/managedconfig/config.go
@@ -1,0 +1,25 @@
+package managedconfig
+
+const (
+	SchemaVersion = "managed-install-v1"
+	DefaultMode   = "observe"
+	DefaultAgent  = "claude"
+)
+
+type Config struct {
+	Version        string      `json:"version"`
+	OrganizationID string      `json:"organization_id"`
+	CloudURL       string      `json:"cloud_url"`
+	Mode           string      `json:"mode"`
+	Agent          string      `json:"agent"`
+	Device         Device      `json:"device,omitempty"`
+	Credentials    Credentials `json:"credentials"`
+}
+
+type Device struct {
+	Label *string `json:"label,omitempty"`
+}
+
+type Credentials struct {
+	InstallTokenRef string `json:"install_token_ref"`
+}

--- a/internal/managedconfig/config_test.go
+++ b/internal/managedconfig/config_test.go
@@ -1,0 +1,186 @@
+package managedconfig
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadMissingConfigReturnsUnmanaged(t *testing.T) {
+	state := Load(context.Background(), Options{Path: filepath.Join(t.TempDir(), "missing.json")})
+	if state.Kind != StateUnmanaged {
+		t.Fatalf("Kind = %q, want %q", state.Kind, StateUnmanaged)
+	}
+}
+
+func TestLoadValidConfigReturnsManagedActive(t *testing.T) {
+	path := writeConfig(t, validConfigJSON())
+	state := Load(context.Background(), Options{Path: path})
+	if state.Kind != StateManagedActive {
+		t.Fatalf("Kind = %q, want %q, errors = %#v", state.Kind, StateManagedActive, state.Errors)
+	}
+	if state.Config.OrganizationID != "org_example" {
+		t.Fatalf("OrganizationID = %q, want org_example", state.Config.OrganizationID)
+	}
+	if !strings.HasPrefix(state.Checksum, "sha256:") {
+		t.Fatalf("Checksum = %q, want sha256 prefix", state.Checksum)
+	}
+}
+
+func TestLoadInvalidJSONReturnsManagedInvalid(t *testing.T) {
+	path := writeConfig(t, `{"version":`)
+	state := Load(context.Background(), Options{Path: path})
+	if state.Kind != StateManagedInvalid {
+		t.Fatalf("Kind = %q, want %q", state.Kind, StateManagedInvalid)
+	}
+	if got := state.Errors[0].Code; got != "invalid_json" {
+		t.Fatalf("error code = %q, want invalid_json", got)
+	}
+}
+
+func TestDecodeRejectsUnknownFields(t *testing.T) {
+	path := writeConfig(t, strings.Replace(validConfigJSON(), `"credentials":`, `"extra": true, "credentials":`, 1))
+	state := Load(context.Background(), Options{Path: path})
+	if state.Kind != StateManagedInvalid {
+		t.Fatalf("Kind = %q, want %q", state.Kind, StateManagedInvalid)
+	}
+	if got := state.Errors[0].Code; got != "invalid_json" {
+		t.Fatalf("error code = %q, want invalid_json", got)
+	}
+}
+
+func TestValidateRejectsUnsupportedVersionModeAgentAndCloudURL(t *testing.T) {
+	cfg := validConfig()
+	cfg.Version = "v0"
+	cfg.Mode = "ask"
+	cfg.Agent = "other"
+	cfg.CloudURL = "http://api.kontext.security?token=bad"
+	errs := Validate(cfg)
+	wantCodes := []string{"unsupported_version", "invalid_cloud_url", "unsupported_mode", "unsupported_agent"}
+	for _, code := range wantCodes {
+		if !hasCode(errs, code) {
+			t.Fatalf("Validate() missing code %q in %#v", code, errs)
+		}
+	}
+}
+
+func TestValidateRejectsMissingRequiredFields(t *testing.T) {
+	errs := Validate(Config{})
+	for _, code := range []string{"unsupported_version", "required", "unsupported_mode", "unsupported_agent"} {
+		if !hasCode(errs, code) {
+			t.Fatalf("Validate() missing code %q in %#v", code, errs)
+		}
+	}
+}
+
+func TestValidateRejectsUnsafeCloudURLParts(t *testing.T) {
+	tests := []string{
+		"https://user:pass@api.kontext.security",
+		"https://api.kontext.security:8443",
+		"https://api.kontext.security?x=1",
+		"https://api.kontext.security#frag",
+	}
+	for _, raw := range tests {
+		t.Run(raw, func(t *testing.T) {
+			cfg := validConfig()
+			cfg.CloudURL = raw
+			if !hasCode(Validate(cfg), "invalid_cloud_url") {
+				t.Fatalf("Validate(%q) did not reject cloud_url", raw)
+			}
+		})
+	}
+}
+
+func TestValidateRejectsUnsupportedCloudHost(t *testing.T) {
+	cfg := validConfig()
+	cfg.CloudURL = "https://attacker.example"
+	errs := Validate(cfg)
+	if !hasCode(errs, "unsupported_cloud_host") {
+		t.Fatalf("Validate() missing unsupported_cloud_host in %#v", errs)
+	}
+}
+
+func TestCredentialRefs(t *testing.T) {
+	for _, raw := range []string{"keychain:kontext-managed-install-token", "env:KONTEXT_INSTALL_TOKEN"} {
+		t.Run(raw, func(t *testing.T) {
+			if _, err := ParseCredentialRef(raw); err != nil {
+				t.Fatalf("ParseCredentialRef() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestCredentialRefsRejectKeychainWhitespace(t *testing.T) {
+	cfg := validConfig()
+	cfg.Credentials.InstallTokenRef = "keychain:foo bar"
+	errs := Validate(cfg)
+	if !hasCode(errs, "invalid_credential_ref") {
+		t.Fatalf("Validate() missing invalid_credential_ref in %#v", errs)
+	}
+}
+
+func TestValidateRejectsRawTokenValues(t *testing.T) {
+	for _, raw := range []string{
+		"sk_live_123",
+		"token:secret",
+		"header.payload.signature",
+		"abcdefghijklmnopqrstuvwxyz1234567890",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			cfg := validConfig()
+			cfg.Credentials.InstallTokenRef = raw
+			if !hasCode(Validate(cfg), "inline_secret_rejected") && !hasCode(Validate(cfg), "invalid_credential_ref") {
+				t.Fatalf("Validate(%q) did not reject raw token", raw)
+			}
+		})
+	}
+}
+
+func writeConfig(t *testing.T, data string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "managed.json")
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	return path
+}
+
+func validConfigJSON() string {
+	return `{
+  "version": "managed-install-v1",
+  "organization_id": "org_example",
+  "cloud_url": "https://api.kontext.security",
+  "mode": "observe",
+  "agent": "claude",
+  "device": {
+    "label": "optional-human-label"
+  },
+  "credentials": {
+    "install_token_ref": "keychain:kontext-managed-install-token"
+  }
+}`
+}
+
+func validConfig() Config {
+	label := "optional-human-label"
+	return Config{
+		Version:        SchemaVersion,
+		OrganizationID: "org_example",
+		CloudURL:       "https://api.kontext.security",
+		Mode:           DefaultMode,
+		Agent:          DefaultAgent,
+		Device:         Device{Label: &label},
+		Credentials:    Credentials{InstallTokenRef: "keychain:kontext-managed-install-token"},
+	}
+}
+
+func hasCode(errs []ValidationError, code string) bool {
+	for _, err := range errs {
+		if err.Code == code {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/managedconfig/credential_ref.go
+++ b/internal/managedconfig/credential_ref.go
@@ -1,0 +1,51 @@
+package managedconfig
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+)
+
+type CredentialRef struct {
+	Scheme string
+	Name   string
+}
+
+var envNamePattern = regexp.MustCompile(`^[A-Z_][A-Z0-9_]*$`)
+
+func ParseCredentialRef(raw string) (CredentialRef, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return CredentialRef{}, errors.New("install token reference is required")
+	}
+	scheme, value, ok := strings.Cut(raw, ":")
+	if !ok {
+		return CredentialRef{}, errors.New("install token reference must use keychain: or env:")
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return CredentialRef{}, errors.New("install token reference value is required")
+	}
+	switch scheme {
+	case "keychain":
+		if strings.ContainsAny(value, " \n\r\t") {
+			return CredentialRef{}, errors.New("keychain service name must not contain whitespace")
+		}
+		return CredentialRef{Scheme: scheme, Name: value}, nil
+	case "env":
+		if !envNamePattern.MatchString(value) {
+			return CredentialRef{}, errors.New("env token reference must be an environment variable name")
+		}
+		return CredentialRef{Scheme: scheme, Name: value}, nil
+	default:
+		return CredentialRef{}, errors.New("install token reference must use keychain: or env:")
+	}
+}
+
+func RedactCredentialRef(raw string) string {
+	ref, err := ParseCredentialRef(raw)
+	if err != nil {
+		return ""
+	}
+	return ref.Scheme + ":" + ref.Name
+}

--- a/internal/managedconfig/errors.go
+++ b/internal/managedconfig/errors.go
@@ -1,0 +1,14 @@
+package managedconfig
+
+type ValidationError struct {
+	Code    string `json:"code"`
+	Field   string `json:"field,omitempty"`
+	Message string `json:"message"`
+}
+
+func (e ValidationError) Error() string {
+	if e.Field == "" {
+		return e.Message
+	}
+	return e.Field + ": " + e.Message
+}

--- a/internal/managedconfig/load.go
+++ b/internal/managedconfig/load.go
@@ -1,0 +1,124 @@
+package managedconfig
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+)
+
+type SourceKind string
+
+const (
+	SourceFile        SourceKind = "file"
+	SourceEnvOverride SourceKind = "env_override"
+)
+
+type StateKind string
+
+const (
+	StateUnmanaged      StateKind = "unmanaged"
+	StateManagedActive  StateKind = "managed_active"
+	StateManagedInvalid StateKind = "managed_invalid"
+)
+
+type Options struct {
+	Path       string
+	SourceKind SourceKind
+	Now        func() time.Time
+}
+
+type State struct {
+	Kind       StateKind
+	Config     Config
+	SourcePath string
+	SourceKind SourceKind
+	Checksum   string
+	LoadedAt   time.Time
+	Errors     []ValidationError
+}
+
+func DefaultPath() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return "/Library/Application Support/Kontext/managed.json"
+	case "windows":
+		if programData := os.Getenv("ProgramData"); programData != "" {
+			return filepath.Join(programData, "Kontext", "managed.json")
+		}
+		return `C:\ProgramData\Kontext\managed.json`
+	default:
+		return "/etc/kontext/managed.json"
+	}
+}
+
+func Load(ctx context.Context, opts Options) State {
+	path := opts.Path
+	if path == "" {
+		path = DefaultPath()
+	}
+	sourceKind := opts.SourceKind
+	if sourceKind == "" {
+		sourceKind = SourceFile
+	}
+	now := opts.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	loadedAt := now().UTC()
+	if err := ctx.Err(); err != nil {
+		return invalidState(path, sourceKind, "", loadedAt, ValidationError{Code: "load_failed", Message: err.Error()})
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return State{Kind: StateUnmanaged, SourcePath: path, SourceKind: sourceKind, LoadedAt: loadedAt}
+		}
+		return invalidState(path, sourceKind, "", loadedAt, ValidationError{Code: "load_failed", Message: err.Error()})
+	}
+	checksum := Checksum(data)
+	cfg, err := Decode(data)
+	if err != nil {
+		return invalidState(path, sourceKind, checksum, loadedAt, ValidationError{Code: "invalid_json", Message: err.Error()})
+	}
+	if errs := Validate(cfg); len(errs) > 0 {
+		return State{Kind: StateManagedInvalid, Config: cfg, SourcePath: path, SourceKind: sourceKind, Checksum: checksum, LoadedAt: loadedAt, Errors: errs}
+	}
+	return State{Kind: StateManagedActive, Config: cfg, SourcePath: path, SourceKind: sourceKind, Checksum: checksum, LoadedAt: loadedAt}
+}
+
+func Decode(data []byte) (Config, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var cfg Config
+	if err := decoder.Decode(&cfg); err != nil {
+		return Config{}, err
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return Config{}, errors.New("unexpected trailing JSON value")
+	}
+	return cfg, nil
+}
+
+func Checksum(data []byte) string {
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func invalidState(path string, sourceKind SourceKind, checksum string, loadedAt time.Time, err ValidationError) State {
+	return State{
+		Kind:       StateManagedInvalid,
+		SourcePath: path,
+		SourceKind: sourceKind,
+		Checksum:   checksum,
+		LoadedAt:   loadedAt,
+		Errors:     []ValidationError{err},
+	}
+}

--- a/internal/managedconfig/validate.go
+++ b/internal/managedconfig/validate.go
@@ -1,0 +1,89 @@
+package managedconfig
+
+import (
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+var jwtLikePattern = regexp.MustCompile(`^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$`)
+
+const DefaultCloudHost = "api.kontext.security"
+
+func Validate(cfg Config) []ValidationError {
+	var errs []ValidationError
+	if cfg.Version != SchemaVersion {
+		errs = append(errs, ValidationError{Code: "unsupported_version", Field: "version", Message: `version must be "managed-install-v1"`})
+	}
+	if strings.TrimSpace(cfg.OrganizationID) == "" {
+		errs = append(errs, ValidationError{Code: "required", Field: "organization_id", Message: "organization_id is required"})
+	}
+	if strings.TrimSpace(cfg.CloudURL) == "" {
+		errs = append(errs, ValidationError{Code: "required", Field: "cloud_url", Message: "cloud_url is required"})
+	} else if cloudErr := validateCloudURL(cfg.CloudURL); cloudErr != nil {
+		errs = append(errs, *cloudErr)
+	}
+	if cfg.Mode != DefaultMode {
+		errs = append(errs, ValidationError{Code: "unsupported_mode", Field: "mode", Message: "only observe is supported in managed-install-v1"})
+	}
+	if cfg.Agent != DefaultAgent {
+		errs = append(errs, ValidationError{Code: "unsupported_agent", Field: "agent", Message: "only claude is supported in managed-install-v1"})
+	}
+	if cfg.Device.Label != nil {
+		label := strings.TrimSpace(*cfg.Device.Label)
+		if label == "" {
+			errs = append(errs, ValidationError{Code: "invalid_device_label", Field: "device.label", Message: "device label must be non-empty when provided"})
+		} else if len(label) > 128 {
+			errs = append(errs, ValidationError{Code: "invalid_device_label", Field: "device.label", Message: "device label must be 128 characters or fewer"})
+		}
+	}
+	tokenRef := strings.TrimSpace(cfg.Credentials.InstallTokenRef)
+	if tokenRef == "" {
+		errs = append(errs, ValidationError{Code: "required", Field: "credentials.install_token_ref", Message: "install token reference is required"})
+	} else if looksLikeRawToken(tokenRef) {
+		errs = append(errs, ValidationError{Code: "inline_secret_rejected", Field: "credentials.install_token_ref", Message: "install tokens must be referenced, not stored inline"})
+	} else if _, err := ParseCredentialRef(tokenRef); err != nil {
+		errs = append(errs, ValidationError{Code: "invalid_credential_ref", Field: "credentials.install_token_ref", Message: err.Error()})
+	}
+	return errs
+}
+
+func validateCloudURL(raw string) *ValidationError {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return &ValidationError{Code: "invalid_cloud_url", Field: "cloud_url", Message: "cloud_url must be an absolute https URL"}
+	}
+	if parsed.Scheme != "https" {
+		return &ValidationError{Code: "invalid_cloud_url", Field: "cloud_url", Message: "cloud_url must use https"}
+	}
+	if parsed.Hostname() != DefaultCloudHost {
+		return &ValidationError{Code: "unsupported_cloud_host", Field: "cloud_url", Message: "cloud_url must use api.kontext.security"}
+	}
+	if parsed.Port() != "" {
+		return &ValidationError{Code: "invalid_cloud_url", Field: "cloud_url", Message: "cloud_url must not contain a custom port"}
+	}
+	if parsed.User != nil {
+		return &ValidationError{Code: "invalid_cloud_url", Field: "cloud_url", Message: "cloud_url must not contain username or password"}
+	}
+	if parsed.RawQuery != "" {
+		return &ValidationError{Code: "invalid_cloud_url", Field: "cloud_url", Message: "cloud_url must not contain a query string"}
+	}
+	if parsed.Fragment != "" {
+		return &ValidationError{Code: "invalid_cloud_url", Field: "cloud_url", Message: "cloud_url must not contain a fragment"}
+	}
+	return nil
+}
+
+func looksLikeRawToken(raw string) bool {
+	lower := strings.ToLower(raw)
+	if strings.HasPrefix(lower, "token:") || strings.HasPrefix(lower, "bearer:") || strings.HasPrefix(lower, "sk_") {
+		return true
+	}
+	if jwtLikePattern.MatchString(raw) {
+		return true
+	}
+	if !strings.Contains(raw, ":") && len(raw) >= 32 {
+		return true
+	}
+	return false
+}

--- a/schemas/managed.v1.json
+++ b/schemas/managed.v1.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kontext.security/schemas/managed.v1.json",
+  "title": "Kontext managed install config v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "organization_id",
+    "cloud_url",
+    "mode",
+    "agent",
+    "credentials"
+  ],
+  "properties": {
+    "version": {
+      "const": "managed-install-v1"
+    },
+    "organization_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "cloud_url": {
+      "type": "string",
+      "format": "uri",
+      "pattern": "^https://api\\.kontext\\.security(/[^?#]*)?$"
+    },
+    "mode": {
+      "const": "observe"
+    },
+    "agent": {
+      "const": "claude"
+    },
+    "device": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        }
+      }
+    },
+    "credentials": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "install_token_ref"
+      ],
+      "properties": {
+        "install_token_ref": {
+          "type": "string",
+          "pattern": "^(keychain:[^\\s]+|env:[A-Z_][A-Z0-9_]*)$"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Where we are

ENG-357 needs a generic managed endpoint config contract in `kontext-cli` before daemon lifecycle, streaming, or deployment packaging can safely build on it.

There was no strict local reader for MDM-written managed config, no shared schema, and no safe way to report whether an endpoint is managed without each later feature inventing its own shape.

## Where we want to go

`kontext-cli` should have one small, reusable contract for managed observe configuration: org ID, cloud URL, mode, agent, optional device label, and an install-token reference that never stores raw secrets.

Invalid managed config must fail closed as `managed_invalid`, not silently look unmanaged.

## How we get there

Add `internal/managedconfig` with strict JSON decoding, validation, checksum/source metadata, credential-ref parsing/redaction, platform-aware default paths, and a public `schemas/managed.v1.json` schema.

Validate with focused package tests covering missing config, invalid JSON, unknown fields, required fields, cloud URL safety, supported mode/agent, and token-ref rejection.
