### PR TITLE
refactor(guard): consolidate allow/deny decision type

### DIFF
--- a/internal/guard/decision/decision.go
+++ b/internal/guard/decision/decision.go
@@ -1,0 +1,8 @@
+package decision
+
+type Decision string
+
+const (
+	Allow Decision = "allow"
+	Deny  Decision = "deny"
+)

--- a/internal/guard/judge/types.go
+++ b/internal/guard/judge/types.go
@@ -5,14 +5,16 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-)
 
-type Decision string
+	"github.com/kontext-security/kontext-cli/internal/guard/decision"
+)
 
 const (
-	DecisionAllow Decision = "allow"
-	DecisionDeny  Decision = "deny"
+	DecisionAllow = decision.Allow
+	DecisionDeny  = decision.Deny
 )
+
+type Decision = decision.Decision
 
 type RiskLevel string
 

--- a/internal/guard/policy/types.go
+++ b/internal/guard/policy/types.go
@@ -5,14 +5,16 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-)
 
-type Decision string
+	"github.com/kontext-security/kontext-cli/internal/guard/decision"
+)
 
 const (
-	DecisionAllow Decision = "allow"
-	DecisionDeny  Decision = "deny"
+	DecisionAllow = decision.Allow
+	DecisionDeny  = decision.Deny
 )
+
+type Decision = decision.Decision
 
 type Stage string
 

--- a/internal/guard/risk/types.go
+++ b/internal/guard/risk/types.go
@@ -3,6 +3,8 @@ package risk
 import (
 	"encoding/json"
 	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/guard/decision"
 )
 
 type HookEvent struct {
@@ -28,12 +30,12 @@ const (
 	EventUnknown                      EventType = "unknown"
 )
 
-type Decision string
-
 const (
-	DecisionAllow Decision = "allow"
-	DecisionDeny  Decision = "deny"
+	DecisionAllow = decision.Allow
+	DecisionDeny  = decision.Deny
 )
+
+type Decision = decision.Decision
 
 type AuthorizationDecision string
 


### PR DESCRIPTION
Summary
This cleans up Guard decision typing by consolidating the shared allow/deny `Decision` type across `internal/guard/policy`, `internal/guard/risk`, and `internal/guard/judge`.

Before this, three packages each defined their own `Decision` + `DecisionAllow/DecisionDeny`, which made it easy for those definitions to drift and forced cross-package comparisons to rely on identical string constants.

Now `internal/guard/decision.Decision` is the canonical type:

```go
type Decision = decision.Decision

const (
	DecisionAllow = decision.Allow
	DecisionDeny  = decision.Deny
)
```

Why
Policy evaluation and risk telemetry both speak in allow/deny decisions; they should share the same domain type:

`risk.RiskEvent`
-> `policy.Engine.Evaluate`
-> `policy.Result.Decision` / `judge.Output.Decision`

This PR does not broaden behavior beyond the cleanup scope.

What changed
Added `internal/guard/decision` (canonical allow/deny `Decision`)
Consolidated duplicate `Decision` definitions in policy/risk/judge into type aliases
Kept existing package-level constants (`DecisionAllow/DecisionDeny`) to avoid churn

Verification
`go test ./internal/guard/risk -count=1`
`go test ./internal/guard/policy -count=1`
`go test ./internal/guard/judge -count=1`
`go vet ./...`
`git diff --check`

