### PR TITLE
feat(managed): stream ledger batches to hosted backend

### DIFF
--- a/internal/guard/store/sqlite/ledger.go
+++ b/internal/guard/store/sqlite/ledger.go
@@ -12,8 +12,9 @@ import (
 type LedgerRecord map[string]any
 
 type LedgerExportOptions struct {
-	UpdatedAfter *time.Time
-	Limit        int
+	UpdatedAfter   *time.Time
+	UpdatedAfterID string
+	Limit          int
 }
 
 type LedgerBatch struct {
@@ -21,10 +22,16 @@ type LedgerBatch struct {
 	Actions            []LedgerRecord            `json:"authorization_actions"`
 	Receipts           []LedgerRecord            `json:"authorization_receipts"`
 	ReceiptChainAnchor *LedgerReceiptChainAnchor `json:"receipt_chain_anchor,omitempty"`
+	Cursor             *LedgerCursor             `json:"-"`
 }
 
 type LedgerReceiptChainAnchor struct {
 	PreviousReceiptHash string `json:"previous_receipt_hash"`
+}
+
+type LedgerCursor struct {
+	UpdatedAt time.Time
+	ActionID  string
 }
 
 const authorizationActionsSelect = `
@@ -56,6 +63,10 @@ func (s *Store) LedgerBatch(ctx context.Context, opts LedgerExportOptions) (Ledg
 	if err != nil {
 		return LedgerBatch{}, err
 	}
+	cursor, err := ledgerCursor(actions)
+	if err != nil {
+		return LedgerBatch{}, err
+	}
 	receipts, err := s.authorizationReceiptRangeForActions(ctx, recordIDs(actions))
 	if err != nil {
 		return LedgerBatch{}, err
@@ -73,6 +84,7 @@ func (s *Store) LedgerBatch(ctx context.Context, opts LedgerExportOptions) (Ledg
 		Actions:            actions,
 		Receipts:           receipts,
 		ReceiptChainAnchor: receiptChainAnchor(receipts),
+		Cursor:             cursor,
 	}, nil
 }
 
@@ -108,8 +120,14 @@ func (s *Store) AuthorizationActions(ctx context.Context, opts LedgerExportOptio
 	query := authorizationActionsSelect
 	args := []any{}
 	if opts.UpdatedAfter != nil {
-		query += "\nwhere updated_at > ?"
-		args = append(args, opts.UpdatedAfter.Format(time.RFC3339Nano))
+		if opts.UpdatedAfterID != "" {
+			query += "\nwhere updated_at > ? or (updated_at = ? and id > ?)"
+			updatedAfter := opts.UpdatedAfter.Format(time.RFC3339Nano)
+			args = append(args, updatedAfter, updatedAfter, opts.UpdatedAfterID)
+		} else {
+			query += "\nwhere updated_at > ?"
+			args = append(args, opts.UpdatedAfter.Format(time.RFC3339Nano))
+		}
 	}
 	query += "\norder by updated_at, id"
 	if opts.Limit > 0 {
@@ -117,6 +135,23 @@ func (s *Store) AuthorizationActions(ctx context.Context, opts LedgerExportOptio
 		args = append(args, opts.Limit)
 	}
 	return queryLedgerRecords(ctx, s.db, query, args...)
+}
+
+func ledgerCursor(actions []LedgerRecord) (*LedgerCursor, error) {
+	if len(actions) == 0 {
+		return nil, nil
+	}
+	last := actions[len(actions)-1]
+	rawUpdatedAt, _ := last["updated_at"].(string)
+	actionID, _ := last["id"].(string)
+	if rawUpdatedAt == "" || actionID == "" {
+		return nil, nil
+	}
+	updatedAt, err := time.Parse(time.RFC3339Nano, rawUpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &LedgerCursor{UpdatedAt: updatedAt, ActionID: actionID}, nil
 }
 
 func (s *Store) authorizationActionsByIDs(ctx context.Context, ids []string) ([]LedgerRecord, error) {

--- a/internal/guard/store/sqlite/store_test.go
+++ b/internal/guard/store/sqlite/store_test.go
@@ -639,6 +639,72 @@ func TestLedgerBatchLimitReturnsReceiptsForSelectedActions(t *testing.T) {
 	}
 }
 
+func TestLedgerBatchCursorUsesUpdatedAtAndActionID(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	first, err := store.SaveDecision(context.Background(), risk.HookEvent{
+		SessionID:     "s1",
+		HookEventName: "PreToolUse",
+		ToolName:      "Read",
+		ToolUseID:     "tool-1",
+	}, risk.RiskDecision{
+		Decision:   risk.DecisionAllow,
+		Reason:     "normal",
+		ReasonCode: "normal_tool_call",
+		RiskEvent:  risk.RiskEvent{Type: risk.EventNormalToolCall},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := store.SaveDecision(context.Background(), risk.HookEvent{
+		SessionID:     "s1",
+		HookEventName: "PreToolUse",
+		ToolName:      "Read",
+		ToolUseID:     "tool-2",
+	}, risk.RiskDecision{
+		Decision:   risk.DecisionAllow,
+		Reason:     "normal",
+		ReasonCode: "normal_tool_call",
+		RiskEvent:  risk.RiskEvent{Type: risk.EventNormalToolCall},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sharedUpdated := "2026-05-19T10:00:00Z"
+	if _, err := store.db.ExecContext(context.Background(), `
+update authorization_actions
+set updated_at = ?
+where id in (?, ?)
+	`, sharedUpdated, first.ID, second.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	firstBatch, err := store.LedgerBatch(context.Background(), LedgerExportOptions{Limit: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstBatch.Cursor == nil {
+		t.Fatal("first batch cursor = nil")
+	}
+
+	secondBatch, err := store.LedgerBatch(context.Background(), LedgerExportOptions{
+		UpdatedAfter:   &firstBatch.Cursor.UpdatedAt,
+		UpdatedAfterID: firstBatch.Cursor.ActionID,
+		Limit:          1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(secondBatch.Actions) != 1 || secondBatch.Actions[0]["id"] == firstBatch.Cursor.ActionID {
+		t.Fatalf("second batch actions = %+v, cursor = %+v", secondBatch.Actions, firstBatch.Cursor)
+	}
+}
+
 func TestLedgerBatchIncludesReceiptChainAnchorForIncrementalExports(t *testing.T) {
 	store, err := OpenStore(t.TempDir() + "/guard.db")
 	if err != nil {

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
@@ -11,24 +12,30 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
 	"github.com/kontext-security/kontext-cli/internal/installation"
 	"github.com/kontext-security/kontext-cli/internal/managedconfig"
+	"github.com/kontext-security/kontext-cli/internal/managedstream"
 	"github.com/kontext-security/kontext-cli/internal/runtimehost"
 )
 
 type DaemonOptions struct {
-	SocketPath  string
-	DBPath      string
-	IdleTimeout time.Duration
-	Diagnostic  diagnostic.Logger
+	SocketPath       string
+	DBPath           string
+	IdleTimeout      time.Duration
+	StreamStatePath  string
+	StreamInterval   time.Duration
+	StreamHTTPClient *http.Client
+	Diagnostic       diagnostic.Logger
 }
 
 func RunDaemon(ctx context.Context, opts DaemonOptions) error {
-	if _, err := managedconfig.Load(); err != nil {
+	loadedConfig, err := managedconfig.Load()
+	if err != nil {
 		if errors.Is(err, managedconfig.ErrNotManaged) {
 			return err
 		}
 		return fmt.Errorf("load managed config: %w", err)
 	}
-	if _, err := installation.Ensure(); err != nil {
+	installationState, err := installation.Ensure()
+	if err != nil {
 		return fmt.Errorf("ensure installation identity: %w", err)
 	}
 
@@ -61,6 +68,23 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 	}
 	defer host.Close(context.Background())
 
+	streamCtx, stopStream := context.WithCancel(ctx)
+	defer stopStream()
+	streamErr := make(chan error, 1)
+	go func() {
+		streamErr <- managedstream.Run(streamCtx, managedstream.Options{
+			DBPath:         dbPath,
+			StatePath:      opts.StreamStatePath,
+			CloudURL:       loadedConfig.Config.CloudURL,
+			OrganizationID: loadedConfig.Config.OrganizationID,
+			InstallationID: installationState.InstallationID,
+			DeviceLabel:    loadedConfig.Config.Device.Label,
+			Interval:       opts.StreamInterval,
+			HTTPClient:     opts.StreamHTTPClient,
+			Diagnostic:     opts.Diagnostic,
+		})
+	}()
+
 	idleTimeout := opts.IdleTimeout
 	if idleTimeout == 0 {
 		idleTimeout = DefaultIdleTimeout()
@@ -72,6 +96,11 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 		select {
 		case <-ctx.Done():
 			return nil
+		case err := <-streamErr:
+			if err != nil {
+				opts.Diagnostic.Printf("managed stream exited: %v\n", err)
+			}
+			streamErr = nil
 		case <-cleanup.C:
 			if err := cleanupStaleSessions(ctx, dbPath, idleTimeout); err != nil {
 				opts.Diagnostic.Printf("managed observe cleanup: %v\n", err)

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -99,8 +99,9 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 		case err := <-streamErr:
 			if err != nil {
 				opts.Diagnostic.Printf("managed stream exited: %v\n", err)
+				return fmt.Errorf("managed stream failed: %w", err)
 			}
-			streamErr = nil
+			return nil
 		case <-cleanup.C:
 			if err := cleanupStaleSessions(ctx, dbPath, idleTimeout); err != nil {
 				opts.Diagnostic.Printf("managed observe cleanup: %v\n", err)

--- a/internal/managedobserve/daemon_test.go
+++ b/internal/managedobserve/daemon_test.go
@@ -2,6 +2,9 @@ package managedobserve
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -82,6 +85,96 @@ func TestDaemonSessionEndClosesHookSessionID(t *testing.T) {
 	session = waitForSession(t, store, "claude-session-end")
 	if session.Status != "closed" || session.ClosedAt == nil {
 		t.Fatalf("session = %+v, want actual hook session closed", session)
+	}
+}
+
+func TestDaemonStreamsLedgerBatches(t *testing.T) {
+	requests := make(chan map[string]any, 1)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/authorization-ledger/batches" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("Decode() error = %v", err)
+		}
+		requests <- body
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	dir := t.TempDir()
+	socketDir, err := os.MkdirTemp("/tmp", "kontext-managedobserve-stream-test-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp() error = %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	socketPath := filepath.Join(socketDir, "kontext.sock")
+	dbPath := filepath.Join(dir, "guard.db")
+	writeTestManagedConfigWithCloudURL(t, filepath.Join(dir, "managed.json"), server.URL)
+	writeTestInstallation(t, filepath.Join(dir, "installation.json"))
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- RunDaemon(ctx, DaemonOptions{
+			SocketPath:       socketPath,
+			DBPath:           dbPath,
+			IdleTimeout:      time.Hour,
+			StreamStatePath:  filepath.Join(dir, "stream-state.json"),
+			StreamInterval:   20 * time.Millisecond,
+			StreamHTTPClient: server.Client(),
+		})
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Fatalf("RunDaemon() error = %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("RunDaemon did not stop")
+		}
+	})
+	waitForSocket(t, socketPath, errCh)
+
+	client := localruntime.NewClient(socketPath)
+	client.Timeout = time.Second
+	if _, err := client.Process(context.Background(), hook.Event{
+		SessionID: "claude-stream-session",
+		Agent:     "claude",
+		HookName:  hook.HookPreToolUse,
+		ToolName:  "Read",
+		CWD:       "/tmp/project",
+	}); err != nil {
+		t.Fatalf("Process() error = %v", err)
+	}
+
+	select {
+	case body := <-requests:
+		if body["organization_id"] != "org_123" {
+			t.Fatalf("organization_id = %v", body["organization_id"])
+		}
+		if body["installation_id"] != "ins_0123456789abcdefghijklmnopqrstuv" {
+			t.Fatalf("installation_id = %v", body["installation_id"])
+		}
+		actions, ok := body["authorization_actions"].([]any)
+		if !ok {
+			t.Fatalf("authorization_actions = %#v", body["authorization_actions"])
+		}
+		found := false
+		for _, raw := range actions {
+			action, ok := raw.(map[string]any)
+			if ok && action["session_id"] == "claude-stream-session" {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("authorization_actions = %#v, want claude stream session action", body["authorization_actions"])
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for hosted ledger batch")
 	}
 }
 
@@ -234,12 +327,18 @@ func waitForSocket(t *testing.T, socketPath string, errCh <-chan error) {
 
 func writeTestManagedConfig(t *testing.T, path string) {
 	t.Helper()
+	writeTestManagedConfigWithCloudURL(t, path, "https://app.kontext.dev")
+}
+
+func writeTestManagedConfigWithCloudURL(t *testing.T, path, cloudURL string) {
+	t.Helper()
 	if err := os.WriteFile(path, []byte(`{
   "version": "managed-install-v1",
   "organization_id": "org_123",
-  "cloud_url": "https://app.kontext.dev",
+  "cloud_url": "`+cloudURL+`",
   "mode": "observe",
   "agent": "claude",
+  "device": {"label": "test-mac"},
   "credentials": {"install_token_ref": "env:KONTEXT_INSTALL_TOKEN"}
 }`), 0o600); err != nil {
 		t.Fatalf("WriteFile(managed config) error = %v", err)

--- a/internal/managedobserve/daemon_test.go
+++ b/internal/managedobserve/daemon_test.go
@@ -41,10 +41,7 @@ func TestDaemonPreservesHookSessionIDs(t *testing.T) {
 	store := openTestStore(t, dbPath)
 	defer store.Close()
 	for _, sessionID := range []string{"claude-session-one", "claude-session-two"} {
-		session, err := store.Session(context.Background(), sessionID)
-		if err != nil {
-			t.Fatalf("Session(%s) error = %v", sessionID, err)
-		}
+		session := waitForSession(t, store, sessionID)
 		if session.ID != sessionID || session.Source != "daemon_observed" || session.Status != "open" {
 			t.Fatalf("session %s = %+v, want open daemon-observed session", sessionID, session)
 		}
@@ -304,7 +301,7 @@ func startTestDaemon(t *testing.T) (string, string, func()) {
 
 func waitForSocket(t *testing.T, socketPath string, errCh <-chan error) {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
 		select {
 		case err := <-errCh:
@@ -365,7 +362,7 @@ func openTestStore(t *testing.T, dbPath string) *sqlite.Store {
 
 func waitForSession(t *testing.T, store *sqlite.Store, sessionID string) sqlite.SessionRecord {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
 	var lastErr error
 	for time.Now().Before(deadline) {
 		session, err := store.Session(context.Background(), sessionID)

--- a/internal/managedstream/stream.go
+++ b/internal/managedstream/stream.go
@@ -1,0 +1,295 @@
+package managedstream
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kontext-security/kontext-cli/internal/diagnostic"
+	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
+)
+
+const (
+	SchemaVersion   = "authorization-ledger-v1"
+	DefaultEndpoint = "/api/v1/authorization-ledger/batches"
+
+	DefaultBatchLimit = 500
+	DefaultInterval   = 10 * time.Second
+
+	envStatePath = "KONTEXT_MANAGED_STREAM_STATE"
+	envInterval  = "KONTEXT_MANAGED_STREAM_INTERVAL"
+)
+
+type Options struct {
+	DBPath         string
+	StatePath      string
+	CloudURL       string
+	OrganizationID string
+	InstallationID string
+	DeviceLabel    string
+	Interval       time.Duration
+	BatchLimit     int
+	HTTPClient     *http.Client
+	Diagnostic     diagnostic.Logger
+}
+
+type Payload struct {
+	SchemaVersion      string                           `json:"schema_version"`
+	OrganizationID     string                           `json:"organization_id"`
+	InstallationID     string                           `json:"installation_id"`
+	BatchID            string                           `json:"batch_id"`
+	SentAt             string                           `json:"sent_at"`
+	Device             *Device                          `json:"device,omitempty"`
+	Sessions           []sqlite.LedgerRecord            `json:"agent_sessions"`
+	Actions            []sqlite.LedgerRecord            `json:"authorization_actions"`
+	Receipts           []sqlite.LedgerRecord            `json:"authorization_receipts"`
+	ReceiptChainAnchor *sqlite.LedgerReceiptChainAnchor `json:"receipt_chain_anchor,omitempty"`
+}
+
+type Device struct {
+	Label string `json:"label,omitempty"`
+}
+
+type State struct {
+	UpdatedAfter string `json:"updated_after,omitempty"`
+	ActionID     string `json:"action_id,omitempty"`
+}
+
+func Run(ctx context.Context, opts Options) error {
+	if err := validateOptions(opts); err != nil {
+		return err
+	}
+	interval := opts.Interval
+	if interval == 0 {
+		interval = DefaultIntervalFromEnv()
+	}
+
+	if err := Flush(ctx, opts); err != nil {
+		opts.Diagnostic.Printf("managed stream flush: %v\n", err)
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := Flush(ctx, opts); err != nil {
+				opts.Diagnostic.Printf("managed stream flush: %v\n", err)
+			}
+		}
+	}
+}
+
+func Flush(ctx context.Context, opts Options) error {
+	if err := validateOptions(opts); err != nil {
+		return err
+	}
+	store, err := sqlite.OpenStore(opts.DBPath)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	statePath := opts.StatePath
+	if statePath == "" {
+		statePath = DefaultStatePath()
+	}
+	state, err := LoadState(statePath)
+	if err != nil {
+		return err
+	}
+
+	var updatedAfter *time.Time
+	if state.UpdatedAfter != "" {
+		parsed, err := time.Parse(time.RFC3339Nano, state.UpdatedAfter)
+		if err != nil {
+			return fmt.Errorf("parse managed stream state: %w", err)
+		}
+		updatedAfter = &parsed
+	}
+
+	limit := opts.BatchLimit
+	if limit <= 0 {
+		limit = DefaultBatchLimit
+	}
+	batch, err := store.LedgerBatch(ctx, sqlite.LedgerExportOptions{
+		UpdatedAfter:   updatedAfter,
+		UpdatedAfterID: state.ActionID,
+		Limit:          limit,
+	})
+	if err != nil {
+		return err
+	}
+	if len(batch.Actions) == 0 {
+		return nil
+	}
+
+	payload := Payload{
+		SchemaVersion:      SchemaVersion,
+		OrganizationID:     opts.OrganizationID,
+		InstallationID:     opts.InstallationID,
+		BatchID:            "batch_" + uuid.NewString(),
+		SentAt:             time.Now().UTC().Format(time.RFC3339Nano),
+		Sessions:           batch.Sessions,
+		Actions:            batch.Actions,
+		Receipts:           batch.Receipts,
+		ReceiptChainAnchor: batch.ReceiptChainAnchor,
+	}
+	if label := strings.TrimSpace(opts.DeviceLabel); label != "" {
+		payload.Device = &Device{Label: label}
+	}
+	if err := post(ctx, opts, payload); err != nil {
+		return err
+	}
+
+	if batch.Cursor != nil {
+		return SaveState(statePath, State{
+			UpdatedAfter: batch.Cursor.UpdatedAt.UTC().Format(time.RFC3339Nano),
+			ActionID:     batch.Cursor.ActionID,
+		})
+	}
+	return nil
+}
+
+func post(ctx context.Context, opts Options, payload Payload) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	endpoint, err := endpointURL(opts.CloudURL)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := opts.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Second}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("hosted ledger ingest failed: status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func endpointURL(cloudURL string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(cloudURL))
+	if err != nil {
+		return "", err
+	}
+	parsed.Path = DefaultEndpoint
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String(), nil
+}
+
+func DefaultStatePath() string {
+	if path := strings.TrimSpace(os.Getenv(envStatePath)); path != "" {
+		return path
+	}
+	if dir, err := os.UserConfigDir(); err == nil && dir != "" {
+		return filepath.Join(dir, "Kontext", "managed-observe", "stream-state.json")
+	}
+	return filepath.Join("managed-observe", "stream-state.json")
+}
+
+func DefaultIntervalFromEnv() time.Duration {
+	if value := strings.TrimSpace(os.Getenv(envInterval)); value != "" {
+		if parsed, err := time.ParseDuration(value); err == nil && parsed > 0 {
+			return parsed
+		}
+	}
+	return DefaultInterval
+}
+
+func LoadState(path string) (State, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return State{}, nil
+		}
+		return State{}, err
+	}
+	var state State
+	if err := json.Unmarshal(data, &state); err != nil {
+		return State{}, err
+	}
+	state.UpdatedAfter = strings.TrimSpace(state.UpdatedAfter)
+	state.ActionID = strings.TrimSpace(state.ActionID)
+	return state, nil
+}
+
+func SaveState(path string, state State) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	temp, err := os.CreateTemp(filepath.Dir(path), ".stream-state-*.tmp")
+	if err != nil {
+		return err
+	}
+	tempPath := temp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tempPath)
+		}
+	}()
+	if err := temp.Chmod(0o600); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if _, err := temp.Write(data); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
+}
+
+func validateOptions(opts Options) error {
+	if strings.TrimSpace(opts.DBPath) == "" {
+		return errors.New("managed stream requires db path")
+	}
+	if strings.TrimSpace(opts.CloudURL) == "" {
+		return errors.New("managed stream requires cloud url")
+	}
+	if strings.TrimSpace(opts.OrganizationID) == "" {
+		return errors.New("managed stream requires organization id")
+	}
+	if strings.TrimSpace(opts.InstallationID) == "" {
+		return errors.New("managed stream requires installation id")
+	}
+	return nil
+}

--- a/internal/managedstream/stream.go
+++ b/internal/managedstream/stream.go
@@ -104,7 +104,7 @@ func Flush(ctx context.Context, opts Options) error {
 
 	statePath := opts.StatePath
 	if statePath == "" {
-		statePath = DefaultStatePath()
+		statePath = DefaultStatePathForDB(opts.DBPath)
 	}
 	state, err := LoadState(statePath)
 	if err != nil {
@@ -212,6 +212,16 @@ func DefaultStatePath() string {
 		return filepath.Join(dir, "Kontext", "managed-observe", "stream-state.json")
 	}
 	return filepath.Join("managed-observe", "stream-state.json")
+}
+
+func DefaultStatePathForDB(dbPath string) string {
+	if path := strings.TrimSpace(os.Getenv(envStatePath)); path != "" {
+		return path
+	}
+	if dbPath = strings.TrimSpace(dbPath); dbPath != "" {
+		return filepath.Join(filepath.Dir(dbPath), "stream-state.json")
+	}
+	return DefaultStatePath()
 }
 
 func DefaultIntervalFromEnv() time.Duration {

--- a/internal/managedstream/stream_test.go
+++ b/internal/managedstream/stream_test.go
@@ -94,6 +94,36 @@ func TestFlushDoesNotAdvanceCursorWhenHostedBackendFails(t *testing.T) {
 	}
 }
 
+func TestFlushDefaultsStatePathBesideLedgerDB(t *testing.T) {
+	t.Setenv(envStatePath, "")
+	store, dbPath := testStore(t)
+	saveTestDecision(t, store, "session-1", "toolu_1")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(server.Close)
+
+	if err := Flush(context.Background(), Options{
+		DBPath:         dbPath,
+		CloudURL:       server.URL,
+		OrganizationID: "org_123",
+		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
+		HTTPClient:     server.Client(),
+	}); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+
+	statePath := filepath.Join(filepath.Dir(dbPath), "stream-state.json")
+	state, err := LoadState(statePath)
+	if err != nil {
+		t.Fatalf("LoadState() error = %v", err)
+	}
+	if state.UpdatedAfter == "" {
+		t.Fatal("updated_after was not persisted")
+	}
+}
+
 func TestFlushUsesUpdatedAfterCursor(t *testing.T) {
 	store, dbPath := testStore(t)
 	saveTestDecision(t, store, "session-1", "toolu_1")

--- a/internal/managedstream/stream_test.go
+++ b/internal/managedstream/stream_test.go
@@ -1,0 +1,161 @@
+package managedstream
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/guard/risk"
+	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
+)
+
+func TestFlushPostsLedgerBatchWithInstallationIdentity(t *testing.T) {
+	store, dbPath := testStore(t)
+	saveTestDecision(t, store, "session-1", "toolu_1")
+
+	var got Payload
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != DefaultEndpoint {
+			t.Fatalf("path = %q, want %q", r.URL.Path, DefaultEndpoint)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("Decode() error = %v", err)
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(server.Close)
+
+	statePath := filepath.Join(t.TempDir(), "stream-state.json")
+	if err := Flush(context.Background(), Options{
+		DBPath:         dbPath,
+		StatePath:      statePath,
+		CloudURL:       server.URL,
+		OrganizationID: "org_123",
+		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
+		DeviceLabel:    "michel-macbook",
+		HTTPClient:     server.Client(),
+	}); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+
+	if got.SchemaVersion != SchemaVersion {
+		t.Fatalf("schema_version = %q, want %q", got.SchemaVersion, SchemaVersion)
+	}
+	if got.OrganizationID != "org_123" {
+		t.Fatalf("organization_id = %q", got.OrganizationID)
+	}
+	if got.InstallationID != "ins_0123456789abcdefghijklmnopqrstuv" {
+		t.Fatalf("installation_id = %q", got.InstallationID)
+	}
+	if got.Device == nil || got.Device.Label != "michel-macbook" {
+		t.Fatalf("device = %+v", got.Device)
+	}
+	if len(got.Sessions) != 1 || len(got.Actions) != 1 || len(got.Receipts) != 1 {
+		t.Fatalf("batch counts = sessions %d actions %d receipts %d", len(got.Sessions), len(got.Actions), len(got.Receipts))
+	}
+
+	state, err := LoadState(statePath)
+	if err != nil {
+		t.Fatalf("LoadState() error = %v", err)
+	}
+	if state.UpdatedAfter == "" {
+		t.Fatal("updated_after was not persisted")
+	}
+}
+
+func TestFlushDoesNotAdvanceCursorWhenHostedBackendFails(t *testing.T) {
+	store, dbPath := testStore(t)
+	saveTestDecision(t, store, "session-1", "toolu_1")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	statePath := filepath.Join(t.TempDir(), "stream-state.json")
+	if err := Flush(context.Background(), Options{
+		DBPath:         dbPath,
+		StatePath:      statePath,
+		CloudURL:       server.URL,
+		OrganizationID: "org_123",
+		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
+		HTTPClient:     server.Client(),
+	}); err == nil {
+		t.Fatal("Flush() error = nil, want hosted failure")
+	}
+
+	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+		t.Fatalf("state file error = %v, want not exist", err)
+	}
+}
+
+func TestFlushUsesUpdatedAfterCursor(t *testing.T) {
+	store, dbPath := testStore(t)
+	saveTestDecision(t, store, "session-1", "toolu_1")
+
+	statePath := filepath.Join(t.TempDir(), "stream-state.json")
+	if err := SaveState(statePath, State{UpdatedAfter: time.Now().Add(time.Hour).UTC().Format(time.RFC3339Nano)}); err != nil {
+		t.Fatalf("SaveState() error = %v", err)
+	}
+
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(server.Close)
+
+	if err := Flush(context.Background(), Options{
+		DBPath:         dbPath,
+		StatePath:      statePath,
+		CloudURL:       server.URL,
+		OrganizationID: "org_123",
+		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
+		HTTPClient:     server.Client(),
+	}); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if called {
+		t.Fatal("server was called despite cursor being newer than action")
+	}
+}
+
+func testStore(t *testing.T) (*sqlite.Store, string) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "guard.db")
+	store, err := sqlite.OpenStore(dbPath)
+	if err != nil {
+		t.Fatalf("OpenStore() error = %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store, dbPath
+}
+
+func saveTestDecision(t *testing.T, store *sqlite.Store, sessionID, toolUseID string) {
+	t.Helper()
+	_, err := store.SaveDecision(context.Background(), risk.HookEvent{
+		SessionID:     sessionID,
+		Agent:         "claude",
+		CWD:           "/tmp/project",
+		HookEventName: "PreToolUse",
+		ToolName:      "Read",
+		ToolUseID:     toolUseID,
+	}, risk.RiskDecision{
+		Decision:   risk.DecisionAllow,
+		ReasonCode: "OBSERVE_MODE",
+		Reason:     "Allowed in observe mode",
+		RiskEvent: risk.RiskEvent{
+			Operation:      "read",
+			OperationClass: "read",
+			ResourceClass:  "file",
+		},
+	})
+	if err != nil {
+		t.Fatalf("SaveDecision() error = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds managed ledger streaming from `kontext-cli` to the hosted ingestion endpoint at `/api/v1/authorization-ledger/batches`.
- Sends the same local dashboard ledger records plus hosted routing fields: `organization_id`, `installation_id` from `installation.json`, generated `batch_id`, `sent_at`, optional device label, sessions, actions, receipts, and receipt chain anchor.
- Starts the stream loop from managed observe mode after the local runtime host starts, so the normal `claude` managed flow can keep the hosted dashboard updated without blocking hooks.
- Persists a durable cursor after successful hosted ingestion and scopes the default cursor path beside the selected ledger DB, so alternate managed DBs do not share unrelated stream state.

## Review comments

- Addressed: default stream state now follows the selected ledger DB path unless `KONTEXT_MANAGED_STREAM_STATE` explicitly overrides it.
- Addressed: managed observe now returns an error if the stream goroutine exits unexpectedly, instead of silently continuing without hosted streaming.
- Deferred intentionally: ingest authentication headers, tracked in [ENG-383](https://linear.app/cobrowser/issue/ENG-383/add-authenticated-hosted-ledger-ingest-binding-for-managed), because ENG-360’s hosted endpoint is currently no-auth for the pilot wiring pass.

## Verification

- [x] `go test ./...`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`

## Release notes

- [x] conventional commit title matches semver intent
