### PR TITLE
[AUTOMATION] fix(clawpatch): keep Claude settings artifacts private

### DIFF
--- a/internal/guard/cli/cli.go
+++ b/internal/guard/cli/cli.go
@@ -28,7 +28,8 @@ import (
 )
 
 const (
-	defaultBaseURL = "http://" + server.DefaultAddr
+	defaultBaseURL  = "http://" + server.DefaultAddr
+	privateFileMode = 0o600
 )
 
 // Run executes the Kontext command line.
@@ -440,7 +441,8 @@ func readClaudeSettings() (string, map[string]any, error) {
 }
 
 func backupFile(path, label string) error {
-	if _, err := os.Stat(path); os.IsNotExist(err) {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
 		return nil
 	} else if err != nil {
 		return err
@@ -450,16 +452,33 @@ func backupFile(path, label string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(backupPath, input, 0o644)
+	return os.WriteFile(backupPath, input, privateMode(info.Mode()))
 }
 
 func writeJSONFile(path string, value any) error {
+	mode := os.FileMode(privateFileMode)
+	if info, err := os.Stat(path); err == nil {
+		mode = privateMode(info.Mode())
+	} else if !os.IsNotExist(err) {
+		return err
+	}
 	bytes, err := json.MarshalIndent(value, "", "  ")
 	if err != nil {
 		return err
 	}
 	bytes = append(bytes, '\n')
-	return os.WriteFile(path, bytes, 0o644)
+	if err := os.WriteFile(path, bytes, mode); err != nil {
+		return err
+	}
+	return os.Chmod(path, mode)
+}
+
+func privateMode(mode os.FileMode) os.FileMode {
+	private := mode.Perm() & privateFileMode
+	if private == 0 {
+		return privateFileMode
+	}
+	return private
 }
 
 func mergeHooks(raw any, hookCommand string) map[string]any {

--- a/internal/guard/cli/cli_test.go
+++ b/internal/guard/cli/cli_test.go
@@ -196,6 +196,56 @@ func TestUninstallClaudeHooksPreservesNonGuardHookInMixedGroup(t *testing.T) {
 	}
 }
 
+func TestInstallClaudeHooksKeepsSettingsArtifactsPrivate(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(settingsPath, []byte(`{"hooks":{}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	if err := installClaudeHooks(&stdout, filepath.Join(home, "kontext.sock")); err != nil {
+		t.Fatal(err)
+	}
+
+	assertPrivateFileMode(t, settingsPath)
+	backups, err := filepath.Glob(settingsPath + ".kontext-guard-backup-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(backups) != 1 {
+		t.Fatalf("backup count = %d, want 1", len(backups))
+	}
+	assertPrivateFileMode(t, backups[0])
+}
+
+func TestInstallClaudeHooksCreatesNewSettingsFilePrivate(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	var stdout bytes.Buffer
+	if err := installClaudeHooks(&stdout, filepath.Join(home, "kontext.sock")); err != nil {
+		t.Fatal(err)
+	}
+
+	assertPrivateFileMode(t, filepath.Join(home, ".claude", "settings.json"))
+}
+
+func assertPrivateFileMode(t *testing.T, path string) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got&0o077 != 0 {
+		t.Fatalf("%s mode = %04o, want no group/world permissions", path, got)
+	}
+}
+
 func TestPrintHookStatusReportsGuardAndHostedConflict(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
## Where We Are

Claude hook install and uninstall were writing backup and rewritten settings files with broader permissions than the original settings file. A user can start with `~/.claude/settings.json` at `0600` and end up with backup artifacts readable by other local users.

## Where We Want To Go

Keep every Claude settings artifact private. Existing settings, rewritten settings, and generated backups should all stay at private file modes.

## How do we get there

Preserve private permissions when backing up and rewriting Claude settings files, and default new settings files to `0600`. Add focused CLI tests that assert the rewritten settings file and backup file are not group or world readable.

Validation:
- `go test ./...`
- `go vet ./...`
- `npm exec --yes --package pnpm@10.0.0 -- pnpm install --frozen-lockfile`
- `npm exec --yes --package pnpm@10.0.0 -- pnpm --dir web/guard-dashboard typecheck`
- `git diff --check`

