### PR TITLE
fix(clawpatch): guard local runtime socket cleanup

### DIFF
--- a/internal/localruntime/service.go
+++ b/internal/localruntime/service.go
@@ -64,8 +64,16 @@ func NewService(opts Options) (*Service, error) {
 func (s *Service) SocketPath() string { return s.socketPath }
 
 func (s *Service) Start(ctx context.Context) error {
-	if err := os.Remove(s.socketPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("remove stale local runtime socket: %w", err)
+	info, err := os.Lstat(s.socketPath)
+	if err == nil {
+		if info.Mode()&os.ModeSocket == 0 {
+			return fmt.Errorf("local runtime socket path exists and is not a Unix socket: %s", s.socketPath)
+		}
+		if err := os.Remove(s.socketPath); err != nil {
+			return fmt.Errorf("remove stale local runtime socket: %w", err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect local runtime socket: %w", err)
 	}
 	ln, err := net.Listen("unix", s.socketPath)
 	if err != nil {

--- a/internal/localruntime/service_test.go
+++ b/internal/localruntime/service_test.go
@@ -183,6 +183,42 @@ func TestServiceShutdownDrainsAfterSocketRemoveError(t *testing.T) {
 	}
 }
 
+func TestServiceStartRejectsNonSocketPath(t *testing.T) {
+	t.Parallel()
+
+	socketPath := filepath.Join(t.TempDir(), "kontext.sock")
+	if err := os.WriteFile(socketPath, []byte("keep"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	core, err := runtimecore.New(&stubRuntime{})
+	if err != nil {
+		t.Fatalf("runtimecore.New() error = %v", err)
+	}
+	service, err := NewService(Options{
+		SocketPath: socketPath,
+		Core:       core,
+		AgentName:  "claude",
+	})
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	err = service.Start(context.Background())
+	if err == nil {
+		t.Fatal("Start() error = nil, want non-socket path error")
+	}
+	if !strings.Contains(err.Error(), "not a Unix socket") {
+		t.Fatalf("Start() error = %v, want non-socket path error", err)
+	}
+	got, readErr := os.ReadFile(socketPath)
+	if readErr != nil {
+		t.Fatalf("ReadFile() error = %v", readErr)
+	}
+	if string(got) != "keep" {
+		t.Fatalf("socket path contents = %q, want preserved file", got)
+	}
+}
+
 func TestServiceUsesCustomFailureResult(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Where We Are

Starting the local runtime with a custom `--socket` path can delete an arbitrary existing file before the daemon binds its Unix socket. A mistyped socket path can destroy user data instead of failing safely.

## Where We Want To Go

Starting the local runtime should only remove a stale Unix socket. Any regular file, directory, symlink, or other non-socket path should stay intact and return a clear error.

## How do we get there

Check the existing path with `os.Lstat` before cleanup, remove it only when it is a Unix socket, and return an error for any other file type. Added a regression test that pre-creates a regular file at the socket path and asserts `Start` fails without deleting it. Verified with `go test ./...`, `go vet ./...`, `npm exec --yes --package pnpm@10.0.0 -- pnpm install --frozen-lockfile`, `npm exec --yes --package pnpm@10.0.0 -- pnpm --dir web/guard-dashboard typecheck`, and `git diff --check`.
