### PR TITLE
fix(clawpatch): address daily finding

### DIFF
--- a/internal/localruntime/socket.go
+++ b/internal/localruntime/socket.go
@@ -1,9 +1,11 @@
 package localruntime
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 )
 
 func DefaultSocketPath() string {
@@ -14,5 +16,31 @@ func DefaultSocketPath() string {
 }
 
 func EnsureSocketDir(socketPath string) error {
-	return os.MkdirAll(filepath.Dir(socketPath), 0o700)
+	dir := filepath.Dir(socketPath)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s is a symlink", dir)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", dir)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return errors.New("socket directory ownership is unavailable")
+	}
+	if int(stat.Uid) != os.Getuid() {
+		return fmt.Errorf("socket directory %s is owned by uid %d, want %d", dir, stat.Uid, os.Getuid())
+	}
+	if info.Mode().Perm() != 0o700 {
+		if err := os.Chmod(dir, 0o700); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/localruntime/socket_test.go
+++ b/internal/localruntime/socket_test.go
@@ -1,0 +1,52 @@
+package localruntime
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEnsureSocketDirHardensExistingDirectoryPermissions(t *testing.T) {
+	t.Parallel()
+
+	parent := filepath.Join(t.TempDir(), "guard")
+	if err := os.Mkdir(parent, 0o777); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+
+	socketPath := filepath.Join(parent, "kontext.sock")
+	if err := EnsureSocketDir(socketPath); err != nil {
+		t.Fatalf("EnsureSocketDir() error = %v", err)
+	}
+
+	info, err := os.Stat(parent)
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Fatalf("directory mode = %o, want 700", got)
+	}
+}
+
+func TestEnsureSocketDirRejectsSymlinkParent(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	target := filepath.Join(base, "target")
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+	link := filepath.Join(base, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	err := EnsureSocketDir(filepath.Join(link, "kontext.sock"))
+	if err == nil {
+		t.Fatal("EnsureSocketDir() error = nil, want symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "is a symlink") {
+		t.Fatalf("EnsureSocketDir() error = %v, want symlink rejection", err)
+	}
+}


### PR DESCRIPTION
## Where We Are

The Local Guard daemon binds an unauthenticated Unix socket under a predictable /tmp path, but it accepted any pre-existing parent directory state there. That left a hole where a symlinked, permissive, or wrong-owner socket directory could weaken the local trust boundary before the daemon started.

## Where We Want To Go

We want Guard startup to fail closed unless the socket parent directory is a real directory owned by the current user with 0700 permissions, so the runtime socket stays private to the local user.

## How do we get there

This change hardens localruntime.EnsureSocketDir to mirror the managed-observe checks: create the directory if needed, reject symlinks and non-directories, verify current-user ownership, and chmod the directory to 0700 when needed. It also adds focused tests that prove an existing permissive directory is tightened and a symlink parent is rejected. Verification: `go test ./...`, `go vet ./...`, `npm exec --yes --package pnpm@10.0.0 -- pnpm install --frozen-lockfile`, `npm exec --yes --package pnpm@10.0.0 -- pnpm --dir web/guard-dashboard typecheck`, and `git diff --check` all passed.
