### PR TITLE
test(judge): deflake llama-server process timeouts

### DIFF
--- a/internal/guard/judge/llama_server_test.go
+++ b/internal/guard/judge/llama_server_test.go
@@ -15,6 +15,11 @@ import (
 	"time"
 )
 
+const (
+	llamaServerTestStartupTimeout      = 15 * time.Second
+	llamaServerTestEarlyExitMaxElapsed = 5 * time.Second
+)
+
 func TestBuildLlamaServerArgsUsesLocalModel(t *testing.T) {
 	got := BuildLlamaServerArgs(LlamaServerOptions{
 		ModelPath: "/models/qwen.gguf",
@@ -92,7 +97,7 @@ func TestStartLlamaServerHealthCheckAndStop(t *testing.T) {
 		BinaryPath:     binaryPath,
 		ModelPath:      modelPath,
 		Port:           port,
-		StartupTimeout: 2 * time.Second,
+		StartupTimeout: llamaServerTestStartupTimeout,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -113,13 +118,13 @@ func TestStartLlamaServerEarlyExitDoesNotWaitForStopTimeout(t *testing.T) {
 		BinaryPath:     binaryPath,
 		ModelPath:      modelPath,
 		Port:           freeTCPPort(t),
-		StartupTimeout: 2 * time.Second,
+		StartupTimeout: llamaServerTestStartupTimeout,
 	})
 	if err == nil {
 		t.Fatal("StartLlamaServer() error = nil, want early exit error")
 	}
-	if elapsed := time.Since(start); elapsed > 1500*time.Millisecond {
-		t.Fatalf("early exit took %s, want less than 1.5s", elapsed)
+	if elapsed := time.Since(start); elapsed > llamaServerTestEarlyExitMaxElapsed {
+		t.Fatalf("early exit took %s, want less than %s", elapsed, llamaServerTestEarlyExitMaxElapsed)
 	}
 }
 


### PR DESCRIPTION
Summary
This cleans up internal/guard/judge llama-server process tests by making the startup and early-exit timeouts resilient under parallel and race load.

Before this, go test ./... and go test -race ./... could fail on main because the llama-server harness used a 2s startup timeout and a 1.5s early-exit threshold, which was too tight when tests run concurrently.

Now the tests use shared, more realistic thresholds (15s startup timeout; 5s early-exit max), so they pass reliably without changing runtime behavior.

Why
This gives kontext-cli a cleaner maintenance path for the judge runtime test harness:

StartLlamaServer(...)
-> waitHealthy(...) polling loop
-> fake llama-server subprocess
-> stable tests under parallel/race execution

This PR does not broaden behavior beyond the cleanup scope.

What changed
Added shared llama-server test timeout constants
Relaxed startup timeout to 15s
Relaxed early-exit assertion to 5s max

Verification
go test ./internal/guard/judge -count=1
go test ./... -count=1
go vet ./...
go test -race ./...
git diff --check

