### PR TITLE
[AUTOMATION] fix: optimize internal/guard/policy evaluation category checks

### DIFF
--- a/internal/guard/policy/engine.go
+++ b/internal/guard/policy/engine.go
@@ -21,9 +21,10 @@ func (e Engine) Evaluate(event risk.RiskEvent, cfg Config) Result {
 	if cfg.RulePack == "" {
 		cfg.RulePack = e.pack.ID
 	}
+	enabled := enabledCategories(cfg.Profile)
 
 	for _, rule := range e.pack.Rules {
-		if !categoryEnabled(cfg.Profile, rule.Category) || !rule.When(event) {
+		if !enabled[rule.Category] || !rule.When(event) {
 			continue
 		}
 		return Result{

--- a/internal/guard/policy/profiles.go
+++ b/internal/guard/policy/profiles.go
@@ -29,7 +29,3 @@ func enabledCategories(profile Profile) map[RuleCategory]bool {
 	}
 	return categories
 }
-
-func categoryEnabled(profile Profile, category RuleCategory) bool {
-	return enabledCategories(profile)[category]
-}


### PR DESCRIPTION
## Summary
This optimizes deterministic policy evaluation by reusing the enabled category set for the full rule pass.

Before this, `internal/guard/policy/engine.go` rebuilt the same profile category map for every rule check, which added repeated allocations on every hook decision.

Now one enabled-category map is built once per evaluation and reused across the rule loop.

## Why
This gives kontext-cli a cheaper runtime path for deterministic guard policy decisions:

hook event
-> `internal/guard/policy.Engine.Evaluate`
-> one profile category map + rule matching result

This PR does not broaden behavior beyond the optimization scope.

## What changed
Optimized deterministic policy category checks in `internal/guard/policy/engine.go`
Removed repeated enabled-category map construction during the per-rule loop
Preserved existing profile gating and rule matching behavior
Used existing policy tests to verify behavior did not change

## Verification
`go test ./internal/guard/policy`
`go test ./internal/guard/judge -run TestStartLlamaServerHealthCheckAndStop -count=1 -v`
`go test ./internal/guard/judge -count=1`
`go test ./...`
`go vet ./...`
`git diff --check`


