### PR TITLE
feat(managed): add installation identity store

### DIFF
--- a/internal/installation/filelock_unix.go
+++ b/internal/installation/filelock_unix.go
@@ -1,0 +1,41 @@
+//go:build !windows
+
+package installation
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+func lockFileAt(ctx context.Context, path string) (func(), error) {
+	if err := os.MkdirAll(filepath.Dir(path), dirMode); err != nil {
+		return nil, err
+	}
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, fileMode)
+		if err != nil {
+			return nil, err
+		}
+		if err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+			_ = file.Close()
+			if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
+				if err := waitForLockRetry(ctx); err != nil {
+					return nil, err
+				}
+				continue
+			}
+			return nil, err
+		}
+		return func() {
+			_ = unix.Flock(int(file.Fd()), unix.LOCK_UN)
+			_ = file.Close()
+		}, nil
+	}
+}

--- a/internal/installation/filelock_windows.go
+++ b/internal/installation/filelock_windows.go
@@ -1,0 +1,50 @@
+//go:build windows
+
+package installation
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockFileAt(ctx context.Context, path string) (func(), error) {
+	if err := os.MkdirAll(filepath.Dir(path), dirMode); err != nil {
+		return nil, err
+	}
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, fileMode)
+		if err != nil {
+			return nil, err
+		}
+		var overlapped windows.Overlapped
+		err = windows.LockFileEx(
+			windows.Handle(file.Fd()),
+			windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+			0,
+			1,
+			0,
+			&overlapped,
+		)
+		if err != nil {
+			_ = file.Close()
+			if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+				if err := waitForLockRetry(ctx); err != nil {
+					return nil, err
+				}
+				continue
+			}
+			return nil, err
+		}
+		return func() {
+			_ = windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, &overlapped)
+			_ = file.Close()
+		}, nil
+	}
+}

--- a/internal/installation/installation.go
+++ b/internal/installation/installation.go
@@ -1,0 +1,31 @@
+package installation
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+)
+
+const SchemaVersion = "managed-installation-v1"
+
+type Installation struct {
+	Version        string    `json:"version"`
+	InstallationID string    `json:"installation_id"`
+	CreatedAt      time.Time `json:"created_at"`
+	CreatedBy      string    `json:"created_by"`
+}
+
+func DefaultPath() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return "/Library/Application Support/Kontext/installation.json"
+	case "windows":
+		if programData := os.Getenv("ProgramData"); programData != "" {
+			return filepath.Join(programData, "Kontext", "installation.json")
+		}
+		return `C:\ProgramData\Kontext\installation.json`
+	default:
+		return "/var/lib/kontext/installation.json"
+	}
+}

