### PR TITLE
feat(claude): expose managed settings CLI

### DIFF
--- a/cmd/kontext/main.go
+++ b/cmd/kontext/main.go
@@ -46,6 +46,7 @@ func main() {
 	root.AddCommand(logoutCmd())
 	root.AddCommand(hookCmd())
 	root.AddCommand(doctorCmd())
+	root.AddCommand(claudeCmd())
 	root.AddCommand(guardCmd())
 
 	if err := root.Execute(); err != nil {
@@ -74,6 +75,72 @@ func guardCmd() *cobra.Command {
 			return guardcli.Run(context.Background(), args, cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr())
 		},
 	}
+}
+
+func claudeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "claude",
+		Short: "Manage Claude Code integration",
+	}
+	cmd.AddCommand(claudeManagedSettingsCmd())
+	return cmd
+}
+
+func claudeManagedSettingsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "managed-settings",
+		Short: "Render and validate Claude Code managed settings",
+	}
+	cmd.AddCommand(claudeManagedSettingsTemplateCmd())
+	cmd.AddCommand(claudeManagedSettingsValidateCmd())
+	return cmd
+}
+
+func claudeManagedSettingsTemplateCmd() *cobra.Command {
+	var kontextBinary string
+
+	cmd := &cobra.Command{
+		Use:   "template",
+		Short: "Print Claude Code managed settings for Kontext hooks",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			data, err := claudemanaged.TemplateJSON(kontextBinary)
+			if err != nil {
+				return err
+			}
+			_, err = cmd.OutOrStdout().Write(data)
+			return err
+		},
+	}
+	cmd.Flags().StringVar(&kontextBinary, "kontext-binary", claudemanaged.DefaultKontextBinary, "Kontext executable path for managed hooks")
+	return cmd
+}
+
+func claudeManagedSettingsValidateCmd() *cobra.Command {
+	var kontextBinary string
+
+	cmd := &cobra.Command{
+		Use:   "validate [path]",
+		Short: "Validate Claude Code managed settings for Kontext hooks",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path := claudemanaged.DefaultManagedSettingsPath()
+			if len(args) == 1 {
+				path = args[0]
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf("read managed settings: %w", err)
+			}
+			if err := claudemanaged.Validate(data, kontextBinary); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Claude managed settings valid: %s\n", path)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&kontextBinary, "kontext-binary", claudemanaged.DefaultKontextBinary, "Kontext executable path expected in managed hooks")
+	return cmd
 }
 
 func startCmd() *cobra.Command {

--- a/cmd/kontext/main_test.go
+++ b/cmd/kontext/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -11,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kontext-security/kontext-cli/internal/claudemanaged"
 	"github.com/kontext-security/kontext-cli/internal/hook"
 	"github.com/kontext-security/kontext-cli/internal/run"
 	"github.com/zalando/go-keyring"
@@ -157,6 +159,69 @@ func TestHookCmdModeDoesNotDefaultFromEnv(t *testing.T) {
 	}
 }
 
+func TestClaudeManagedSettingsTemplateCmdPrintsValidJSON(t *testing.T) {
+	cmd := claudeManagedSettingsTemplateCmd()
+	cmd.SetArgs([]string{"--kontext-binary", "/opt/kontext/bin/kontext"})
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var settings claudemanaged.Settings
+	if err := json.Unmarshal(stdout.Bytes(), &settings); err != nil {
+		t.Fatalf("template is invalid JSON: %v", err)
+	}
+	if err := claudemanaged.Validate(stdout.Bytes(), "/opt/kontext/bin/kontext"); err != nil {
+		t.Fatalf("Validate(template) error = %v", err)
+	}
+}
+
+func TestClaudeManagedSettingsValidateCmdPassesGeneratedTemplate(t *testing.T) {
+	data, err := claudemanaged.TemplateJSON("/opt/kontext/bin/kontext")
+	if err != nil {
+		t.Fatalf("TemplateJSON() error = %v", err)
+	}
+	path := writeTempManagedSettings(t, data)
+
+	cmd := claudeManagedSettingsValidateCmd()
+	cmd.SetArgs([]string{path, "--kontext-binary", "/opt/kontext/bin/kontext"})
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Claude managed settings valid") {
+		t.Fatalf("stdout = %q, want valid message", stdout.String())
+	}
+}
+
+func TestClaudeManagedSettingsValidateCmdRejectsShellFormHooks(t *testing.T) {
+	data := []byte(`{
+  "hooks": {
+    "SessionStart": [{"matcher": "", "hooks": [{"type": "command", "command": "/usr/local/bin/kontext", "args": ["hook", "session-start"], "timeout": 5}]}],
+    "PreToolUse": [{"matcher": "", "hooks": [{"type": "command", "command": "/usr/local/bin/kontext hook pre-tool-use", "timeout": 5}]}],
+    "PostToolUse": [{"matcher": "", "hooks": [{"type": "command", "command": "/usr/local/bin/kontext", "args": ["hook", "post-tool-use"], "timeout": 5}]}],
+    "PostToolUseFailure": [{"matcher": "", "hooks": [{"type": "command", "command": "/usr/local/bin/kontext", "args": ["hook", "post-tool-use-failure"], "timeout": 5}]}],
+    "SessionEnd": [{"matcher": "", "hooks": [{"type": "command", "command": "/usr/local/bin/kontext", "args": ["hook", "session-end"], "timeout": 5}]}]
+  }
+}`)
+	path := writeTempManagedSettings(t, data)
+
+	cmd := claudeManagedSettingsValidateCmd()
+	cmd.SetArgs([]string{path})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want shell-form error")
+	}
+	if !strings.Contains(err.Error(), "shell-form Kontext command") {
+		t.Fatalf("error = %q, want shell-form error", err.Error())
+	}
+}
+
 func TestExpectedHookEventFromArgs(t *testing.T) {
 	event, err := expectedHookEventFromArgs([]string{"pre-tool-use"})
 	if err != nil {
@@ -173,6 +238,16 @@ func TestExpectedHookEventFromArgs(t *testing.T) {
 	if !strings.Contains(err.Error(), "unknown hook event alias") {
 		t.Fatalf("error = %q, want unknown alias", err.Error())
 	}
+}
+
+func writeTempManagedSettings(t *testing.T, data []byte) string {
+	t.Helper()
+
+	path := t.TempDir() + "/managed-settings.json"
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	return path
 }
 
 func TestLogoutCmdAlreadyLoggedOut(t *testing.T) {


### PR DESCRIPTION
## Where We Are

PR #179 defines the Claude Code managed settings contract for Kontext. This PR exposes that contract through the public CLI so deployment tooling and humans can render and validate the managed settings file without hand-writing JSON.

## Where We Want To Go

Add a small CLI surface for ENG-358:

- print the generic Claude managed settings template
- validate a managed settings file against the Kontext contract

## Build

Adds:

- `kontext claude managed-settings template [--kontext-binary /usr/local/bin/kontext]`
- `kontext claude managed-settings validate [path] [--kontext-binary /usr/local/bin/kontext]`
- OS-specific default validation path from the contract package when `[path]` is omitted
- validation output that is usable by deployment tooling before shipping managed settings to machines

## Stack Split

This is intentionally only the CLI exposure branch. The contract, event list, template JSON, validator, default managed-settings paths, and `kontext hook <event>` alias handling live downstack in #179.

ENG-359 owns daemon/socket lifecycle behavior after these managed hooks exist. This PR should not open/close sessions, self-heal sockets, start daemons, or add deployment packaging.

## Non-goals

- no daemon start/self-heal
- no socket recovery
- no session reopen logic
- no idle cleanup
- no hosted streaming or hosted ingestion API
- no Addigy/pkg/LaunchAgent packaging
- no Katana-specific managed settings file
- no shell-form hook commands
- no `allowManagedHooksOnly` rollout decision

## Verification

- `go test ./internal/claudemanaged ./cmd/kontext ./internal/hookcmd ./internal/localruntime`
- `go test ./...`
- `gofmt -l internal/claudemanaged cmd/kontext internal/hook internal/hookcmd internal/localruntime`
- `git diff --check -- internal/claudemanaged cmd/kontext internal/hook internal/hookcmd internal/localruntime`
- Codex review against `feat/eng-358-claude-managed-settings-contract`
