### PR TITLE
fix: optimize Claude hook status scanning

### DIFF
--- a/internal/guard/cli/cli.go
+++ b/internal/guard/cli/cli.go
@@ -290,7 +290,7 @@ func PrintHookStatus(out io.Writer) {
 	hosted := false
 	guard := false
 	for _, raw := range hooks {
-		for _, command := range hookCommands(raw) {
+		visitHookCommands(raw, func(command string) {
 			switch {
 			case isGuardHookCommand(command):
 				guard = true
@@ -299,7 +299,7 @@ func PrintHookStatus(out io.Writer) {
 				hosted = true
 				fmt.Fprintf(out, "Claude Code hosted hook: %s\n", command)
 			}
-		}
+		})
 	}
 	if guard && hosted {
 		fmt.Fprintln(out, "Claude Code hook mode: conflict (hosted and Guard hooks are both installed)")
@@ -316,12 +316,11 @@ func PrintHookStatus(out io.Writer) {
 	fmt.Fprintln(out, "Claude Code hook mode: no Kontext hook detected")
 }
 
-func hookCommands(raw any) []string {
+func visitHookCommands(raw any, visit func(string)) {
 	groups, ok := raw.([]any)
 	if !ok {
-		return nil
+		return
 	}
-	var commands []string
 	for _, group := range groups {
 		groupMap, ok := group.(map[string]any)
 		if !ok {
@@ -337,11 +336,10 @@ func hookCommands(raw any) []string {
 				continue
 			}
 			if command, ok := hookMap["command"].(string); ok {
-				commands = append(commands, command)
+				visit(command)
 			}
 		}
 	}
-	return commands
 }
 
 func runHooks(args []string, out io.Writer) error {

--- a/internal/guard/cli/cli_test.go
+++ b/internal/guard/cli/cli_test.go
@@ -196,6 +196,50 @@ func TestUninstallClaudeHooksPreservesNonGuardHookInMixedGroup(t *testing.T) {
 	}
 }
 
+func TestPrintHookStatusReportsGuardAndHostedConflict(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	settings := `{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {"type": "command", "command": "/usr/local/bin/kontext hook --agent claude --mode observe"}
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {"type": "command", "command": "/usr/local/bin/kontext hook --agent claude"}
+        ]
+      }
+    ]
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(settings), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	PrintHookStatus(&out)
+
+	got := out.String()
+	if !strings.Contains(got, "Claude Code Guard hook: /usr/local/bin/kontext hook --agent claude --mode observe") {
+		t.Fatalf("PrintHookStatus() = %q, want guard hook line", got)
+	}
+	if !strings.Contains(got, "Claude Code hosted hook: /usr/local/bin/kontext hook --agent claude") {
+		t.Fatalf("PrintHookStatus() = %q, want hosted hook line", got)
+	}
+	if !strings.Contains(got, "Claude Code hook mode: conflict (hosted and Guard hooks are both installed)") {
+		t.Fatalf("PrintHookStatus() = %q, want conflict mode", got)
+	}
+}
+
 func TestValidateLocalJudgeURLRejectsHostedURL(t *testing.T) {
 	if err := validateLocalJudgeURL("https://api.example.com/v1"); err == nil {
 		t.Fatal("validateLocalJudgeURL() error = nil, want hosted URL rejection")


### PR DESCRIPTION
Summary
This optimizes Claude hook status scanning by reading hook commands in one pass instead of building a temporary command slice first.

Before this, `PrintHookStatus` in `internal/guard/cli/cli.go` collected every command into an intermediate `[]string` before classifying it, which added avoidable allocation and an extra pass over the same hook entries.

Now a single visitor is the canonical path:

```go
visitHookCommands(raw, func(command string) {
    // classify command in place
})
```

Why
This gives kontext-cli a cheaper maintenance/runtime path for Claude hook inspection:

Claude settings JSON
-> PrintHookStatus
-> visitHookCommands
-> hook mode output

This PR does not broaden behavior beyond the optimization scope.

What changed
Optimized Claude hook status scanning in `internal/guard/cli/cli.go`
Removed the temporary command slice used during hook inspection
Preserved hosted vs Guard hook detection and output text
Updated tests for mixed hosted and Guard hook conflict output

Verification
`go test ./internal/guard/cli`
`go test ./internal/guard/judge`
`go test ./...`
`go vet ./...`
`git diff --check`
