### PR TITLE
fix(sidecar): preserve tool payloads on marshal errors

### DIFF
--- a/internal/sidecar/conversions.go
+++ b/internal/sidecar/conversions.go
@@ -2,6 +2,8 @@ package sidecar
 
 import (
 	"encoding/json"
+	"fmt"
+	"reflect"
 
 	agentv1 "github.com/kontext-security/kontext-cli/gen/kontext/agent/v1"
 	"github.com/kontext-security/kontext-cli/internal/backend"
@@ -45,5 +47,118 @@ func marshalMap(value map[string]any) (json.RawMessage, error) {
 	if value == nil {
 		return nil, nil
 	}
-	return json.Marshal(value)
+	data, err := json.Marshal(value)
+	if err == nil {
+		return data, nil
+	}
+
+	// Preserve hook flow, but surface the failure to callers.
+	sanitized := sanitizeMapForJSON(value, 12)
+	sanitizedData, sanitizeErr := json.Marshal(sanitized)
+	if sanitizeErr == nil {
+		return sanitizedData, err
+	}
+
+	// Last resort: ensure we emit valid JSON.
+	fallback, _ := json.Marshal(map[string]any{
+		"kontextMarshalError":         err.Error(),
+		"kontextMarshalFallbackError": sanitizeErr.Error(),
+		"kontextMarshalValueType":     fmt.Sprintf("%T", value),
+	})
+	return fallback, err
+}
+
+func sanitizeMapForJSON(value map[string]any, maxDepth int) map[string]any {
+	seen := map[uintptr]bool{}
+	out := make(map[string]any, len(value))
+	for key, val := range value {
+		out[key] = sanitizeJSONValue(val, 0, maxDepth, seen)
+	}
+	return out
+}
+
+func sanitizeJSONValue(value any, depth, maxDepth int, seen map[uintptr]bool) any {
+	if value == nil {
+		return nil
+	}
+	if depth >= maxDepth {
+		return fmt.Sprintf("<max_depth:%T>", value)
+	}
+
+	switch v := value.(type) {
+	case json.RawMessage:
+		if json.Valid(v) {
+			return v
+		}
+		return string(v)
+	case *json.RawMessage:
+		if v == nil {
+			return nil
+		}
+		if json.Valid(*v) {
+			return *v
+		}
+		return string(*v)
+	case error:
+		return v.Error()
+	}
+
+	rv := reflect.ValueOf(value)
+	for rv.Kind() == reflect.Interface || rv.Kind() == reflect.Pointer {
+		if rv.IsNil() {
+			return nil
+		}
+		rv = rv.Elem()
+	}
+
+	switch rv.Kind() {
+	case reflect.Map:
+		if rv.IsNil() {
+			return nil
+		}
+		ptr := rv.Pointer()
+		if ptr != 0 && seen[ptr] {
+			return "<cycle>"
+		}
+		if ptr != 0 {
+			seen[ptr] = true
+		}
+
+		out := map[string]any{}
+		iter := rv.MapRange()
+		for iter.Next() {
+			key := fmt.Sprint(iter.Key().Interface())
+			out[key] = sanitizeJSONValue(iter.Value().Interface(), depth+1, maxDepth, seen)
+		}
+		return out
+	case reflect.Slice, reflect.Array:
+		// Keep []byte as-is; encoding/json can handle it.
+		if rv.Kind() == reflect.Slice && rv.Type().Elem().Kind() == reflect.Uint8 {
+			return rv.Bytes()
+		}
+		if rv.Kind() == reflect.Slice {
+			ptr := rv.Pointer()
+			if ptr != 0 && seen[ptr] {
+				return "<cycle>"
+			}
+			if ptr != 0 {
+				seen[ptr] = true
+			}
+		}
+
+		n := rv.Len()
+		out := make([]any, 0, n)
+		for i := 0; i < n; i++ {
+			out = append(out, sanitizeJSONValue(rv.Index(i).Interface(), depth+1, maxDepth, seen))
+		}
+		return out
+	case reflect.Struct:
+		// Avoid re-triggering marshal failures on structs with unsupported fields.
+		return fmt.Sprintf("%v", value)
+	case reflect.Func, reflect.Chan, reflect.Complex64, reflect.Complex128, reflect.UnsafePointer:
+		return fmt.Sprintf("<unsupported:%T>", value)
+	default:
+		// Most scalars (string/bool/numbers) pass through fine.
+		return value
+	}
 }

--- a/internal/sidecar/conversions_test.go
+++ b/internal/sidecar/conversions_test.go
@@ -1,6 +1,7 @@
 package sidecar
 
 import (
+	"encoding/json"
 	"testing"
 
 	agentv1 "github.com/kontext-security/kontext-cli/gen/kontext/agent/v1"
@@ -26,5 +27,31 @@ func TestHookResultFromHostedResultMapsProtoDecision(t *testing.T) {
 	}
 	if result.ReasonCode != "needs_approval" || result.RequestID != "req-123" || result.Epoch != "epoch-1" {
 		t.Fatalf("result metadata = %+v, want hosted metadata preserved", result)
+	}
+}
+
+func TestMarshalMapSanitizesUnsupportedTypesAndReturnsError(t *testing.T) {
+	t.Parallel()
+
+	data, err := marshalMap(map[string]any{
+		"fn":     func() {},
+		"nested": map[any]any{1: func() {}},
+	})
+	if err == nil {
+		t.Fatal("marshalMap() err = nil, want error for unsupported types")
+	}
+	var out map[string]any
+	if unmarshalErr := json.Unmarshal(data, &out); unmarshalErr != nil {
+		t.Fatalf("marshalMap() JSON = %s: %v", data, unmarshalErr)
+	}
+	if out["fn"] != "<unsupported:func()>" {
+		t.Fatalf("fn = %v, want unsupported placeholder", out["fn"])
+	}
+	nested, ok := out["nested"].(map[string]any)
+	if !ok {
+		t.Fatalf("nested = %T, want map", out["nested"])
+	}
+	if nested["1"] != "<unsupported:func()>" {
+		t.Fatalf("nested[1] = %v, want unsupported placeholder", nested["1"])
 	}
 }

--- a/internal/sidecar/sidecar.go
+++ b/internal/sidecar/sidecar.go
@@ -2,7 +2,7 @@ package sidecar
 
 import (
 	"context"
-	"encoding/json"
+	"fmt"
 	"net/url"
 	"os"
 	"os/exec"
@@ -248,33 +248,35 @@ func buildHookEventRequestFromEvent(event hook.Event) *agentv1.ProcessHookEventR
 	}
 
 	if event.ToolInput != nil {
-		hookEvent.ToolInput = enrichToolInput(event)
+		input, err := enrichToolInput(event)
+		hookEvent.ToolInput = input
+		hookEvent.Error = appendHookEventError(hookEvent.Error, err, "tool_input marshal")
 	}
 	if event.ToolResponse != nil {
-		hookEvent.ToolResponse, _ = marshalMap(event.ToolResponse)
+		resp, err := marshalMap(event.ToolResponse)
+		hookEvent.ToolResponse = resp
+		hookEvent.Error = appendHookEventError(hookEvent.Error, err, "tool_response marshal")
 	}
 
 	return hookEvent
 }
 
