### PR TITLE
fix: optimize login scope resolution

### DIFF
--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -204,21 +204,18 @@ func resolveLoginScopes(scopes []string) []string {
 	}
 
 	resolved := append([]string(nil), baseScopes...)
+	seen := make(map[string]struct{}, len(baseScopes)+len(scopes))
+	for _, scope := range resolved {
+		seen[scope] = struct{}{}
+	}
 	for _, scope := range scopes {
-		if !hasScope(resolved, scope) {
-			resolved = append(resolved, scope)
+		if _, ok := seen[scope]; ok {
+			continue
 		}
+		seen[scope] = struct{}{}
+		resolved = append(resolved, scope)
 	}
 	return resolved
-}
-
-func hasScope(scopes []string, scope string) bool {
-	for _, existing := range scopes {
-		if existing == scope {
-			return true
-		}
-	}
-	return false
 }
 
 func applyTokenExtraEmailFallback(session *Session, token *oauth2.Token) {

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -67,6 +67,23 @@ func TestResolveLoginScopesDeduplicatesDefaultScopes(t *testing.T) {
 	}
 }
 
+func TestResolveLoginScopesDeduplicatesRepeatedCustomScopes(t *testing.T) {
+	t.Parallel()
+
+	input := []string{"gateway:access", "gateway:access", "profile", "audit:read", "audit:read"}
+	got := resolveLoginScopes(input)
+	want := []string{
+		"openid",
+		"email",
+		"profile",
+		"gateway:access",
+		"audit:read",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("resolveLoginScopes(%#v) = %#v, want %#v", input, got, want)
+	}
+}
+
 func TestDecodeJWTClaims(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Summary
This optimizes internal/auth/oidc.go by deduplicating requested login scopes in one pass.

Before this, resolveLoginScopes rescanned the accumulated scope slice for every requested scope, which made repeated scope merges do avoidable linear work as the requested scope list grew.

Now a single seen-set is the canonical path:

```go
resolved := append([]string(nil), baseScopes...)
seen := make(map[string]struct{}, len(baseScopes)+len(scopes))
for _, scope := range resolved {
    seen[scope] = struct{}{}
}
```

Why
This gives kontext-cli a cheaper runtime path for OIDC login scope resolution:

requested scopes
-> resolveLoginScopes
-> ordered deduplicated scopes

This PR does not broaden behavior beyond the optimization scope.

What changed
Optimized login scope deduplication in internal/auth/oidc.go
Removed repeated linear membership scans
Preserved existing scope order and default scope behavior
Updated tests for repeated custom scopes

Verification
`go test ./internal/auth`
`go test ./...`
`go vet ./...`
`git diff --check`
