### PR TITLE
feat(managedobserve): add daemon lifecycle

### DIFF
--- a/cmd/kontext/main.go
+++ b/cmd/kontext/main.go
@@ -16,11 +16,13 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/agent"
 	"github.com/kontext-security/kontext-cli/internal/auth"
 	"github.com/kontext-security/kontext-cli/internal/claudemanaged"
+	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 	guardcli "github.com/kontext-security/kontext-cli/internal/guard/cli"
 	guardhookruntime "github.com/kontext-security/kontext-cli/internal/guard/hookruntime"
 	"github.com/kontext-security/kontext-cli/internal/hook"
 	"github.com/kontext-security/kontext-cli/internal/hookcmd"
 	"github.com/kontext-security/kontext-cli/internal/localruntime"
+	"github.com/kontext-security/kontext-cli/internal/managedobserve"
 	"github.com/kontext-security/kontext-cli/internal/run"
 	"github.com/kontext-security/kontext-cli/internal/update"
 
@@ -45,6 +47,7 @@ func main() {
 	root.AddCommand(loginCmd())
 	root.AddCommand(logoutCmd())
 	root.AddCommand(hookCmd())
+	root.AddCommand(managedObserveDaemonCmd())
 	root.AddCommand(doctorCmd())
 	root.AddCommand(claudeCmd())
 	root.AddCommand(guardCmd())
@@ -285,6 +288,17 @@ func hookCmd() *cobra.Command {
 				os.Exit(2)
 			}
 
+			explicitSocket := cmd.Flags().Changed("socket")
+			explicitMode := cmd.Flags().Changed("mode")
+			if shouldUseManagedObserve(explicitSocket, explicitMode) {
+				lifecycle := managedobserve.NewLifecycle()
+				lifecycle.Diagnostic = diagnostic.New(cmd.ErrOrStderr(), diagnostic.EnabledFromEnv())
+				hookcmd.RunWithExpectedEvent(a, expectedEvent, func(e hook.Event) (hook.Result, error) {
+					return lifecycle.Process(context.Background(), e), nil
+				})
+				return nil
+			}
+
 			resolvedSocketPath := resolveHookSocketPath(socketPath)
 			if mode != "" {
 				hookMode, err := guardhookruntime.ParseMode(mode)
@@ -309,6 +323,43 @@ func hookCmd() *cobra.Command {
 	cmd.Flags().StringVar(&socketPath, "socket", "", "Unix socket path for local hook runtime")
 	cmd.Flags().StringVar(&mode, "mode", "", "hook mode: observe or enforce")
 
+	return cmd
+}
+
+func shouldUseManagedObserve(explicitSocket, explicitMode bool) bool {
+	return !explicitSocket && !explicitMode && os.Getenv("KONTEXT_SOCKET") == "" && managedobserve.Active()
+}
+
+func managedObserveDaemonCmd() *cobra.Command {
+	var socketPath, dbPath, idleTimeout string
+	cmd := &cobra.Command{
+		Use:    "managed-observe-daemon",
+		Short:  "Run the managed observe socket daemon",
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			timeout := managedobserve.DefaultIdleTimeout()
+			if idleTimeout != "" {
+				parsed, err := time.ParseDuration(idleTimeout)
+				if err != nil || parsed <= 0 {
+					return fmt.Errorf("--idle-timeout must be a positive duration")
+				}
+				timeout = parsed
+			}
+			return managedobserve.RunDaemon(context.Background(), managedobserve.DaemonOptions{
+				SocketPath:  socketPath,
+				DBPath:      dbPath,
+				IdleTimeout: timeout,
+				Diagnostic:  diagnostic.New(cmd.ErrOrStderr(), diagnostic.EnabledFromEnv()),
+			})
+		},
+	}
+	cmd.Flags().StringVar(&socketPath, "socket", "", "managed observe socket path")
+	cmd.Flags().StringVar(&dbPath, "db", "", "managed observe database path")
+	cmd.Flags().StringVar(&idleTimeout, "idle-timeout", "", "managed observe stale session timeout")
+	_ = cmd.Flags().MarkHidden("socket")
+	_ = cmd.Flags().MarkHidden("db")
+	_ = cmd.Flags().MarkHidden("idle-timeout")
 	return cmd
 }
 

--- a/cmd/kontext/main_test.go
+++ b/cmd/kontext/main_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -159,6 +160,30 @@ func TestHookCmdModeDoesNotDefaultFromEnv(t *testing.T) {
 	}
 }
 
