### PR TITLE
refactor(hookruntime): drop redundant sink wrapper

### DIFF
--- a/internal/hookcmd/hook.go
+++ b/internal/hookcmd/hook.go
@@ -24,8 +24,7 @@ func run(stdin io.Reader, stdout, stderr io.Writer, a agent.Agent, evaluate func
 
 func runWithExpectedEvent(stdin io.Reader, stdout, stderr io.Writer, a agent.Agent, expected hook.HookName, evaluate func(hook.Event) (hook.Result, error)) int {
 	codec := agentCodec{agentName: a.Name(), agent: a, expected: expected}
-	sink := hookruntime.SinkFunc(evaluate)
-	return hookruntime.Run(stdin, stdout, stderr, codec, sink)
+	return hookruntime.Run(stdin, stdout, stderr, codec, evaluate)
 }
 
 type agentCodec struct {

--- a/internal/hookruntime/claude.go
+++ b/internal/hookruntime/claude.go
@@ -8,7 +8,7 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/hook"
 )
 
-type ClaudeHookInput struct {
+type claudeHookInput struct {
 	SessionID        string         `json:"session_id"`
 	SessionIDAlt     string         `json:"sessionId"`
 	HookEventName    string         `json:"hook_event_name"`
@@ -44,7 +44,7 @@ type claudeHookSpecificOutput struct {
 }
 
 func DecodeClaudeEvent(input []byte, agentName string) (hook.Event, error) {
-	var h ClaudeHookInput
+	var h claudeHookInput
 	if err := json.Unmarshal(input, &h); err != nil {
 		return hook.Event{}, fmt.Errorf("claude: decode hook input: %w", err)
 	}

--- a/internal/hookruntime/runner.go
+++ b/internal/hookruntime/runner.go
@@ -12,17 +12,7 @@ type Codec interface {
 	EncodeHookResult(hook.Event, hook.Result) ([]byte, error)
 }
 
-type Sink interface {
-	ProcessHookEvent(hook.Event) (hook.Result, error)
-}
-
-type SinkFunc func(hook.Event) (hook.Result, error)
-
-func (f SinkFunc) ProcessHookEvent(event hook.Event) (hook.Result, error) {
-	return f(event)
-}
-
-func Run(stdin io.Reader, stdout, stderr io.Writer, codec Codec, sink Sink) int {
+func Run(stdin io.Reader, stdout, stderr io.Writer, codec Codec, evaluate func(hook.Event) (hook.Result, error)) int {
 	input, err := io.ReadAll(stdin)
 	if err != nil {
 		fmt.Fprintf(stderr, "kontext: failed to read stdin: %v\n", err)
@@ -35,7 +25,7 @@ func Run(stdin io.Reader, stdout, stderr io.Writer, codec Codec, sink Sink) int 
 		return 2
 	}
 
-	result, err := sink.ProcessHookEvent(event)
+	result, err := evaluate(event)
 	if err != nil {
 		fmt.Fprintf(stderr, "kontext: evaluation error: %v\n", err)
 		return 2

--- a/internal/hookruntime/runner_test.go
+++ b/internal/hookruntime/runner_test.go
@@ -22,9 +22,9 @@ func TestRunWritesStructuredDenyResult(t *testing.T) {
 		stdout,
 		stderr,
 		codec,
-		SinkFunc(func(hook.Event) (hook.Result, error) {
+		func(hook.Event) (hook.Result, error) {
 			return hook.Result{Decision: hook.DecisionDeny, Reason: "blocked by policy"}, nil
-		}),
+		},
 	)
 
 	if code != 0 {
@@ -53,9 +53,9 @@ func TestRunWritesStructuredAskResult(t *testing.T) {
 		stdout,
 		stderr,
 		codec,
-		SinkFunc(func(hook.Event) (hook.Result, error) {
+		func(hook.Event) (hook.Result, error) {
 			return hook.Result{Decision: hook.DecisionAsk, Reason: "approval required"}, nil
-		}),
+		},
 	)
 
 	if code != 0 {


### PR DESCRIPTION
Summary
This cleans up hook evaluation by removing the redundant Sink wrapper in internal/hookruntime, so the canonical runner path is just Run(..., evaluateFn).

Before this, internal/hookcmd only used hookruntime.SinkFunc to adapt a plain function to the Sink interface, which added API surface with no behavior.

Now Run takes evaluate func(hook.Event) (hook.Result, error) directly, and the Claude hook input struct is unexported.

Why
cmd/kontext hook entry
-> internal/hookcmd.Run
-> internal/hookruntime.Run
-> agent.EncodeHookResult
-> exit code + structured output

This PR does not broaden behavior beyond the cleanup scope.

What changed
Removed internal/hookruntime.Sink and SinkFunc
Changed internal/hookruntime.Run to accept evaluate func(...)
Unexported Claude hook input struct (claudeHookInput)

Verification
bash -n scripts/*.sh
go test ./internal/hookruntime ./internal/hookcmd ./internal/agent/claude
go vet ./internal/hookruntime ./internal/hookcmd ./internal/agent/claude
git diff --check

