### PR TITLE
feat(managed): add installation identity store

### DIFF
--- a/internal/installation/state.go
+++ b/internal/installation/state.go
@@ -1,0 +1,205 @@
+package installation
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	DefaultPath = "/Library/Application Support/Kontext/installation.json"
+	EnvPath     = "KONTEXT_INSTALLATION_STATE"
+)
+
+var ErrNotFound = errors.New("installation state not found")
+
+type State struct {
+	InstallationID string `json:"installation_id"`
+}
+
+func PathFromEnv() string {
+	if path := strings.TrimSpace(os.Getenv(EnvPath)); path != "" {
+		return path
+	}
+	return DefaultPath
+}
+
+func Load() (State, error) {
+	return LoadFile(PathFromEnv())
+}
+
+func LoadFile(path string) (State, error) {
+	if err := validateStateFile(path); err != nil {
+		return State{}, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return State{}, ErrNotFound
+		}
+		return State{}, err
+	}
+	return parse(data)
+}
+
+func Ensure() (State, error) {
+	return EnsureFile(PathFromEnv())
+}
+
+func EnsureFile(path string) (State, error) {
+	state, err := LoadFile(path)
+	if err == nil {
+		return state, nil
+	}
+	if !errors.Is(err, ErrNotFound) {
+		return State{}, err
+	}
+
+	state, err = newState()
+	if err != nil {
+		return State{}, err
+	}
+	data, err := encode(state)
+	if err != nil {
+		return State{}, err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return State{}, err
+	}
+
+	temp, err := writeTempState(filepath.Dir(path), data)
+	if err != nil {
+		return State{}, err
+	}
+	defer os.Remove(temp)
+
+	if err := os.Link(temp, path); err == nil {
+		if err := syncDir(filepath.Dir(path)); err != nil {
+			return State{}, err
+		}
+		return state, nil
+	} else if errors.Is(err, os.ErrExist) {
+		return LoadFile(path)
+	} else {
+		return State{}, err
+	}
+}
+
+func validateStateFile(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return errors.New("installation state must not be a symlink")
+	}
+	if !info.Mode().IsRegular() {
+		return errors.New("installation state must be a regular file")
+	}
+	if info.Mode().Perm() != 0o600 {
+		return errors.New("installation state must have 0600 permissions")
+	}
+	return nil
+}
+
+func parse(data []byte) (State, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+
+	var state State
+	if err := decoder.Decode(&state); err != nil {
+		return State{}, err
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return State{}, errors.New("unexpected trailing JSON value")
+	}
+	if err := validate(state); err != nil {
+		return State{}, err
+	}
+	return state, nil
+}
+
+func encode(state State) ([]byte, error) {
+	if err := validate(state); err != nil {
+		return nil, err
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
+func writeTempState(dir string, data []byte) (string, error) {
+	file, err := os.CreateTemp(dir, ".installation-*.tmp")
+	if err != nil {
+		return "", err
+	}
+	path := file.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			file.Close()
+			os.Remove(path)
+		}
+	}()
+
+	if err := file.Chmod(0o600); err != nil {
+		return "", err
+	}
+	if _, err := file.Write(data); err != nil {
+		return "", err
+	}
+	if err := file.Sync(); err != nil {
+		return "", err
+	}
+	if err := file.Close(); err != nil {
+		return "", err
+	}
+	cleanup = false
+	return path, nil
+}
+
+func syncDir(dir string) error {
+	file, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	return file.Sync()
+}
+
+func newState() (State, error) {
+	var random [24]byte
+	if _, err := rand.Read(random[:]); err != nil {
+		return State{}, err
+	}
+	return State{
+		InstallationID: "ins_" + base64.RawURLEncoding.EncodeToString(random[:]),
+	}, nil
+}
+
+func validate(state State) error {
+	if !strings.HasPrefix(state.InstallationID, "ins_") {
+		return fmt.Errorf("installation_id must start with %q", "ins_")
+	}
+	encoded := strings.TrimPrefix(state.InstallationID, "ins_")
+	if len(encoded) != 32 {
+		return errors.New("installation_id must be a generated installation id")
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil || len(decoded) != 24 {
+		return errors.New("installation_id must be a generated installation id")
+	}
+	return nil
+}

--- a/internal/installation/state_test.go
+++ b/internal/installation/state_test.go
@@ -1,0 +1,210 @@
+package installation
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestLoadFileMissingReturnsErrNotFound(t *testing.T) {
+	_, err := LoadFile(filepath.Join(t.TempDir(), "missing.json"))
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("LoadFile() error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestLoadFileExistingState(t *testing.T) {
+	state := mustNewState(t)
+	path := writeState(t, state)
+
+	loaded, err := LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+	if loaded.InstallationID != state.InstallationID {
+		t.Fatalf("InstallationID = %q", loaded.InstallationID)
+	}
+}
+
+func TestLoadFileRejectsInvalidJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "installation.json")
+	if err := os.WriteFile(path, []byte(`{"installation_id":`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if _, err := LoadFile(path); err == nil {
+		t.Fatalf("LoadFile() error = nil, want failure")
+	}
+}
+
+func TestLoadFileRejectsUnknownFields(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "installation.json")
+	state := mustNewState(t)
+	if err := os.WriteFile(path, []byte(`{"installation_id":"`+state.InstallationID+`","hostname":"mac"}`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	err := loadFileError(path)
+	if err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("LoadFile() error = %v, want unknown field", err)
+	}
+}
+
+func TestLoadFileRejectsTrailingJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "installation.json")
+	state := mustNewState(t)
+	if err := os.WriteFile(path, []byte(`{"installation_id":"`+state.InstallationID+`"}{}`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	err := loadFileError(path)
+	if err == nil || !strings.Contains(err.Error(), "trailing JSON") {
+		t.Fatalf("LoadFile() error = %v, want trailing JSON", err)
+	}
+}
+
+func TestEnsureFileCreatesIDWithPrivateMode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "installation.json")
+
+	state, err := EnsureFile(path)
+	if err != nil {
+		t.Fatalf("EnsureFile() error = %v", err)
+	}
+	if !strings.HasPrefix(state.InstallationID, "ins_") {
+		t.Fatalf("InstallationID = %q, want ins_ prefix", state.InstallationID)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("mode = %o, want 0600", got)
+	}
+	loaded, err := LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+	if loaded.InstallationID != state.InstallationID {
+		t.Fatalf("persisted ID = %q, want %q", loaded.InstallationID, state.InstallationID)
+	}
+}
+
+func TestLoadFileRejectsMalformedInstallationID(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "installation.json")
+	if err := os.WriteFile(path, []byte(`{"installation_id":"ins_x"}`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if _, err := LoadFile(path); err == nil {
+		t.Fatalf("LoadFile() error = nil, want malformed ID failure")
+	}
+}
+
+func TestLoadFileRejectsUnsafeMode(t *testing.T) {
+	path := writeState(t, mustNewState(t))
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+	if _, err := LoadFile(path); err == nil {
+		t.Fatalf("LoadFile() error = nil, want unsafe mode failure")
+	}
+}
+
+func TestLoadFileRejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.json")
+	if err := os.WriteFile(target, []byte(`{"installation_id":"ins_x"}`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	link := filepath.Join(dir, "installation.json")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+	if _, err := LoadFile(link); err == nil {
+		t.Fatalf("LoadFile() error = nil, want symlink failure")
+	}
+}
+
+func TestEnsureFilePreservesExistingID(t *testing.T) {
+	existing := mustNewState(t)
+	path := writeState(t, existing)
+
+	state, err := EnsureFile(path)
+	if err != nil {
+		t.Fatalf("EnsureFile() error = %v", err)
+	}
+	if state.InstallationID != existing.InstallationID {
+		t.Fatalf("InstallationID = %q, want existing", state.InstallationID)
+	}
+}
+
+func TestEnsureFileConcurrentFirstRunReturnsPersistedID(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "installation.json")
+	const workers = 32
+
+	var wg sync.WaitGroup
+	results := make(chan State, workers)
+	errs := make(chan error, workers)
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			state, err := EnsureFile(path)
+			if err != nil {
+				errs <- err
+				return
+			}
+			results <- state
+		}()
+	}
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	for err := range errs {
+		t.Fatalf("EnsureFile() concurrent error = %v", err)
+	}
+	persisted, err := LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+	for state := range results {
+		if state.InstallationID != persisted.InstallationID {
+			t.Fatalf("concurrent ID = %q, want persisted %q", state.InstallationID, persisted.InstallationID)
+		}
+	}
+}
+
+func TestPathFromEnvHonorsOverride(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "installation.json")
+	t.Setenv(EnvPath, " "+path+" ")
+	if got := PathFromEnv(); got != path {
+		t.Fatalf("PathFromEnv() = %q, want %q", got, path)
+	}
+}
+
+func writeState(t *testing.T, state State) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "installation.json")
+	data, err := encode(state)
+	if err != nil {
+		t.Fatalf("encode() error = %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	return path
+}
+
+func mustNewState(t *testing.T) State {
+	t.Helper()
+	state, err := newState()
+	if err != nil {
+		t.Fatalf("newState() error = %v", err)
+	}
+	return state
+}
+
+func loadFileError(path string) error {
+	_, err := LoadFile(path)
+	return err
+}


### PR DESCRIPTION
## Where we are

ENG-357 also needs a stable local installation identity that future managed hook, daemon, and streaming code can rely on. The CLI did not have a persisted non-PII install ID yet.

## Where we want to go

Add only the local installation identity store: load an existing `installation.json` or create one stable `ins_...` ID safely. The state file must stay minimal and must not include timestamps, hostname, user identity, org ID, cloud metadata, status output, or deployment wiring.

## How we get there

This PR adds `internal/installation` with the macOS default state path, `KONTEXT_INSTALLATION_STATE` override, strict JSON decoding, exact generated ID validation, `0600` state files, unsafe existing-file rejection, and concurrency-safe first creation via a synced temp file plus exclusive link. Validation covered locally with `go test ./internal/installation`, `go test -count=200 ./internal/installation`, stack validation with `go test ./internal/managedconfig ./internal/installation`, `go test ./...`, `gofmt -l internal/managedconfig internal/installation`, and `git diff --check -- internal/managedconfig internal/installation`.
