### PR TITLE
fix(clawpatch): address daily finding

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "packageManager": "pnpm@10.0.0",
   "scripts": {
     "build": "./scripts/build-guard-dashboard-assets.sh",
-    "test": "go test ./... && go vet ./...",
+    "test": "go test -race ./... && go vet ./...",
     "dev": "pnpm --dir web/guard-dashboard dev"
   }
 }


### PR DESCRIPTION
## Where We Are

The root workspace test script skipped the documented `go test -race ./...` check. A change could pass `pnpm test` while still missing the race detector run that the README tells contributors to use.

## Where We Want To Go

`pnpm test` should enforce the same race detector check the repo documents, so the default local test path catches data races before merge.

## How do we get there

Update the root `test` script in `package.json` to run `go test -race ./...` before `go vet ./...`. Verification: `go test ./...`, `go vet ./...`, `npm exec --yes --package pnpm@10.0.0 -- pnpm install --frozen-lockfile`, `npm exec --yes --package pnpm@10.0.0 -- pnpm --dir web/guard-dashboard typecheck`, and `git diff --check` all passed in the temp checkout.
