### PR TITLE
fix(managed): gate managed loopback HTTP config

### DIFF
--- a/internal/managedconfig/config.go
+++ b/internal/managedconfig/config.go
@@ -24,8 +24,9 @@ const (
 	Mode    = "observe"
 	Agent   = "claude"
 
-	DefaultPath = "/Library/Application Support/Kontext/managed.json"
-	EnvPath     = "KONTEXT_MANAGED_CONFIG"
+	DefaultPath  = "/Library/Application Support/Kontext/managed.json"
+	EnvPath      = "KONTEXT_MANAGED_CONFIG"
+	EnvAllowHTTP = "KONTEXT_MANAGED_ALLOW_HTTP_LOCALHOST"
 )
 
 var ErrNotManaged = errors.New("managed config not found")
@@ -204,8 +205,8 @@ func validateCloudURL(value string) error {
 		return fmt.Errorf("cloud_url is invalid: %w", err)
 	}
 	if parsed.Scheme != "https" {
-		if parsed.Scheme != "http" || !isLoopbackHost(parsed.Hostname()) {
-			return errors.New("cloud_url must use https unless it is loopback http")
+		if parsed.Scheme != "http" || !allowHTTPLoopback(parsed.Hostname()) {
+			return errors.New("cloud_url must use https unless local loopback http is explicitly enabled")
 		}
 	}
 	if parsed.Host == "" || parsed.Hostname() == "" {
@@ -235,7 +236,12 @@ func validateCloudURL(value string) error {
 	return nil
 }
 
-func isLoopbackHost(host string) bool {
+func allowHTTPLoopback(host string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(EnvAllowHTTP))) {
+	case "1", "true", "yes", "on":
+	default:
+		return false
+	}
 	if strings.EqualFold(host, "localhost") {
 		return true
 	}

--- a/internal/managedconfig/config_test.go
+++ b/internal/managedconfig/config_test.go
@@ -106,10 +106,15 @@ func TestParseRejectsInvalidCloudURL(t *testing.T) {
 	}
 }
 
-func TestParseAcceptsLoopbackHTTPCloudURLForLocalE2E(t *testing.T) {
+func TestParseAllowsLoopbackHTTPCloudURLOnlyWithExplicitDevOverride(t *testing.T) {
 	for _, cloudURL := range []string{"http://127.0.0.1:4000", "http://localhost:4000", "http://[::1]:4000"} {
 		t.Run(cloudURL, func(t *testing.T) {
 			input := strings.Replace(validConfigJSON(), "https://api.kontext.dev", cloudURL, 1)
+			if _, err := Parse([]byte(input)); err == nil {
+				t.Fatal("Parse() error = nil, want loopback http rejected without override")
+			}
+
+			t.Setenv(EnvAllowHTTP, "1")
 			cfg, err := Parse([]byte(input))
 			if err != nil {
 				t.Fatalf("Parse() error = %v", err)
@@ -118,6 +123,11 @@ func TestParseAcceptsLoopbackHTTPCloudURLForLocalE2E(t *testing.T) {
 				t.Fatalf("CloudURL = %q, want %q", cfg.CloudURL, cloudURL)
 			}
 		})
+	}
+
+	remote := strings.Replace(validConfigJSON(), "https://api.kontext.dev", "http://api.kontext.dev", 1)
+	if _, err := Parse([]byte(remote)); err == nil {
+		t.Fatal("Parse() error = nil, want remote http rejected with override")
 	}
 }
 


### PR DESCRIPTION
Linear: ENG-419

Summary:
- Requires KONTEXT_MANAGED_ALLOW_HTTP_LOCALHOST=1 before managed config accepts loopback HTTP.
- Keeps production/default managed configs HTTPS-only.

Validation:
- go test ./internal/managedconfig ./internal/managedobserve ./internal/managedstream ./cmd/kontext