### PR TITLE
fix(clawpatch): address daily finding

### DIFF
--- a/internal/guard/cli/cli.go
+++ b/internal/guard/cli/cli.go
@@ -406,8 +406,8 @@ func uninstallClaudeHooks(out io.Writer) error {
 		}
 		filtered := make([]any, 0, len(list))
 		for _, entry := range list {
-			if !isGuardHookEntry(entry) {
-				filtered = append(filtered, entry)
+			if updated, keep := removeGuardHookCommands(entry); keep {
+				filtered = append(filtered, updated)
 			}
 		}
 		hooks[hookName] = filtered
@@ -473,8 +473,8 @@ func mergeHooks(raw any, hookCommand string) map[string]any {
 		var list []any
 		if existing, ok := hooks[hookName].([]any); ok {
 			for _, entry := range existing {
-				if !isGuardHookEntry(entry) {
-					list = append(list, entry)
+				if updated, keep := removeGuardHookCommands(entry); keep {
+					list = append(list, updated)
 				}
 			}
 		}
@@ -501,6 +501,38 @@ func mergeHooks(raw any, hookCommand string) map[string]any {
 		hooks[hookName] = list
 	}
 	return hooks
+}
+
+func removeGuardHookCommands(entry any) (any, bool) {
+	group, ok := entry.(map[string]any)
+	if !ok {
+		return entry, !isGuardHookEntry(entry)
+	}
+	rawHooks, ok := group["hooks"].([]any)
+	if !ok {
+		return entry, !isGuardHookEntry(entry)
+	}
+	filtered := make([]any, 0, len(rawHooks))
+	for _, rawHook := range rawHooks {
+		if isGuardHookObject(rawHook) {
+			continue
+		}
+		filtered = append(filtered, rawHook)
+	}
+	if len(filtered) == 0 {
+		return nil, false
+	}
+	group["hooks"] = filtered
+	return group, true
+}
+
+func isGuardHookObject(raw any) bool {
+	hookMap, ok := raw.(map[string]any)
+	if !ok {
+		return false
+	}
+	command, ok := hookMap["command"].(string)
+	return ok && isGuardHookCommand(command)
 }
 
 func isGuardHookEntry(entry any) bool {

--- a/internal/guard/cli/cli_test.go
+++ b/internal/guard/cli/cli_test.go
@@ -107,6 +107,95 @@ func TestMergeHooksInstallsOnlyToolHooks(t *testing.T) {
 	}
 }
 
+func TestMergeHooksPreservesNonGuardHookInMixedGroup(t *testing.T) {
+	t.Parallel()
+
+	hooks := mergeHooks(map[string]any{
+		"PreToolUse": []any{
+			map[string]any{
+				"matcher": "Bash",
+				"hooks": []any{
+					map[string]any{
+						"type":    "command",
+						"command": "/usr/local/bin/custom-hook",
+					},
+					map[string]any{
+						"type":    "command",
+						"command": "/usr/local/bin/kontext hook --agent claude --mode observe",
+					},
+				},
+			},
+		},
+	}, `/usr/local/bin/kontext hook --agent claude --mode "${KONTEXT_MODE:-observe}" --socket /tmp/kontext.sock`)
+
+	list := hooks["PreToolUse"].([]any)
+	group := list[0].(map[string]any)
+	if group["matcher"] != "Bash" {
+		t.Fatalf("matcher = %v, want Bash", group["matcher"])
+	}
+	groupHooks := group["hooks"].([]any)
+	if len(groupHooks) != 1 {
+		t.Fatalf("mixed group hook count = %d, want 1", len(groupHooks))
+	}
+	command := groupHooks[0].(map[string]any)["command"]
+	if command != "/usr/local/bin/custom-hook" {
+		t.Fatalf("preserved command = %v, want custom hook", command)
+	}
+}
+
+func TestUninstallClaudeHooksPreservesNonGuardHookInMixedGroup(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	settings := `{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {"type": "command", "command": "/usr/local/bin/custom-hook"},
+          {"type": "command", "command": "/usr/local/bin/kontext hook --agent claude --mode observe"}
+        ]
+      }
+    ]
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(settings), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	if err := uninstallClaudeHooks(&stdout); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	hooks := got["hooks"].(map[string]any)
+	list := hooks["PreToolUse"].([]any)
+	group := list[0].(map[string]any)
+	if group["matcher"] != "Bash" {
+		t.Fatalf("matcher = %v, want Bash", group["matcher"])
+	}
+	groupHooks := group["hooks"].([]any)
+	if len(groupHooks) != 1 {
+		t.Fatalf("mixed group hook count = %d, want 1", len(groupHooks))
+	}
+	command := groupHooks[0].(map[string]any)["command"]
+	if command != "/usr/local/bin/custom-hook" {
+		t.Fatalf("preserved command = %v, want custom hook", command)
+	}
+}
+
 func TestValidateLocalJudgeURLRejectsHostedURL(t *testing.T) {
 	if err := validateLocalJudgeURL("https://api.example.com/v1"); err == nil {
 		t.Fatal("validateLocalJudgeURL() error = nil, want hosted URL rejection")


### PR DESCRIPTION
## Where We Are

Installing or uninstalling Kontext Guard Claude hooks can delete unrelated hooks when they share the same Claude hook group. The current code removes whole groups based on a string match, so mixed groups lose non-Guard commands.

## Where We Want To Go

Guard hook management should remove only Kontext Guard commands and leave unrelated Claude hooks and their matchers intact. That keeps hook install and uninstall safe for users who already have custom commands in the same group.

## How do we get there

This change filters nested hook commands instead of dropping whole groups, keeps mixed groups when non-Guard commands remain, and adds regression coverage for both merge and uninstall paths in `internal/guard/cli`. Verified with `go test ./...`, `go vet ./...`, `npm exec --yes --package pnpm@10.0.0 -- pnpm install --frozen-lockfile`, `npm exec --yes --package pnpm@10.0.0 -- pnpm --dir web/guard-dashboard typecheck`, and `git diff --check`.
