### PR TITLE
ENG-410: test(managed): cover hosted device labels

### DIFF
--- a/internal/managedobserve/daemon_test.go
+++ b/internal/managedobserve/daemon_test.go
@@ -91,7 +91,18 @@ func TestDaemonSessionEndClosesHookSessionID(t *testing.T) {
 }
 
 func TestDaemonStreamsLedgerBatches(t *testing.T) {
-	requests := make(chan map[string]any, 1)
+	type ledgerBatchRequest struct {
+		OrganizationID string `json:"organization_id"`
+		InstallationID string `json:"installation_id"`
+		Device         *struct {
+			Label string `json:"label"`
+		} `json:"device,omitempty"`
+		Actions []struct {
+			SessionID string `json:"session_id"`
+		} `json:"authorization_actions"`
+	}
+
+	requests := make(chan ledgerBatchRequest, 1)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v1/authorization-ledger/batches" {
 			t.Fatalf("path = %q", r.URL.Path)
@@ -99,7 +110,7 @@ func TestDaemonStreamsLedgerBatches(t *testing.T) {
 		if got := r.Header.Get("Authorization"); got != "Bearer test-install-token" {
 			t.Fatalf("Authorization = %q, want bearer install token", got)
 		}
-		var body map[string]any
+		var body ledgerBatchRequest
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatalf("Decode() error = %v", err)
 		}
@@ -158,25 +169,23 @@ func TestDaemonStreamsLedgerBatches(t *testing.T) {
 
 	select {
 	case body := <-requests:
-		if body["organization_id"] != "org_123" {
-			t.Fatalf("organization_id = %v", body["organization_id"])
+		if body.OrganizationID != "org_123" {
+			t.Fatalf("organization_id = %q", body.OrganizationID)
 		}
-		if body["installation_id"] != "ins_0123456789abcdefghijklmnopqrstuv" {
-			t.Fatalf("installation_id = %v", body["installation_id"])
+		if body.InstallationID != "ins_0123456789abcdefghijklmnopqrstuv" {
+			t.Fatalf("installation_id = %q", body.InstallationID)
 		}
-		actions, ok := body["authorization_actions"].([]any)
-		if !ok {
-			t.Fatalf("authorization_actions = %#v", body["authorization_actions"])
+		if body.Device == nil || body.Device.Label != "test-mac" {
+			t.Fatalf("device = %+v, want label from managed config", body.Device)
 		}
 		found := false
-		for _, raw := range actions {
-			action, ok := raw.(map[string]any)
-			if ok && action["session_id"] == "claude-stream-session" {
+		for _, action := range body.Actions {
+			if action.SessionID == "claude-stream-session" {
 				found = true
 			}
 		}
 		if !found {
-			t.Fatalf("authorization_actions = %#v, want claude stream session action", body["authorization_actions"])
+			t.Fatalf("authorization_actions = %+v, want claude stream session action", body.Actions)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for hosted ledger batch")

--- a/internal/managedstream/stream_test.go
+++ b/internal/managedstream/stream_test.go
@@ -19,18 +19,7 @@ func TestFlushPostsLedgerBatchWithInstallationIdentity(t *testing.T) {
 	saveTestDecision(t, store, "session-1", "toolu_1")
 
 	var got Payload
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != DefaultEndpoint {
-			t.Fatalf("path = %q, want %q", r.URL.Path, DefaultEndpoint)
-		}
-		if got := r.Header.Get("Authorization"); got != "Bearer test-install-token" {
-			t.Fatalf("Authorization = %q, want bearer install token", got)
-		}
-		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
-			t.Fatalf("Decode() error = %v", err)
-		}
-		w.WriteHeader(http.StatusAccepted)
-	}))
+	server := capturePayloadServer(t, &got)
 	t.Cleanup(server.Close)
 
 	statePath := filepath.Join(t.TempDir(), "stream-state.json")
@@ -74,6 +63,32 @@ func TestFlushPostsLedgerBatchWithInstallationIdentity(t *testing.T) {
 	}
 	if state.UpdatedAfter == "" {
 		t.Fatal("updated_after was not persisted")
+	}
+}
+
+func TestFlushOmitsBlankDeviceLabel(t *testing.T) {
+	store, dbPath := testStore(t)
+	saveTestDecision(t, store, "session-1", "toolu_1")
+
+	var got Payload
+	server := capturePayloadServer(t, &got)
+	t.Cleanup(server.Close)
+
+	if err := Flush(context.Background(), Options{
+		DBPath:         dbPath,
+		StatePath:      filepath.Join(t.TempDir(), "stream-state.json"),
+		CloudURL:       server.URL,
+		OrganizationID: "org_123",
+		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
+		InstallToken:   "test-install-token",
+		DeviceLabel:    " \t\n ",
+		HTTPClient:     server.Client(),
+	}); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+
+	if got.Device != nil {
+		t.Fatalf("device = %+v, want omitted", got.Device)
 	}
 }
 
@@ -176,6 +191,22 @@ func testStore(t *testing.T) (*sqlite.Store, string) {
 	}
 	t.Cleanup(func() { _ = store.Close() })
 	return store, dbPath
+}
+
+func capturePayloadServer(t *testing.T, got *Payload) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != DefaultEndpoint {
+			t.Fatalf("path = %q, want %q", r.URL.Path, DefaultEndpoint)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-install-token" {
+			t.Fatalf("Authorization = %q, want bearer install token", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(got); err != nil {
+			t.Fatalf("Decode() error = %v", err)
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
 }
 
 func saveTestDecision(t *testing.T, store *sqlite.Store, sessionID, toolUseID string) {


### PR DESCRIPTION
## Where We Are

The CLI already reads `managed.json.device.label` and includes it in hosted trace/ledger metadata, but the managed observe daemon and blank-label behavior were not pinned tightly enough by tests. That made it easy to accidentally add hostname, ComputerName, `scutil`, or `os.Hostname` fallback behavior later.

## Where We Want To Go

The hosted device label path should stay explicit: use the configured managed label when it is present, and omit the `device` object when the label is blank. The CLI should not guess a fallback label.

## How do we get there

Strengthen the managed observe daemon test so it decodes the hosted ledger request and asserts the configured `device.label` is forwarded. Add managed stream coverage proving blank labels omit the `device` object instead of sending empty metadata. Verified with `go test ./internal/managedconfig ./internal/managedstream ./internal/managedobserve`, `go test ./...`, `go vet ./...`, `git diff --check`, and the PR CI checks on #227.
