### PR TITLE
fix(hook): decode array tool_response from MCP tools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kontext-security/kontext-cli
 
-go 1.25.10
+go 1.25.11
 
 require (
 	connectrpc.com/connect v1.19.2

--- a/internal/hookruntime/claude.go
+++ b/internal/hookruntime/claude.go
@@ -1,6 +1,7 @@
 package hookruntime
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -9,25 +10,25 @@ import (
 )
 
 type claudeHookInput struct {
-	SessionID        string         `json:"session_id"`
-	SessionIDAlt     string         `json:"sessionId"`
-	HookEventName    string         `json:"hook_event_name"`
-	HookEventNameAlt string         `json:"hookEventName"`
-	HookEventLegacy  string         `json:"hook_event"`
-	ToolName         string         `json:"tool_name"`
-	ToolNameAlt      string         `json:"toolName"`
-	ToolInput        map[string]any `json:"tool_input"`
-	ToolInputAlt     map[string]any `json:"toolInput"`
-	ToolResponse     map[string]any `json:"tool_response"`
-	ToolResponseAlt  map[string]any `json:"toolResponse"`
-	ToolUseID        string         `json:"tool_use_id"`
-	ToolUseIDAlt     string         `json:"toolUseId"`
-	ToolUseIDUpper   string         `json:"toolUseID"`
-	CWD              string         `json:"cwd"`
-	PermissionMode   *string        `json:"permission_mode"`
-	DurationMs       *int64         `json:"duration_ms"`
-	Error            *string        `json:"error"`
-	IsInterrupt      *bool          `json:"is_interrupt"`
+	SessionID        string          `json:"session_id"`
+	SessionIDAlt     string          `json:"sessionId"`
+	HookEventName    string          `json:"hook_event_name"`
+	HookEventNameAlt string          `json:"hookEventName"`
+	HookEventLegacy  string          `json:"hook_event"`
+	ToolName         string          `json:"tool_name"`
+	ToolNameAlt      string          `json:"toolName"`
+	ToolInput        map[string]any  `json:"tool_input"`
+	ToolInputAlt     map[string]any  `json:"toolInput"`
+	ToolResponse     json.RawMessage `json:"tool_response"`
+	ToolResponseAlt  json.RawMessage `json:"toolResponse"`
+	ToolUseID        string          `json:"tool_use_id"`
+	ToolUseIDAlt     string          `json:"toolUseId"`
+	ToolUseIDUpper   string          `json:"toolUseID"`
+	CWD              string          `json:"cwd"`
+	PermissionMode   *string         `json:"permission_mode"`
+	DurationMs       *int64          `json:"duration_ms"`
+	Error            *string         `json:"error"`
+	IsInterrupt      *bool           `json:"is_interrupt"`
 }
 
 type claudeHookOutput struct {
@@ -58,7 +59,7 @@ func DecodeClaudeEvent(input []byte, agentName string) (hook.Event, error) {
 		HookName:       hook.HookName(hookName),
 		ToolName:       firstString(h.ToolName, h.ToolNameAlt),
 		ToolInput:      firstMap(h.ToolInput, h.ToolInputAlt),
-		ToolResponse:   firstMap(h.ToolResponse, h.ToolResponseAlt),
+		ToolResponse:   normalizeToolResponse(h.ToolResponse, h.ToolResponseAlt),
 		ToolUseID:      firstString(h.ToolUseID, h.ToolUseIDAlt, h.ToolUseIDUpper),
 		CWD:            h.CWD,
 		PermissionMode: stringPtrValue(h.PermissionMode),
@@ -81,6 +82,28 @@ func firstMap(values ...map[string]any) map[string]any {
 	for _, value := range values {
 		if value != nil {
 			return value
+		}
+	}
+	return nil
+}
+
+// normalizeToolResponse decodes the tool_response payload, which Claude Code
+// delivers as a JSON object for built-in tools but as an array (of content
+// blocks) for MCP tools. Object payloads are returned as-is; any other shape is
+// wrapped under "content" so the rest of the pipeline keeps a map[string]any.
+func normalizeToolResponse(values ...json.RawMessage) map[string]any {
+	for _, raw := range values {
+		trimmed := bytes.TrimSpace(raw)
+		if len(trimmed) == 0 || string(trimmed) == "null" {
+			continue
+		}
+		var obj map[string]any
+		if err := json.Unmarshal(trimmed, &obj); err == nil {
+			return obj
+		}
+		var v any
+		if err := json.Unmarshal(trimmed, &v); err == nil {
+			return map[string]any{"content": v}
 		}
 	}
 	return nil

--- a/internal/hookruntime/claude.go
+++ b/internal/hookruntime/claude.go
@@ -98,17 +98,23 @@ func normalizeToolResponse(values ...json.RawMessage) map[string]any {
 			continue
 		}
 		var obj map[string]any
-		if err := json.Unmarshal(trimmed, &obj); err == nil {
+		if err := decodeUseNumber(trimmed, &obj); err == nil {
 			return obj
 		}
 		var v any
-		decoder := json.NewDecoder(bytes.NewReader(trimmed))
-		decoder.UseNumber()
-		if err := decoder.Decode(&v); err == nil {
+		if err := decodeUseNumber(trimmed, &v); err == nil {
 			return map[string]any{"content": v}
 		}
 	}
 	return nil
+}
+
+// decodeUseNumber unmarshals JSON while preserving numeric precision, so large
+// integer IDs beyond float64's exact range survive recording and hashing.
+func decodeUseNumber(data []byte, dst any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	return decoder.Decode(dst)
 }
 
 func EncodeClaudeResult(hookEventName string, result hook.Result) ([]byte, error) {

--- a/internal/hookruntime/claude.go
+++ b/internal/hookruntime/claude.go
@@ -102,7 +102,9 @@ func normalizeToolResponse(values ...json.RawMessage) map[string]any {
 			return obj
 		}
 		var v any
-		if err := json.Unmarshal(trimmed, &v); err == nil {
+		decoder := json.NewDecoder(bytes.NewReader(trimmed))
+		decoder.UseNumber()
+		if err := decoder.Decode(&v); err == nil {
 			return map[string]any{"content": v}
 		}
 	}

--- a/internal/hookruntime/claude_test.go
+++ b/internal/hookruntime/claude_test.go
@@ -1,6 +1,9 @@
 package hookruntime
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestDecodeClaudeEventToolResponseObject(t *testing.T) {
 	t.Parallel()
@@ -30,6 +33,26 @@ func TestDecodeClaudeEventToolResponseArray(t *testing.T) {
 	}
 	if len(content) != 1 {
 		t.Fatalf("len(content) = %d, want 1", len(content))
+	}
+}
+
+func TestDecodeClaudeEventToolResponsePreservesLargeNumbers(t *testing.T) {
+	t.Parallel()
+
+	// Large IDs must not be rounded through float64 when wrapping array payloads.
+	input := []byte(`{"hook_event_name":"PostToolUse","tool_name":"mcp__x__get","tool_response":[{"id":9007199254740993}]}`)
+	ev, err := DecodeClaudeEvent(input, "claude")
+	if err != nil {
+		t.Fatalf("DecodeClaudeEvent() error = %v", err)
+	}
+	content := ev.ToolResponse["content"].([]any)
+	id := content[0].(map[string]any)["id"]
+	num, ok := id.(json.Number)
+	if !ok {
+		t.Fatalf("id type = %T, want json.Number (UseNumber)", id)
+	}
+	if num.String() != "9007199254740993" {
+		t.Fatalf("id = %s, want 9007199254740993 (no float rounding)", num.String())
 	}
 }
 

--- a/internal/hookruntime/claude_test.go
+++ b/internal/hookruntime/claude_test.go
@@ -39,20 +39,26 @@ func TestDecodeClaudeEventToolResponseArray(t *testing.T) {
 func TestDecodeClaudeEventToolResponsePreservesLargeNumbers(t *testing.T) {
 	t.Parallel()
 
-	// Large IDs must not be rounded through float64 when wrapping array payloads.
-	input := []byte(`{"hook_event_name":"PostToolUse","tool_name":"mcp__x__get","tool_response":[{"id":9007199254740993}]}`)
-	ev, err := DecodeClaudeEvent(input, "claude")
+	// Large IDs must not be rounded through float64, for both array (MCP) and
+	// object (built-in) payloads.
+	arrInput := []byte(`{"hook_event_name":"PostToolUse","tool_name":"mcp__x__get","tool_response":[{"id":9007199254740993}]}`)
+	arrEv, err := DecodeClaudeEvent(arrInput, "claude")
 	if err != nil {
-		t.Fatalf("DecodeClaudeEvent() error = %v", err)
+		t.Fatalf("DecodeClaudeEvent(array) error = %v", err)
 	}
-	content := ev.ToolResponse["content"].([]any)
-	id := content[0].(map[string]any)["id"]
-	num, ok := id.(json.Number)
-	if !ok {
-		t.Fatalf("id type = %T, want json.Number (UseNumber)", id)
+	arrID := arrEv.ToolResponse["content"].([]any)[0].(map[string]any)["id"]
+	if num, ok := arrID.(json.Number); !ok || num.String() != "9007199254740993" {
+		t.Fatalf("array id = %v (%T), want json.Number 9007199254740993", arrID, arrID)
 	}
-	if num.String() != "9007199254740993" {
-		t.Fatalf("id = %s, want 9007199254740993 (no float rounding)", num.String())
+
+	objInput := []byte(`{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_response":{"id":9007199254740993}}`)
+	objEv, err := DecodeClaudeEvent(objInput, "claude")
+	if err != nil {
+		t.Fatalf("DecodeClaudeEvent(object) error = %v", err)
+	}
+	objID := objEv.ToolResponse["id"]
+	if num, ok := objID.(json.Number); !ok || num.String() != "9007199254740993" {
+		t.Fatalf("object id = %v (%T), want json.Number 9007199254740993", objID, objID)
 	}
 }
 

--- a/internal/hookruntime/claude_test.go
+++ b/internal/hookruntime/claude_test.go
@@ -1,0 +1,47 @@
+package hookruntime
+
+import "testing"
+
+func TestDecodeClaudeEventToolResponseObject(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_response":{"stdout":"ok","stderr":""}}`)
+	ev, err := DecodeClaudeEvent(input, "claude")
+	if err != nil {
+		t.Fatalf("DecodeClaudeEvent() error = %v", err)
+	}
+	if got := ev.ToolResponse["stdout"]; got != "ok" {
+		t.Fatalf("ToolResponse[stdout] = %v, want \"ok\"", got)
+	}
+}
+
+func TestDecodeClaudeEventToolResponseArray(t *testing.T) {
+	t.Parallel()
+
+	// MCP tools (e.g. Linear) return tool_response as an array of content blocks.
+	input := []byte(`{"hook_event_name":"PostToolUse","tool_name":"mcp__linear__get_issue","tool_response":[{"type":"text","text":"hello"}]}`)
+	ev, err := DecodeClaudeEvent(input, "claude")
+	if err != nil {
+		t.Fatalf("DecodeClaudeEvent() error = %v, array tool_response must not break decoding", err)
+	}
+	content, ok := ev.ToolResponse["content"].([]any)
+	if !ok {
+		t.Fatalf("ToolResponse[content] type = %T, want []any", ev.ToolResponse["content"])
+	}
+	if len(content) != 1 {
+		t.Fatalf("len(content) = %d, want 1", len(content))
+	}
+}
+
+func TestDecodeClaudeEventToolResponseAbsent(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`{"hook_event_name":"PreToolUse","tool_name":"Bash"}`)
+	ev, err := DecodeClaudeEvent(input, "claude")
+	if err != nil {
+		t.Fatalf("DecodeClaudeEvent() error = %v", err)
+	}
+	if ev.ToolResponse != nil {
+		t.Fatalf("ToolResponse = %v, want nil", ev.ToolResponse)
+	}
+}


### PR DESCRIPTION
## Problem
The `PostToolUse` hook couldn't decode **any** MCP tool result. `claudeHookInput.tool_response` was typed `map[string]any`, but Claude Code delivers MCP tool results (Linear, Gmail, etc.) as a JSON **array** of content blocks. `json.Unmarshal` rejected the whole payload, so the hook aborted before recording the event.

**Impact:** every MCP tool call was silently skipping observation. Built-in tools (which return objects) were unaffected.

## Fix
`internal/hookruntime/claude.go`:
- Changed `tool_response` fields to `json.RawMessage` so decoding no longer fails on shape.
- Added `normalizeToolResponse()`: object payloads pass through unchanged; arrays (and any other non-object shape) are wrapped under `"content"`, keeping the downstream `map[string]any` pipeline (observe DB hashing, risk types) unchanged. Nothing reads specific response keys, so the wrapper is safe.
- Added regression tests for the object / array / absent cases.

## Verification
- `go build ./...` clean
- `go test ./internal/hookruntime/... ./internal/localruntime/...` passes
- Rebuilt `bin/kontext` and confirmed a live Linear MCP call no longer errors

Linear: ENG-430 — https://linear.app/cobrowser/issue/ENG-430/fix-posttooluse-hook-dropping-mcp-tool-responses-array-tool-response

🤖 Generated with [Claude Code](https://claude.com/claude-code)