### PR TITLE
fix(clawpatch): address daily finding

### DIFF
--- a/web/guard-dashboard/src/App.tsx
+++ b/web/guard-dashboard/src/App.tsx
@@ -119,7 +119,10 @@ export default function App() {
         if (selectedRef.current !== id) return;
         applyEvents(next);
       })
-      .catch((e: unknown) => setError(errorMessage(e)));
+      .catch((e: unknown) => {
+        if (selectedRef.current !== id) return;
+        setError(errorMessage(e));
+      });
   }
 
   function loadPolicy() {


### PR DESCRIPTION
## Where We Are

The guard dashboard can show a stale event-load error after the user has already switched to a different session. That makes the current session look broken even when the failed request belonged to an older session.

## Where We Want To Go

Only the currently selected session should be allowed to update dashboard state. Old event request failures should be ignored the same way old successful responses are already ignored.

## How do we get there

Guard the `loadEvents` error path with the same `selectedRef.current !== id` check already used on the success path, so stale failures cannot overwrite the current session state. Local validation passed for `go vet ./...`, `pnpm install --frozen-lockfile`, `pnpm --dir web/guard-dashboard typecheck`, and `git diff --check`. `go test ./...` still fails in `internal/guard/judge` because `TestStartLlamaServerHealthCheckAndStop` and `TestStartLlamaServerEarlyExitDoesNotWaitForStopTimeout` timed out, which is unrelated to this dashboard-only change.
