### PR TITLE
fix: optimize login scope resolution

### DIFF
--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -204,21 +204,18 @@ func resolveLoginScopes(scopes []string) []string {
 	}
 
 	resolved := append([]string(nil), baseScopes...)
+	seen := make(map[string]struct{}, len(baseScopes)+len(scopes))
+	for _, scope := range resolved {
+		seen[scope] = struct{}{}
+	}
 	for _, scope := range scopes {
-		if !hasScope(resolved, scope) {
-			resolved = append(resolved, scope)
+		if _, ok := seen[scope]; ok {
+			continue
 		}
+		seen[scope] = struct{}{}
+		resolved = append(resolved, scope)
 	}
 	return resolved
-}
-
-func hasScope(scopes []string, scope string) bool {
-	for _, existing := range scopes {
-		if existing == scope {
-			return true
-		}
-	}
-	return false
 }
 
 func applyTokenExtraEmailFallback(session *Session, token *oauth2.Token) {

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -67,6 +67,23 @@ func TestResolveLoginScopesDeduplicatesDefaultScopes(t *testing.T) {
 	}
 }
 
+func TestResolveLoginScopesDeduplicatesCustomScopesInOrder(t *testing.T) {
+	t.Parallel()
+
+	input := []string{"gateway:access", "profile", "gateway:access", "org:read"}
+	got := resolveLoginScopes(input)
+	want := []string{
+		"openid",
+		"email",
+		"profile",
+		"gateway:access",
+		"org:read",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("resolveLoginScopes(%#v) = %#v, want %#v", input, got, want)
+	}
+}
+
 func TestDecodeJWTClaims(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Summary
This optimizes login scope resolution by deduplicating requested scopes in one pass.

Before this, `resolveLoginScopes` in `internal/auth/oidc.go` rescanned the growing output slice for every requested scope, which made large custom scope lists do avoidable repeated work during login.

Now one ordered seen-set is the canonical path.

Why
This gives kontext-cli a cheaper runtime path for login scope assembly:

requested scopes
-> resolveLoginScopes
-> deduplicated ordered scope list

This PR does not broaden behavior beyond the optimization scope.

What changed
Optimized `internal/auth/oidc.go` login scope deduplication
Removed repeated linear scans of the growing `resolved` slice
Preserved base-scope precedence and first-seen custom scope order
Updated tests for duplicate custom scope handling

Verification
`go test ./internal/auth`
`go test ./internal/guard/judge -count=1`
`go test ./internal/guard/judge -run 'TestStartLlamaServerHealthCheckAndStop|TestStartLlamaServerEarlyExitDoesNotWaitForStopTimeout' -count=1 -v`
`go test ./...`
`go vet ./...`
`git diff --check`
