### PR TITLE
feat(claude): add managed settings contract

### DIFF
--- a/cmd/kontext/main.go
+++ b/cmd/kontext/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"strings"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/kontext-security/kontext-cli/internal/agent"
 	"github.com/kontext-security/kontext-cli/internal/auth"
+	"github.com/kontext-security/kontext-cli/internal/claudemanaged"
 	guardcli "github.com/kontext-security/kontext-cli/internal/guard/cli"
 	guardhookruntime "github.com/kontext-security/kontext-cli/internal/guard/hookruntime"
 	"github.com/kontext-security/kontext-cli/internal/hook"
@@ -198,10 +200,18 @@ func hookCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:    "hook",
+		Use:    "hook [event]",
 		Short:  "Process a hook event (called by the agent, not by users)",
 		Hidden: true,
+		Args: func(cmd *cobra.Command, args []string) error {
+			_, err := expectedHookEventFromArgs(args)
+			return err
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			expectedEvent, err := expectedHookEventFromArgs(args)
+			if err != nil {
+				return err
+			}
 			a, ok := agent.Get(agentName)
 			if !ok {
 				fmt.Fprintf(os.Stderr, "unknown agent: %s\n", agentName)
@@ -214,11 +224,14 @@ func hookCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				adapter := guardhookruntime.AgentAdapter{Agent: a, AgentName: agentName}
+				var adapter guardhookruntime.Adapter = guardhookruntime.AgentAdapter{Agent: a, AgentName: agentName}
+				if expectedEvent != "" {
+					adapter = expectedHookAdapter{Adapter: adapter, expected: expectedEvent}
+				}
 				processor := rootHookProcessor{socketPath: resolvedSocketPath, mode: hookMode}
 				return guardhookruntime.Run(context.Background(), adapter, processor, hookMode, cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr())
 			}
-			hookcmd.Run(a, func(e hook.Event) (hook.Result, error) {
+			hookcmd.RunWithExpectedEvent(a, expectedEvent, func(e hook.Event) (hook.Result, error) {
 				return evaluateHookWithSidecar(resolvedSocketPath, e)
 			})
 			return nil
@@ -230,6 +243,36 @@ func hookCmd() *cobra.Command {
 	cmd.Flags().StringVar(&mode, "mode", "", "hook mode: observe or enforce")
 
 	return cmd
+}
+
+type expectedHookAdapter struct {
+	guardhookruntime.Adapter
+	expected hook.HookName
+}
+
+func (a expectedHookAdapter) Decode(in io.Reader) (hook.Event, error) {
+	event, err := a.Adapter.Decode(in)
+	if err != nil {
+		return hook.Event{}, err
+	}
+	if event.HookName != a.expected {
+		return hook.Event{}, fmt.Errorf("hook event alias %q does not match stdin event %q", a.expected, event.HookName)
+	}
+	return event, nil
+}
+
+func expectedHookEventFromArgs(args []string) (hook.HookName, error) {
+	if len(args) == 0 {
+		return "", nil
+	}
+	if len(args) > 1 {
+		return "", fmt.Errorf("expected at most one hook event alias")
+	}
+	event, ok := claudemanaged.ParseEventAlias(args[0])
+	if !ok {
+		return "", fmt.Errorf("unknown hook event alias %q", args[0])
+	}
+	return event, nil
 }
 
 type rootHookProcessor struct {

--- a/cmd/kontext/main_test.go
+++ b/cmd/kontext/main_test.go
@@ -157,6 +157,24 @@ func TestHookCmdModeDoesNotDefaultFromEnv(t *testing.T) {
 	}
 }
 
+func TestExpectedHookEventFromArgs(t *testing.T) {
+	event, err := expectedHookEventFromArgs([]string{"pre-tool-use"})
+	if err != nil {
+		t.Fatalf("expectedHookEventFromArgs() error = %v", err)
+	}
+	if event != hook.HookPreToolUse {
+		t.Fatalf("event = %q, want PreToolUse", event)
+	}
+
+	_, err = expectedHookEventFromArgs([]string{"pretooluse"})
+	if err == nil {
+		t.Fatal("expectedHookEventFromArgs() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "unknown hook event alias") {
+		t.Fatalf("error = %q, want unknown alias", err.Error())
+	}
+}
+
 func TestLogoutCmdAlreadyLoggedOut(t *testing.T) {
 	cmd := newLogoutCmd(func() error { return keyring.ErrNotFound })
 

--- a/internal/claudemanaged/settings.go
+++ b/internal/claudemanaged/settings.go
@@ -1,0 +1,234 @@
+package claudemanaged
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/kontext-security/kontext-cli/internal/hook"
+)
+
+const (
+	ManagedSettingsPath        = "/Library/Application Support/ClaudeCode/managed-settings.json"
+	LinuxManagedSettingsPath   = "/etc/claude-code/managed-settings.json"
+	WindowsManagedSettingsPath = `C:\Program Files\ClaudeCode\managed-settings.json`
+	DefaultKontextBinary       = "/usr/local/bin/kontext"
+	DefaultHookTimeout         = 20
+)
+
+type Event struct {
+	Name  hook.HookName
+	Alias string
+}
+
+var SupportedEvents = []Event{
+	{Name: hook.HookSessionStart, Alias: "session-start"},
+	{Name: hook.HookPreToolUse, Alias: "pre-tool-use"},
+	{Name: hook.HookPostToolUse, Alias: "post-tool-use"},
+	{Name: hook.HookPostToolUseFailed, Alias: "post-tool-use-failure"},
+	{Name: hook.HookSessionEnd, Alias: "session-end"},
+}
+
+func DefaultManagedSettingsPath() string {
+	return managedSettingsPathForGOOS(runtime.GOOS)
+}
+
+func managedSettingsPathForGOOS(goos string) string {
+	switch goos {
+	case "windows":
+		return WindowsManagedSettingsPath
+	case "linux":
+		return LinuxManagedSettingsPath
+	default:
+		return ManagedSettingsPath
+	}
+}
+
+type Settings struct {
+	Hooks                 map[string][]MatcherGroup `json:"hooks"`
+	DisableAllHooks       *bool                     `json:"disableAllHooks,omitempty"`
+	AllowManagedHooksOnly *bool                     `json:"allowManagedHooksOnly,omitempty"`
+}
+
+type MatcherGroup struct {
+	Matcher string    `json:"matcher"`
+	Hooks   []Handler `json:"hooks"`
+}
+
+type Handler struct {
+	Type    string   `json:"type"`
+	Command string   `json:"command"`
+	Args    []string `json:"args,omitempty"`
+	Timeout int      `json:"timeout,omitempty"`
+}
+
+func Template(kontextBinary string) Settings {
+	kontextBinary = strings.TrimSpace(kontextBinary)
+	if kontextBinary == "" {
+		kontextBinary = DefaultKontextBinary
+	}
+	settings := Settings{Hooks: make(map[string][]MatcherGroup, len(SupportedEvents))}
+	for _, event := range SupportedEvents {
+		settings.Hooks[event.Name.String()] = []MatcherGroup{{
+			Matcher: "",
+			Hooks: []Handler{{
+				Type:    "command",
+				Command: kontextBinary,
+				Args:    []string{"hook", event.Alias},
+				Timeout: DefaultHookTimeout,
+			}},
+		}}
+	}
+	return settings
+}
+
+func TemplateJSON(kontextBinary string) ([]byte, error) {
+	data, err := json.MarshalIndent(Template(kontextBinary), "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal managed settings template: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+func Validate(data []byte, kontextBinary string) error {
+	kontextBinary = strings.TrimSpace(kontextBinary)
+	if kontextBinary == "" {
+		kontextBinary = DefaultKontextBinary
+	}
+
+	var settings Settings
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return fmt.Errorf("parse managed settings: %w", err)
+	}
+
+	var problems []string
+	if settings.Hooks == nil {
+		problems = append(problems, "hooks missing")
+	}
+	if settings.DisableAllHooks != nil && *settings.DisableAllHooks {
+		problems = append(problems, "disableAllHooks must not be true")
+	}
+
+	for _, event := range SupportedEvents {
+		if err := validateEvent(settings.Hooks[event.Name.String()], event, kontextBinary); err != nil {
+			problems = append(problems, err.Error())
+		}
+	}
+
+	if len(problems) > 0 {
+		return errors.New(strings.Join(problems, "; "))
+	}
+	return nil
+}
+
+func ParseEventAlias(value string) (hook.HookName, bool) {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	for _, event := range SupportedEvents {
+		if normalized == event.Alias {
+			return event.Name, true
+		}
+	}
+	return "", false
+}
+
+func AliasForEvent(name hook.HookName) (string, bool) {
+	for _, event := range SupportedEvents {
+		if event.Name == name {
+			return event.Alias, true
+		}
+	}
+	return "", false
+}
+
+func validateEvent(groups []MatcherGroup, event Event, kontextBinary string) error {
+	if len(groups) == 0 {
+		return fmt.Errorf("%s hook missing", event.Name)
+	}
+
+	wantArgs := []string{"hook", event.Alias}
+	foundValid := false
+	foundRestrictiveMatcher := false
+	for _, group := range groups {
+		for _, handler := range group.Hooks {
+			if isShellFormKontextHandler(handler, kontextBinary) {
+				return fmt.Errorf("%s uses shell-form Kontext command; use command plus args", event.Name)
+			}
+			if handler.Command != kontextBinary {
+				continue
+			}
+			if handler.Type != "command" {
+				return fmt.Errorf("%s Kontext handler type = %q, want command", event.Name, handler.Type)
+			}
+			if len(handler.Args) == 0 {
+				return fmt.Errorf("%s Kontext handler args missing", event.Name)
+			}
+			if !sameStrings(handler.Args, wantArgs) {
+				return fmt.Errorf("%s Kontext handler args = %q, want %q", event.Name, handler.Args, wantArgs)
+			}
+			if !isAllMatcher(group.Matcher) {
+				foundRestrictiveMatcher = true
+				continue
+			}
+			foundValid = true
+		}
+	}
+
+	if foundValid {
+		return nil
+	}
+	if foundRestrictiveMatcher {
+		return fmt.Errorf("%s Kontext command hook uses matcher %q; use an empty matcher for full event coverage", event.Name, firstRestrictiveMatcher(groups, kontextBinary, wantArgs))
+	}
+	return fmt.Errorf("%s Kontext command hook missing for %s", event.Name, kontextBinary)
+}
+
+func isShellFormKontextHandler(handler Handler, kontextBinary string) bool {
+	if len(handler.Args) > 0 {
+		return false
+	}
+	command := strings.TrimSpace(handler.Command)
+	if command == "" {
+		return false
+	}
+	command = strings.NewReplacer("'", "", `"`, "").Replace(command)
+	fields := strings.Fields(command)
+	if len(fields) < 2 || fields[1] != "hook" {
+		return false
+	}
+	if fields[0] == kontextBinary {
+		return true
+	}
+	base := filepath.Base(kontextBinary)
+	return base == "kontext" && fields[0] == "kontext"
+}
+
+func isAllMatcher(value string) bool {
+	matcher := strings.TrimSpace(value)
+	return matcher == "" || matcher == "*"
+}
+
+func firstRestrictiveMatcher(groups []MatcherGroup, kontextBinary string, wantArgs []string) string {
+	for _, group := range groups {
+		for _, handler := range group.Hooks {
+			if handler.Command == kontextBinary && handler.Type == "command" && sameStrings(handler.Args, wantArgs) && !isAllMatcher(group.Matcher) {
+				return group.Matcher
+			}
+		}
+	}
+	return ""
+}
+
+func sameStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/claudemanaged/settings_test.go
+++ b/internal/claudemanaged/settings_test.go
@@ -1,0 +1,256 @@
+package claudemanaged
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestTemplateIncludesManagedKontextHooks(t *testing.T) {
+	t.Parallel()
+
+	settings := Template("/opt/kontext/bin/kontext")
+	if len(settings.Hooks) != len(SupportedEvents) {
+		t.Fatalf("hooks count = %d, want %d", len(settings.Hooks), len(SupportedEvents))
+	}
+	if settings.AllowManagedHooksOnly != nil {
+		t.Fatal("AllowManagedHooksOnly set, want omitted")
+	}
+	if settings.DisableAllHooks != nil {
+		t.Fatal("DisableAllHooks set, want omitted")
+	}
+
+	for _, event := range SupportedEvents {
+		groups := settings.Hooks[event.Name.String()]
+		if len(groups) != 1 {
+			t.Fatalf("%s groups = %d, want 1", event.Name, len(groups))
+		}
+		if groups[0].Matcher != "" {
+			t.Fatalf("%s matcher = %q, want empty", event.Name, groups[0].Matcher)
+		}
+		if len(groups[0].Hooks) != 1 {
+			t.Fatalf("%s handlers = %d, want 1", event.Name, len(groups[0].Hooks))
+		}
+		handler := groups[0].Hooks[0]
+		if handler.Type != "command" {
+			t.Fatalf("%s handler type = %q, want command", event.Name, handler.Type)
+		}
+		if handler.Command != "/opt/kontext/bin/kontext" {
+			t.Fatalf("%s command = %q, want binary path", event.Name, handler.Command)
+		}
+		wantArgs := []string{"hook", event.Alias}
+		if !sameStrings(handler.Args, wantArgs) {
+			t.Fatalf("%s args = %q, want %q", event.Name, handler.Args, wantArgs)
+		}
+		if handler.Timeout != DefaultHookTimeout {
+			t.Fatalf("%s timeout = %d, want %d", event.Name, handler.Timeout, DefaultHookTimeout)
+		}
+	}
+}
+
+func TestTemplateJSONUsesExecForm(t *testing.T) {
+	t.Parallel()
+
+	data, err := TemplateJSON("/usr/local/bin/kontext")
+	if err != nil {
+		t.Fatalf("TemplateJSON() error = %v", err)
+	}
+	if strings.Contains(string(data), "/usr/local/bin/kontext hook") {
+		t.Fatalf("template contains shell-form command: %s", data)
+	}
+
+	var decoded Settings
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if err := Validate(data, "/usr/local/bin/kontext"); err != nil {
+		t.Fatalf("Validate(template) error = %v", err)
+	}
+}
+
+func TestTemplateTrimsKontextBinary(t *testing.T) {
+	t.Parallel()
+
+	settings := Template(" /usr/local/bin/kontext ")
+	handler := settings.Hooks["PreToolUse"][0].Hooks[0]
+	if handler.Command != "/usr/local/bin/kontext" {
+		t.Fatalf("command = %q, want trimmed binary path", handler.Command)
+	}
+}
+
+func TestManagedSettingsPathForGOOS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		goos string
+		want string
+	}{
+		{goos: "darwin", want: ManagedSettingsPath},
+		{goos: "linux", want: LinuxManagedSettingsPath},
+		{goos: "windows", want: WindowsManagedSettingsPath},
+		{goos: "freebsd", want: ManagedSettingsPath},
+	}
+
+	for _, tt := range tests {
+		if got := managedSettingsPathForGOOS(tt.goos); got != tt.want {
+			t.Fatalf("managedSettingsPathForGOOS(%q) = %q, want %q", tt.goos, got, tt.want)
+		}
+	}
+}
+
+func TestValidateRejectsInvalidManagedSettings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		mutate  func(Settings) Settings
+		wantErr string
+	}{
+		{
+			name: "missing event",
+			mutate: func(settings Settings) Settings {
+				delete(settings.Hooks, "SessionEnd")
+				return settings
+			},
+			wantErr: "SessionEnd hook missing",
+		},
+		{
+			name: "shell form",
+			mutate: func(settings Settings) Settings {
+				settings.Hooks["PreToolUse"][0].Hooks[0].Command = "/usr/local/bin/kontext hook pre-tool-use"
+				settings.Hooks["PreToolUse"][0].Hooks[0].Args = nil
+				return settings
+			},
+			wantErr: "PreToolUse uses shell-form Kontext command",
+		},
+		{
+			name: "shell form after valid handler",
+			mutate: func(settings Settings) Settings {
+				settings.Hooks["PreToolUse"][0].Hooks = append(settings.Hooks["PreToolUse"][0].Hooks, Handler{
+					Type:    "command",
+					Command: "/usr/local/bin/kontext hook pre-tool-use",
+				})
+				return settings
+			},
+			wantErr: "PreToolUse uses shell-form Kontext command",
+		},
+		{
+			name: "quoted shell form after valid handler",
+			mutate: func(settings Settings) Settings {
+				settings.Hooks["PreToolUse"][0].Hooks = append(settings.Hooks["PreToolUse"][0].Hooks, Handler{
+					Type:    "command",
+					Command: "'/usr/local/bin/kontext' hook pre-tool-use",
+				})
+				return settings
+			},
+			wantErr: "PreToolUse uses shell-form Kontext command",
+		},
+		{
+			name: "unrelated command mentions kontext hook",
+			mutate: func(settings Settings) Settings {
+				settings.Hooks["PreToolUse"][0].Hooks = append(settings.Hooks["PreToolUse"][0].Hooks, Handler{
+					Type:    "command",
+					Command: `/bin/echo "kontext hook pre-tool-use"`,
+				})
+				return settings
+			},
+		},
+		{
+			name: "missing args",
+			mutate: func(settings Settings) Settings {
+				settings.Hooks["PreToolUse"][0].Hooks[0].Args = nil
+				return settings
+			},
+			wantErr: "PreToolUse Kontext handler args missing",
+		},
+		{
+			name: "restrictive matcher",
+			mutate: func(settings Settings) Settings {
+				settings.Hooks["PreToolUse"][0].Matcher = "Bash"
+				return settings
+			},
+			wantErr: "PreToolUse Kontext command hook uses matcher \"Bash\"",
+		},
+		{
+			name: "wrong handler type",
+			mutate: func(settings Settings) Settings {
+				settings.Hooks["PreToolUse"][0].Hooks[0].Type = "prompt"
+				return settings
+			},
+			wantErr: "PreToolUse Kontext handler type = \"prompt\", want command",
+		},
+		{
+			name: "disable all hooks",
+			mutate: func(settings Settings) Settings {
+				value := true
+				settings.DisableAllHooks = &value
+				return settings
+			},
+			wantErr: "disableAllHooks must not be true",
+		},
+		{
+			name: "managed hooks only allowed",
+			mutate: func(settings Settings) Settings {
+				value := true
+				settings.AllowManagedHooksOnly = &value
+				return settings
+			},
+		},
+		{
+			name: "unrelated settings ignored",
+			mutate: func(settings Settings) Settings {
+				settings.Hooks["PreCompact"] = []MatcherGroup{{
+					Matcher: "",
+					Hooks: []Handler{{
+						Type:    "command",
+						Command: "/bin/echo",
+						Args:    []string{"ok"},
+					}},
+				}}
+				return settings
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			settings := tt.mutate(Template("/usr/local/bin/kontext"))
+			data, err := json.Marshal(settings)
+			if err != nil {
+				t.Fatalf("Marshal() error = %v", err)
+			}
+
+			err = Validate(data, "/usr/local/bin/kontext")
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() error = %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("Validate() error = nil, want non-nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Validate() error = %q, want %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseEventAlias(t *testing.T) {
+	t.Parallel()
+
+	got, ok := ParseEventAlias("pre-tool-use")
+	if !ok {
+		t.Fatal("ParseEventAlias() ok = false")
+	}
+	if got.String() != "PreToolUse" {
+		t.Fatalf("ParseEventAlias() = %q, want PreToolUse", got)
+	}
+	if _, ok := ParseEventAlias("pretooluse"); ok {
+		t.Fatal("ParseEventAlias(pretooluse) ok = true, want false")
+	}
+}

--- a/internal/hook/domain.go
+++ b/internal/hook/domain.go
@@ -8,9 +8,11 @@ import (
 type HookName string
 
 const (
+	HookSessionStart      HookName = "SessionStart"
 	HookPreToolUse        HookName = "PreToolUse"
 	HookPostToolUse       HookName = "PostToolUse"
 	HookPostToolUseFailed HookName = "PostToolUseFailure"
+	HookSessionEnd        HookName = "SessionEnd"
 	HookUserPromptSubmit  HookName = "UserPromptSubmit"
 )
 

--- a/internal/hookcmd/hook.go
+++ b/internal/hookcmd/hook.go
@@ -1,6 +1,7 @@
 package hookcmd
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -13,8 +14,16 @@ func Run(a agent.Agent, evaluate func(hook.Event) (hook.Result, error)) {
 	os.Exit(run(os.Stdin, os.Stdout, os.Stderr, a, evaluate))
 }
 
+func RunWithExpectedEvent(a agent.Agent, expected hook.HookName, evaluate func(hook.Event) (hook.Result, error)) {
+	os.Exit(runWithExpectedEvent(os.Stdin, os.Stdout, os.Stderr, a, expected, evaluate))
+}
+
 func run(stdin io.Reader, stdout, stderr io.Writer, a agent.Agent, evaluate func(hook.Event) (hook.Result, error)) int {
-	codec := agentCodec{agentName: a.Name(), agent: a}
+	return runWithExpectedEvent(stdin, stdout, stderr, a, "", evaluate)
+}
+
+func runWithExpectedEvent(stdin io.Reader, stdout, stderr io.Writer, a agent.Agent, expected hook.HookName, evaluate func(hook.Event) (hook.Result, error)) int {
+	codec := agentCodec{agentName: a.Name(), agent: a, expected: expected}
 	sink := hookruntime.SinkFunc(evaluate)
 	return hookruntime.Run(stdin, stdout, stderr, codec, sink)
 }
@@ -22,6 +31,7 @@ func run(stdin io.Reader, stdout, stderr io.Writer, a agent.Agent, evaluate func
 type agentCodec struct {
 	agentName string
 	agent     agent.Agent
+	expected  hook.HookName
 }
 
 func (c agentCodec) DecodeHookEvent(input []byte) (hook.Event, error) {
@@ -31,6 +41,9 @@ func (c agentCodec) DecodeHookEvent(input []byte) (hook.Event, error) {
 	}
 	if event.Agent == "" {
 		event.Agent = c.agentName
+	}
+	if c.expected != "" && event.HookName != c.expected {
+		return hook.Event{}, fmt.Errorf("hook event alias %q does not match stdin event %q", c.expected, event.HookName)
 	}
 	return event, nil
 }

--- a/internal/hookcmd/hook_test.go
+++ b/internal/hookcmd/hook_test.go
@@ -12,6 +12,7 @@ import (
 
 type stubAgent struct {
 	decodeErr         error
+	event             hook.HookName
 	encodeErr         error
 	allowUpdatedInput map[string]any
 	blockingDecision  hook.Decision
@@ -24,7 +25,11 @@ func (s *stubAgent) DecodeHookInput(input []byte) (hook.Event, error) {
 	if s.decodeErr != nil {
 		return hook.Event{}, s.decodeErr
 	}
-	return hook.Event{HookName: hook.HookPreToolUse}, nil
+	event := s.event
+	if event == "" {
+		event = hook.HookPreToolUse
+	}
+	return hook.Event{HookName: event}, nil
 }
 
 func (s *stubAgent) EncodeHookResult(event hook.Event, result hook.Result) ([]byte, error) {
@@ -136,6 +141,25 @@ func TestRunReturnsErrorWhenWriteFails(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "failed to write hook output") {
 		t.Fatalf("stderr = %q, want write failure", stderr.String())
+	}
+}
+
+func TestRunWithExpectedEventRejectsMismatch(t *testing.T) {
+	t.Parallel()
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	code := runWithExpectedEvent(strings.NewReader(`{"hook_event_name":"PostToolUse"}`), stdout, stderr, &stubAgent{event: hook.HookPostToolUse}, hook.HookPreToolUse, func(hook.Event) (hook.Result, error) {
+		t.Fatal("evaluate should not be called")
+		return hook.Result{}, nil
+	})
+
+	if code != 2 {
+		t.Fatalf("runWithExpectedEvent() exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "does not match stdin event") {
+		t.Fatalf("stderr = %q, want mismatch error", stderr.String())
 	}
 }
 

--- a/internal/localruntime/conversions.go
+++ b/internal/localruntime/conversions.go
@@ -144,7 +144,7 @@ func rawMap(data json.RawMessage) (map[string]any, error) {
 
 func normalizeHookName(value string) (hook.HookName, bool) {
 	switch hookName := hook.HookName(strings.TrimSpace(value)); hookName {
-	case hook.HookPreToolUse, hook.HookPostToolUse, hook.HookPostToolUseFailed, hook.HookUserPromptSubmit:
+	case hook.HookSessionStart, hook.HookPreToolUse, hook.HookPostToolUse, hook.HookPostToolUseFailed, hook.HookSessionEnd, hook.HookUserPromptSubmit:
 		return hookName, true
 	default:
 		return "", false


### PR DESCRIPTION
## Where We Are

ENG-357 added Kontext managed endpoint primitives under `/Library/Application Support/Kontext`, but Claude Code reads endpoint-managed settings from its own file:

`/Library/Application Support/ClaudeCode/managed-settings.json`

Katana employees will still run plain `claude`, so Claude Code needs an enterprise-managed hook contract that invokes Kontext without shell aliases or user-editable project settings.

## Where We Want To Go

Define the generic Claude Code managed settings hook contract for Kontext.

This PR owns the reusable contract package: event list, JSON model, exec-form template generation, validation, default managed-settings paths, and shared hook event aliases. It does not install the file or manage daemon/runtime lifecycle.

## Build

Adds `internal/claudemanaged` with:

- macOS `ManagedSettingsPath = "/Library/Application Support/ClaudeCode/managed-settings.json"`
- Linux/WSL default path: `/etc/claude-code/managed-settings.json`
- Windows default path: `C:\Program Files\ClaudeCode\managed-settings.json`
- managed hook template generation using Claude Code's `hooks` JSON shape
- exec-form command handlers with `command`, `args`, and `timeout`
- the five ENG-358 events: `SessionStart`, `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `SessionEnd`
- lowercase hook aliases: `session-start`, `pre-tool-use`, `post-tool-use`, `post-tool-use-failure`, `session-end`
- validation that rejects missing required Kontext hooks, shell-form Kontext commands, restrictive matchers, invalid handler type/args, and `disableAllHooks: true`
- shared hook constants plus local runtime hook-name acceptance for the ENG-358 lifecycle event names
- hidden `kontext hook <event>` alias support, because the managed template emits that argv shape

The generated handler shape is:

```json
{
  "type": "command",
  "command": "/usr/local/bin/kontext",
  "args": ["hook", "pre-tool-use"],
  "timeout": 20
}
```

## Stack Split

This branch is the contract branch. The upstack PR #180 exposes the CLI commands that print/validate this contract.

Claude Code command hooks support `args` exec-form, so the template intentionally avoids shell-form commands. The actual Claude hook event is still decoded from stdin; the argv alias is only a guardrail and routing hint.

## Non-goals

- no daemon start/self-heal
- no socket recovery
- no session reopen logic
- no idle cleanup
- no hosted streaming or hosted ingestion API
- no Addigy/pkg/LaunchAgent packaging
- no Katana-specific managed settings file
- no shell-form hook commands
- no `allowManagedHooksOnly` rollout decision

Runtime recovery and lifecycle side effects belong to ENG-359. Deployment packaging belongs to ENG-363.

## Verification

- `go test ./internal/claudemanaged ./cmd/kontext ./internal/hookcmd ./internal/localruntime`
- `go test ./...`
- `gofmt -l internal/claudemanaged cmd/kontext internal/hook internal/hookcmd internal/localruntime`
- `git diff --check -- internal/claudemanaged cmd/kontext internal/hook internal/hookcmd internal/localruntime`
- Codex review against `origin/main`
