### PR TITLE
fix: optimize internal/credential template entry ordering

### DIFF
--- a/internal/credential/template_file.go
+++ b/internal/credential/template_file.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 )
 
@@ -52,15 +51,14 @@ func LoadTemplateFile(path string) (*TemplateFile, error) {
 	}
 
 	type effectiveAssignment struct {
-		entry     *Entry
-		invalid   *InvalidPlaceholder
-		lastIndex int
+		entry   *Entry
+		invalid *InvalidPlaceholder
 	}
 
 	assignments := make(map[string]effectiveAssignment)
 	seenKeys := make(map[string]struct{})
+	assignmentOrder := make([]string, 0)
 	scanner := bufio.NewScanner(f)
-	lineIndex := 0
 	for scanner.Scan() {
 		line := scanner.Text()
 		trimmed := strings.TrimSpace(line)
@@ -92,8 +90,8 @@ func LoadTemplateFile(path string) (*TemplateFile, error) {
 		value := strings.TrimSpace(parts[1])
 		normalizedValue := normalizePlaceholderValue(value)
 		result.ExistingValues[envVar] = value
-		assignment := effectiveAssignment{lastIndex: lineIndex}
-		lineIndex++
+		assignment := effectiveAssignment{}
+		assignmentOrder = append(assignmentOrder, envVar)
 
 		matches := placeholder.FindStringSubmatch(normalizedValue)
 		if matches != nil {
@@ -131,12 +129,18 @@ func LoadTemplateFile(path string) (*TemplateFile, error) {
 	}
 
 	keys := make([]string, 0, len(assignments))
-	for envVar := range assignments {
+	seenAssignments := make(map[string]struct{}, len(assignments))
+	for i := len(assignmentOrder) - 1; i >= 0; i-- {
+		envVar := assignmentOrder[i]
+		if _, exists := seenAssignments[envVar]; exists {
+			continue
+		}
+		seenAssignments[envVar] = struct{}{}
 		keys = append(keys, envVar)
 	}
-	sort.Slice(keys, func(i, j int) bool {
-		return assignments[keys[i]].lastIndex < assignments[keys[j]].lastIndex
-	})
+	for i, j := 0, len(keys)-1; i < j; i, j = i+1, j-1 {
+		keys[i], keys[j] = keys[j], keys[i]
+	}
 	for _, envVar := range keys {
 		assignment := assignments[envVar]
 		if assignment.invalid != nil {

--- a/internal/credential/template_file_test.go
+++ b/internal/credential/template_file_test.go
@@ -217,6 +217,36 @@ func TestLoadTemplateFilePreservesLastDuplicatePlaceholderAssignment(t *testing.
 	}
 }
 
+func TestLoadTemplateFilePreservesLastAssignmentOrderWithoutSort(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), ".env.kontext")
+	content := strings.Join([]string{
+		"FIRST={{kontext:first}}",
+		"SECOND={{kontext:second}}",
+		"FIRST=literal",
+		"THIRD={{kontext:third}}",
+		"SECOND={{kontext:second-late}}",
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+
+	doc, err := LoadTemplateFile(path)
+	if err != nil {
+		t.Fatalf("LoadTemplateFile() error = %v", err)
+	}
+	if got, want := len(doc.Entries), 2; got != want {
+		t.Fatalf("entries len = %d, want %d", got, want)
+	}
+	if got := doc.Entries[0].EnvVar; got != "THIRD" {
+		t.Fatalf("first entry env var = %q, want %q", got, "THIRD")
+	}
+	if got := doc.Entries[1].EnvVar; got != "SECOND" {
+		t.Fatalf("second entry env var = %q, want %q", got, "SECOND")
+	}
+}
+
 func TestLoadTemplateFileCollectsInvalidPlaceholders(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- explain the user-facing change
- link the issue or context if relevant

## Verification

- [ ] `go test ./...`
- [ ] `go test -race ./...`
- [ ] `go vet ./...`
- [ ] `buf generate` if protobuf or generated code changed

## Release notes

- [ ] conventional commit title matches semver intent
