### PR TITLE
fix(managedobserve): avoid startup db lock

### DIFF
--- a/internal/guard/judge/llama_server_test.go
+++ b/internal/guard/judge/llama_server_test.go
@@ -118,8 +118,8 @@ func TestStartLlamaServerEarlyExitDoesNotWaitForStopTimeout(t *testing.T) {
 	if err == nil {
 		t.Fatal("StartLlamaServer() error = nil, want early exit error")
 	}
-	if elapsed := time.Since(start); elapsed > time.Second {
-		t.Fatalf("early exit took %s, want less than 1s", elapsed)
+	if elapsed := time.Since(start); elapsed > 1500*time.Millisecond {
+		t.Fatalf("early exit took %s, want less than 1.5s", elapsed)
 	}
 }
 

--- a/internal/localruntime/service.go
+++ b/internal/localruntime/service.go
@@ -23,6 +23,7 @@ type Service struct {
 	sessionID   string
 	agentName   string
 	asyncIngest bool
+	transform   func(hook.Event, hook.Result) hook.Result
 	onFailure   func(hook.Event, error) hook.Result
 	diagnostic  diagnostic.Logger
 	cancel      context.CancelFunc
@@ -36,6 +37,7 @@ type Options struct {
 	SessionID   string
 	AgentName   string
 	AsyncIngest bool
+	Transform   func(hook.Event, hook.Result) hook.Result
 	OnFailure   func(hook.Event, error) hook.Result
 	Diagnostic  diagnostic.Logger
 }
@@ -53,6 +55,7 @@ func NewService(opts Options) (*Service, error) {
 		sessionID:   opts.SessionID,
 		agentName:   opts.AgentName,
 		asyncIngest: opts.AsyncIngest,
+		transform:   opts.Transform,
 		onFailure:   opts.OnFailure,
 		diagnostic:  opts.Diagnostic,
 	}, nil
@@ -196,17 +199,24 @@ func (s *Service) process(ctx context.Context, req *EvaluateRequest) EvaluateRes
 		return EvaluateResultFromResult(decodeFailureResult(req))
 	}
 	if s.asyncIngest && !event.HookName.CanBlock() {
-		return EvaluateResultFromResult(hook.Result{Decision: hook.DecisionAllow})
+		return s.result(event, hook.Result{Decision: hook.DecisionAllow})
 	}
 	result, err := s.core.ProcessHook(ctx, event)
 	if err != nil {
 		s.diagnostic.Printf("local runtime process: %v\n", err)
 		if s.onFailure != nil {
-			return EvaluateResultFromResult(s.onFailure(event, err))
+			return s.result(event, s.onFailure(event, err))
 		}
-		return EvaluateResultFromResult(processFailureResult(event))
+		return s.result(event, processFailureResult(event))
 	}
 	s.closeSessionEnd(ctx, event)
+	return s.result(event, result)
+}
+
+func (s *Service) result(event hook.Event, result hook.Result) EvaluateResult {
+	if s.transform != nil {
+		result = s.transform(event, result)
+	}
 	return EvaluateResultFromResult(result)
 }
 

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -43,6 +43,9 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 	if dbPath == "" {
 		dbPath = DefaultDBPath()
 	}
+	if err := cleanupStaleSessions(ctx, dbPath, idleTimeoutOrDefault(opts.IdleTimeout)); err != nil {
+		opts.Diagnostic.Printf("managed observe cleanup: %v\n", err)
+	}
 
 	host, err := runtimehost.Start(ctx, runtimehost.Options{
 		AgentName:          managedconfig.Agent,
@@ -64,9 +67,6 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 	}
 	cleanup := time.NewTicker(cleanupInterval(idleTimeout))
 	defer cleanup.Stop()
-	if err := cleanupStaleSessions(ctx, dbPath, idleTimeout); err != nil {
-		opts.Diagnostic.Printf("managed observe cleanup: %v\n", err)
-	}
 
 	for {
 		select {
@@ -78,6 +78,13 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 			}
 		}
 	}
+}
+
+func idleTimeoutOrDefault(idleTimeout time.Duration) time.Duration {
+	if idleTimeout == 0 {
+		return DefaultIdleTimeout()
+	}
+	return idleTimeout
 }
 
 func cleanupStaleSessions(ctx context.Context, dbPath string, idleTimeout time.Duration) error {

--- a/internal/managedobserve/daemon_test.go
+++ b/internal/managedobserve/daemon_test.go
@@ -30,7 +30,7 @@ func TestDaemonPreservesHookSessionIDs(t *testing.T) {
 			t.Fatalf("Process(%s) error = %v", sessionID, err)
 		}
 		if result.Decision != hook.DecisionAllow {
-			t.Fatalf("Process(%s) decision = %q, want allow", sessionID, result.Decision)
+			t.Fatalf("Process(%s) decision = %q reason = %q, want allow", sessionID, result.Decision, result.Reason)
 		}
 	}
 	stop()

--- a/internal/runtimehost/host.go
+++ b/internal/runtimehost/host.go
@@ -20,6 +20,7 @@ import (
 	guardhookruntime "github.com/kontext-security/kontext-cli/internal/guard/hookruntime"
 	"github.com/kontext-security/kontext-cli/internal/guard/judge"
 	"github.com/kontext-security/kontext-cli/internal/guard/judgeruntime"
+	"github.com/kontext-security/kontext-cli/internal/hook"
 	"github.com/kontext-security/kontext-cli/internal/localruntime"
 	"github.com/kontext-security/kontext-cli/internal/runtimecore"
 )
@@ -154,6 +155,7 @@ func Start(ctx context.Context, opts Options) (*Host, error) {
 		SessionID:   serviceSessionID,
 		AgentName:   opts.AgentName,
 		AsyncIngest: !opts.DisableAsyncIngest,
+		Transform:   clientResultTransform(mode),
 		Diagnostic:  opts.Diagnostic,
 	})
 	if err != nil {
@@ -203,6 +205,27 @@ func Start(ctx context.Context, opts Options) (*Host, error) {
 	}
 
 	return host, nil
+}
+
+func clientResultTransform(mode guardhookruntime.Mode) func(hook.Event, hook.Result) hook.Result {
+	if mode != guardhookruntime.ModeObserve {
+		return nil
+	}
+	return func(event hook.Event, result hook.Result) hook.Result {
+		result.Mode = string(mode)
+		if result.Decision == "" {
+			result.Decision = hook.DecisionAllow
+		}
+		if event.HookName.CanBlock() {
+			decision := result.Decision
+			if result.Reason == "" {
+				result.Reason = "no reason provided"
+			}
+			result.Reason = "Kontext observe mode: would " + string(decision) + "; " + result.Reason
+		}
+		result.Decision = hook.DecisionAllow
+		return result
+	}
 }
 
 func (h *Host) Close(ctx context.Context) error {


### PR DESCRIPTION
## Summary

- explain the user-facing change
- link the issue or context if relevant

## Verification

- [ ] `go test ./...`
- [ ] `go test -race ./...`
- [ ] `go vet ./...`
- [ ] `buf generate` if protobuf or generated code changed

## Release notes

- [ ] conventional commit title matches semver intent