-func enrichToolInput(event hook.Event) []byte {
+func enrichToolInput(event hook.Event) ([]byte, error) {
 	input := cloneMap(event.ToolInput)
 	data, err := marshalMap(input)
-	if err != nil {
-		return nil
-	}
+	// Return best-effort JSON plus the marshal error for upstream reporting.
 	if event.HookName != hook.HookPreToolUse || event.ToolName != "Bash" || event.CWD == "" || len(input) == 0 {
-		return data
+		return data, err
 	}
 	if _, ok := input["command"].(string); !ok {
 		if _, ok := input["cmd"].(string); !ok {
-			return data
+			return data, err
 		}
 	}
 
 	gitContext, ok := collectGitContext(event.CWD)
 	if !ok {
-		return data
+		return data, err
 	}
 
 	kontext, _ := input["kontext"].(map[string]any)
@@ -284,11 +286,13 @@ func enrichToolInput(event hook.Event) []byte {
 	kontext["git"] = gitContext
 	input["kontext"] = kontext
 
-	data, err = json.Marshal(input)
-	if err != nil {
-		return nil
+	enriched, enrichedErr := marshalMap(input)
+	if err == nil {
+		err = enrichedErr
+	} else if enrichedErr != nil {
+		err = joinErrors(err, enrichedErr)
 	}
-	return data
+	return enriched, err
 }
 
 func cloneMap(input map[string]any) map[string]any {
@@ -300,6 +304,28 @@ func cloneMap(input map[string]any) map[string]any {
 		out[key] = value
 	}
 	return out
+}
+
+func appendHookEventError(existing *string, err error, context string) *string {
+	if err == nil {
+		return existing
+	}
+	msg := "sidecar: " + context + " failed: " + err.Error()
+	if existing == nil || *existing == "" {
+		return &msg
+	}
+	combined := *existing + "\n" + msg
+	return &combined
+}
+
+func joinErrors(a, b error) error {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	return fmt.Errorf("%v; %v", a, b)
 }
 
 func collectGitContext(cwd string) (map[string]any, bool) {

--- a/internal/sidecar/sidecar_test.go
+++ b/internal/sidecar/sidecar_test.go
@@ -607,6 +607,65 @@ func TestBuildHookEventRequestPreservesTelemetryPayload(t *testing.T) {
 	assertJSONEqual(t, got.ToolResponse, toolResponse)
 }
 
+func TestBuildHookEventRequestSurfacesToolMarshalFailures(t *testing.T) {
+	t.Parallel()
+
+	got := buildHookEventRequestFromEvent(hook.Event{
+		SessionID:    "session-123",
+		Agent:        "claude",
+		HookName:     hook.HookPostToolUse,
+		ToolName:     "Bash",
+		ToolInput:    map[string]any{"command": func() {}},
+		ToolResponse: map[string]any{"stdout": func() {}},
+	})
+
+	if got.Error == nil {
+		t.Fatal("Error = nil, want marshal failure surfaced")
+	}
+	if !strings.Contains(got.GetError(), "tool_input marshal failed") {
+		t.Fatalf("Error = %q, want tool_input marshal failure context", got.GetError())
+	}
+	if !strings.Contains(got.GetError(), "tool_response marshal failed") {
+		t.Fatalf("Error = %q, want tool_response marshal failure context", got.GetError())
+	}
+
+	var input map[string]any
+	if err := json.Unmarshal(got.ToolInput, &input); err != nil {
+		t.Fatalf("ToolInput JSON = %s: %v", got.ToolInput, err)
+	}
+	if input["command"] != "<unsupported:func()>" {
+		t.Fatalf("ToolInput.command = %v, want unsupported placeholder", input["command"])
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(got.ToolResponse, &resp); err != nil {
+		t.Fatalf("ToolResponse JSON = %s: %v", got.ToolResponse, err)
+	}
+	if resp["stdout"] != "<unsupported:func()>" {
+		t.Fatalf("ToolResponse.stdout = %v, want unsupported placeholder", resp["stdout"])
+	}
+}
+
+func TestBuildHookEventRequestAppendsMarshalFailuresToExistingError(t *testing.T) {
+	t.Parallel()
+
+	got := buildHookEventRequestFromEvent(hook.Event{
+		SessionID: "session-123",
+		Agent:     "claude",
+		HookName:  hook.HookPostToolUse,
+		ToolName:  "Bash",
+		Error:     "tool failed",
+		ToolInput: map[string]any{"command": func() {}},
+	})
+
+	if !strings.Contains(got.GetError(), "tool failed") {
+		t.Fatalf("Error = %q, want original error preserved", got.GetError())
+	}
+	if !strings.Contains(got.GetError(), "tool_input marshal failed") {
+		t.Fatalf("Error = %q, want marshal failure appended", got.GetError())
+	}
+}
+
 func TestBuildHookEventRequestEnrichesBashPreToolUseWithGitContext(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Summary
This cleans up sidecar hook telemetry by stopping JSON marshal failures from silently dropping ToolInput/ToolResponse.

Before this, marshal errors in internal/sidecar would result in nil ToolInput/ToolResponse (and the error was ignored), which made bad payload shapes invisible and removed the best debug signal.

Now internal/sidecar always sends best-effort valid JSON:
- unsupported values are sanitized into placeholders
- the marshal failure is appended into ProcessHookEventRequest.Error

Why
This gives kontext-cli a cleaner maintenance path for hosted hook evaluation:

hook.Event
-> internal/sidecar buildHookEventRequestFromEvent
-> ProcessHookEventRequest with preserved tool payloads
-> backend can debug/triage without missing context

This PR does not broaden behavior beyond the cleanup scope.

What changed
- Preserved ToolInput/ToolResponse by sanitizing unmarshalable values instead of dropping payloads
- Surfaced marshal failures by appending context to the request Error field
- Added tests covering sanitize + error surfacing

Verification
go test ./internal/sidecar -count=1
go test ./... -count=1
go vet ./...
git diff --check

