### PR TITLE
fix: optimize managed settings validation scan

### DIFF
--- a/internal/claudemanaged/settings.go
+++ b/internal/claudemanaged/settings.go
@@ -157,7 +157,7 @@ func validateEvent(groups []MatcherGroup, event Event, kontextBinary string) err
 
 	wantArgs := []string{"hook", event.Alias}
 	foundValid := false
-	foundRestrictiveMatcher := false
+	firstRestrictiveMatcher := ""
 	for _, group := range groups {
 		for _, handler := range group.Hooks {
 			if isShellFormKontextHandler(handler, kontextBinary) {
@@ -179,7 +179,9 @@ func validateEvent(groups []MatcherGroup, event Event, kontextBinary string) err
 				return err
 			}
 			if !isAllMatcher(group.Matcher) {
-				foundRestrictiveMatcher = true
+				if firstRestrictiveMatcher == "" {
+					firstRestrictiveMatcher = group.Matcher
+				}
 				continue
 			}
 			foundValid = true
@@ -189,8 +191,8 @@ func validateEvent(groups []MatcherGroup, event Event, kontextBinary string) err
 	if foundValid {
 		return nil
 	}
-	if foundRestrictiveMatcher {
-		return fmt.Errorf("%s Kontext command hook uses matcher %q; use an empty matcher for full event coverage", event.Name, firstRestrictiveMatcher(groups, kontextBinary, wantArgs))
+	if firstRestrictiveMatcher != "" {
+		return fmt.Errorf("%s Kontext command hook uses matcher %q; use an empty matcher for full event coverage", event.Name, firstRestrictiveMatcher)
 	}
 	return fmt.Errorf("%s Kontext command hook missing for %s", event.Name, kontextBinary)
 }
@@ -231,17 +233,6 @@ func isShellFormKontextHandler(handler Handler, kontextBinary string) bool {
 func isAllMatcher(value string) bool {
 	matcher := strings.TrimSpace(value)
 	return matcher == "" || matcher == "*"
-}
-
-func firstRestrictiveMatcher(groups []MatcherGroup, kontextBinary string, wantArgs []string) string {
-	for _, group := range groups {
-		for _, handler := range group.Hooks {
-			if handler.Command == kontextBinary && handler.Type == "command" && sameStrings(handler.Args, wantArgs) && !isAllMatcher(group.Matcher) {
-				return group.Matcher
-			}
-		}
-	}
-	return ""
 }
 
 func sameStrings(a, b []string) bool {

--- a/internal/claudemanaged/settings_test.go
+++ b/internal/claudemanaged/settings_test.go
@@ -246,6 +246,31 @@ func TestValidateRejectsInvalidManagedSettings(t *testing.T) {
 			wantErr: "PreToolUse Kontext command hook uses matcher \"Bash\"",
 		},
 		{
+			name: "first restrictive matcher wins",
+			mutate: func(settings Settings) Settings {
+				settings.Hooks["PreToolUse"] = []MatcherGroup{
+					{
+						Matcher: "Bash",
+						Hooks: []Handler{{
+							Type:    "command",
+							Command: "/usr/local/bin/kontext",
+							Args:    []string{"hook", "pre-tool-use"},
+						}},
+					},
+					{
+						Matcher: "Git",
+						Hooks: []Handler{{
+							Type:    "command",
+							Command: "/usr/local/bin/kontext",
+							Args:    []string{"hook", "pre-tool-use"},
+						}},
+					},
+				}
+				return settings
+			},
+			wantErr: "PreToolUse Kontext command hook uses matcher \"Bash\"",
+		},
+		{
 			name: "wrong handler type",
 			mutate: func(settings Settings) Settings {
 				settings.Hooks["PreToolUse"][0].Hooks[0].Type = "prompt"


### PR DESCRIPTION
Summary
This optimizes Claude managed settings validation by keeping restrictive matcher detection in the first scan.

Before this, restrictive matcher validation in internal/claudemanaged/settings.go rescanned the same hook groups after the main handler walk, which made the error path do duplicate work and split the logic across two passes.

Now the first scan is the canonical path:

firstRestrictiveMatcher := ""
for each matching handler {
  if matcher is restrictive and firstRestrictiveMatcher == "" { record it }
}

Why
This gives kontext-cli a cheaper maintenance/runtime path for Claude managed settings validation:

managed-settings json
-> internal/claudemanaged.Validate
-> validateEvent single-pass matcher selection

This PR does not broaden behavior beyond the optimization scope.

What changed
Optimized restrictive matcher handling in internal/claudemanaged/settings.go
Removed the second scan through matcher groups on the restrictive matcher error path
Preserved existing validation behavior and error messages
Updated tests for first restrictive matcher reporting

Verification
go test ./internal/claudemanaged
go vet ./...
git diff --check

go test ./... reached an unrelated flaky baseline failure in internal/guard/judge on TestStartLlamaServerEarlyExitDoesNotWaitForStopTimeout; rerunning that exact test passed without code changes.
