### PR TITLE
feat(managed): report deployed package version to ledger

### DIFF
--- a/internal/managedconfig/config.go
+++ b/internal/managedconfig/config.go
@@ -27,6 +27,9 @@ const (
 	DefaultPath  = "/Library/Application Support/Kontext/managed.json"
 	EnvPath      = "KONTEXT_MANAGED_CONFIG"
 	EnvAllowHTTP = "KONTEXT_MANAGED_ALLOW_HTTP_LOCALHOST"
+
+	DeploymentVersionPath    = "/Library/Application Support/Kontext/deployment-version"
+	EnvDeploymentVersionPath = "KONTEXT_DEPLOYMENT_VERSION_PATH"
 )
 
 var ErrNotManaged = errors.New("managed config not found")
@@ -67,6 +70,20 @@ func PathFromEnv() string {
 		return path
 	}
 	return DefaultPath
+}
+
+// DeploymentVersion returns the installed package version recorded in the
+// deployment marker, or "" if the marker is missing or unreadable.
+func DeploymentVersion() string {
+	path := DeploymentVersionPath
+	if override := strings.TrimSpace(os.Getenv(EnvDeploymentVersionPath)); override != "" {
+		path = override
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
 }
 
 func Load() (LoadedConfig, error) {

--- a/internal/managedconfig/config_test.go
+++ b/internal/managedconfig/config_test.go
@@ -203,6 +203,24 @@ func TestPathFromEnvHonorsOverride(t *testing.T) {
 	}
 }
 
+func TestDeploymentVersionReadsAndTrimsMarker(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "deployment-version")
+	if err := os.WriteFile(marker, []byte("  0.2.0\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	t.Setenv(EnvDeploymentVersionPath, marker)
+	if got := DeploymentVersion(); got != "0.2.0" {
+		t.Fatalf("DeploymentVersion() = %q, want %q", got, "0.2.0")
+	}
+}
+
+func TestDeploymentVersionMissingMarkerReturnsEmpty(t *testing.T) {
+	t.Setenv(EnvDeploymentVersionPath, filepath.Join(t.TempDir(), "missing"))
+	if got := DeploymentVersion(); got != "" {
+		t.Fatalf("DeploymentVersion() = %q, want empty", got)
+	}
+}
+
 func TestLoadFileReturnsChecksumAndPath(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "managed.json")
 	if err := os.WriteFile(path, []byte(validConfigJSON()), 0o600); err != nil {

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -77,16 +77,17 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 	streamErr := make(chan error, 1)
 	go func() {
 		streamErr <- managedstream.Run(streamCtx, managedstream.Options{
-			DBPath:         dbPath,
-			StatePath:      opts.StreamStatePath,
-			CloudURL:       loadedConfig.Config.CloudURL,
-			OrganizationID: loadedConfig.Config.OrganizationID,
-			InstallationID: installationState.InstallationID,
-			InstallToken:   installToken,
-			DeviceLabel:    loadedConfig.Config.Device.Label,
-			Interval:       opts.StreamInterval,
-			HTTPClient:     opts.StreamHTTPClient,
-			Diagnostic:     opts.Diagnostic,
+			DBPath:            dbPath,
+			StatePath:         opts.StreamStatePath,
+			CloudURL:          loadedConfig.Config.CloudURL,
+			OrganizationID:    loadedConfig.Config.OrganizationID,
+			InstallationID:    installationState.InstallationID,
+			InstallToken:      installToken,
+			DeviceLabel:       loadedConfig.Config.Device.Label,
+			DeploymentVersion: managedconfig.DeploymentVersion,
+			Interval:          opts.StreamInterval,
+			HTTPClient:        opts.StreamHTTPClient,
+			Diagnostic:        opts.Diagnostic,
 		})
 	}()
 

--- a/internal/managedstream/stream.go
+++ b/internal/managedstream/stream.go
@@ -31,17 +31,18 @@ const (
 )
 
 type Options struct {
-	DBPath         string
-	StatePath      string
-	CloudURL       string
-	OrganizationID string
-	InstallationID string
-	InstallToken   string
-	DeviceLabel    string
-	Interval       time.Duration
-	BatchLimit     int
-	HTTPClient     *http.Client
-	Diagnostic     diagnostic.Logger
+	DBPath            string
+	StatePath         string
+	CloudURL          string
+	OrganizationID    string
+	InstallationID    string
+	InstallToken      string
+	DeviceLabel       string
+	DeploymentVersion func() string
+	Interval          time.Duration
+	BatchLimit        int
+	HTTPClient        *http.Client
+	Diagnostic        diagnostic.Logger
 }
 
 type Payload struct {
@@ -58,7 +59,8 @@ type Payload struct {
 }
 
 type Device struct {
-	Label string `json:"label,omitempty"`
+	Label             string `json:"label,omitempty"`
+	DeploymentVersion string `json:"deployment_version,omitempty"`
 }
 
 type State struct {
@@ -148,8 +150,15 @@ func Flush(ctx context.Context, opts Options) error {
 		Receipts:           batch.Receipts,
 		ReceiptChainAnchor: batch.ReceiptChainAnchor,
 	}
-	if label := strings.TrimSpace(opts.DeviceLabel); label != "" {
-		payload.Device = &Device{Label: label}
+	// Resolve the deployment version per flush so an in-place package upgrade
+	// is reflected without restarting the daemon.
+	label := strings.TrimSpace(opts.DeviceLabel)
+	deploymentVersion := ""
+	if opts.DeploymentVersion != nil {
+		deploymentVersion = strings.TrimSpace(opts.DeploymentVersion())
+	}
+	if label != "" || deploymentVersion != "" {
+		payload.Device = &Device{Label: label, DeploymentVersion: deploymentVersion}
 	}
 	if err := post(ctx, opts, payload); err != nil {
 		return err

--- a/internal/managedstream/stream_test.go
+++ b/internal/managedstream/stream_test.go
@@ -92,6 +92,46 @@ func TestFlushOmitsBlankDeviceLabel(t *testing.T) {
 	}
 }
 
+func TestFlushResolvesDeploymentVersionPerFlush(t *testing.T) {
+	store, dbPath := testStore(t)
+	saveTestDecision(t, store, "session-1", "toolu_1")
+
+	var got Payload
+	server := capturePayloadServer(t, &got)
+	t.Cleanup(server.Close)
+
+	version := "  0.2.0  "
+	flushOpts := func() Options {
+		return Options{
+			DBPath:            dbPath,
+			StatePath:         filepath.Join(t.TempDir(), "stream-state.json"),
+			CloudURL:          server.URL,
+			OrganizationID:    "org_123",
+			InstallationID:    "ins_0123456789abcdefghijklmnopqrstuv",
+			InstallToken:      "test-install-token",
+			DeploymentVersion: func() string { return version },
+			HTTPClient:        server.Client(),
+		}
+	}
+
+	if err := Flush(context.Background(), flushOpts()); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if got.Device == nil || got.Device.DeploymentVersion != "0.2.0" {
+		t.Fatalf("device = %+v, want deployment_version 0.2.0", got.Device)
+	}
+
+	// A later flush reflects a marker change (e.g. in-place upgrade) without
+	// rebuilding the daemon's options. Fresh state path re-posts the decision.
+	version = "0.3.0"
+	if err := Flush(context.Background(), flushOpts()); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if got.Device == nil || got.Device.DeploymentVersion != "0.3.0" {
+		t.Fatalf("device = %+v, want deployment_version 0.3.0", got.Device)
+	}
+}
+
 func TestFlushDoesNotAdvanceCursorWhenHostedBackendFails(t *testing.T) {
 	store, dbPath := testStore(t)
 	saveTestDecision(t, store, "session-1", "toolu_1")


### PR DESCRIPTION
## What

The dashboard's Endpoint inventory needs to show which `.pkg` version each Mac is actually running. That version only lives on disk in the deployment marker (`/Library/Application Support/Kontext/deployment-version`) — we never sent it, so the dashboard was falling back to the CLI build version instead.

This reads that marker and includes it as `device.deployment_version` in each ledger batch, right alongside the device label we already send.

## Notes

- Best-effort: if the marker is missing or unreadable, the field is simply omitted (no behavior change for those endpoints).
- Mirrors the existing `device.label` plumbing — read in the managed-observe daemon, carried through `managedstream.Options`, marshaled on the `Device` envelope.
- The Kontext backend must accept the new `device.deployment_version` field before this rolls out (its `device` schema is strict). That change is landing separately.

## Test

- `go test ./internal/managedstream/... ./internal/managedconfig/...` — marker is read/trimmed (and empty when absent); payload carries `deployment_version` when set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)