--- a/internal/installation/store.go
+++ b/internal/installation/store.go
@@ -1,0 +1,180 @@
+package installation
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	fileMode = 0o600
+	dirMode  = 0o755
+)
+
+type Option func(*options)
+
+type options struct {
+	now func() time.Time
+}
+
+func WithClock(now func() time.Time) Option {
+	return func(opts *options) {
+		if now != nil {
+			opts.now = now
+		}
+	}
+}
+
+func Load(path string) (Installation, error) {
+	if path == "" {
+		path = DefaultPath()
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Installation{}, err
+	}
+	return decode(data)
+}
+
+func Ensure(ctx context.Context, path string, opts ...Option) (Installation, error) {
+	if path == "" {
+		path = DefaultPath()
+	}
+	if err := ctx.Err(); err != nil {
+		return Installation{}, err
+	}
+	unlock, err := lockFileAt(ctx, path+".lock")
+	if err != nil {
+		return Installation{}, err
+	}
+	defer unlock()
+
+	existing, err := Load(path)
+	if err == nil {
+		return existing, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return Installation{}, err
+	}
+	cfg := options{now: func() time.Time { return time.Now().UTC() }}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	id, err := newInstallationID()
+	if err != nil {
+		return Installation{}, err
+	}
+	inst := Installation{
+		Version:        SchemaVersion,
+		InstallationID: id,
+		CreatedAt:      cfg.now().UTC(),
+		CreatedBy:      "kontext-cli",
+	}
+	data, err := encode(inst)
+	if err != nil {
+		return Installation{}, err
+	}
+	if err := writeFileAtomic(path, data, fileMode); err != nil {
+		return Installation{}, err
+	}
+	return inst, nil
+}
+
+func decode(data []byte) (Installation, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var inst Installation
+	if err := decoder.Decode(&inst); err != nil {
+		return Installation{}, err
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return Installation{}, errors.New("unexpected trailing JSON value")
+	}
+	if err := validate(inst); err != nil {
+		return Installation{}, err
+	}
+	return inst, nil
+}
+
+func encode(inst Installation) ([]byte, error) {
+	if err := validate(inst); err != nil {
+		return nil, err
+	}
+	data, err := json.MarshalIndent(inst, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
+func validate(inst Installation) error {
+	if inst.Version != SchemaVersion {
+		return fmt.Errorf("version must be %q", SchemaVersion)
+	}
+	if !strings.HasPrefix(inst.InstallationID, "ins_") || len(inst.InstallationID) < 12 {
+		return errors.New("installation_id must use ins_ prefix")
+	}
+	if inst.CreatedAt.IsZero() {
+		return errors.New("created_at is required")
+	}
+	if strings.TrimSpace(inst.CreatedBy) == "" {
+		return errors.New("created_by is required")
+	}
+	return nil
+}
+
+func newInstallationID() (string, error) {
+	var data [16]byte
+	if _, err := rand.Read(data[:]); err != nil {
+		return "", err
+	}
+	return "ins_" + hex.EncodeToString(data[:]), nil
+}
+
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), dirMode); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+func waitForLockRetry(ctx context.Context) error {
+	timer := time.NewTimer(25 * time.Millisecond)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/installation/store_test.go
+++ b/internal/installation/store_test.go
@@ -1,0 +1,93 @@
+package installation
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestEnsureGeneratesInstallationWhenMissing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "installation.json")
+	now := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+	inst, err := Ensure(context.Background(), path, WithClock(func() time.Time { return now }))
+	if err != nil {
+		t.Fatalf("Ensure() error = %v", err)
+	}
+	if !strings.HasPrefix(inst.InstallationID, "ins_") {
+		t.Fatalf("InstallationID = %q, want ins_ prefix", inst.InstallationID)
+	}
+	if !inst.CreatedAt.Equal(now) {
+		t.Fatalf("CreatedAt = %v, want %v", inst.CreatedAt, now)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("file mode = %o, want 0600", got)
+	}
+}
+
+func TestEnsurePreservesExistingInstallation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "installation.json")
+	first, err := Ensure(context.Background(), path)
+	if err != nil {
+		t.Fatalf("first Ensure() error = %v", err)
+	}
+	second, err := Ensure(context.Background(), path)
+	if err != nil {
+		t.Fatalf("second Ensure() error = %v", err)
+	}
+	if second.InstallationID != first.InstallationID {
+		t.Fatalf("InstallationID changed from %q to %q", first.InstallationID, second.InstallationID)
+	}
+}
+
+func TestEnsureConcurrentCallersReturnPersistedInstallation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "installation.json")
+	const callers = 8
+	var wg sync.WaitGroup
+	results := make(chan Installation, callers)
+	errs := make(chan error, callers)
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			inst, err := Ensure(context.Background(), path)
+			if err != nil {
+				errs <- err
+				return
+			}
+			results <- inst
+		}()
+	}
+	wg.Wait()
+	close(results)
+	close(errs)
+	for err := range errs {
+		t.Fatalf("Ensure() error = %v", err)
+	}
+	persisted, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	for inst := range results {
+		if inst.InstallationID != persisted.InstallationID {
+			t.Fatalf("caller got %q, persisted %q", inst.InstallationID, persisted.InstallationID)
+		}
+	}
+}
+
+func TestLoadRejectsMalformedInstallation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "installation.json")
+	if err := os.WriteFile(path, []byte(`{"version":"bad"}`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if _, err := Load(path); err == nil {
+		t.Fatal("Load() error = nil, want error")
+	}
+}


### PR DESCRIPTION
## Where we are

Managed endpoints need a stable local installation identity that survives MDM rewrites of `managed.json`.

Before this branch, there was no generic local install-state store for later daemon, hook, and streaming code to share.

## Where we want to go

`kontext-cli` should create and preserve a non-PII `installation_id` in local state, separate from admin-managed config and separate from authentication.

Concurrent install/init paths should return the same persisted identity instead of racing and registering different IDs.

## How we get there

Add `internal/installation` with platform-aware default paths, strict JSON loading, random `ins_...` ID generation, atomic writes, and OS file locking for `Ensure`.

Cover generation, preservation, malformed state, safe file permissions, and concurrent callers with focused tests.
