### PR TITLE
feat(claudemanaged): mark lifecycle hooks async

### DIFF
--- a/internal/claudemanaged/settings.go
+++ b/internal/claudemanaged/settings.go
@@ -22,14 +22,15 @@ const (
 type Event struct {
 	Name  hook.HookName
 	Alias string
+	Async bool
 }
 
 var SupportedEvents = []Event{
-	{Name: hook.HookSessionStart, Alias: "session-start"},
+	{Name: hook.HookSessionStart, Alias: "session-start", Async: true},
 	{Name: hook.HookPreToolUse, Alias: "pre-tool-use"},
 	{Name: hook.HookPostToolUse, Alias: "post-tool-use"},
 	{Name: hook.HookPostToolUseFailed, Alias: "post-tool-use-failure"},
-	{Name: hook.HookSessionEnd, Alias: "session-end"},
+	{Name: hook.HookSessionEnd, Alias: "session-end", Async: true},
 }
 
 func DefaultManagedSettingsPath() string {
@@ -63,6 +64,7 @@ type Handler struct {
 	Command string   `json:"command"`
 	Args    []string `json:"args,omitempty"`
 	Timeout int      `json:"timeout,omitempty"`
+	Async   *bool    `json:"async,omitempty"`
 }
 
 func Template(kontextBinary string) Settings {
@@ -72,14 +74,19 @@ func Template(kontextBinary string) Settings {
 	}
 	settings := Settings{Hooks: make(map[string][]MatcherGroup, len(SupportedEvents))}
 	for _, event := range SupportedEvents {
+		handler := Handler{
+			Type:    "command",
+			Command: kontextBinary,
+			Args:    []string{"hook", event.Alias},
+			Timeout: DefaultHookTimeout,
+		}
+		if event.Async {
+			value := true
+			handler.Async = &value
+		}
 		settings.Hooks[event.Name.String()] = []MatcherGroup{{
 			Matcher: "",
-			Hooks: []Handler{{
-				Type:    "command",
-				Command: kontextBinary,
-				Args:    []string{"hook", event.Alias},
-				Timeout: DefaultHookTimeout,
-			}},
+			Hooks:   []Handler{handler},
 		}}
 	}
 	return settings
@@ -168,6 +175,9 @@ func validateEvent(groups []MatcherGroup, event Event, kontextBinary string) err
 			if !sameStrings(handler.Args, wantArgs) {
 				return fmt.Errorf("%s Kontext handler args = %q, want %q", event.Name, handler.Args, wantArgs)
 			}
+			if err := validateAsync(event, handler.Async); err != nil {
+				return err
+			}
 			if !isAllMatcher(group.Matcher) {
 				foundRestrictiveMatcher = true
 				continue
@@ -183,6 +193,19 @@ func validateEvent(groups []MatcherGroup, event Event, kontextBinary string) err
 		return fmt.Errorf("%s Kontext command hook uses matcher %q; use an empty matcher for full event coverage", event.Name, firstRestrictiveMatcher(groups, kontextBinary, wantArgs))
 	}
 	return fmt.Errorf("%s Kontext command hook missing for %s", event.Name, kontextBinary)
+}
+
+func validateAsync(event Event, async *bool) error {
+	if event.Async {
+		if async == nil || !*async {
+			return fmt.Errorf("%s Kontext handler async must be true", event.Name)
+		}
+		return nil
+	}
+	if async != nil {
+		return fmt.Errorf("%s Kontext handler async must be omitted", event.Name)
+	}
+	return nil
 }
 
 func isShellFormKontextHandler(handler Handler, kontextBinary string) bool {

--- a/internal/claudemanaged/settings_test.go
+++ b/internal/claudemanaged/settings_test.go
@@ -45,6 +45,13 @@ func TestTemplateIncludesManagedKontextHooks(t *testing.T) {
 		if handler.Timeout != DefaultHookTimeout {
 			t.Fatalf("%s timeout = %d, want %d", event.Name, handler.Timeout, DefaultHookTimeout)
 		}
+		if event.Async {
+			if handler.Async == nil || !*handler.Async {
+				t.Fatalf("%s async = %v, want true", event.Name, handler.Async)
+			}
+		} else if handler.Async != nil {
+			t.Fatalf("%s async = %v, want omitted", event.Name, *handler.Async)
+		}
 	}
 }
 
@@ -65,6 +72,47 @@ func TestTemplateJSONUsesExecForm(t *testing.T) {
 	}
 	if err := Validate(data, "/usr/local/bin/kontext"); err != nil {
 		t.Fatalf("Validate(template) error = %v", err)
+	}
+}
+
+func TestTemplateJSONOnlyMarksLifecycleHooksAsync(t *testing.T) {
+	t.Parallel()
+
+	data, err := TemplateJSON("/usr/local/bin/kontext")
+	if err != nil {
+		t.Fatalf("TemplateJSON() error = %v", err)
+	}
+
+	var raw struct {
+		Hooks map[string][]struct {
+			Hooks []map[string]any `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	for _, event := range SupportedEvents {
+		groups, ok := raw.Hooks[event.Name.String()]
+		if !ok {
+			t.Fatalf("%s hook missing", event.Name)
+		}
+		if len(groups) != 1 {
+			t.Fatalf("%s groups = %d, want 1", event.Name, len(groups))
+		}
+		handlers := groups[0].Hooks
+		if len(handlers) != 1 {
+			t.Fatalf("%s handlers = %d, want 1", event.Name, len(handlers))
+		}
+		async, hasAsync := handlers[0]["async"]
+		if event.Async {
+			asyncBool, ok := async.(bool)
+			if !hasAsync || !ok || !asyncBool {
+				t.Fatalf("%s async = %v, want boolean true", event.Name, async)
+			}
+		} else if hasAsync {
+			t.Fatalf("%s async emitted, want omitted", event.Name)
+		}
 	}
 }
 
@@ -162,6 +210,32 @@ func TestValidateRejectsInvalidManagedSettings(t *testing.T) {
 				return settings
 			},
 			wantErr: "PreToolUse Kontext handler args missing",
+		},
+		{
+			name: "missing lifecycle async",
+			mutate: func(settings Settings) Settings {
+				settings.Hooks["SessionStart"][0].Hooks[0].Async = nil
+				return settings
+			},
+			wantErr: "SessionStart Kontext handler async must be true",
+		},
+		{
+			name: "false lifecycle async",
+			mutate: func(settings Settings) Settings {
+				value := false
+				settings.Hooks["SessionEnd"][0].Hooks[0].Async = &value
+				return settings
+			},
+			wantErr: "SessionEnd Kontext handler async must be true",
+		},
+		{
+			name: "async decision hook",
+			mutate: func(settings Settings) Settings {
+				value := true
+				settings.Hooks["PreToolUse"][0].Hooks[0].Async = &value
+				return settings
+			},
+			wantErr: "PreToolUse Kontext handler async must be omitted",
 		},
 		{
 			name: "restrictive matcher",


### PR DESCRIPTION
## Where We Are

Claude command hooks run synchronously unless a handler sets `async: true`. The managed settings template currently emits every Kontext hook without that field, so lifecycle observe hooks can block Claude startup and shutdown even though they only record side effects.

## Where We Want To Go

Generated managed settings should keep the lifecycle observe hooks non-blocking while leaving tool hooks synchronous. `PreToolUse` stays synchronous because it is the enforcement and self-heal point.

## How do we get there

Add optional `async` support to the Claude managed handler schema and set it only for `SessionStart` and `SessionEnd` in the generated template. Tests cover the typed template, emitted JSON, and validation with async lifecycle handlers. Verified with `go test ./internal/claudemanaged ./cmd/kontext` and `go test ./...`.