+func TestManagedObserveDoesNotOverrideEnvSocket(t *testing.T) {
+	writeManagedConfigForCmdTest(t)
+	t.Setenv("KONTEXT_SOCKET", filepath.Join(t.TempDir(), "kontext.sock"))
+
+	if shouldUseManagedObserve(false, false) {
+		t.Fatal("shouldUseManagedObserve() = true with KONTEXT_SOCKET set")
+	}
+}
+
+func TestManagedObserveEligibleWithManagedConfig(t *testing.T) {
+	writeManagedConfigForCmdTest(t)
+	t.Setenv("KONTEXT_SOCKET", "")
+
+	if !shouldUseManagedObserve(false, false) {
+		t.Fatal("shouldUseManagedObserve() = false with managed config")
+	}
+	if shouldUseManagedObserve(true, false) {
+		t.Fatal("shouldUseManagedObserve() = true with explicit socket")
+	}
+	if shouldUseManagedObserve(false, true) {
+		t.Fatal("shouldUseManagedObserve() = true with explicit mode")
+	}
+}
+
 func TestClaudeManagedSettingsTemplateCmdPrintsValidJSON(t *testing.T) {
 	cmd := claudeManagedSettingsTemplateCmd()
 	cmd.SetArgs([]string{"--kontext-binary", "/opt/kontext/bin/kontext"})
@@ -176,6 +201,22 @@ func TestClaudeManagedSettingsTemplateCmdPrintsValidJSON(t *testing.T) {
 	if err := claudemanaged.Validate(stdout.Bytes(), "/opt/kontext/bin/kontext"); err != nil {
 		t.Fatalf("Validate(template) error = %v", err)
 	}
+}
+
+func writeManagedConfigForCmdTest(t *testing.T) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "managed.json")
+	if err := os.WriteFile(path, []byte(`{
+  "version": "managed-install-v1",
+  "organization_id": "org_123",
+  "cloud_url": "https://app.kontext.dev",
+  "mode": "observe",
+  "agent": "claude",
+  "credentials": {"install_token_ref": "env:KONTEXT_INSTALL_TOKEN"}
+}`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	t.Setenv("KONTEXT_MANAGED_CONFIG", path)
 }
 
 func TestClaudeManagedSettingsValidateCmdPassesGeneratedTemplate(t *testing.T) {

--- a/internal/guard/store/sqlite/store.go
+++ b/internal/guard/store/sqlite/store.go
@@ -345,6 +345,14 @@ on conflict(id) do update set
   agent = coalesce(nullif(excluded.agent, ''), agent_sessions.agent),
   cwd = coalesce(nullif(excluded.cwd, ''), agent_sessions.cwd),
   mode = coalesce(nullif(excluded.mode, ''), agent_sessions.mode),
+  status = case
+    when agent_sessions.source = 'wrapper_owned' then agent_sessions.status
+    else 'open'
+  end,
+  closed_at = case
+    when agent_sessions.source = 'wrapper_owned' then agent_sessions.closed_at
+    else null
+  end,
   updated_at = excluded.updated_at
 	`, sessionID, agent, cwd, mode, now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano))
 	if err != nil {
@@ -361,6 +369,18 @@ update agent_sessions
 set status = 'closed', closed_at = ?, updated_at = ?
 where id = ?
 	`, now, now, sessionID)
+	return err
+}
+
+func (s *Store) CloseStaleDaemonObservedSessions(ctx context.Context, olderThan time.Time) error {
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	_, err := s.db.ExecContext(ctx, `
+update agent_sessions
+set status = 'closed', closed_at = ?, updated_at = ?
+where source = 'daemon_observed'
+  and status = 'open'
+  and updated_at < ?
+	`, now, now, olderThan.UTC().Format(time.RFC3339Nano))
 	return err
 }
 

--- a/internal/guard/store/sqlite/store_test.go
+++ b/internal/guard/store/sqlite/store_test.go
@@ -989,6 +989,68 @@ func TestEnsureObservedSessionPreservesExistingLifecycle(t *testing.T) {
 	}
 }
 
