### PR TITLE
fix: optimize managed settings event lookups

### DIFF
--- a/internal/claudemanaged/settings.go
+++ b/internal/claudemanaged/settings.go
@@ -32,6 +32,18 @@ var SupportedEvents = []Event{
 	{Name: hook.HookSessionEnd, Alias: "session-end", Async: true},
 }
 
+var (
+	eventNameByAlias = make(map[string]hook.HookName, len(SupportedEvents))
+	aliasByEventName = make(map[hook.HookName]string, len(SupportedEvents))
+)
+
+func init() {
+	for _, event := range SupportedEvents {
+		eventNameByAlias[event.Alias] = event.Name
+		aliasByEventName[event.Name] = event.Alias
+	}
+}
+
 func DefaultManagedSettingsPath() string {
 	return managedSettingsPathForGOOS(runtime.GOOS)
 }
@@ -131,21 +143,13 @@ func Validate(data []byte, kontextBinary string) error {
 
 func ParseEventAlias(value string) (hook.HookName, bool) {
 	normalized := strings.ToLower(strings.TrimSpace(value))
-	for _, event := range SupportedEvents {
-		if normalized == event.Alias {
-			return event.Name, true
-		}
-	}
-	return "", false
+	name, ok := eventNameByAlias[normalized]
+	return name, ok
 }
 
 func AliasForEvent(name hook.HookName) (string, bool) {
-	for _, event := range SupportedEvents {
-		if event.Name == name {
-			return event.Alias, true
-		}
-	}
-	return "", false
+	alias, ok := aliasByEventName[name]
+	return alias, ok
 }
 
 func validateEvent(groups []MatcherGroup, event Event, kontextBinary string) error {

--- a/internal/claudemanaged/settings_test.go
+++ b/internal/claudemanaged/settings_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/hook"
 )
 
 func TestTemplateIncludesManagedKontextHooks(t *testing.T) {
@@ -317,5 +319,20 @@ func TestParseEventAlias(t *testing.T) {
 	}
 	if _, ok := ParseEventAlias("pretooluse"); ok {
 		t.Fatal("ParseEventAlias(pretooluse) ok = true, want false")
+	}
+}
+
+func TestAliasForEvent(t *testing.T) {
+	t.Parallel()
+
+	got, ok := AliasForEvent(hook.HookPreToolUse)
+	if !ok {
+		t.Fatal("AliasForEvent() ok = false")
+	}
+	if got != "pre-tool-use" {
+		t.Fatalf("AliasForEvent() = %q, want pre-tool-use", got)
+	}
+	if _, ok := AliasForEvent(hook.HookName("Missing")); ok {
+		t.Fatal("AliasForEvent(Missing) ok = true, want false")
 	}
 }


### PR DESCRIPTION
Summary
This optimizes managed settings event lookups by replacing repeated scans of supported events with direct alias and name maps.

Before this, ParseEventAlias and AliasForEvent both rescanned SupportedEvents on every lookup in internal/claudemanaged/settings.go, which made managed hook event resolution do avoidable linear work.

Now precomputed alias and event-name maps are the canonical path:

```go
name, ok := eventNameByAlias[normalized]
alias, ok := aliasByEventName[name]
```

Why
This gives kontext-cli a cheaper maintenance and runtime path for managed settings hook resolution:

managed settings commands
-> internal/claudemanaged event lookup helpers
-> stable hook name and alias resolution

This PR does not broaden behavior beyond the optimization scope.

What changed
Optimized managed settings event alias and reverse-alias lookup
Removed repeated SupportedEvents scans from ParseEventAlias and AliasForEvent
Preserved existing trimming, case normalization, and missing-event behavior
Updated tests for reverse alias lookup behavior

Verification
go test ./internal/claudemanaged
go test ./internal/guard/judge
go test ./...
go vet ./...
git diff --check
