### PR TITLE
[AUTOMATION] fix: optimize guard hook entry scan

### DIFF
--- a/internal/guard/cli/cli.go
+++ b/internal/guard/cli/cli.go
@@ -290,7 +290,7 @@ func PrintHookStatus(out io.Writer) {
 	hosted := false
 	guard := false
 	for _, raw := range hooks {
-		visitHookCommands(raw, func(command string) {
+		walkHookCommands(raw, func(command string) bool {
 			switch {
 			case isGuardHookCommand(command):
 				guard = true
@@ -299,6 +299,7 @@ func PrintHookStatus(out io.Writer) {
 				hosted = true
 				fmt.Fprintf(out, "Claude Code hosted hook: %s\n", command)
 			}
+			return false
 		})
 	}
 	if guard && hosted {
@@ -316,10 +317,10 @@ func PrintHookStatus(out io.Writer) {
 	fmt.Fprintln(out, "Claude Code hook mode: no Kontext hook detected")
 }
 
-func visitHookCommands(raw any, visit func(string)) {
+func walkHookCommands(raw any, visit func(string) bool) bool {
 	groups, ok := raw.([]any)
 	if !ok {
-		return
+		return false
 	}
 	for _, group := range groups {
 		groupMap, ok := group.(map[string]any)
@@ -336,10 +337,13 @@ func visitHookCommands(raw any, visit func(string)) {
 				continue
 			}
 			if command, ok := hookMap["command"].(string); ok {
-				visit(command)
+				if visit(command) {
+					return true
+				}
 			}
 		}
 	}
+	return false
 }
 
 func runHooks(args []string, out io.Writer) error {
@@ -534,7 +538,12 @@ func isGuardHookObject(raw any) bool {
 }
 
 func isGuardHookEntry(entry any) bool {
-	return isGuardHookCommand(fmt.Sprintf("%v", entry))
+	if command, ok := entry.(string); ok {
+		return isGuardHookCommand(command)
+	}
+	return walkHookCommands([]any{entry}, func(command string) bool {
+		return isGuardHookCommand(command)
+	})
 }
 
 func isGuardHookCommand(command string) bool {


### PR DESCRIPTION
Summary
This optimizes Guard hook entry scans by walking nested hook commands in place and stopping at the first guard match.

Before this, hook status and uninstall fallback paths could format an entire hook entry with fmt.Sprintf and then scan the full string for a match, which did extra allocation and extra text scanning in internal/guard/cli/cli.go.

Now the canonical path walks the real command fields directly and can return as soon as a guard hook is found.

Why
This gives kontext-cli a cheaper maintenance/runtime path for Claude hook inspection:

Claude settings entry
-> walkHookCommands
-> guard hook classification without whole-entry string formatting

This PR does not broaden behavior beyond the optimization scope.

What changed
Optimized guard hook entry detection in internal/guard/cli/cli.go
Removed whole-entry fmt.Sprintf scanning for nested hook detection
Preserved hosted vs Guard hook classification and uninstall behavior
Updated no tests; existing guard CLI tests cover the touched paths

Verification
go test ./internal/guard/cli
go test ./internal/guard/judge -run 'TestStartLlamaServerHealthCheckAndStop|TestStartLlamaServerEarlyExitDoesNotWaitForStopTimeout' -count=1
go test ./...
go vet ./...
git diff --check

