### PR TITLE
fix(clawpatch): address daily finding

### DIFF
--- a/internal/hook/domain.go
+++ b/internal/hook/domain.go
@@ -20,6 +20,15 @@ func (h HookName) String() string {
 	return string(h)
 }
 
+func (h HookName) IsKnown() bool {
+	switch h {
+	case HookSessionStart, HookPreToolUse, HookPostToolUse, HookPostToolUseFailed, HookSessionEnd, HookUserPromptSubmit:
+		return true
+	default:
+		return false
+	}
+}
+
 func (h HookName) CanBlock() bool {
 	return h == HookPreToolUse
 }

--- a/internal/runtimecore/core.go
+++ b/internal/runtimecore/core.go
@@ -87,6 +87,9 @@ func ValidateEvaluateHook(event hook.Event) error {
 	if event.HookName == "" {
 		return errors.New("hook event name is required")
 	}
+	if !event.HookName.IsKnown() {
+		return fmt.Errorf("hook event %q is not recognized", event.HookName)
+	}
 	if !event.HookName.CanBlock() {
 		return fmt.Errorf("hook event %q cannot be evaluated for enforcement", event.HookName)
 	}
@@ -111,6 +114,9 @@ func (c *Core) IngestEvent(ctx context.Context, event hook.Event) (hook.Result, 
 func ValidateIngestEvent(event hook.Event) error {
 	if event.HookName == "" {
 		return errors.New("hook event name is required")
+	}
+	if !event.HookName.IsKnown() {
+		return fmt.Errorf("hook event %q is not recognized", event.HookName)
 	}
 	if event.HookName.CanBlock() {
 		return fmt.Errorf("hook event %q must be evaluated for enforcement", event.HookName)

--- a/internal/runtimecore/core_test.go
+++ b/internal/runtimecore/core_test.go
@@ -54,6 +54,22 @@ func TestProcessHookRoutesByBlockingCapability(t *testing.T) {
 	}
 }
 
+func TestProcessHookRejectsUnknownHookNames(t *testing.T) {
+	runtime := &recordingRuntime{}
+	core, err := New(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = core.ProcessHook(context.Background(), hook.Event{HookName: hook.HookName("pretooluse")})
+	if err == nil {
+		t.Fatal("ProcessHook() error = nil, want unknown hook rejection")
+	}
+	if runtime.evaluateCalls != 0 || runtime.ingestCalls != 0 {
+		t.Fatalf("calls evaluate=%d ingest=%d, want no runtime calls", runtime.evaluateCalls, runtime.ingestCalls)
+	}
+}
+
 func TestProcessHookEnsuresSessionBeforeEvaluation(t *testing.T) {
 	runtime := &recordingSessionRuntime{
 		recordingRuntime: recordingRuntime{


### PR DESCRIPTION
## Where We Are

Clawpatch found that `runtimecore` accepts unknown hook names and routes them through the telemetry path instead of rejecting them. That lets malformed or case-shifted enforcement events bypass fail-closed validation.

## Where We Want To Go

Unknown hook names should fail immediately before the runtime decides whether to evaluate or ingest them. That keeps enforcement strict and makes bad hook payloads visible instead of silently downgrading them.

## How do we get there

Added `HookName.IsKnown()` in `internal/hook/domain.go` and used it in both `ValidateEvaluateHook` and `ValidateIngestEvent` so unknown hook names return an error before routing. Added a regression test that proves `ProcessHook` rejects an unknown hook without calling either runtime path. Verified with `go test ./...`, `go vet ./...`, `npm exec --yes --package pnpm@10.0.0 -- pnpm install --frozen-lockfile`, `npm exec --yes --package pnpm@10.0.0 -- pnpm --dir web/guard-dashboard typecheck`, and `git diff --check`.