+func TestEnsureObservedSessionReopensClosedDaemonObservedSession(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	if _, err := store.OpenSession(context.Background(), "session-123", "claude", "/tmp/project", "daemon_observed", ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CloseSession(context.Background(), "session-123"); err != nil {
+		t.Fatal(err)
+	}
+
+	observed, err := store.EnsureObservedSession(context.Background(), "session-123", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observed.Source != "daemon_observed" || observed.Status != "open" || observed.ClosedAt != nil {
+		t.Fatalf("observed session = %+v, want reopened daemon-observed session", observed)
+	}
+}
+
+func TestCloseStaleDaemonObservedSessionsOnlyClosesDaemonObserved(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	if _, err := store.OpenSession(context.Background(), "daemon-old", "claude", "/tmp/project", "daemon_observed", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.OpenSession(context.Background(), "wrapper-old", "claude", "/tmp/project", "wrapper_owned", "backend-123"); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().UTC().Add(-time.Hour).Format(time.RFC3339Nano)
+	if _, err := store.db.ExecContext(context.Background(), `
+update agent_sessions set updated_at = ? where id in ('daemon-old', 'wrapper-old')
+	`, old); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.CloseStaleDaemonObservedSessions(context.Background(), time.Now().UTC().Add(-30*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	daemon, err := store.Session(context.Background(), "daemon-old")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrapper, err := store.Session(context.Background(), "wrapper-old")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if daemon.Status != "closed" || daemon.ClosedAt == nil {
+		t.Fatalf("daemon session = %+v, want closed", daemon)
+	}
+	if wrapper.Status != "open" || wrapper.ClosedAt != nil {
+		t.Fatalf("wrapper session = %+v, want still open", wrapper)
+	}
+}
+
 func TestSessionsRejectsInvalidStoredTimestamp(t *testing.T) {
 	store, err := OpenStore(t.TempDir() + "/guard.db")
 	if err != nil {

--- a/internal/localruntime/service.go
+++ b/internal/localruntime/service.go
@@ -3,6 +3,7 @@ package localruntime
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"os"
 	"sync"
@@ -60,7 +61,9 @@ func NewService(opts Options) (*Service, error) {
 func (s *Service) SocketPath() string { return s.socketPath }
 
 func (s *Service) Start(ctx context.Context) error {
-	os.Remove(s.socketPath)
+	if err := os.Remove(s.socketPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove stale local runtime socket: %w", err)
+	}
 	ln, err := net.Listen("unix", s.socketPath)
 	if err != nil {
 		return err
@@ -81,10 +84,15 @@ func (s *Service) Shutdown(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	var shutdownErr error
 	if s.listener != nil {
-		_ = s.listener.Close()
+		if err := s.listener.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+			shutdownErr = errors.Join(shutdownErr, err)
+		}
 	}
-	_ = os.Remove(s.socketPath)
+	if err := os.Remove(s.socketPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		shutdownErr = errors.Join(shutdownErr, fmt.Errorf("remove local runtime socket: %w", err))
+	}
 
 	if s.serveDone != nil {
 		select {
@@ -93,7 +101,7 @@ func (s *Service) Shutdown(ctx context.Context) error {
 			if s.cancel != nil {
 				s.cancel()
 			}
-			return ctx.Err()
+			return errors.Join(shutdownErr, ctx.Err())
 		}
 	}
 
@@ -107,12 +115,12 @@ func (s *Service) Shutdown(ctx context.Context) error {
 		if s.cancel != nil {
 			s.cancel()
 		}
-		return nil
+		return shutdownErr
 	case <-ctx.Done():
 		if s.cancel != nil {
 			s.cancel()
 		}
-		return ctx.Err()
+		return errors.Join(shutdownErr, ctx.Err())
 	}
 }
 
@@ -176,7 +184,9 @@ func (s *Service) ingestEvent(ctx context.Context, req *EvaluateRequest) {
 	}
 	if _, err := s.core.IngestEvent(ctx, event); err != nil {
 		s.diagnostic.Printf("local runtime ingest: %v\n", err)
+		return
 	}
+	s.closeSessionEnd(ctx, event)
 }
 
 func (s *Service) process(ctx context.Context, req *EvaluateRequest) EvaluateResult {
@@ -196,7 +206,17 @@ func (s *Service) process(ctx context.Context, req *EvaluateRequest) EvaluateRes
 		}
 		return EvaluateResultFromResult(processFailureResult(event))
 	}
+	s.closeSessionEnd(ctx, event)
 	return EvaluateResultFromResult(result)
+}
+
+func (s *Service) closeSessionEnd(ctx context.Context, event hook.Event) {
+	if event.HookName != hook.HookSessionEnd {
+		return
+	}
+	if err := s.core.CloseSession(ctx, event.SessionID); err != nil {
+		s.diagnostic.Printf("local runtime session close: %v\n", err)
+	}
 }
 
 func decodeFailureResult(req *EvaluateRequest) hook.Result {

--- a/internal/localruntime/service_test.go
+++ b/internal/localruntime/service_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -116,6 +117,66 @@ func TestServiceShutdownDrainsAsyncIngest(t *testing.T) {
 	case err := <-done:
 		if err != nil {
 			t.Fatalf("Shutdown() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Shutdown() did not return after async ingest completed")
+	}
+}
+
+func TestServiceShutdownDrainsAfterSocketRemoveError(t *testing.T) {
+	t.Parallel()
+
+	runtime := &stubRuntime{
+		ingestStarted: make(chan struct{}),
+		releaseIngest: make(chan struct{}),
+	}
+	service := newTestService(t, runtime, true)
+	client := NewClient(service.SocketPath())
+
+	result, err := client.Process(context.Background(), hook.Event{
+		SessionID: "agent-session",
+		HookName:  hook.HookPostToolUse,
+		ToolName:  "Bash",
+	})
+	if err != nil {
+		t.Fatalf("Process() error = %v", err)
+	}
+	if result.Decision != hook.DecisionAllow {
+		t.Fatalf("Process().Decision = %q, want allow", result.Decision)
+	}
+	select {
+	case <-runtime.ingestStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("async ingest did not start")
+	}
+
+	nonEmptyDir := filepath.Join(t.TempDir(), "remove-error")
+	if err := os.Mkdir(nonEmptyDir, 0o700); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(nonEmptyDir, "child"), []byte("busy"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	service.socketPath = nonEmptyDir
+
+	done := make(chan error, 1)
+	go func() {
+		done <- service.Shutdown(context.Background())
+	}()
+	select {
+	case err := <-done:
+		t.Fatalf("Shutdown() returned before async ingest drained: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(runtime.releaseIngest)
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Shutdown() error = nil, want socket remove error")
+		}
+		if !strings.Contains(err.Error(), "remove local runtime socket") {
+			t.Fatalf("Shutdown() error = %v, want socket remove error", err)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("Shutdown() did not return after async ingest completed")

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -1,0 +1,98 @@
+package managedobserve
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/diagnostic"
+	guardhookruntime "github.com/kontext-security/kontext-cli/internal/guard/hookruntime"
+	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
+	"github.com/kontext-security/kontext-cli/internal/installation"
+	"github.com/kontext-security/kontext-cli/internal/managedconfig"
+	"github.com/kontext-security/kontext-cli/internal/runtimehost"
+)
+
+type DaemonOptions struct {
+	SocketPath  string
+	DBPath      string
+	IdleTimeout time.Duration
+	Diagnostic  diagnostic.Logger
+}
+
+func RunDaemon(ctx context.Context, opts DaemonOptions) error {
+	if _, err := managedconfig.Load(); err != nil {
+		if errors.Is(err, managedconfig.ErrNotManaged) {
+			return err
+		}
+		return fmt.Errorf("load managed config: %w", err)
+	}
+	if _, err := installation.Ensure(); err != nil {
+		return fmt.Errorf("ensure installation identity: %w", err)
+	}
+
+	socketPath := opts.SocketPath
+	if socketPath == "" {
+		socketPath = DefaultSocketPath()
+	}
+	if err := EnsureSocketDir(socketPath); err != nil {
+		return fmt.Errorf("prepare managed observe socket dir: %w", err)
+	}
+	dbPath := opts.DBPath
+	if dbPath == "" {
+		dbPath = DefaultDBPath()
+	}
+
+	host, err := runtimehost.Start(ctx, runtimehost.Options{
+		AgentName:          managedconfig.Agent,
+		DBPath:             dbPath,
+		SocketPath:         socketPath,
+		Mode:               guardhookruntime.ModeObserve,
+		Diagnostic:         opts.Diagnostic,
+		SkipInitialSession: true,
+		DisableAsyncIngest: true,
+	})
+	if err != nil {
+		return err
+	}
+	defer host.Close(context.Background())
+
+	idleTimeout := opts.IdleTimeout
+	if idleTimeout == 0 {
+		idleTimeout = DefaultIdleTimeout()
+	}
+	cleanup := time.NewTicker(cleanupInterval(idleTimeout))
+	defer cleanup.Stop()
+	if err := cleanupStaleSessions(ctx, dbPath, idleTimeout); err != nil {
+		opts.Diagnostic.Printf("managed observe cleanup: %v\n", err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-cleanup.C:
+			if err := cleanupStaleSessions(ctx, dbPath, idleTimeout); err != nil {
+				opts.Diagnostic.Printf("managed observe cleanup: %v\n", err)
+			}
+		}
+	}
+}
+
+func cleanupStaleSessions(ctx context.Context, dbPath string, idleTimeout time.Duration) error {
+	store, err := sqlite.OpenStore(dbPath)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+	return store.CloseStaleDaemonObservedSessions(ctx, time.Now().UTC().Add(-idleTimeout))
+}
+
+func cleanupInterval(idleTimeout time.Duration) time.Duration {
+	interval := idleTimeout / 2
+	if interval <= 0 {
+		return time.Nanosecond
+	}
+	return interval
+}

--- a/internal/managedobserve/daemon_test.go
+++ b/internal/managedobserve/daemon_test.go
@@ -1,0 +1,281 @@
+package managedobserve
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
+	"github.com/kontext-security/kontext-cli/internal/hook"
+	"github.com/kontext-security/kontext-cli/internal/localruntime"
+)
+
+func TestDaemonPreservesHookSessionIDs(t *testing.T) {
+	socketPath, dbPath, stop := startTestDaemon(t)
+
+	client := localruntime.NewClient(socketPath)
+	client.Timeout = time.Second
+	for _, sessionID := range []string{"claude-session-one", "claude-session-two"} {
+		result, err := client.Process(context.Background(), hook.Event{
+			SessionID: sessionID,
+			Agent:     "claude",
+			HookName:  hook.HookPreToolUse,
+			ToolName:  "Read",
+			CWD:       "/tmp/project",
+		})
+		if err != nil {
+			t.Fatalf("Process(%s) error = %v", sessionID, err)
+		}
+		if result.Decision != hook.DecisionAllow {
+			t.Fatalf("Process(%s) decision = %q, want allow", sessionID, result.Decision)
+		}
+	}
+	stop()
+
+	store := openTestStore(t, dbPath)
+	defer store.Close()
+	for _, sessionID := range []string{"claude-session-one", "claude-session-two"} {
+		session, err := store.Session(context.Background(), sessionID)
+		if err != nil {
+			t.Fatalf("Session(%s) error = %v", sessionID, err)
+		}
+		if session.ID != sessionID || session.Source != "daemon_observed" || session.Status != "open" {
+			t.Fatalf("session %s = %+v, want open daemon-observed session", sessionID, session)
+		}
+	}
+}
+
+func TestDaemonSessionEndClosesHookSessionID(t *testing.T) {
+	socketPath, dbPath, stop := startTestDaemon(t)
+
+	client := localruntime.NewClient(socketPath)
+	client.Timeout = time.Second
+	if _, err := client.Process(context.Background(), hook.Event{
+		SessionID: "claude-session-end",
+		Agent:     "claude",
+		HookName:  hook.HookPreToolUse,
+		ToolName:  "Read",
+		CWD:       "/tmp/project",
+	}); err != nil {
+		t.Fatalf("PreToolUse error = %v", err)
+	}
+	store := openTestStore(t, dbPath)
+	defer store.Close()
+	session := waitForSession(t, store, "claude-session-end")
+	if session.Status != "open" {
+		t.Fatalf("session after PreToolUse = %+v, want open", session)
+	}
+
+	if _, err := client.Process(context.Background(), hook.Event{
+		SessionID: "claude-session-end",
+		Agent:     "claude",
+		HookName:  hook.HookSessionEnd,
+		CWD:       "/tmp/project",
+	}); err != nil {
+		t.Fatalf("SessionEnd error = %v", err)
+	}
+	stop()
+
+	session = waitForSession(t, store, "claude-session-end")
+	if session.Status != "closed" || session.ClosedAt == nil {
+		t.Fatalf("session = %+v, want actual hook session closed", session)
+	}
+}
+
+func TestCleanupIntervalNeverReturnsZero(t *testing.T) {
+	if got := cleanupInterval(time.Nanosecond); got != time.Nanosecond {
+		t.Fatalf("cleanupInterval(1ns) = %s, want 1ns", got)
+	}
+	if got := cleanupInterval(time.Hour); got != 30*time.Minute {
+		t.Fatalf("cleanupInterval(1h) = %s, want 30m", got)
+	}
+}
+
+func TestEnsureSocketDirTightensOwnerWritableDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix socket directory permissions are not portable to windows")
+	}
+	dir := filepath.Join(t.TempDir(), "socket-dir")
+	if err := os.Mkdir(dir, 0o777); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+	if err := os.Chmod(dir, 0o777); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+
+	if err := EnsureSocketDir(filepath.Join(dir, "kontext.sock")); err != nil {
+		t.Fatalf("EnsureSocketDir() error = %v", err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Fatalf("socket dir mode = %#o, want 0700", got)
+	}
+}
+
+func TestEnsureSocketDirRestoresOwnerWritePermission(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix socket directory permissions are not portable to windows")
+	}
+	dir := filepath.Join(t.TempDir(), "socket-dir")
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+
+	if err := EnsureSocketDir(filepath.Join(dir, "kontext.sock")); err != nil {
+		t.Fatalf("EnsureSocketDir() error = %v", err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Fatalf("socket dir mode = %#o, want 0700", got)
+	}
+}
+
+func TestEnsureSocketDirRejectsNonDirectoryParent(t *testing.T) {
+	parent := filepath.Join(t.TempDir(), "socket-parent")
+	if err := os.WriteFile(parent, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if err := EnsureSocketDir(filepath.Join(parent, "kontext.sock")); err == nil {
+		t.Fatal("EnsureSocketDir() error = nil, want failure for non-directory parent")
+	}
+}
+
+func TestEnsureSocketDirRejectsSymlinkParent(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "target")
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+	link := filepath.Join(t.TempDir(), "socket-link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+	if err := EnsureSocketDir(filepath.Join(link, "kontext.sock")); err == nil {
+		t.Fatal("EnsureSocketDir() error = nil, want failure for symlink parent")
+	}
+}
+
+func startTestDaemon(t *testing.T) (string, string, func()) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	dir := t.TempDir()
+	socketDir, err := os.MkdirTemp("/tmp", "kontext-managedobserve-daemon-test-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp() error = %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	socketPath := filepath.Join(socketDir, "kontext.sock")
+	dbPath := filepath.Join(dir, "guard.db")
+	writeTestManagedConfig(t, filepath.Join(dir, "managed.json"))
+	writeTestInstallation(t, filepath.Join(dir, "installation.json"))
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- RunDaemon(ctx, DaemonOptions{
+			SocketPath:  socketPath,
+			DBPath:      dbPath,
+			IdleTimeout: time.Hour,
+		})
+	}()
+	waitForSocket(t, socketPath, errCh)
+	stopped := false
+	stop := func() {
+		if stopped {
+			return
+		}
+		stopped = true
+		cancel()
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Fatalf("RunDaemon() error = %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("RunDaemon did not stop")
+		}
+	}
+	t.Cleanup(stop)
+	return socketPath, dbPath, stop
+}
+
+func waitForSocket(t *testing.T, socketPath string, errCh <-chan error) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-errCh:
+			t.Fatalf("RunDaemon exited early: %v", err)
+		default:
+		}
+		client := localruntime.NewClient(socketPath)
+		client.Timeout = 20 * time.Millisecond
+		if _, err := client.Process(context.Background(), hook.Event{
+			SessionID: "probe-session",
+			Agent:     "claude",
+			HookName:  hook.HookSessionStart,
+		}); err == nil {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("managed observe daemon socket %s did not become ready", socketPath)
+}
+
+func writeTestManagedConfig(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(`{
+  "version": "managed-install-v1",
+  "organization_id": "org_123",
+  "cloud_url": "https://app.kontext.dev",
+  "mode": "observe",
+  "agent": "claude",
+  "credentials": {"install_token_ref": "env:KONTEXT_INSTALL_TOKEN"}
+}`), 0o600); err != nil {
+		t.Fatalf("WriteFile(managed config) error = %v", err)
+	}
+	t.Setenv("KONTEXT_MANAGED_CONFIG", path)
+}
+
+func writeTestInstallation(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(`{"installation_id":"ins_0123456789abcdefghijklmnopqrstuv"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(installation) error = %v", err)
+	}
+	t.Setenv("KONTEXT_INSTALLATION_STATE", path)
+}
+
+func openTestStore(t *testing.T, dbPath string) *sqlite.Store {
+	t.Helper()
+	store, err := sqlite.OpenStore(dbPath)
+	if err != nil {
+		t.Fatalf("OpenStore() error = %v", err)
+	}
+	return store
+}
+
+func waitForSession(t *testing.T, store *sqlite.Store, sessionID string) sqlite.SessionRecord {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		session, err := store.Session(context.Background(), sessionID)
+		if err == nil {
+			return session
+		}
+		lastErr = err
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("Session(%s) error = %v", sessionID, lastErr)
+	return sqlite.SessionRecord{}
+}

--- a/internal/managedobserve/defaults.go
+++ b/internal/managedobserve/defaults.go
@@ -1,0 +1,87 @@
+package managedobserve
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const (
+	DefaultLaunchdLabel = "security.kontext.managed-observe"
+
+	envSocketPath     = "KONTEXT_MANAGED_OBSERVE_SOCKET"
+	envDBPath         = "KONTEXT_MANAGED_OBSERVE_DB"
+	envIdleTimeout    = "KONTEXT_MANAGED_OBSERVE_IDLE_TIMEOUT"
+	envLaunchdLabel   = "KONTEXT_MANAGED_OBSERVE_LAUNCHD_LABEL"
+	defaultIdleWindow = 30 * time.Minute
+)
+
+func DefaultSocketPath() string {
+	if path := strings.TrimSpace(os.Getenv(envSocketPath)); path != "" {
+		return path
+	}
+	return filepath.Join("/tmp", fmt.Sprintf("kontext-managed-observe-%d", os.Getuid()), "kontext.sock")
+}
+
+func DefaultDBPath() string {
+	if path := strings.TrimSpace(os.Getenv(envDBPath)); path != "" {
+		return path
+	}
+	if dir, err := os.UserConfigDir(); err == nil && dir != "" {
+		return filepath.Join(dir, "Kontext", "managed-observe", "guard.db")
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, "Library", "Application Support", "Kontext", "managed-observe", "guard.db")
+	}
+	return filepath.Join("managed-observe", "guard.db")
+}
+
+func DefaultIdleTimeout() time.Duration {
+	if value := strings.TrimSpace(os.Getenv(envIdleTimeout)); value != "" {
+		if parsed, err := time.ParseDuration(value); err == nil && parsed > 0 {
+			return parsed
+		}
+	}
+	return defaultIdleWindow
+}
+
+func DefaultLabel() string {
+	if label := strings.TrimSpace(os.Getenv(envLaunchdLabel)); label != "" {
+		return label
+	}
+	return DefaultLaunchdLabel
+}
+
+func EnsureSocketDir(socketPath string) error {
+	dir := filepath.Dir(socketPath)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s is a symlink", dir)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", dir)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return errors.New("socket directory ownership is unavailable")
+	}
+	if int(stat.Uid) != os.Getuid() {
+		return fmt.Errorf("socket directory %s is owned by uid %d, want %d", dir, stat.Uid, os.Getuid())
+	}
+	if info.Mode().Perm() != 0o700 {
+		if err := os.Chmod(dir, 0o700); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/managedobserve/lifecycle.go
+++ b/internal/managedobserve/lifecycle.go
@@ -1,0 +1,187 @@
+package managedobserve
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"os/exec"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/diagnostic"
+	guardhookruntime "github.com/kontext-security/kontext-cli/internal/guard/hookruntime"
+	"github.com/kontext-security/kontext-cli/internal/hook"
+	"github.com/kontext-security/kontext-cli/internal/localruntime"
+	"github.com/kontext-security/kontext-cli/internal/managedconfig"
+)
+
+const (
+	sessionStartWait = 400 * time.Millisecond
+	preToolUseWait   = 250 * time.Millisecond
+	asyncHookWait    = 120 * time.Millisecond
+	probeTimeout     = 60 * time.Millisecond
+)
+
+var launchdMu sync.Mutex
+
+type Lifecycle struct {
+	SocketPath string
+	Label      string
+	Kickstart  func(context.Context, string) error
+	Diagnostic diagnostic.Logger
+}
+
+func NewLifecycle() Lifecycle {
+	return Lifecycle{
+		SocketPath: DefaultSocketPath(),
+		Label:      DefaultLabel(),
+		Kickstart:  KickstartLaunchd,
+	}
+}
+
+func Active() bool {
+	_, err := managedconfig.Load()
+	return err == nil
+}
+
+func (l Lifecycle) Process(ctx context.Context, event hook.Event) hook.Result {
+	if l.SocketPath == "" {
+		l.SocketPath = DefaultSocketPath()
+	}
+	if l.Label == "" {
+		l.Label = DefaultLabel()
+	}
+	if l.Kickstart == nil {
+		l.Kickstart = KickstartLaunchd
+	}
+
+	switch event.HookName {
+	case hook.HookSessionStart:
+		return l.processWithKickstart(ctx, event, sessionStartWait)
+	case hook.HookPreToolUse:
+		return l.processWithKickstart(ctx, event, preToolUseWait)
+	default:
+		return l.processIfAvailable(ctx, event, asyncHookWait)
+	}
+}
+
+func (l Lifecycle) processWithKickstart(ctx context.Context, event hook.Event, budget time.Duration) hook.Result {
+	ctx, cancel := context.WithTimeout(ctx, budget)
+	defer cancel()
+
+	if !l.probe(ctx) {
+		launchdMu.Lock()
+		if !l.probe(ctx) {
+			if err := l.Kickstart(ctx, l.Label); err != nil {
+				l.Diagnostic.Printf("managed observe kickstart: %v\n", err)
+			}
+		}
+		launchdMu.Unlock()
+	}
+	if l.waitForProbe(ctx) {
+		return observeResult(event, l.call(ctx, event))
+	}
+	return observeResult(event, hook.Result{Decision: hook.DecisionAllow, Reason: "managed observe daemon unavailable"})
+}
+
+func (l Lifecycle) processIfAvailable(ctx context.Context, event hook.Event, budget time.Duration) hook.Result {
+	ctx, cancel := context.WithTimeout(ctx, budget)
+	defer cancel()
+	if !l.probe(ctx) {
+		return observeResult(event, hook.Result{Decision: hook.DecisionAllow, Reason: "managed observe daemon unavailable"})
+	}
+	return observeResult(event, l.call(ctx, event))
+}
+
+func (l Lifecycle) probe(ctx context.Context) bool {
+	dialer := net.Dialer{Timeout: probeTimeout}
+	conn, err := dialer.DialContext(ctx, "unix", l.SocketPath)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+func (l Lifecycle) waitForProbe(ctx context.Context) bool {
+	for {
+		if l.probe(ctx) {
+			return true
+		}
+		timer := time.NewTimer(10 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return false
+		case <-timer.C:
+		}
+	}
+}
+
+func (l Lifecycle) call(ctx context.Context, event hook.Event) hook.Result {
+	client := localruntime.NewClient(l.SocketPath)
+	client.Timeout = time.Until(deadlineOr(ctx, time.Now().Add(asyncHookWait)))
+	if client.Timeout <= 0 {
+		client.Timeout = asyncHookWait
+	}
+	result, err := client.Process(ctx, event)
+	if err != nil {
+		l.Diagnostic.Printf("managed observe call: %v\n", err)
+		return hook.Result{Decision: hook.DecisionAllow, Reason: "managed observe daemon unavailable"}
+	}
+	return result
+}
+
+func observeResult(event hook.Event, result hook.Result) hook.Result {
+	result.Mode = string(guardhookruntime.ModeObserve)
+	if result.Decision == "" {
+		result.Decision = hook.DecisionAllow
+	}
+	if event.HookName == hook.HookPreToolUse {
+		decision := result.Decision
+		if result.Reason == "" {
+			result.Reason = "no reason provided"
+		}
+		if decision != hook.DecisionAllow {
+			result.Reason = "Kontext observe mode: would " + string(decision) + "; " + result.Reason
+		}
+		result.Decision = hook.DecisionAllow
+		return result
+	}
+	result.Decision = hook.DecisionAllow
+	return result
+}
+
+func deadlineOr(ctx context.Context, fallback time.Time) time.Time {
+	if deadline, ok := ctx.Deadline(); ok {
+		return deadline
+	}
+	return fallback
+}
+
+func KickstartLaunchd(ctx context.Context, label string) error {
+	if runtime.GOOS != "darwin" {
+		return nil
+	}
+	if label == "" {
+		return errors.New("launchd label is required")
+	}
+	cmd := exec.CommandContext(ctx, "launchctl", "kickstart", "gui/"+itoa(os.Getuid())+"/"+label)
+	return cmd.Run()
+}
+
+func itoa(value int) string {
+	if value == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for value > 0 {
+		i--
+		buf[i] = byte('0' + value%10)
+		value /= 10
+	}
+	return string(buf[i:])
+}

--- a/internal/managedobserve/lifecycle_test.go
+++ b/internal/managedobserve/lifecycle_test.go
@@ -1,0 +1,211 @@
+package managedobserve
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/diagnostic"
+	guardhookruntime "github.com/kontext-security/kontext-cli/internal/guard/hookruntime"
+	"github.com/kontext-security/kontext-cli/internal/hook"
+	"github.com/kontext-security/kontext-cli/internal/localruntime"
+)
+
+func TestLifecycleMissingSocketKickstartsAndFailsOpenObserve(t *testing.T) {
+	t.Setenv("KONTEXT_ACCESS_MODE", "enforce")
+	kickstarts := 0
+	lifecycle := Lifecycle{
+		SocketPath: filepath.Join(t.TempDir(), "missing.sock"),
+		Label:      DefaultLaunchdLabel,
+		Kickstart: func(context.Context, string) error {
+			kickstarts++
+			return nil
+		},
+	}
+
+	result := lifecycle.Process(context.Background(), hook.Event{
+		HookName: hook.HookPreToolUse,
+		ToolName: "Bash",
+	})
+
+	if kickstarts != 1 {
+		t.Fatalf("kickstarts = %d, want 1", kickstarts)
+	}
+	if result.Decision != hook.DecisionAllow || result.Mode != string(guardhookruntime.ModeObserve) {
+		t.Fatalf("result = %+v, want observe allow", result)
+	}
+}
+
+func TestLifecyclePollsAfterKickstartWithinDeadline(t *testing.T) {
+	socketPath := filepath.Join("/tmp", fmt.Sprintf("kontext-managedobserve-delayed-test-%d.sock", time.Now().UnixNano()))
+	t.Cleanup(func() { _ = os.Remove(socketPath) })
+	ready := make(chan struct{})
+	done := make(chan struct{})
+
+	lifecycle := Lifecycle{
+		SocketPath: socketPath,
+		Label:      DefaultLaunchdLabel,
+		Kickstart: func(context.Context, string) error {
+			go func() {
+				time.Sleep(50 * time.Millisecond)
+				ln, err := net.Listen("unix", socketPath)
+				if err != nil {
+					close(done)
+					return
+				}
+				defer ln.Close()
+				defer close(done)
+				close(ready)
+				for i := 0; i < 2; i++ {
+					conn, err := ln.Accept()
+					if err != nil {
+						return
+					}
+					if i == 0 {
+						_ = conn.Close()
+						continue
+					}
+					var req localruntime.EvaluateRequest
+					if err := localruntime.ReadMessage(conn, &req); err == nil {
+						_ = localruntime.WriteMessage(conn, localruntime.EvaluateResult{
+							Decision: "deny",
+							Allowed:  false,
+							Reason:   "delayed policy",
+						})
+					}
+					_ = conn.Close()
+				}
+			}()
+			return nil
+		},
+	}
+
+	result := lifecycle.Process(context.Background(), hook.Event{HookName: hook.HookPreToolUse})
+	if result.Decision != hook.DecisionAllow || result.Mode != string(guardhookruntime.ModeObserve) {
+		t.Fatalf("result = %+v, want observe allow", result)
+	}
+	if result.Reason != "Kontext observe mode: would deny; delayed policy" {
+		t.Fatalf("reason = %q, want delayed daemon result", result.Reason)
+	}
+	select {
+	case <-ready:
+	case <-time.After(time.Second):
+		t.Fatal("delayed daemon did not start")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("delayed daemon did not receive request")
+	}
+}
+
+func TestLifecycleKickstartFailureIsDiagnosedAndFailsOpen(t *testing.T) {
+	var output bytes.Buffer
+	lifecycle := Lifecycle{
+		SocketPath: filepath.Join(t.TempDir(), "missing.sock"),
+		Label:      DefaultLaunchdLabel,
+		Kickstart: func(context.Context, string) error {
+			return errors.New("launchd refused")
+		},
+		Diagnostic: diagnostic.New(&output, true),
+	}
+
+	result := lifecycle.Process(context.Background(), hook.Event{
+		HookName: hook.HookPreToolUse,
+		ToolName: "Bash",
+	})
+
+	if result.Decision != hook.DecisionAllow || result.Mode != string(guardhookruntime.ModeObserve) {
+		t.Fatalf("result = %+v, want observe allow", result)
+	}
+	if !strings.Contains(output.String(), "managed observe kickstart: launchd refused") {
+		t.Fatalf("diagnostic output = %q, want kickstart failure", output.String())
+	}
+}
+
+func TestLifecycleHealthySocketDoesNotKickstart(t *testing.T) {
+	socketPath := filepath.Join("/tmp", fmt.Sprintf("kontext-managedobserve-test-%d.sock", time.Now().UnixNano()))
+	t.Cleanup(func() { _ = os.Remove(socketPath) })
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Listen() error = %v", err)
+	}
+	defer ln.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 2; i++ {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		var req localruntime.EvaluateRequest
+		if err := localruntime.ReadMessage(conn, &req); err != nil {
+			return
+		}
+		_ = localruntime.WriteMessage(conn, localruntime.EvaluateResult{
+			Decision: "deny",
+			Allowed:  false,
+			Reason:   "policy deny",
+		})
+	}()
+
+	lifecycle := Lifecycle{
+		SocketPath: socketPath,
+		Label:      DefaultLaunchdLabel,
+		Kickstart: func(context.Context, string) error {
+			t.Fatal("kickstart should not be called")
+			return nil
+		},
+	}
+	result := lifecycle.Process(context.Background(), hook.Event{HookName: hook.HookPreToolUse})
+	if result.Decision != hook.DecisionAllow || result.Mode != string(guardhookruntime.ModeObserve) {
+		t.Fatalf("result = %+v, want observe allow", result)
+	}
+	if result.Reason != "Kontext observe mode: would deny; policy deny" {
+		t.Fatalf("reason = %q, want observe deny reason", result.Reason)
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("server did not receive request")
+	}
+}
+
+func TestActiveRequiresValidManagedConfig(t *testing.T) {
+	t.Setenv("KONTEXT_MANAGED_CONFIG", filepath.Join(t.TempDir(), "missing.json"))
+	if Active() {
+		t.Fatal("Active() = true for missing config")
+	}
+
+	path := filepath.Join(t.TempDir(), "managed.json")
+	if err := os.WriteFile(path, []byte(`{
+  "version": "managed-install-v1",
+  "organization_id": "org_123",
+  "cloud_url": "https://app.kontext.dev",
+  "mode": "observe",
+  "agent": "claude",
+  "credentials": {"install_token_ref": "env:KONTEXT_INSTALL_TOKEN"}
+}`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	t.Setenv("KONTEXT_MANAGED_CONFIG", path)
+	if !Active() {
+		t.Fatal("Active() = false for valid config")
+	}
+}

--- a/internal/run/local.go
+++ b/internal/run/local.go
@@ -37,7 +37,7 @@ func StartLocal(ctx context.Context, opts Options) error {
 		JudgeConfigFromEnv:    true,
 		JudgeManagedDefault:   true,
 		JudgeDownloadProgress: ui.HandleDownloadProgress,
-		Mode:                  string(mode),
+		Mode:                  mode,
 		Diagnostic:            diagnostics,
 		Out:                   os.Stderr,
 	})

--- a/internal/runtimehost/host.go
+++ b/internal/runtimehost/host.go
@@ -36,9 +36,11 @@ type Options struct {
 	JudgeConfigFromEnv        bool
 	JudgeManagedDefault       bool
 	JudgeDownloadProgress     judge.DownloadProgressHandler
-	Mode                      string
+	Mode                      guardhookruntime.Mode
 	Diagnostic                diagnostic.Logger
 	Out                       io.Writer
+	SkipInitialSession        bool
+	DisableAsyncIngest        bool
 }
 
 type Host struct {
@@ -66,7 +68,7 @@ func Start(ctx context.Context, opts Options) (*Host, error) {
 	if strings.TrimSpace(opts.AgentName) == "" {
 		return nil, errors.New("runtime host requires agent name")
 	}
-	mode, err := ResolveMode(opts.Mode)
+	mode, err := ResolveMode(string(opts.Mode))
 	if err != nil {
 		return nil, err
 	}
@@ -142,12 +144,16 @@ func Start(ctx context.Context, opts Options) (*Host, error) {
 		closeJudge:            closeJudge,
 	}
 
+	serviceSessionID := sessionID
+	if opts.SkipInitialSession {
+		serviceSessionID = ""
+	}
 	runtimeService, err := localruntime.NewService(localruntime.Options{
 		SocketPath:  socketPath,
 		Core:        localServer.RuntimeCore(),
-		SessionID:   sessionID,
+		SessionID:   serviceSessionID,
 		AgentName:   opts.AgentName,
-		AsyncIngest: true,
+		AsyncIngest: !opts.DisableAsyncIngest,
 		Diagnostic:  opts.Diagnostic,
 	})
 	if err != nil {
@@ -164,17 +170,19 @@ func Start(ctx context.Context, opts Options) (*Host, error) {
 	if cwd == "" {
 		cwd, _ = os.Getwd()
 	}
-	if _, err := localServer.RuntimeCore().OpenSession(ctx, runtimecore.Session{
-		ID:         sessionID,
-		Agent:      opts.AgentName,
-		CWD:        cwd,
-		Source:     runtimecore.SessionSourceWrapperOwned,
-		ExternalID: sessionID,
-	}); err != nil {
-		_ = host.Close(context.Background())
-		return nil, fmt.Errorf("open runtime session: %w", err)
+	if !opts.SkipInitialSession {
+		if _, err := localServer.RuntimeCore().OpenSession(ctx, runtimecore.Session{
+			ID:         sessionID,
+			Agent:      opts.AgentName,
+			CWD:        cwd,
+			Source:     runtimecore.SessionSourceWrapperOwned,
+			ExternalID: sessionID,
+		}); err != nil {
+			_ = host.Close(context.Background())
+			return nil, fmt.Errorf("open runtime session: %w", err)
+		}
+		host.sessionOpened = true
 	}
-	host.sessionOpened = true
 
 	if opts.StartDashboard {
 		addr, err := DashboardAddr(opts.DashboardAddr, opts.AllowNonLoopbackDashboard)


### PR DESCRIPTION
## Where We Are

Managed Claude hooks already call `kontext hook <event>`, and ENG-357 provides the local managed config plus installation identity. There was no narrow local lifecycle layer to keep a managed observe socket available when employees run plain `claude`.

## Where We Want To Go

When a valid managed config exists, unmanaged-looking Claude hook calls should use a lightweight observe daemon path that records locally and never blocks the developer workflow. Explicit local wrapper paths must keep their existing behavior.

## How do we get there

This adds the hidden `kontext managed-observe-daemon` command, a managed observe lifecycle helper with short socket probes and launchd `kickstart`, and daemon-owned stale session cleanup. The hook command only switches to this path when no `--socket` or `--mode` is passed and the managed config is valid; managed results are forced through observe/fail-open handling even if hosted access mode says enforce. Validation passed with `go test ./internal/managedobserve ./internal/guard/store/sqlite ./cmd/kontext ./internal/localruntime ./internal/runtimehost`, `gofmt -l`, and `git diff --check`. Full `go test ./...` still hits existing llama-server timing failures in `internal/guard/judge`.
