### PR TITLE
feat(guard): improve local judge startup progress

### DIFF
--- a/internal/guard/cli/cli.go
+++ b/internal/guard/cli/cli.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -21,9 +20,11 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 	"github.com/kontext-security/kontext-cli/internal/guard/app/server"
 	"github.com/kontext-security/kontext-cli/internal/guard/judge"
+	"github.com/kontext-security/kontext-cli/internal/guard/judgeruntime"
 	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
 	"github.com/kontext-security/kontext-cli/internal/hook"
 	"github.com/kontext-security/kontext-cli/internal/localruntime"
+	"github.com/kontext-security/kontext-cli/internal/startupui"
 )
 
 const (
@@ -126,24 +127,29 @@ func runDaemon(ctx context.Context, args []string, out io.Writer) error {
 			return err
 		}
 	}
-	localJudge, closeJudge, judgeStatus, err := configureLocalJudge(ctx, localJudgeConfig{
-		URL:            *judgeURL,
-		Model:          *judgeModel,
-		Timeout:        *judgeTimeout,
-		Managed:        *judgeManaged,
-		ServerBin:      *judgeServerBin,
-		ModelPath:      *judgeModelPath,
-		HFRepo:         *judgeHFRepo,
-		HFFile:         *judgeHFFile,
-		HFRevision:     *judgeHFRevision,
-		CacheDir:       resolvedJudgeCacheDir(*judgeCacheDir, *dbPath),
-		Port:           *judgePort,
-		StartupTimeout: *judgeStartupTimeout,
+	ui := startupui.New(out)
+	localJudge, closeJudge, _, err := judgeruntime.Configure(ctx, judgeruntime.Config{
+		URL:              *judgeURL,
+		Model:            *judgeModel,
+		Timeout:          *judgeTimeout,
+		Managed:          *judgeManaged,
+		ServerBin:        *judgeServerBin,
+		ModelPath:        *judgeModelPath,
+		HFRepo:           *judgeHFRepo,
+		HFFile:           *judgeHFFile,
+		HFRevision:       *judgeHFRevision,
+		CacheDir:         judgeruntime.ResolvedCacheDir(*judgeCacheDir, *dbPath),
+		Port:             *judgePort,
+		StartupTimeout:   *judgeStartupTimeout,
+		DownloadProgress: ui.HandleDownloadProgress,
 	})
 	if err != nil {
 		return err
 	}
 	defer closeJudge()
+	if err := ui.Err(); err != nil {
+		return fmt.Errorf("write startup output: %w", err)
+	}
 	localServer, closeStore, err := server.OpenDefaultServerWithOptions(*dbPath, server.Options{
 		Judge: localJudge,
 	})
@@ -174,178 +180,15 @@ func runDaemon(ctx context.Context, args []string, out io.Writer) error {
 	fmt.Fprintf(out, "Hook runtime: unix://%s\n", *socketPath)
 	fmt.Fprintln(out, "Mode: observe (Claude Code runs normally; decisions are recorded as would allow / would deny).")
 	fmt.Fprintf(out, "Dashboard: http://%s\n", *addr)
-	if localJudge != nil {
-		fmt.Fprintf(out, "Local judge: %s\n", judgeStatus)
-	} else {
-		fmt.Fprintln(out, "Local judge: disabled")
-	}
+	fmt.Fprintln(out, localJudgeStatusLine(localJudge))
 	if !*noOpen {
 		_ = browser.OpenURL("http://" + *addr)
 	}
 	return localServer.ListenAndServe(*addr)
 }
 
-type localJudgeConfig struct {
-	URL            string
-	Model          string
-	Timeout        time.Duration
-	Managed        bool
-	ServerBin      string
-	ModelPath      string
-	HFRepo         string
-	HFFile         string
-	HFRevision     string
-	CacheDir       string
-	Port           int
-	StartupTimeout time.Duration
-}
-
-func configureLocalJudge(ctx context.Context, cfg localJudgeConfig) (judge.Judge, func(), string, error) {
-	closeFn := func() {}
-	if cfg.Managed {
-		return configureManagedJudge(ctx, cfg)
-	}
-	if strings.TrimSpace(cfg.URL) == "" && strings.TrimSpace(cfg.Model) == "" {
-		return nil, closeFn, "", nil
-	}
-	if strings.TrimSpace(cfg.URL) == "" || strings.TrimSpace(cfg.Model) == "" {
-		return nil, closeFn, "", fmt.Errorf("--judge-url and --judge-model must be set together")
-	}
-	if err := validateLocalJudgeURL(cfg.URL); err != nil {
-		return nil, closeFn, "", err
-	}
-	localJudge, err := judge.NewOpenAICompatibleJudge(judge.HTTPOptions{
-		BaseURL: cfg.URL,
-		Model:   cfg.Model,
-		Timeout: cfg.Timeout,
-	})
-	if err != nil {
-		return nil, closeFn, "", err
-	}
-	return localJudge, closeFn, fmt.Sprintf("%s at %s", cfg.Model, cfg.URL), nil
-}
-
-func configureManagedJudge(ctx context.Context, cfg localJudgeConfig) (judge.Judge, func(), string, error) {
-	closeFn := func() {}
-	modelPath := strings.TrimSpace(cfg.ModelPath)
-	modelName := strings.TrimSpace(cfg.Model)
-	if modelPath == "" && looksLikeGGUFPath(modelName) {
-		modelPath = modelName
-		modelName = ""
-	}
-	hfRepo := strings.TrimSpace(cfg.HFRepo)
-	hfFile := strings.TrimSpace(cfg.HFFile)
-	if modelPath == "" && hfRepo == "" {
-		hfRepo = judge.DefaultLlamaServerHFRepo
-		if hfFile == "" {
-			hfFile = judge.DefaultLlamaServerHFFile
-		}
-	}
-	if modelName == "" {
-		modelName = managedJudgeModelName(modelPath, hfRepo, hfFile)
-	}
-	host, port, baseURL, err := managedJudgeListenConfig(cfg.URL, cfg.Port)
-	if err != nil {
-		return nil, closeFn, "", err
-	}
-	server, err := judge.StartLlamaServer(ctx, judge.LlamaServerOptions{
-		BinaryPath:     cfg.ServerBin,
-		ModelPath:      modelPath,
-		HFRepo:         hfRepo,
-		HFFile:         hfFile,
-		HFRevision:     cfg.HFRevision,
-		CacheDir:       cfg.CacheDir,
-		Host:           host,
-		Port:           port,
-		StartupTimeout: cfg.StartupTimeout,
-	})
-	if err != nil {
-		unavailable := judge.UnavailableJudge{
-			Runtime: judge.DefaultLlamaServerRuntime,
-			Model:   modelName,
-			Kind:    judge.FailureUnavailable,
-			Err:     err,
-		}
-		return unavailable, closeFn, fmt.Sprintf("%s unavailable (%v)", modelName, err), nil
-	}
-	closeFn = func() {
-		_ = server.Stop()
-	}
-	localJudge, err := judge.NewOpenAICompatibleJudge(judge.HTTPOptions{
-		BaseURL: baseURL,
-		Model:   modelName,
-		Runtime: judge.DefaultLlamaServerRuntime,
-		Timeout: cfg.Timeout,
-	})
-	if err != nil {
-		closeFn()
-		return nil, func() {}, "", err
-	}
-	return localJudge, closeFn, fmt.Sprintf("%s at %s (%s)", modelName, baseURL, judge.DefaultLlamaServerRuntime), nil
-}
-
-func managedJudgeListenConfig(rawURL string, port int) (string, int, string, error) {
-	if port <= 0 {
-		port = judge.DefaultLlamaServerPort
-	}
-	rawURL = strings.TrimSpace(rawURL)
-	if rawURL == "" {
-		return judge.DefaultLlamaServerHost, port, managedJudgeBaseURL(judge.DefaultLlamaServerHost, port), nil
-	}
-	if err := validateLocalJudgeURL(rawURL); err != nil {
-		return "", 0, "", err
-	}
-	parsed, err := url.Parse(rawURL)
-	if err != nil {
-		return "", 0, "", fmt.Errorf("parse judge URL: %w", err)
-	}
-	if parsed.Scheme != "http" {
-		return "", 0, "", fmt.Errorf("managed judge URL must use http")
-	}
-	host := parsed.Hostname()
-	if host == "" {
-		return "", 0, "", fmt.Errorf("managed judge URL must include host")
-	}
-	if parsed.Port() != "" {
-		parsedPort, err := strconv.Atoi(parsed.Port())
-		if err != nil || parsedPort <= 0 {
-			return "", 0, "", fmt.Errorf("managed judge URL has invalid port %q", parsed.Port())
-		}
-		port = parsedPort
-	}
-	return host, port, managedJudgeBaseURL(host, port), nil
-}
-
-func managedJudgeBaseURL(host string, port int) string {
-	return (&url.URL{
-		Scheme: "http",
-		Host:   net.JoinHostPort(host, strconv.Itoa(port)),
-	}).String()
-}
-
-func looksLikeGGUFPath(value string) bool {
-	value = strings.TrimSpace(value)
-	return strings.HasSuffix(strings.ToLower(value), ".gguf") || strings.Contains(value, string(filepath.Separator))
-}
-
-func managedJudgeModelName(modelPath, hfRepo, hfFile string) string {
-	if strings.TrimSpace(hfRepo) != "" {
-		return strings.TrimSpace(hfRepo)
-	}
-	if strings.TrimSpace(modelPath) != "" {
-		return filepath.Base(modelPath)
-	}
-	if strings.TrimSpace(hfFile) != "" {
-		return strings.TrimSpace(hfFile)
-	}
-	return "local-judge"
-}
-
-func resolvedJudgeCacheDir(cacheDir, dbPath string) string {
-	if strings.TrimSpace(cacheDir) != "" {
-		return cacheDir
-	}
-	return defaultJudgeCacheDir(dbPath)
+func localJudgeStatusLine(localJudge judge.Judge) string {
+	return "Local judge: " + startupui.LocalJudgeSummary(localJudge != nil, judge.IsUnavailable(localJudge))
 }
 
 func verifyClaudeCode() error {

--- a/internal/guard/cli/cli_test.go
+++ b/internal/guard/cli/cli_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/kontext-security/kontext-cli/internal/guard/judge"
+	"github.com/kontext-security/kontext-cli/internal/guard/judgeruntime"
 )
 
 func TestGuardHookCompatibilityCommandIsRetired(t *testing.T) {
@@ -203,7 +204,7 @@ func TestJudgeEvalChecksExpectedRiskCategoriesAndReason(t *testing.T) {
 }
 
 func TestConfigureManagedJudgeFailsOpenWhenModelMissing(t *testing.T) {
-	localJudge, closeJudge, status, err := configureLocalJudge(context.Background(), localJudgeConfig{
+	localJudge, closeJudge, status, err := judgeruntime.Configure(context.Background(), judgeruntime.Config{
 		Managed:   true,
 		ModelPath: filepath.Join(t.TempDir(), "missing.gguf"),
 		Model:     "qwen",
@@ -227,7 +228,7 @@ func TestConfigureManagedJudgeFailsOpenWhenModelMissing(t *testing.T) {
 
 func TestConfigureManagedJudgeUsesJudgeModelAsGGUFPath(t *testing.T) {
 	modelPath := filepath.Join(t.TempDir(), "qwen.gguf")
-	localJudge, closeJudge, status, err := configureLocalJudge(context.Background(), localJudgeConfig{
+	localJudge, closeJudge, status, err := judgeruntime.Configure(context.Background(), judgeruntime.Config{
 		Managed: true,
 		Model:   modelPath,
 		Port:    18083,
@@ -246,7 +247,7 @@ func TestConfigureManagedJudgeUsesJudgeModelAsGGUFPath(t *testing.T) {
 
 func TestResolvedJudgeCacheDirUsesParsedDBPath(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "custom", "guard.db")
-	got := resolvedJudgeCacheDir("", dbPath)
+	got := judgeruntime.ResolvedCacheDir("", dbPath)
 	want := filepath.Join(filepath.Dir(dbPath), "judge-models")
 	if got != want {
 		t.Fatalf("cache dir = %q, want %q", got, want)
@@ -254,14 +255,14 @@ func TestResolvedJudgeCacheDirUsesParsedDBPath(t *testing.T) {
 }
 
 func TestResolvedJudgeCacheDirPrefersExplicitValue(t *testing.T) {
-	got := resolvedJudgeCacheDir("/explicit/cache", filepath.Join(t.TempDir(), "guard.db"))
+	got := judgeruntime.ResolvedCacheDir("/explicit/cache", filepath.Join(t.TempDir(), "guard.db"))
 	if got != "/explicit/cache" {
 		t.Fatalf("cache dir = %q, want explicit cache", got)
 	}
 }
 
 func TestManagedJudgeListenConfigDefaultsToJudgePort(t *testing.T) {
-	host, port, baseURL, err := managedJudgeListenConfig("", 18081)
+	host, port, baseURL, err := judgeruntime.ManagedListenConfig("", 18081)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -271,7 +272,7 @@ func TestManagedJudgeListenConfigDefaultsToJudgePort(t *testing.T) {
 }
 
 func TestManagedJudgeListenConfigAppliesJudgeURLPort(t *testing.T) {
-	host, port, baseURL, err := managedJudgeListenConfig("http://localhost:18082/v1", 18081)
+	host, port, baseURL, err := judgeruntime.ManagedListenConfig("http://localhost:18082/v1", 18081)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -281,11 +282,34 @@ func TestManagedJudgeListenConfigAppliesJudgeURLPort(t *testing.T) {
 }
 
 func TestManagedJudgeListenConfigRejectsHTTPS(t *testing.T) {
-	_, _, _, err := managedJudgeListenConfig("https://127.0.0.1:18082", 18081)
+	_, _, _, err := judgeruntime.ManagedListenConfig("https://127.0.0.1:18082", 18081)
 	if err == nil {
-		t.Fatal("managedJudgeListenConfig() error = nil, want HTTPS rejection")
+		t.Fatal("ManagedListenConfig() error = nil, want HTTPS rejection")
 	}
 	if !strings.Contains(err.Error(), "managed judge URL must use http") {
 		t.Fatalf("err = %v, want managed http error", err)
 	}
+}
+
+func TestLocalJudgeStatusLineSummarizesManagedJudge(t *testing.T) {
+	got := localJudgeStatusLine(fakeJudge{})
+	if got != "Local judge: ready" {
+		t.Fatalf("status line = %q, want ready", got)
+	}
+	if strings.Contains(got, "http://127.0.0.1:18080") || strings.Contains(got, "(llama-server)") {
+		t.Fatalf("status line leaked managed judge internals: %q", got)
+	}
+}
+
+func TestLocalJudgeStatusLineUsesStructuredUnavailableState(t *testing.T) {
+	got := localJudgeStatusLine(judge.UnavailableJudge{Model: "unavailable-model"})
+	if got != "Local judge: unavailable" {
+		t.Fatalf("status line = %q, want unavailable", got)
+	}
+}
+
+type fakeJudge struct{}
+
+func (fakeJudge) Decide(context.Context, judge.Input) (judge.Result, error) {
+	return judge.Result{}, nil
 }

--- a/internal/guard/judge/llama_server.go
+++ b/internal/guard/judge/llama_server.go
@@ -29,18 +29,19 @@ const (
 )
 
 type LlamaServerOptions struct {
-	BinaryPath     string
-	ModelPath      string
-	HFRepo         string
-	HFFile         string
-	HFRevision     string
-	CacheDir       string
-	Host           string
-	Port           int
-	StartupTimeout time.Duration
-	HTTPClient     *http.Client
-	Stdout         io.Writer
-	Stderr         io.Writer
+	BinaryPath       string
+	ModelPath        string
+	HFRepo           string
+	HFFile           string
+	HFRevision       string
+	CacheDir         string
+	Host             string
+	Port             int
+	StartupTimeout   time.Duration
+	HTTPClient       *http.Client
+	Stdout           io.Writer
+	Stderr           io.Writer
+	DownloadProgress DownloadProgressHandler
 }
 
 type LlamaServer struct {
@@ -49,6 +50,26 @@ type LlamaServer struct {
 	wait    chan error
 	cmd     *exec.Cmd
 }
+
+type DownloadProgressEvent string
+
+const (
+	DownloadProgressCacheCheck DownloadProgressEvent = "cache_check"
+	DownloadProgressCacheHit   DownloadProgressEvent = "cache_hit"
+	DownloadProgressStart      DownloadProgressEvent = "download_start"
+	DownloadProgressUpdate     DownloadProgressEvent = "download_update"
+	DownloadProgressDone       DownloadProgressEvent = "download_done"
+	DownloadProgressError      DownloadProgressEvent = "download_error"
+)
+
+type DownloadProgress struct {
+	Event        DownloadProgressEvent
+	CurrentBytes int64
+	TotalBytes   int64
+	Err          error
+}
+
+type DownloadProgressHandler func(DownloadProgress)
 
 func StartLlamaServer(ctx context.Context, opts LlamaServerOptions) (*LlamaServer, error) {
 	opts = normalizeLlamaServerOptions(opts)
@@ -134,12 +155,21 @@ func ResolveLlamaServerModel(ctx context.Context, opts LlamaServerOptions) (stri
 	if err != nil {
 		return "", err
 	}
-	if _, err := os.Stat(cachedPath); err == nil {
+	emitDownloadProgress(opts.DownloadProgress, DownloadProgress{
+		Event: DownloadProgressCacheCheck,
+	})
+	if info, err := os.Stat(cachedPath); err == nil {
+		size := info.Size()
+		emitDownloadProgress(opts.DownloadProgress, DownloadProgress{
+			Event:        DownloadProgressCacheHit,
+			CurrentBytes: size,
+			TotalBytes:   size,
+		})
 		return cachedPath, nil
 	} else if !os.IsNotExist(err) {
 		return "", err
 	}
-	if err := downloadHFModel(ctx, opts.HTTPClient, repo, revision, file, cachedPath); err != nil {
+	if err := downloadHFModel(ctx, opts.HTTPClient, repo, revision, file, cachedPath, opts.DownloadProgress); err != nil {
 		return "", err
 	}
 	return cachedPath, nil
@@ -282,7 +312,7 @@ func normalizeLlamaServerOptions(opts LlamaServerOptions) LlamaServerOptions {
 	return opts
 }
 
-func downloadHFModel(ctx context.Context, client *http.Client, repo, revision, file, targetPath string) error {
+func downloadHFModel(ctx context.Context, client *http.Client, repo, revision, file, targetPath string, progress DownloadProgressHandler) error {
 	if client == nil {
 		client = &http.Client{Timeout: DefaultLlamaServerDownloadTimeout}
 	}
@@ -296,26 +326,99 @@ func downloadHFModel(ctx context.Context, client *http.Client, repo, revision, f
 	req.Header.Set("User-Agent", "kontext-guard")
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("download judge model: %w", err)
+		wrapped := fmt.Errorf("download judge model: %w", err)
+		emitDownloadProgress(progress, DownloadProgress{Event: DownloadProgressError, Err: wrapped})
+		return wrapped
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("download judge model returned %s", resp.Status)
+		err := fmt.Errorf("download judge model returned %s", resp.Status)
+		emitDownloadProgress(progress, DownloadProgress{Event: DownloadProgressError, Err: err})
+		return err
 	}
+	totalBytes := resp.ContentLength
+	if totalBytes < 0 {
+		totalBytes = 0
+	}
+	emitDownloadProgress(progress, DownloadProgress{
+		Event:      DownloadProgressStart,
+		TotalBytes: totalBytes,
+	})
 	tmp, err := os.CreateTemp(filepath.Dir(targetPath), filepath.Base(targetPath)+".*.tmp")
 	if err != nil {
+		emitDownloadProgress(progress, DownloadProgress{Event: DownloadProgressError, Err: err})
 		return err
 	}
 	tmpPath := tmp.Name()
-	defer os.Remove(tmpPath)
-	if _, err := io.Copy(tmp, resp.Body); err != nil {
-		_ = tmp.Close()
+	removeTemp := true
+	defer func() {
+		if removeTemp {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	reader := &progressReader{
+		reader: resp.Body,
+		onProgress: func(current int64) {
+			emitDownloadProgress(progress, DownloadProgress{
+				Event:        DownloadProgressUpdate,
+				CurrentBytes: current,
+				TotalBytes:   totalBytes,
+			})
+		},
+	}
+	written, err := io.Copy(tmp, reader)
+	if err != nil {
+		err = closeAndRemoveTemp(tmp, tmpPath, err)
+		removeTemp = false
+		emitDownloadProgress(progress, DownloadProgress{Event: DownloadProgressError, Err: err})
 		return err
 	}
 	if err := tmp.Close(); err != nil {
+		err = errors.Join(err, os.Remove(tmpPath))
+		removeTemp = false
+		emitDownloadProgress(progress, DownloadProgress{Event: DownloadProgressError, Err: err})
 		return err
 	}
-	return os.Rename(tmpPath, targetPath)
+	if err := os.Rename(tmpPath, targetPath); err != nil {
+		err = errors.Join(err, os.Remove(tmpPath))
+		removeTemp = false
+		emitDownloadProgress(progress, DownloadProgress{Event: DownloadProgressError, Err: err})
+		return err
+	}
+	removeTemp = false
+	emitDownloadProgress(progress, DownloadProgress{
+		Event:        DownloadProgressDone,
+		CurrentBytes: written,
+		TotalBytes:   written,
+	})
+	return nil
+}
+
+func closeAndRemoveTemp(tmp *os.File, path string, cause error) error {
+	return errors.Join(cause, tmp.Close(), os.Remove(path))
+}
+
+type progressReader struct {
+	reader     io.Reader
+	current    int64
+	onProgress func(int64)
+}
+
+func (r *progressReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	if n > 0 {
+		r.current += int64(n)
+		if r.onProgress != nil {
+			r.onProgress(r.current)
+		}
+	}
+	return n, err
+}
+
+func emitDownloadProgress(progress DownloadProgressHandler, event DownloadProgress) {
+	if progress != nil {
+		progress(event)
+	}
 }
 
 func hfResolveURL(repo, revision, file string) string {

--- a/internal/guard/judge/llama_server_test.go
+++ b/internal/guard/judge/llama_server_test.go
@@ -142,20 +142,15 @@ func TestCachedHFModelPathIncludesRevision(t *testing.T) {
 
 func TestResolveLlamaServerModelUsesCachedFile(t *testing.T) {
 	cacheDir := t.TempDir()
-	want, err := CachedHFModelPath(cacheDir, "Qwen/Qwen3-0.6B-GGUF", "main", "Qwen3-0.6B-Q8_0.gguf")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(filepath.Dir(want), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(want, []byte("gguf"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	want := writeCachedTestHFModel(t, cacheDir, []byte("gguf"))
+	var events []DownloadProgress
 	got, err := ResolveLlamaServerModel(context.Background(), LlamaServerOptions{
 		CacheDir: cacheDir,
 		HFRepo:   "Qwen/Qwen3-0.6B-GGUF",
 		HFFile:   "Qwen3-0.6B-Q8_0.gguf",
+		DownloadProgress: func(event DownloadProgress) {
+			events = append(events, event)
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -163,33 +158,18 @@ func TestResolveLlamaServerModelUsesCachedFile(t *testing.T) {
 	if got != want {
 		t.Fatalf("model path = %q, want %q", got, want)
 	}
+	if len(events) != 2 || events[0].Event != DownloadProgressCacheCheck || events[1].Event != DownloadProgressCacheHit {
+		t.Fatalf("events = %+v, want cache check + hit", events)
+	}
 }
 
 func TestResolveLlamaServerModelDownloadsToCache(t *testing.T) {
 	cacheDir := t.TempDir()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	got, err := resolveTestHFModel(t, cacheDir, "main", nil, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/Qwen/Qwen3-0.6B-GGUF/resolve/main/Qwen3-0.6B-Q8_0.gguf" {
 			t.Fatalf("download path = %q", r.URL.Path)
 		}
 		_, _ = w.Write([]byte("gguf"))
-	}))
-	defer server.Close()
-	target, err := url.Parse(server.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	got, err := ResolveLlamaServerModel(context.Background(), LlamaServerOptions{
-		CacheDir:   cacheDir,
-		HFRepo:     "Qwen/Qwen3-0.6B-GGUF",
-		HFFile:     "Qwen3-0.6B-Q8_0.gguf",
-		HFRevision: "main",
-		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			rewritten := req.Clone(req.Context())
-			rewritten.URL.Scheme = target.Scheme
-			rewritten.URL.Host = target.Host
-			return http.DefaultTransport.RoundTrip(rewritten)
-		})},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -203,31 +183,110 @@ func TestResolveLlamaServerModelDownloadsToCache(t *testing.T) {
 	}
 }
 
-func TestResolveLlamaServerModelDownloadsCustomRevision(t *testing.T) {
+func TestResolveLlamaServerModelEmitsDownloadProgress(t *testing.T) {
+	tests := []struct {
+		name           string
+		handler        http.HandlerFunc
+		wantErr        bool
+		wantStartTotal int64
+	}{
+		{
+			name: "known content length",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Length", "4")
+				_, _ = w.Write([]byte("gguf"))
+			},
+			wantStartTotal: 4,
+		},
+		{
+			name: "unknown content length",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Del("Content-Length")
+				w.(http.Flusher).Flush()
+				_, _ = w.Write([]byte("gguf"))
+			},
+		},
+		{
+			name: "http failure",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "nope", http.StatusBadGateway)
+			},
+			wantErr: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cacheDir := t.TempDir()
+			wantPath, err := CachedHFModelPath(cacheDir, "Qwen/Qwen3-0.6B-GGUF", "main", "Qwen3-0.6B-Q8_0.gguf")
+			if err != nil {
+				t.Fatal(err)
+			}
+			var events []DownloadProgress
+			_, err = resolveTestHFModel(t, cacheDir, "main", func(event DownloadProgress) {
+				events = append(events, event)
+			}, test.handler)
+			if test.wantErr {
+				if err == nil {
+					t.Fatal("ResolveLlamaServerModel() error = nil, want failure")
+				}
+				if _, statErr := os.Stat(wantPath); !os.IsNotExist(statErr) {
+					t.Fatalf("final model stat err = %v, want not exist", statErr)
+				}
+				if !hasProgressEvent(events, DownloadProgressError) {
+					t.Fatalf("events = %+v, want error event", events)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertDownloadProgress(t, events, test.wantStartTotal)
+		})
+	}
+}
+
+func TestDownloadHFModelEmitsDownloadErrorWhenTempFileCannotBeCreated(t *testing.T) {
 	cacheDir := t.TempDir()
+	readOnlyDir := filepath.Join(cacheDir, "readonly")
+	if err := os.MkdirAll(readOnlyDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(readOnlyDir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(readOnlyDir, 0o755) })
+	if probe, err := os.CreateTemp(readOnlyDir, "probe"); err == nil {
+		_ = probe.Close()
+		_ = os.Remove(probe.Name())
+		t.Skip("filesystem allows writes to chmod 0555 directory")
+	}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/Qwen/Qwen3-0.6B-GGUF/resolve/refs/pr/1/Qwen3-0.6B-Q8_0.gguf" {
-			t.Fatalf("download path = %q", r.URL.Path)
-		}
 		_, _ = w.Write([]byte("gguf"))
 	}))
-	defer server.Close()
+	t.Cleanup(server.Close)
 	target, err := url.Parse(server.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
+	var events []DownloadProgress
+	err = downloadHFModel(context.Background(), rewriteHFClient(target), "Qwen/Qwen3-0.6B-GGUF", "main", "Qwen3-0.6B-Q8_0.gguf", filepath.Join(readOnlyDir, "model.gguf"), func(event DownloadProgress) {
+		events = append(events, event)
+	})
+	if err == nil {
+		t.Fatal("downloadHFModel() error = nil, want temp file failure")
+	}
+	if !hasProgressEvent(events, DownloadProgressError) {
+		t.Fatalf("events = %+v, want error event", events)
+	}
+}
 
-	got, err := ResolveLlamaServerModel(context.Background(), LlamaServerOptions{
-		CacheDir:   cacheDir,
-		HFRepo:     "Qwen/Qwen3-0.6B-GGUF",
-		HFFile:     "Qwen3-0.6B-Q8_0.gguf",
-		HFRevision: "refs/pr/1",
-		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			rewritten := req.Clone(req.Context())
-			rewritten.URL.Scheme = target.Scheme
-			rewritten.URL.Host = target.Host
-			return http.DefaultTransport.RoundTrip(rewritten)
-		})},
+func TestResolveLlamaServerModelDownloadsCustomRevision(t *testing.T) {
+	cacheDir := t.TempDir()
+	got, err := resolveTestHFModel(t, cacheDir, "refs/pr/1", nil, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/Qwen/Qwen3-0.6B-GGUF/resolve/refs/pr/1/Qwen3-0.6B-Q8_0.gguf" {
+			t.Fatalf("download path = %q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte("gguf"))
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -252,6 +311,69 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
+}
+
+func writeCachedTestHFModel(t *testing.T, cacheDir string, contents []byte) string {
+	t.Helper()
+	path, err := CachedHFModelPath(cacheDir, "Qwen/Qwen3-0.6B-GGUF", "main", "Qwen3-0.6B-Q8_0.gguf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, contents, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func resolveTestHFModel(t *testing.T, cacheDir string, revision string, progress DownloadProgressHandler, handler http.HandlerFunc) (string, error) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	target, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ResolveLlamaServerModel(context.Background(), LlamaServerOptions{
+		CacheDir:         cacheDir,
+		HFRepo:           "Qwen/Qwen3-0.6B-GGUF",
+		HFFile:           "Qwen3-0.6B-Q8_0.gguf",
+		HFRevision:       revision,
+		HTTPClient:       rewriteHFClient(target),
+		DownloadProgress: progress,
+	})
+}
+
+func rewriteHFClient(target *url.URL) *http.Client {
+	return &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		rewritten := req.Clone(req.Context())
+		rewritten.URL.Scheme = target.Scheme
+		rewritten.URL.Host = target.Host
+		return http.DefaultTransport.RoundTrip(rewritten)
+	})}
+}
+
+func hasProgressEvent(events []DownloadProgress, want DownloadProgressEvent) bool {
+	for _, event := range events {
+		if event.Event == want {
+			return true
+		}
+	}
+	return false
+}
+
+func assertDownloadProgress(t *testing.T, events []DownloadProgress, wantStartTotal int64) {
+	t.Helper()
+	if !hasProgressEvent(events, DownloadProgressStart) || !hasProgressEvent(events, DownloadProgressUpdate) || !hasProgressEvent(events, DownloadProgressDone) {
+		t.Fatalf("events = %+v, want start/update/done", events)
+	}
+	for _, event := range events {
+		if event.Event == DownloadProgressStart && event.TotalBytes != wantStartTotal {
+			t.Fatalf("start total bytes = %d, want %d", event.TotalBytes, wantStartTotal)
+		}
+	}
 }
 
 func TestFakeLlamaServerProcess(t *testing.T) {

--- a/internal/guard/judge/status.go
+++ b/internal/guard/judge/status.go
@@ -1,0 +1,13 @@
+package judge
+
+func IsUnavailable(localJudge Judge) bool {
+	if localJudge == nil {
+		return false
+	}
+	switch localJudge.(type) {
+	case UnavailableJudge, *UnavailableJudge:
+		return true
+	}
+	metadataProvider, ok := localJudge.(MetadataProvider)
+	return ok && metadataProvider.Metadata().FailureKind == FailureUnavailable
+}

--- a/internal/guard/judge/unavailable.go
+++ b/internal/guard/judge/unavailable.go
@@ -26,8 +26,13 @@ func (j UnavailableJudge) Decide(context.Context, Input) (Result, error) {
 }
 
 func (j UnavailableJudge) Metadata() Metadata {
+	kind := strings.TrimSpace(j.Kind)
+	if kind == "" {
+		kind = FailureUnavailable
+	}
 	return Metadata{
-		Runtime: strings.TrimSpace(j.Runtime),
-		Model:   strings.TrimSpace(j.Model),
+		Runtime:     strings.TrimSpace(j.Runtime),
+		Model:       strings.TrimSpace(j.Model),
+		FailureKind: kind,
 	}
 }

--- a/internal/guard/judgeruntime/config.go
+++ b/internal/guard/judgeruntime/config.go
@@ -15,18 +15,19 @@ import (
 )
 
 type Config struct {
-	URL            string
-	Model          string
-	Timeout        time.Duration
-	Managed        bool
-	ServerBin      string
-	ModelPath      string
-	HFRepo         string
-	HFFile         string
-	HFRevision     string
-	CacheDir       string
-	Port           int
-	StartupTimeout time.Duration
+	URL              string
+	Model            string
+	Timeout          time.Duration
+	Managed          bool
+	ServerBin        string
+	ModelPath        string
+	HFRepo           string
+	HFFile           string
+	HFRevision       string
+	CacheDir         string
+	Port             int
+	StartupTimeout   time.Duration
+	DownloadProgress judge.DownloadProgressHandler
 }
 
 func ConfigFromEnv(dbPath string, managedDefault bool) (Config, error) {
@@ -114,15 +115,16 @@ func configureManaged(ctx context.Context, cfg Config) (judge.Judge, func(), str
 		return nil, closeFn, "", err
 	}
 	server, err := judge.StartLlamaServer(ctx, judge.LlamaServerOptions{
-		BinaryPath:     cfg.ServerBin,
-		ModelPath:      modelPath,
-		HFRepo:         hfRepo,
-		HFFile:         hfFile,
-		HFRevision:     cfg.HFRevision,
-		CacheDir:       cfg.CacheDir,
-		Host:           host,
-		Port:           port,
-		StartupTimeout: cfg.StartupTimeout,
+		BinaryPath:       cfg.ServerBin,
+		ModelPath:        modelPath,
+		HFRepo:           hfRepo,
+		HFFile:           hfFile,
+		HFRevision:       cfg.HFRevision,
+		CacheDir:         cfg.CacheDir,
+		Host:             host,
+		Port:             port,
+		StartupTimeout:   cfg.StartupTimeout,
+		DownloadProgress: cfg.DownloadProgress,
 	})
 	if err != nil {
 		unavailable := judge.UnavailableJudge{

--- a/internal/run/local.go
+++ b/internal/run/local.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 	"github.com/kontext-security/kontext-cli/internal/runtimehost"
+	"github.com/kontext-security/kontext-cli/internal/startupui"
 )
 
 // StartLocal launches an agent with a wrapper-owned local runtime.
@@ -25,17 +26,20 @@ func StartLocal(ctx context.Context, opts Options) error {
 		return err
 	}
 	cwd, _ := os.Getwd()
+	ui := startupui.New(os.Stderr)
+	ui.Header()
 	host, err := runtimehost.Start(ctx, runtimehost.Options{
-		AgentName:           opts.Agent,
-		CWD:                 cwd,
-		DBPath:              os.Getenv("KONTEXT_DB"),
-		DashboardAddr:       os.Getenv("KONTEXT_ADDR"),
-		StartDashboard:      true,
-		JudgeConfigFromEnv:  true,
-		JudgeManagedDefault: true,
-		Mode:                string(mode),
-		Diagnostic:          diagnostics,
-		Out:                 os.Stderr,
+		AgentName:             opts.Agent,
+		CWD:                   cwd,
+		DBPath:                os.Getenv("KONTEXT_DB"),
+		DashboardAddr:         os.Getenv("KONTEXT_ADDR"),
+		StartDashboard:        true,
+		JudgeConfigFromEnv:    true,
+		JudgeManagedDefault:   true,
+		JudgeDownloadProgress: ui.HandleDownloadProgress,
+		Mode:                  string(mode),
+		Diagnostic:            diagnostics,
+		Out:                   os.Stderr,
 	})
 	if err != nil {
 		return err
@@ -58,25 +62,14 @@ func StartLocal(ctx context.Context, opts Options) error {
 	env = append(env, "KONTEXT_SESSION_ID="+host.SessionID)
 	env = append(env, "KONTEXT_MODE="+string(host.Mode))
 
-	fmt.Fprintf(os.Stderr, "✓ Local session: %s\n", truncateID(host.SessionID))
-	if host.DashboardURL != "" {
-		fmt.Fprintf(os.Stderr, "✓ Dashboard: %s\n", host.DashboardURL)
+	ui.LocalJudgeReady(host.LocalJudgeEnabled, host.LocalJudgeUnavailable)
+	ui.DashboardReady(host.DashboardURL)
+	ui.Mode(string(host.Mode))
+	ui.LocalSessionReady()
+	ui.Launching(opts.Agent)
+	if err := ui.Err(); err != nil {
+		return fmt.Errorf("write startup output: %w", err)
 	}
-	if host.LocalJudgeStatus != "" {
-		fmt.Fprintf(os.Stderr, "✓ Local judge: %s\n", host.LocalJudgeStatus)
-	} else {
-		fmt.Fprintln(os.Stderr, "✓ Local judge: disabled")
-	}
-	printLocalMode(os.Stderr, string(host.Mode))
-	fmt.Fprintf(os.Stderr, "\nLaunching %s...\n\n", opts.Agent)
 
 	return launchAgentWithSettings(ctx, opts.Agent, agentPath, env, opts.Args, settingsPath)
-}
-
-func printLocalMode(out *os.File, mode string) {
-	if mode == "enforce" {
-		fmt.Fprintln(out, "Mode: enforce (deny decisions block supported pre-tool actions).")
-		return
-	}
-	fmt.Fprintln(out, "Mode: observe (agent actions run normally; decisions are recorded as would allow / would deny).")
 }

--- a/internal/runtimehost/host.go
+++ b/internal/runtimehost/host.go
@@ -35,20 +35,23 @@ type Options struct {
 	AllowNonLoopbackDashboard bool
 	JudgeConfigFromEnv        bool
 	JudgeManagedDefault       bool
+	JudgeDownloadProgress     judge.DownloadProgressHandler
 	Mode                      string
 	Diagnostic                diagnostic.Logger
 	Out                       io.Writer
 }
 
 type Host struct {
-	SessionID        string
-	SessionDir       string
-	SocketPath       string
-	DBPath           string
-	DashboardURL     string
-	DashboardErr     error
-	LocalJudgeStatus string
-	Mode             guardhookruntime.Mode
+	SessionID             string
+	SessionDir            string
+	SocketPath            string
+	DBPath                string
+	DashboardURL          string
+	DashboardErr          error
+	LocalJudgeStatus      string
+	LocalJudgeEnabled     bool
+	LocalJudgeUnavailable bool
+	Mode                  guardhookruntime.Mode
 
 	server           *server.Server
 	closeStore       func() error
@@ -85,6 +88,7 @@ func Start(ctx context.Context, opts Options) (*Host, error) {
 		if err != nil {
 			return nil, err
 		}
+		judgeConfig.DownloadProgress = opts.JudgeDownloadProgress
 		localJudge, closeJudge, judgeStatus, err = judgeruntime.Configure(ctx, judgeConfig)
 		if err != nil {
 			return nil, err
@@ -124,15 +128,17 @@ func Start(ctx context.Context, opts Options) (*Host, error) {
 	}
 
 	host := &Host{
-		SessionID:        sessionID,
-		SessionDir:       sessionDir,
-		SocketPath:       socketPath,
-		DBPath:           dbPath,
-		LocalJudgeStatus: judgeStatus,
-		Mode:             mode,
-		server:           localServer,
-		closeStore:       closeStore,
-		closeJudge:       closeJudge,
+		SessionID:             sessionID,
+		SessionDir:            sessionDir,
+		SocketPath:            socketPath,
+		DBPath:                dbPath,
+		LocalJudgeStatus:      judgeStatus,
+		LocalJudgeEnabled:     localJudge != nil,
+		LocalJudgeUnavailable: judge.IsUnavailable(localJudge),
+		Mode:                  mode,
+		server:                localServer,
+		closeStore:            closeStore,
+		closeJudge:            closeJudge,
 	}
 
 	runtimeService, err := localruntime.NewService(localruntime.Options{

--- a/internal/startupui/status.go
+++ b/internal/startupui/status.go
@@ -1,0 +1,326 @@
+package startupui
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/guard/judge"
+	"github.com/mattn/go-isatty"
+)
+
+const (
+	terminalLineWidth       = 100
+	appendProgressBytesStep = 256 * 1000 * 1000
+)
+
+type downloadProgressRenderMode uint8
+
+const (
+	downloadProgressUpdate downloadProgressRenderMode = iota
+	downloadProgressFinal
+)
+
+type Renderer struct {
+	out                io.Writer
+	tty                bool
+	err                error
+	activeLine         bool
+	downloadStarted    time.Time
+	lastTTYUpdate      time.Time
+	lastPercentBucket  int64
+	lastByteCheckpoint int64
+	downloadComplete   bool
+}
+
+func New(out io.Writer) *Renderer {
+	return NewWithTTY(out, isTerminal(out))
+}
+
+func NewWithTTY(out io.Writer, tty bool) *Renderer {
+	if out == nil {
+		out = io.Discard
+	}
+	return &Renderer{out: out, tty: tty, lastPercentBucket: -1}
+}
+
+func (r *Renderer) Err() error {
+	if r == nil {
+		return nil
+	}
+	return r.err
+}
+
+func (r *Renderer) Header() {
+	r.line("Kontext • Starting local guard")
+	r.line("")
+}
+
+func (r *Renderer) HandleDownloadProgress(event judge.DownloadProgress) {
+	switch event.Event {
+	case judge.DownloadProgressCacheCheck:
+		if r.tty {
+			r.replaceLine("Checking local model cache...")
+			return
+		}
+		r.line("Checking local model cache...")
+	case judge.DownloadProgressCacheHit:
+		if r.tty {
+			r.clearActiveLine()
+		}
+	case judge.DownloadProgressStart:
+		if r.tty {
+			r.finishActiveLine("✓ Model cache checked")
+			r.line("• Downloading local judge model")
+		} else {
+			r.line("Downloading local judge model...")
+		}
+		r.downloadStarted = time.Now()
+		r.lastTTYUpdate = time.Time{}
+		r.lastPercentBucket = -1
+		r.lastByteCheckpoint = 0
+	case judge.DownloadProgressUpdate:
+		r.renderDownloadProgress(event, downloadProgressUpdate)
+	case judge.DownloadProgressDone:
+		r.renderDownloadProgress(event, downloadProgressFinal)
+		r.downloadComplete = true
+		elapsed := time.Since(r.downloadStarted).Round(time.Second)
+		if elapsed < 0 {
+			elapsed = 0
+		}
+		r.printf("✓ Downloaded local judge model (%s in %s)\n", formatBytes(event.CurrentBytes), formatDuration(elapsed))
+	case judge.DownloadProgressError:
+		if r.tty {
+			r.finishActiveLine("")
+		}
+		if event.Err != nil {
+			r.line("✗ Failed to download local judge model")
+			r.line("  Check your connection, then run `kontext start` again.")
+		}
+	}
+}
+
+func (r *Renderer) LocalJudgeReady(enabled bool, unavailable bool) {
+	if r.tty {
+		r.clearActiveLine()
+	}
+	switch LocalJudgeSummary(enabled, unavailable) {
+	case "disabled":
+		r.line("✓ Local judge disabled")
+		return
+	case "unavailable":
+		r.line("✗ Local judge unavailable")
+		return
+	}
+	if r.downloadComplete {
+		r.line("✓ Local judge model ready")
+		return
+	}
+	r.line("✓ Local judge ready")
+}
+
+func LocalJudgeSummary(enabled bool, unavailable bool) string {
+	if !enabled {
+		return "disabled"
+	}
+	if unavailable {
+		return "unavailable"
+	}
+	return "ready"
+}
+
+func (r *Renderer) DashboardReady(url string) {
+	url = strings.TrimSpace(url)
+	if url == "" {
+		return
+	}
+	r.printf("✓ Dashboard ready at %s\n", url)
+}
+
+func (r *Renderer) Mode(mode string) {
+	if mode == "enforce" {
+		r.line("✓ Mode: enforce (blocking enabled)")
+	}
+}
+
+func (r *Renderer) LocalSessionReady() {
+	r.line("✓ Local session ready")
+}
+
+func (r *Renderer) Launching(agent string) {
+	r.printf("\nLaunching %s...\n\n", agent)
+}
+
+func (r *Renderer) renderDownloadProgress(event judge.DownloadProgress, mode downloadProgressRenderMode) {
+	if event.CurrentBytes <= 0 {
+		return
+	}
+	if r.downloadStarted.IsZero() {
+		r.downloadStarted = time.Now()
+	}
+	if r.tty {
+		now := time.Now()
+		if mode != downloadProgressFinal && !r.lastTTYUpdate.IsZero() && now.Sub(r.lastTTYUpdate) < 120*time.Millisecond {
+			return
+		}
+		r.lastTTYUpdate = now
+		r.replaceLine("  " + r.progressText(event))
+		if mode == downloadProgressFinal {
+			r.finishActiveLine("")
+		}
+		return
+	}
+	if !r.shouldPrintAppendProgress(event, mode) {
+		return
+	}
+	if event.TotalBytes > 0 {
+		r.printf("Progress: %s / %s (%d%%)\n", formatBytes(event.CurrentBytes), formatBytes(event.TotalBytes), percent(event.CurrentBytes, event.TotalBytes))
+		return
+	}
+	r.printf("Progress: %s downloaded\n", formatBytes(event.CurrentBytes))
+}
+
+func (r *Renderer) progressText(event judge.DownloadProgress) string {
+	elapsed := time.Since(r.downloadStarted)
+	speed := 0.0
+	if elapsed > 0 {
+		speed = float64(event.CurrentBytes) / elapsed.Seconds()
+		if speed < 0 {
+			speed = 0
+		}
+	}
+	if event.TotalBytes > 0 {
+		remaining := event.TotalBytes - event.CurrentBytes
+		eta := time.Duration(0)
+		if speed > 0 && remaining > 0 {
+			eta = time.Duration(float64(remaining)/speed) * time.Second
+		}
+		return fmt.Sprintf("%s / %s  %d%%  %s/s  ETA %s", formatBytes(event.CurrentBytes), formatBytes(event.TotalBytes), percent(event.CurrentBytes, event.TotalBytes), formatBytes(int64(speed)), formatDuration(eta))
+	}
+	return fmt.Sprintf("%s downloaded  %s/s", formatBytes(event.CurrentBytes), formatBytes(int64(speed)))
+}
+
+func (r *Renderer) shouldPrintAppendProgress(event judge.DownloadProgress, mode downloadProgressRenderMode) bool {
+	if mode == downloadProgressFinal {
+		return true
+	}
+	if event.TotalBytes > 0 {
+		pct := percent(event.CurrentBytes, event.TotalBytes)
+		bucket := pct / 10
+		if bucket > r.lastPercentBucket {
+			r.lastPercentBucket = bucket
+			return true
+		}
+		return false
+	}
+	if event.CurrentBytes-r.lastByteCheckpoint >= appendProgressBytesStep {
+		r.lastByteCheckpoint = event.CurrentBytes
+		return true
+	}
+	return false
+}
+
+func (r *Renderer) replaceLine(text string) {
+	r.writeTerminalLine(text, false)
+	r.activeLine = true
+}
+
+func (r *Renderer) finishActiveLine(text string) {
+	if !r.activeLine {
+		if text != "" {
+			r.line(text)
+		}
+		return
+	}
+	if text == "" {
+		r.writeTerminalLine("", false)
+	} else {
+		r.writeTerminalLine(text, true)
+	}
+	r.activeLine = false
+}
+
+func (r *Renderer) clearActiveLine() {
+	if !r.activeLine {
+		return
+	}
+	r.writeTerminalLine("", false)
+	r.activeLine = false
+}
+
+func (r *Renderer) writeTerminalLine(text string, newline bool) {
+	if newline {
+		r.printf("\r%-*s\n", terminalLineWidth, text)
+		return
+	}
+	r.printf("\r%-*s\r", terminalLineWidth, text)
+}
+
+func (r *Renderer) line(text string) {
+	_, err := fmt.Fprintln(r.out, text)
+	r.recordWrite(err)
+}
+
+func (r *Renderer) printf(format string, args ...any) {
+	_, err := fmt.Fprintf(r.out, format, args...)
+	r.recordWrite(err)
+}
+
+func (r *Renderer) recordWrite(err error) {
+	if err != nil && r.err == nil {
+		r.err = err
+	}
+}
+
+func formatBytes(bytes int64) string {
+	if bytes < 0 {
+		bytes = 0
+	}
+	units := []string{"B", "KB", "MB", "GB", "TB"}
+	value := float64(bytes)
+	unit := 0
+	for value >= 1000 && unit < len(units)-1 {
+		value /= 1000
+		unit++
+	}
+	if unit == 0 {
+		return fmt.Sprintf("%d %s", bytes, units[unit])
+	}
+	return fmt.Sprintf("%.1f %s", value, units[unit])
+}
+
+func percent(current, total int64) int64 {
+	if total <= 0 || current <= 0 {
+		return 0
+	}
+	pct := current * 100 / total
+	if pct > 100 {
+		return 100
+	}
+	return pct
+}
+
+func formatDuration(duration time.Duration) string {
+	if duration < 0 {
+		duration = 0
+	}
+	seconds := int64(duration.Round(time.Second).Seconds())
+	if seconds < 60 {
+		return fmt.Sprintf("%ds", seconds)
+	}
+	minutes := seconds / 60
+	seconds = seconds % 60
+	if minutes < 60 {
+		return fmt.Sprintf("%dm%02ds", minutes, seconds)
+	}
+	hours := minutes / 60
+	minutes = minutes % 60
+	return fmt.Sprintf("%dh%02dm", hours, minutes)
+}
+
+func isTerminal(out io.Writer) bool {
+	file, ok := out.(*os.File)
+	return ok && isatty.IsTerminal(file.Fd())
+}

--- a/internal/startupui/status_test.go
+++ b/internal/startupui/status_test.go
@@ -1,0 +1,158 @@
+package startupui
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/guard/judge"
+)
+
+func TestRendererNonTTYPrintsStableProgressLines(t *testing.T) {
+	var out bytes.Buffer
+	renderer := NewWithTTY(&out, false)
+
+	renderer.Header()
+	renderer.HandleDownloadProgress(judge.DownloadProgress{Event: judge.DownloadProgressCacheCheck})
+	renderer.HandleDownloadProgress(judge.DownloadProgress{Event: judge.DownloadProgressStart, TotalBytes: 1000})
+	renderer.HandleDownloadProgress(judge.DownloadProgress{Event: judge.DownloadProgressUpdate, CurrentBytes: 500, TotalBytes: 1000})
+	renderer.HandleDownloadProgress(judge.DownloadProgress{Event: judge.DownloadProgressDone, CurrentBytes: 1000, TotalBytes: 1000})
+	renderer.LocalJudgeReady(true, false)
+	renderer.DashboardReady("http://127.0.0.1:4765")
+
+	got := out.String()
+	if strings.Contains(got, "\r") {
+		t.Fatalf("non-TTY output contains carriage return: %q", got)
+	}
+	for _, want := range []string{
+		"Kontext • Starting local guard",
+		"Checking local model cache...",
+		"Downloading local judge model...",
+		"Progress: 500 B / 1.0 KB (50%)",
+		"✓ Local judge model ready",
+		"✓ Dashboard ready at http://127.0.0.1:4765",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output = %q, want %q", got, want)
+		}
+	}
+	if strings.Contains(got, "http://127.0.0.1:18080") || strings.Contains(got, "(llama-server)") {
+		t.Fatalf("output leaked local judge internals: %q", got)
+	}
+	if strings.Contains(got, "Qwen/Qwen3-0.6B-GGUF") {
+		t.Fatalf("output leaked model name: %q", got)
+	}
+}
+
+func TestRendererTTYRedrawsProgressLine(t *testing.T) {
+	var out bytes.Buffer
+	renderer := NewWithTTY(&out, true)
+
+	renderer.HandleDownloadProgress(judge.DownloadProgress{Event: judge.DownloadProgressCacheCheck})
+	renderer.HandleDownloadProgress(judge.DownloadProgress{Event: judge.DownloadProgressStart, TotalBytes: 1000})
+	renderer.HandleDownloadProgress(judge.DownloadProgress{Event: judge.DownloadProgressUpdate, CurrentBytes: 1000, TotalBytes: 1000})
+
+	got := out.String()
+	if !strings.Contains(got, "\r") {
+		t.Fatalf("TTY output = %q, want carriage return", got)
+	}
+	if !strings.Contains(got, "✓ Model cache checked") || !strings.Contains(got, "100%") {
+		t.Fatalf("TTY output = %q, want cache checked and percent", got)
+	}
+}
+
+func TestRendererTTYClearsCacheCheckBeforeJudgeSummary(t *testing.T) {
+	var out bytes.Buffer
+	renderer := NewWithTTY(&out, true)
+
+	renderer.HandleDownloadProgress(judge.DownloadProgress{Event: judge.DownloadProgressCacheCheck})
+	renderer.LocalJudgeReady(true, true)
+
+	got := out.String()
+	if !strings.Contains(got, "\r") {
+		t.Fatalf("TTY output = %q, want carriage return", got)
+	}
+	if !strings.Contains(got, "✗ Local judge unavailable\n") {
+		t.Fatalf("TTY output = %q, want local judge unavailable on a clean line", got)
+	}
+	if strings.Contains(got, "Checking local model cache...✗ Local judge unavailable") {
+		t.Fatalf("TTY output did not clear active cache line: %q", got)
+	}
+}
+
+func TestRendererDownloadErrorHidesRawFailure(t *testing.T) {
+	var out bytes.Buffer
+	renderer := NewWithTTY(&out, false)
+
+	renderer.HandleDownloadProgress(judge.DownloadProgress{
+		Event: judge.DownloadProgressError,
+		Err:   errors.New("get https://huggingface.co/Qwen/Qwen3-0.6B-GGUF: connection refused"),
+	})
+
+	got := out.String()
+	if !strings.Contains(got, "✗ Failed to download local judge model") {
+		t.Fatalf("output = %q, want generic download failure", got)
+	}
+	for _, leaked := range []string{"https://huggingface.co", "Qwen/Qwen3-0.6B-GGUF", "connection refused"} {
+		if strings.Contains(got, leaked) {
+			t.Fatalf("output leaked raw failure %q: %q", leaked, got)
+		}
+	}
+}
+
+func TestRendererModeOnlyPrintsEnforce(t *testing.T) {
+	var out bytes.Buffer
+	renderer := NewWithTTY(&out, false)
+
+	renderer.Mode("observe")
+	renderer.Mode("enforce")
+
+	got := out.String()
+	if strings.Contains(got, "observe") {
+		t.Fatalf("output = %q, want default observe mode hidden", got)
+	}
+	if !strings.Contains(got, "✓ Mode: enforce (blocking enabled)") {
+		t.Fatalf("output = %q, want enforce mode visible", got)
+	}
+}
+
+func TestRendererRecordsWriteError(t *testing.T) {
+	wantErr := errors.New("closed pipe")
+	renderer := NewWithTTY(failingWriter{err: wantErr}, false)
+
+	renderer.Header()
+
+	if !errors.Is(renderer.Err(), wantErr) {
+		t.Fatalf("Err() = %v, want %v", renderer.Err(), wantErr)
+	}
+}
+
+func TestLocalJudgeSummary(t *testing.T) {
+	tests := []struct {
+		name        string
+		enabled     bool
+		unavailable bool
+		want        string
+	}{
+		{name: "disabled", enabled: false, want: "disabled"},
+		{name: "unavailable", enabled: true, unavailable: true, want: "unavailable"},
+		{name: "ready", enabled: true, want: "ready"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := LocalJudgeSummary(test.enabled, test.unavailable)
+			if got != test.want {
+				t.Fatalf("LocalJudgeSummary() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+type failingWriter struct {
+	err error
+}
+
+func (w failingWriter) Write([]byte) (int, error) {
+	return 0, w.err
+}


### PR DESCRIPTION
## Where We Are

`kontext start` was showing startup details that looked like two separate services: a dashboard URL and an internal llama-server URL/model name. First-run model downloads also had very little progress feedback, which made startup feel frozen during larger downloads.

## Where We Want To Go

Startup should feel like a modern CLI: immediate status, calm byte progress for model downloads, append-only logs outside a TTY, and exactly one user-facing URL. The dashboard remains the thing users open; llama-server details stay internal.

## How do we get there

This adds a small startup renderer, wires judge download progress through the managed llama-server path, and updates `kontext start` plus `kontext guard start --judge-managed` to show clean local judge summaries without model names or llama-server URLs. The download path emits cache, start, update, done, and error events while preserving temp-file cleanup on failures.

Validated with `go test ./...`, `git diff --check`, `go vet ./...`, and `codex-review --mode auto`.
