### PR TITLE
[AUTOMATION] fix: optimize auth login scope dedup

### DIFF
--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -204,21 +204,18 @@ func resolveLoginScopes(scopes []string) []string {
 	}
 
 	resolved := append([]string(nil), baseScopes...)
+	seen := make(map[string]struct{}, len(resolved)+len(scopes))
+	for _, scope := range resolved {
+		seen[scope] = struct{}{}
+	}
 	for _, scope := range scopes {
-		if !hasScope(resolved, scope) {
-			resolved = append(resolved, scope)
+		if _, ok := seen[scope]; ok {
+			continue
 		}
+		seen[scope] = struct{}{}
+		resolved = append(resolved, scope)
 	}
 	return resolved
-}
-
-func hasScope(scopes []string, scope string) bool {
-	for _, existing := range scopes {
-		if existing == scope {
-			return true
-		}
-	}
-	return false
 }
 
 func applyTokenExtraEmailFallback(session *Session, token *oauth2.Token) {

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -67,6 +67,23 @@ func TestResolveLoginScopesDeduplicatesDefaultScopes(t *testing.T) {
 	}
 }
 
+func TestResolveLoginScopesDeduplicatesRepeatedCustomScopes(t *testing.T) {
+	t.Parallel()
+
+	input := []string{"gateway:access", "gateway:access", "repo:read", "repo:read"}
+	got := resolveLoginScopes(input)
+	want := []string{
+		"openid",
+		"email",
+		"profile",
+		"gateway:access",
+		"repo:read",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("resolveLoginScopes(%#v) = %#v, want %#v", input, got, want)
+	}
+}
+
 func TestDecodeJWTClaims(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Summary
This optimizes auth login scope resolution by deduplicating requested scopes in one pass.

Before this, every extra scope scanned the already-built slice in [internal/auth/oidc.go](/Users/michelosswald/.codex/worktrees/edb1/kontext-cli/internal/auth/oidc.go), which turned duplicate filtering into repeated linear work.

Now a small seen-set is the canonical path:

```go
seen := make(map[string]struct{}, len(resolved)+len(scopes))
for _, scope := range resolved {
    seen[scope] = struct{}{}
}
```

Why
This gives kontext-cli a cheaper runtime path for OAuth login scope assembly:

login request
-> resolveLoginScopes
-> ordered deduplicated scope list

This PR does not broaden behavior beyond the optimization scope.

What changed
Optimized OAuth login scope dedup in `resolveLoginScopes`
Removed repeated linear membership scans for every requested scope
Preserved scope order and default-vs-identity scope behavior
Updated tests for repeated custom scope deduplication

Verification
go test ./internal/auth
go test ./internal/guard/judge
go test ./...
go vet ./...
git diff --check
