### PR TITLE
[AUTOMATION] feat: clean up hook name parsing

### DIFF
--- a/internal/hook/domain.go
+++ b/internal/hook/domain.go
@@ -18,16 +18,21 @@ func (h HookName) String() string {
 }
 
 func (h HookName) IsKnown() bool {
-	switch h {
-	case HookSessionStart, HookPreToolUse, HookPostToolUse, HookPostToolUseFailed, HookSessionEnd, HookUserPromptSubmit:
-		return true
-	default:
-		return false
-	}
+	_, ok := ParseHookName(string(h))
+	return ok
 }
 
 func (h HookName) CanBlock() bool {
 	return h == HookPreToolUse
+}
+
+func ParseHookName(value string) (HookName, bool) {
+	switch hookName := HookName(strings.TrimSpace(value)); hookName {
+	case HookSessionStart, HookPreToolUse, HookPostToolUse, HookPostToolUseFailed, HookSessionEnd, HookUserPromptSubmit:
+		return hookName, true
+	default:
+		return "", false
+	}
 }
 
 type Decision string

--- a/internal/hook/domain_test.go
+++ b/internal/hook/domain_test.go
@@ -79,3 +79,33 @@ func TestHookNameCanBlock(t *testing.T) {
 		t.Fatalf("HookUserPromptSubmit.CanBlock() = true, want false")
 	}
 }
+
+func TestParseHookName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want HookName
+		ok   bool
+	}{
+		{name: "exact", in: "PreToolUse", want: HookPreToolUse, ok: true},
+		{name: "trimmed", in: " PostToolUseFailure ", want: HookPostToolUseFailed, ok: true},
+		{name: "unknown", in: "pretooluse", ok: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := ParseHookName(tt.in)
+			if ok != tt.ok {
+				t.Fatalf("ParseHookName(%q) ok = %v, want %v", tt.in, ok, tt.ok)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseHookName(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/localruntime/conversions.go
+++ b/internal/localruntime/conversions.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/kontext-security/kontext-cli/internal/hook"
 )
@@ -49,7 +48,7 @@ func EventFromEvaluateRequest(sessionID, fallbackAgent string, req *EvaluateRequ
 	if req.HookEvent == "" {
 		return hook.Event{}, errors.New("hook event missing")
 	}
-	hookName, ok := normalizeHookName(req.HookEvent)
+	hookName, ok := hook.ParseHookName(req.HookEvent)
 	if !ok {
 		return hook.Event{}, fmt.Errorf("unknown hook event %q", req.HookEvent)
 	}
@@ -140,13 +139,4 @@ func rawMap(data json.RawMessage) (map[string]any, error) {
 		return nil, err
 	}
 	return value, nil
-}
-
-func normalizeHookName(value string) (hook.HookName, bool) {
-	switch hookName := hook.HookName(strings.TrimSpace(value)); hookName {
-	case hook.HookSessionStart, hook.HookPreToolUse, hook.HookPostToolUse, hook.HookPostToolUseFailed, hook.HookSessionEnd, hook.HookUserPromptSubmit:
-		return hookName, true
-	default:
-		return "", false
-	}
 }

--- a/internal/localruntime/service.go
+++ b/internal/localruntime/service.go
@@ -231,7 +231,7 @@ func (s *Service) closeSessionEnd(ctx context.Context, event hook.Event) {
 
 func decodeFailureResult(req *EvaluateRequest) hook.Result {
 	if req != nil {
-		hookName, ok := normalizeHookName(req.HookEvent)
+		hookName, ok := hook.ParseHookName(req.HookEvent)
 		if ok && !hookName.CanBlock() {
 			return hook.Result{
 				Decision: hook.DecisionAllow,


### PR DESCRIPTION
Summary
This cleans up hook name parsing by moving the allowlist into one canonical parser.

Before this, the valid hook-name list lived in `internal/hook/domain.go` and `internal/localruntime/conversions.go`, which made local runtime decoding easier to drift out of sync with the hook domain.

Now `hook.ParseHookName` is the canonical path:

`request hook event -> hook.ParseHookName -> hook.HookName -> local runtime handling`

Why
This gives kontext-cli a cleaner maintenance path for local hook evaluation:

`evaluate request`
`-> shared hook parser`
`-> local runtime decode/failure handling`
`-> consistent known-hook behavior`

This PR does not broaden behavior beyond the cleanup scope.

What changed
Consolidated hook name parsing into `internal/hook.ParseHookName`
Removed the duplicate `normalizeHookName` helper from `internal/localruntime`
Updated tests for parser behavior and the local runtime callers

Verification
`go test ./internal/hook ./internal/localruntime`
`go test ./...`
`go vet ./...`
`git diff --check`

