### PR TITLE
[AUTOMATION] fix(clawpatch): restrict guard daemon to loopback

### DIFF
--- a/internal/guard/cli/cli.go
+++ b/internal/guard/cli/cli.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -117,6 +118,9 @@ func runDaemon(ctx context.Context, args []string, out io.Writer) error {
 	judgePort := fs.Int("judge-port", defaultJudgePort, "managed llama-server port")
 	judgeStartupTimeout := fs.Duration("judge-startup-timeout", defaultJudgeStartupTimeout, "managed llama-server startup timeout")
 	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := validateDaemonAddr(*addr); err != nil {
 		return err
 	}
 	if !*skipHookInstall {
@@ -760,6 +764,21 @@ func validateLocalJudgeURL(value string) error {
 	default:
 		return fmt.Errorf("judge URL must point to localhost")
 	}
+}
+
+func validateDaemonAddr(value string) error {
+	host, _, err := net.SplitHostPort(value)
+	if err != nil {
+		return fmt.Errorf("daemon address must be host:port on localhost: %w", err)
+	}
+	if strings.EqualFold(host, "localhost") {
+		return nil
+	}
+	ip := net.ParseIP(host)
+	if ip == nil || !ip.IsLoopback() {
+		return fmt.Errorf("daemon address must bind to localhost")
+	}
+	return nil
 }
 
 func defaultDBPath() string {

--- a/internal/guard/cli/cli_test.go
+++ b/internal/guard/cli/cli_test.go
@@ -252,6 +252,38 @@ func TestValidateLocalJudgeURLAllowsLoopback(t *testing.T) {
 	}
 }
 
+func TestValidateDaemonAddrAllowsLoopback(t *testing.T) {
+	t.Parallel()
+
+	for _, addr := range []string{
+		"localhost:4765",
+		"127.0.0.1:4765",
+		"127.0.0.2:4765",
+		"[::1]:4765",
+	} {
+		if err := validateDaemonAddr(addr); err != nil {
+			t.Fatalf("validateDaemonAddr(%q) error = %v", addr, err)
+		}
+	}
+}
+
+func TestValidateDaemonAddrRejectsNonLoopback(t *testing.T) {
+	t.Parallel()
+
+	for _, addr := range []string{
+		"0.0.0.0:4765",
+		"[::]:4765",
+		"192.168.1.4:4765",
+		":4765",
+		"example.com:4765",
+		"127.0.0.1",
+	} {
+		if err := validateDaemonAddr(addr); err == nil {
+			t.Fatalf("validateDaemonAddr(%q) error = nil, want rejection", addr)
+		}
+	}
+}
+
 func TestJudgeEvalRunsAllowFixtureAgainstLocalServer(t *testing.T) {
 	var calls int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Where We Are

Guard accepts any --addr or KONTEXT_ADDR value today. If someone starts it on 0.0.0.0:4765, the unauthenticated dashboard and API become reachable off-machine.

## Where We Want To Go

Guard should stay local-only by default. The daemon must reject non-loopback bind addresses before it starts listening.

## How do we get there

Add loopback-only address validation in `runDaemon` and cover accepted and rejected addresses with focused CLI tests. Verified with `go test ./...`, `go vet ./...`, `npm exec --yes --package pnpm@10.0.0 -- pnpm install --frozen-lockfile`, `npm exec --yes --package pnpm@10.0.0 -- pnpm --dir web/guard-dashboard typecheck`, and `git diff --check`.
