### PR TITLE
feat(managed): add managed config contract

### DIFF
--- a/internal/managedconfig/config.go
+++ b/internal/managedconfig/config.go
@@ -1,0 +1,230 @@
+package managedconfig
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	Version = "managed-install-v1"
+	Mode    = "observe"
+	Agent   = "claude"
+
+	DefaultPath = "/Library/Application Support/Kontext/managed.json"
+	EnvPath     = "KONTEXT_MANAGED_CONFIG"
+)
+
+var ErrNotManaged = errors.New("managed config not found")
+
+var envNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+type Config struct {
+	Version        string      `json:"version"`
+	OrganizationID string      `json:"organization_id"`
+	CloudURL       string      `json:"cloud_url"`
+	Mode           string      `json:"mode"`
+	Agent          string      `json:"agent"`
+	Credentials    Credentials `json:"credentials"`
+	Device         Device      `json:"device,omitempty"`
+}
+
+type Credentials struct {
+	InstallTokenRef TokenRef `json:"install_token_ref"`
+}
+
+type TokenRef struct {
+	Source string
+	Name   string
+}
+
+type Device struct {
+	Label string `json:"label,omitempty"`
+}
+
+type LoadedConfig struct {
+	Config   Config
+	Path     string
+	Checksum string
+}
+
+func PathFromEnv() string {
+	if path := strings.TrimSpace(os.Getenv(EnvPath)); path != "" {
+		return path
+	}
+	return DefaultPath
+}
+
+func Load() (LoadedConfig, error) {
+	return LoadFile(PathFromEnv())
+}
+
+func LoadFile(path string) (LoadedConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return LoadedConfig{}, ErrNotManaged
+		}
+		return LoadedConfig{}, err
+	}
+	cfg, err := Parse(data)
+	if err != nil {
+		return LoadedConfig{}, err
+	}
+	digest := sha256.Sum256(data)
+	return LoadedConfig{
+		Config:   cfg,
+		Path:     path,
+		Checksum: hex.EncodeToString(digest[:]),
+	}, nil
+}
+
+func Parse(data []byte) (Config, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+
+	var cfg Config
+	if err := decoder.Decode(&cfg); err != nil {
+		return Config{}, err
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return Config{}, errors.New("unexpected trailing JSON value")
+	}
+	return normalizeAndValidate(cfg)
+}
+
+func ParseTokenRef(value string) (TokenRef, error) {
+	value = strings.TrimSpace(value)
+	source, name, ok := strings.Cut(value, ":")
+	if !ok {
+		return TokenRef{}, errors.New("install token ref must use source:name")
+	}
+	ref := TokenRef{
+		Source: strings.TrimSpace(source),
+		Name:   strings.TrimSpace(name),
+	}
+	if err := validateTokenRef(ref); err != nil {
+		return TokenRef{}, err
+	}
+	return ref, nil
+}
+
+func (r TokenRef) String() string {
+	if r.Source == "" && r.Name == "" {
+		return ""
+	}
+	return r.Source + ":" + r.Name
+}
+
+func (r *TokenRef) UnmarshalJSON(data []byte) error {
+	var value string
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	ref, err := ParseTokenRef(value)
+	if err != nil {
+		return err
+	}
+	*r = ref
+	return nil
+}
+
+func (r TokenRef) MarshalJSON() ([]byte, error) {
+	return json.Marshal(r.String())
+}
+
+func normalizeAndValidate(cfg Config) (Config, error) {
+	cfg.Version = strings.TrimSpace(cfg.Version)
+	cfg.OrganizationID = strings.TrimSpace(cfg.OrganizationID)
+	cfg.CloudURL = strings.TrimSpace(cfg.CloudURL)
+	cfg.Mode = strings.TrimSpace(cfg.Mode)
+	cfg.Agent = strings.TrimSpace(cfg.Agent)
+	cfg.Credentials.InstallTokenRef.Source = strings.TrimSpace(cfg.Credentials.InstallTokenRef.Source)
+	cfg.Credentials.InstallTokenRef.Name = strings.TrimSpace(cfg.Credentials.InstallTokenRef.Name)
+	cfg.Device.Label = strings.TrimSpace(cfg.Device.Label)
+
+	if cfg.Version != Version {
+		return Config{}, fmt.Errorf("version must be %q", Version)
+	}
+	if cfg.OrganizationID == "" {
+		return Config{}, errors.New("organization_id is required")
+	}
+	if err := validateCloudURL(cfg.CloudURL); err != nil {
+		return Config{}, err
+	}
+	if cfg.Mode != Mode {
+		return Config{}, fmt.Errorf("mode must be %q", Mode)
+	}
+	if cfg.Agent != Agent {
+		return Config{}, fmt.Errorf("agent must be %q", Agent)
+	}
+	if err := validateTokenRef(cfg.Credentials.InstallTokenRef); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}
+
+func validateCloudURL(value string) error {
+	if value == "" {
+		return errors.New("cloud_url is required")
+	}
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return fmt.Errorf("cloud_url is invalid: %w", err)
+	}
+	if parsed.Scheme != "https" {
+		return errors.New("cloud_url must use https")
+	}
+	if parsed.Host == "" || parsed.Hostname() == "" {
+		return errors.New("cloud_url must include host")
+	}
+	if parsed.Port() == "" && strings.Contains(parsed.Host, ":") {
+		return errors.New("cloud_url must include a valid port")
+	}
+	if port := parsed.Port(); port != "" {
+		value, err := strconv.Atoi(port)
+		if err != nil || value < 1 || value > 65535 {
+			return errors.New("cloud_url must include a valid port")
+		}
+	}
+	if parsed.User != nil {
+		return errors.New("cloud_url must not include userinfo")
+	}
+	if parsed.EscapedPath() != "" && parsed.EscapedPath() != "/" {
+		return errors.New("cloud_url must not include path")
+	}
+	if parsed.RawQuery != "" {
+		return errors.New("cloud_url must not include query")
+	}
+	if parsed.Fragment != "" {
+		return errors.New("cloud_url must not include fragment")
+	}
+	return nil
+}
+
+func validateTokenRef(ref TokenRef) error {
+	switch ref.Source {
+	case "keychain", "env":
+	default:
+		return errors.New("install token ref source must be keychain or env")
+	}
+	if ref.Name == "" {
+		return errors.New("install token ref name is required")
+	}
+	if strings.ContainsAny(ref.Name, " \t\r\n:") {
+		return errors.New("install token ref name must not contain whitespace or colon")
+	}
+	if ref.Source == "env" && !envNamePattern.MatchString(ref.Name) {
+		return errors.New("env install token ref name must be a valid environment variable name")
+	}
+	return nil
+}

