### PR TITLE
[AUTOMATION] fix: optimize internal/auth login scope resolution

### DIFF
--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -204,21 +204,18 @@ func resolveLoginScopes(scopes []string) []string {
 	}
 
 	resolved := append([]string(nil), baseScopes...)
+	seen := make(map[string]struct{}, len(baseScopes)+len(scopes))
+	for _, scope := range baseScopes {
+		seen[scope] = struct{}{}
+	}
 	for _, scope := range scopes {
-		if !hasScope(resolved, scope) {
-			resolved = append(resolved, scope)
+		if _, exists := seen[scope]; exists {
+			continue
 		}
+		seen[scope] = struct{}{}
+		resolved = append(resolved, scope)
 	}
 	return resolved
-}
-
-func hasScope(scopes []string, scope string) bool {
-	for _, existing := range scopes {
-		if existing == scope {
-			return true
-		}
-	}
-	return false
 }
 
 func applyTokenExtraEmailFallback(session *Session, token *oauth2.Token) {

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -67,6 +67,23 @@ func TestResolveLoginScopesDeduplicatesDefaultScopes(t *testing.T) {
 	}
 }
 
+func TestResolveLoginScopesDeduplicatesRepeatedCustomScopes(t *testing.T) {
+	t.Parallel()
+
+	input := []string{"gateway:access", "gateway:access", "profile", "audit:read", "audit:read"}
+	got := resolveLoginScopes(input)
+	want := []string{
+		"openid",
+		"email",
+		"profile",
+		"gateway:access",
+		"audit:read",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("resolveLoginScopes(%#v) = %#v, want %#v", input, got, want)
+	}
+}
+
 func TestDecodeJWTClaims(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Summary
This optimizes login scope resolution by deduplicating requested scopes in one pass.

Before this, `resolveLoginScopes` in `internal/auth/oidc.go` rescanned the resolved slice for every requested scope, which made repeated or long custom scope lists more expensive than needed.

Now a small seen-set is the canonical path:

```go
for _, scope := range scopes {
	if _, exists := seen[scope]; exists {
		continue
	}
	seen[scope] = struct{}{}
	resolved = append(resolved, scope)
}
```

Why
This gives kontext-cli a cheaper runtime path for browser login scope setup:

login input scopes
-> `resolveLoginScopes`
-> stable deduplicated OAuth scope list

This PR does not broaden behavior beyond the optimization scope.

What changed
Optimized `internal/auth/oidc.go` scope deduplication
Removed repeated linear scans during custom scope resolution
Preserved scope order and default-versus-custom base scope behavior
Updated tests for repeated custom scopes

Verification
`go test ./internal/auth`
`go test ./internal/guard/judge -run TestStartLlamaServerHealthCheckAndStop -count=1`
`go test ./...`
`go vet ./...`
`git diff --check`
