### PR TITLE
feat(managed): add enrollment status command

### DIFF
--- a/cmd/kontext/main.go
+++ b/cmd/kontext/main.go
@@ -45,6 +45,7 @@ func main() {
 	root.AddCommand(hookCmd())
 	root.AddCommand(doctorCmd())
 	root.AddCommand(guardCmd())
+	root.AddCommand(statusCmd())
 
 	if err := root.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/cmd/kontext/main_test.go
+++ b/cmd/kontext/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/kontext-security/kontext-cli/internal/hook"
+	"github.com/kontext-security/kontext-cli/internal/installation"
 	"github.com/kontext-security/kontext-cli/internal/run"
 	"github.com/zalando/go-keyring"
 )
@@ -144,6 +146,160 @@ func TestGuardCmdRoutesToLocalGuardMode(t *testing.T) {
 	}
 }
 
+func TestStatusJSONReportsUnmanaged(t *testing.T) {
+	cmd := statusCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	if err := cmd.Flags().Set("json", "true"); err != nil {
+		t.Fatalf("Set json error = %v", err)
+	}
+	if err := cmd.Flags().Set("managed-config", filepathForTest(t, "missing-managed.json")); err != nil {
+		t.Fatalf("Set managed-config error = %v", err)
+	}
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("RunE() error = %v", err)
+	}
+	var payload statusPayload
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if got := payload.Managed.State; got != "unmanaged" {
+		t.Fatalf("state = %q, want unmanaged", got)
+	}
+	if got := payload.Managed.Validation.Status; got != "not_configured" {
+		t.Fatalf("validation status = %q, want not_configured", got)
+	}
+}
+
+func TestStatusJSONReportsManagedActiveAndDoesNotLeakEnvToken(t *testing.T) {
+	t.Setenv("KONTEXT_INSTALL_TOKEN", "super-secret-token")
+	managedPath := filepathForTest(t, "managed.json")
+	installationPath := filepathForTest(t, "installation.json")
+	if err := os.WriteFile(managedPath, []byte(`{
+  "version": "managed-install-v1",
+  "organization_id": "org_example",
+  "cloud_url": "https://api.kontext.security",
+  "mode": "observe",
+  "agent": "claude",
+  "credentials": {
+    "install_token_ref": "env:KONTEXT_INSTALL_TOKEN"
+  }
+}`), 0o600); err != nil {
+		t.Fatalf("WriteFile(managed) error = %v", err)
+	}
+	if _, err := installation.Ensure(context.Background(), installationPath); err != nil {
+		t.Fatalf("Ensure() error = %v", err)
+	}
+
+	cmd := statusCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	if err := cmd.Flags().Set("json", "true"); err != nil {
+		t.Fatalf("Set json error = %v", err)
+	}
+	if err := cmd.Flags().Set("managed-config", managedPath); err != nil {
+		t.Fatalf("Set managed-config error = %v", err)
+	}
+	if err := cmd.Flags().Set("installation-state", installationPath); err != nil {
+		t.Fatalf("Set installation-state error = %v", err)
+	}
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("RunE() error = %v", err)
+	}
+	if strings.Contains(stdout.String(), "super-secret-token") {
+		t.Fatalf("status leaked env token: %s", stdout.String())
+	}
+	var payload statusPayload
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if got := payload.Managed.State; got != "managed_active" {
+		t.Fatalf("state = %q, want managed_active: %s", got, stdout.String())
+	}
+	if got := payload.Managed.CredentialSource; got != "env:KONTEXT_INSTALL_TOKEN" {
+		t.Fatalf("credential source = %q, want env ref", got)
+	}
+	if payload.Managed.InstallationID == "" {
+		t.Fatal("InstallationID is empty")
+	}
+}
+
+func TestStatusDoesNotCreateInstallationState(t *testing.T) {
+	managedPath := filepathForTest(t, "managed.json")
+	installationPath := filepathForTest(t, "installation.json")
+	if err := os.WriteFile(managedPath, []byte(`{
+  "version": "managed-install-v1",
+  "organization_id": "org_example",
+  "cloud_url": "https://api.kontext.security",
+  "mode": "observe",
+  "agent": "claude",
+  "credentials": {
+    "install_token_ref": "keychain:kontext-managed-install-token"
+  }
+}`), 0o600); err != nil {
+		t.Fatalf("WriteFile(managed) error = %v", err)
+	}
+	cmd := statusCmd()
+	if err := cmd.Flags().Set("managed-config", managedPath); err != nil {
+		t.Fatalf("Set managed-config error = %v", err)
+	}
+	if err := cmd.Flags().Set("installation-state", installationPath); err != nil {
+		t.Fatalf("Set installation-state error = %v", err)
+	}
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("RunE() error = %v", err)
+	}
+	if _, err := os.Stat(installationPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("installation state was created or stat failed unexpectedly: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Managed endpoint: active") {
+		t.Fatalf("stdout = %q, want active status", stdout.String())
+	}
+}
+
+func TestStatusJSONDoesNotEchoUnsafeInvalidCloudURL(t *testing.T) {
+	managedPath := filepathForTest(t, "managed.json")
+	if err := os.WriteFile(managedPath, []byte(`{
+  "version": "managed-install-v1",
+  "organization_id": "org_example",
+  "cloud_url": "https://user:pass@api.kontext.security?token=secret",
+  "mode": "observe",
+  "agent": "claude",
+  "credentials": {
+    "install_token_ref": "keychain:kontext-managed-install-token"
+  }
+}`), 0o600); err != nil {
+		t.Fatalf("WriteFile(managed) error = %v", err)
+	}
+	cmd := statusCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	if err := cmd.Flags().Set("json", "true"); err != nil {
+		t.Fatalf("Set json error = %v", err)
+	}
+	if err := cmd.Flags().Set("managed-config", managedPath); err != nil {
+		t.Fatalf("Set managed-config error = %v", err)
+	}
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("RunE() error = %v", err)
+	}
+	if strings.Contains(stdout.String(), "user:pass") || strings.Contains(stdout.String(), "token=secret") {
+		t.Fatalf("status leaked unsafe cloud URL: %s", stdout.String())
+	}
+	var payload statusPayload
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if got := payload.Managed.State; got != "managed_invalid" {
+		t.Fatalf("state = %q, want managed_invalid", got)
+	}
+	if payload.Managed.CloudURL != "" {
+		t.Fatalf("CloudURL = %q, want empty for invalid config", payload.Managed.CloudURL)
+	}
+}
+
 func TestHookCmdModeDoesNotDefaultFromEnv(t *testing.T) {
 	t.Setenv("KONTEXT_MODE", "observe")
 
@@ -155,6 +311,11 @@ func TestHookCmdModeDoesNotDefaultFromEnv(t *testing.T) {
 	if flag.DefValue != "" {
 		t.Fatalf("--mode default = %q, want empty", flag.DefValue)
 	}
+}
+
+func filepathForTest(t *testing.T, name string) string {
+	t.Helper()
+	return fmt.Sprintf("%s/%s", t.TempDir(), name)
 }
 
 func TestLogoutCmdAlreadyLoggedOut(t *testing.T) {

--- a/cmd/kontext/status.go
+++ b/cmd/kontext/status.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kontext-security/kontext-cli/internal/installation"
+	"github.com/kontext-security/kontext-cli/internal/managedconfig"
+)
+
+const managedConfigEnv = "KONTEXT_MANAGED_CONFIG"
+
+type statusPayload struct {
+	Managed managedStatus `json:"managed"`
+}
+
+type managedStatus struct {
+	State             managedconfig.StateKind `json:"state"`
+	StreamingEnabled  bool                    `json:"streaming_enabled,omitempty"`
+	OrganizationID    string                  `json:"organization_id,omitempty"`
+	InstallationID    string                  `json:"installation_id,omitempty"`
+	CloudURL          string                  `json:"cloud_url,omitempty"`
+	Mode              string                  `json:"mode,omitempty"`
+	Agent             string                  `json:"agent,omitempty"`
+	CredentialSource  string                  `json:"credential_source,omitempty"`
+	Config            *statusConfig           `json:"config,omitempty"`
+	InstallationState *statusInstallation     `json:"installation,omitempty"`
+	Validation        statusValidation        `json:"validation"`
+}
+
+type statusConfig struct {
+	Source     string `json:"source,omitempty"`
+	SourceKind string `json:"source_kind,omitempty"`
+	Checksum   string `json:"checksum,omitempty"`
+	LoadedAt   string `json:"loaded_at,omitempty"`
+}
+
+type statusInstallation struct {
+	Source string `json:"source,omitempty"`
+	Status string `json:"status,omitempty"`
+	Error  string `json:"error,omitempty"`
+}
+
+type statusValidation struct {
+	Status string                          `json:"status"`
+	Errors []managedconfig.ValidationError `json:"errors"`
+}
+
+func statusCmd() *cobra.Command {
+	var (
+		jsonOutput       bool
+		managedPath      string
+		installationPath string
+	)
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show local Kontext enrollment status",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configSource := managedconfig.SourceFile
+			if managedPath == "" {
+				if envPath := os.Getenv(managedConfigEnv); envPath != "" {
+					managedPath = envPath
+					configSource = managedconfig.SourceEnvOverride
+				}
+			}
+			payload := buildStatus(context.Background(), managedPath, configSource, installationPath)
+			if jsonOutput {
+				encoder := json.NewEncoder(cmd.OutOrStdout())
+				encoder.SetIndent("", "  ")
+				return encoder.Encode(payload)
+			}
+			printStatus(cmd.OutOrStdout(), payload)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Print status as JSON")
+	cmd.Flags().StringVar(&managedPath, "managed-config", "", "Path to managed config file")
+	cmd.Flags().StringVar(&installationPath, "installation-state", "", "Path to installation state file")
+	_ = cmd.Flags().MarkHidden("managed-config")
+	_ = cmd.Flags().MarkHidden("installation-state")
+	return cmd
+}
+
+func buildStatus(ctx context.Context, managedPath string, sourceKind managedconfig.SourceKind, installationPath string) statusPayload {
+	state := managedconfig.Load(ctx, managedconfig.Options{Path: managedPath, SourceKind: sourceKind})
+	status := managedStatus{
+		State: state.Kind,
+		Config: &statusConfig{
+			Source:     state.SourcePath,
+			SourceKind: string(state.SourceKind),
+			Checksum:   state.Checksum,
+			LoadedAt:   state.LoadedAt.Format("2006-01-02T15:04:05Z07:00"),
+		},
+		Validation: statusValidation{Status: "ok", Errors: []managedconfig.ValidationError{}},
+	}
+	switch state.Kind {
+	case managedconfig.StateUnmanaged:
+		status.Config = nil
+		status.Validation.Status = "not_configured"
+	case managedconfig.StateManagedInvalid:
+		status.StreamingEnabled = false
+		status.Validation.Status = "invalid"
+		status.Validation.Errors = append([]managedconfig.ValidationError(nil), state.Errors...)
+	case managedconfig.StateManagedActive:
+		fillConfigFields(&status, state)
+		instPath := installationPath
+		if instPath == "" {
+			instPath = installation.DefaultPath()
+		}
+		status.InstallationState = &statusInstallation{Source: instPath}
+		inst, err := installation.Load(instPath)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				status.StreamingEnabled = false
+				status.InstallationState.Status = "missing"
+				break
+			}
+			status.State = managedconfig.StateManagedInvalid
+			status.StreamingEnabled = false
+			status.InstallationState.Status = "invalid"
+			status.InstallationState.Error = err.Error()
+			status.Validation.Status = "invalid"
+			status.Validation.Errors = []managedconfig.ValidationError{{
+				Code:    "installation_state_invalid",
+				Field:   "installation",
+				Message: err.Error(),
+			}}
+			break
+		}
+		status.StreamingEnabled = true
+		status.InstallationState.Status = "ok"
+		status.InstallationID = inst.InstallationID
+	}
+	return statusPayload{Managed: status}
+}
+
+func fillConfigFields(status *managedStatus, state managedconfig.State) {
+	status.OrganizationID = state.Config.OrganizationID
+	status.CloudURL = state.Config.CloudURL
+	status.Mode = state.Config.Mode
+	status.Agent = state.Config.Agent
+	status.CredentialSource = managedconfig.RedactCredentialRef(state.Config.Credentials.InstallTokenRef)
+}
+
+func printStatus(w io.Writer, payload statusPayload) {
+	managed := payload.Managed
+	switch managed.State {
+	case managedconfig.StateUnmanaged:
+		fmt.Fprintln(w, "Managed endpoint: unmanaged")
+		return
+	case managedconfig.StateManagedActive:
+		fmt.Fprintln(w, "Managed endpoint: active")
+	case managedconfig.StateManagedInvalid:
+		fmt.Fprintln(w, "Managed endpoint: invalid")
+	default:
+		fmt.Fprintf(w, "Managed endpoint: %s\n", managed.State)
+	}
+	if managed.OrganizationID != "" {
+		fmt.Fprintf(w, "Organization: %s\n", managed.OrganizationID)
+	}
+	if managed.InstallationID != "" {
+		fmt.Fprintf(w, "Installation ID: %s\n", managed.InstallationID)
+	}
+	if managed.CloudURL != "" {
+		fmt.Fprintf(w, "Cloud URL: %s\n", managed.CloudURL)
+	}
+	if managed.Mode != "" {
+		fmt.Fprintf(w, "Mode: %s\n", managed.Mode)
+	}
+	if managed.Agent != "" {
+		fmt.Fprintf(w, "Agent: %s\n", managed.Agent)
+	}
+	if managed.CredentialSource != "" {
+		fmt.Fprintf(w, "Credential: %s\n", managed.CredentialSource)
+	}
+	if managed.Config != nil {
+		fmt.Fprintf(w, "Config source: %s\n", managed.Config.Source)
+		if managed.Config.Checksum != "" {
+			fmt.Fprintf(w, "Config checksum: %s\n", managed.Config.Checksum)
+		}
+		if managed.Config.LoadedAt != "" {
+			fmt.Fprintf(w, "Loaded at: %s\n", managed.Config.LoadedAt)
+		}
+	}
+	if managed.Validation.Status == "ok" {
+		fmt.Fprintln(w, "Validation: ok")
+		return
+	}
+	if len(managed.Validation.Errors) > 0 {
+		fmt.Fprintln(w, "Validation:")
+		for _, err := range managed.Validation.Errors {
+			fmt.Fprintf(w, "- %s: %s\n", err.Code, err.Message)
+		}
+	}
+}


### PR DESCRIPTION
## Where we are

ENG-357 needs a visible status surface so admins and support can tell whether the endpoint is unmanaged, managed active, or managed invalid.

The CLI had no `kontext status` command, and running status must not create installation state or leak managed credentials.

## Where we want to go

`kontext status` should report managed enrollment state in human and JSON forms using the shared config and installation contracts.

It should show config source/checksum/timestamp and installation status, but it must not print raw tokens or echo unsafe rejected config values.

## How we get there

Add `kontext status` with `--json` plus hidden test/dev path overrides, wire it into the root command, and keep it read-only.

Cover unmanaged, active, missing-installation, invalid-installation, redaction, and unsafe invalid cloud URL behavior with CLI tests.