--- a/internal/managedconfig/config_test.go
+++ b/internal/managedconfig/config_test.go
@@ -1,0 +1,201 @@
+package managedconfig
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadFileMissingReturnsErrNotManaged(t *testing.T) {
+	_, err := LoadFile(filepath.Join(t.TempDir(), "missing.json"))
+	if !errors.Is(err, ErrNotManaged) {
+		t.Fatalf("LoadFile() error = %v, want ErrNotManaged", err)
+	}
+}
+
+func TestParseValidConfigNormalizesStrings(t *testing.T) {
+	cfg, err := Parse([]byte(`{
+  "version": " managed-install-v1 ",
+  "organization_id": " org_123 ",
+  "cloud_url": " https://api.kontext.dev ",
+  "mode": " observe ",
+  "agent": " claude ",
+  "credentials": {
+    "install_token_ref": " keychain:kontext-managed-install-token "
+  },
+  "device": {
+    "label": " Engineering Mac "
+  }
+}`))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if cfg.Version != Version || cfg.OrganizationID != "org_123" || cfg.CloudURL != "https://api.kontext.dev" {
+		t.Fatalf("config not normalized: %+v", cfg)
+	}
+	if got := cfg.Credentials.InstallTokenRef; got.Source != "keychain" || got.Name != "kontext-managed-install-token" {
+		t.Fatalf("token ref = %+v", got)
+	}
+	if cfg.Device.Label != "Engineering Mac" {
+		t.Fatalf("device label = %q", cfg.Device.Label)
+	}
+}
+
+func TestParseRejectsUnknownFields(t *testing.T) {
+	_, err := Parse([]byte(`{
+  "version": "managed-install-v1",
+  "organization_id": "org_123",
+  "cloud_url": "https://api.kontext.dev",
+  "mode": "observe",
+  "agent": "claude",
+  "credentials": {"install_token_ref": "env:KONTEXT_INSTALL_TOKEN"},
+  "extra": true
+}`))
+	if err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("Parse() error = %v, want unknown field", err)
+	}
+}
+
+func TestParseRejectsTrailingJSON(t *testing.T) {
+	_, err := Parse([]byte(validConfigJSON() + `{}`))
+	if err == nil || !strings.Contains(err.Error(), "trailing JSON") {
+		t.Fatalf("Parse() error = %v, want trailing JSON", err)
+	}
+}
+
+func TestParseRequiresFields(t *testing.T) {
+	tests := map[string]string{
+		"version":           `"version": ""`,
+		"organization_id":   `"organization_id": ""`,
+		"cloud_url":         `"cloud_url": ""`,
+		"mode":              `"mode": ""`,
+		"agent":             `"agent": ""`,
+		"install_token_ref": `"install_token_ref": ""`,
+	}
+	for name, replacement := range tests {
+		t.Run(name, func(t *testing.T) {
+			input := strings.Replace(validConfigJSON(), replacementFor(name), replacement, 1)
+			if _, err := Parse([]byte(input)); err == nil {
+				t.Fatalf("Parse() error = nil, want failure")
+			}
+		})
+	}
+}
+
+func TestParseRejectsInvalidCloudURL(t *testing.T) {
+	tests := map[string]string{
+		"non_https":     "http://api.kontext.dev",
+		"missing_host":  "https:///path",
+		"invalid_port":  "https://api.kontext.dev:bad",
+		"port_too_high": "https://api.kontext.dev:99999",
+		"userinfo":      "https://user@api.kontext.dev",
+		"path":          "https://api.kontext.dev/org-a",
+		"query":         "https://api.kontext.dev?token=1",
+		"fragment":      "https://api.kontext.dev#frag",
+	}
+	for name, cloudURL := range tests {
+		t.Run(name, func(t *testing.T) {
+			input := strings.Replace(validConfigJSON(), "https://api.kontext.dev", cloudURL, 1)
+			if _, err := Parse([]byte(input)); err == nil {
+				t.Fatalf("Parse() error = nil, want failure")
+			}
+		})
+	}
+}
+
+func TestParseTokenRefAcceptsValidRefs(t *testing.T) {
+	tests := map[string]TokenRef{
+		"keychain:kontext-managed-install-token": {Source: "keychain", Name: "kontext-managed-install-token"},
+		"env:KONTEXT_INSTALL_TOKEN":              {Source: "env", Name: "KONTEXT_INSTALL_TOKEN"},
+	}
+	for input, want := range tests {
+		t.Run(input, func(t *testing.T) {
+			got, err := ParseTokenRef(input)
+			if err != nil {
+				t.Fatalf("ParseTokenRef() error = %v", err)
+			}
+			if got != want {
+				t.Fatalf("ParseTokenRef() = %+v, want %+v", got, want)
+			}
+			if got.String() != input {
+				t.Fatalf("String() = %q, want %q", got.String(), input)
+			}
+		})
+	}
+}
+
+func TestParseTokenRefRejectsInvalidRefs(t *testing.T) {
+	tests := []string{
+		"raw-token-value",
+		"keychain:",
+		"file:token",
+		"env:KONTEXT INSTALL TOKEN",
+		"env:KONTEXT:INSTALL:TOKEN",
+		"env:KONTEXT-INSTALL-TOKEN",
+		"env:1TOKEN",
+	}
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			if _, err := ParseTokenRef(input); err == nil {
+				t.Fatalf("ParseTokenRef() error = nil, want failure")
+			}
+		})
+	}
+}
+
+func TestPathFromEnvHonorsOverride(t *testing.T) {
+	t.Setenv(EnvPath, " "+filepath.Join(t.TempDir(), "managed.json")+" ")
+	if got := PathFromEnv(); got != strings.TrimSpace(os.Getenv(EnvPath)) {
+		t.Fatalf("PathFromEnv() = %q", got)
+	}
+}
+
+func TestLoadFileReturnsChecksumAndPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "managed.json")
+	if err := os.WriteFile(path, []byte(validConfigJSON()), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	loaded, err := LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+	if loaded.Path != path {
+		t.Fatalf("Path = %q, want %q", loaded.Path, path)
+	}
+	if len(loaded.Checksum) != 64 {
+		t.Fatalf("Checksum = %q, want sha256 hex", loaded.Checksum)
+	}
+}
+
+func validConfigJSON() string {
+	return `{
+  "version": "managed-install-v1",
+  "organization_id": "org_123",
+  "cloud_url": "https://api.kontext.dev",
+  "mode": "observe",
+  "agent": "claude",
+  "credentials": {
+    "install_token_ref": "env:KONTEXT_INSTALL_TOKEN"
+  },
+  "device": {
+    "label": "Engineering Mac"
+  }
+}`
+}
+
+func replacementFor(field string) string {
+	switch field {
+	case "install_token_ref":
+		return `"install_token_ref": "env:KONTEXT_INSTALL_TOKEN"`
+	default:
+		return `"` + field + `": "` + map[string]string{
+			"version":         "managed-install-v1",
+			"organization_id": "org_123",
+			"cloud_url":       "https://api.kontext.dev",
+			"mode":            "observe",
+			"agent":           "claude",
+		}[field] + `"`
+	}
+}


### PR DESCRIPTION
## Where we are

ENG-357 needs a small public CLI substrate for managed observe installs. The repo did not have a stable machine-managed config contract that later hook, daemon, and streaming work can share.

## Where we want to go

Add only the reusable managed config primitive: load `managed.json`, strictly decode it, normalize fields, and reject bad admin intent before later managed-install code consumes it. No JSON schema, status command, deployment artifacts, hook wiring, daemon wiring, or token resolution is included here.

## How we get there

This PR adds `internal/managedconfig` with the macOS managed config default path, `KONTEXT_MANAGED_CONFIG` override, strict JSON decoding, checksum reporting, required-field validation, HTTPS cloud-origin validation, and `keychain:` / `env:` token refs. Validation covered locally with `go test ./internal/managedconfig`, stack validation with `go test ./internal/managedconfig ./internal/installation`, `go test ./...`, `gofmt -l internal/managedconfig internal/installation`, and `git diff --check -- internal/managedconfig internal/installation`.
