### PR TITLE
[AUTOMATION] feat: clean up runtime host startup

### DIFF
--- a/internal/runtimehost/host.go
+++ b/internal/runtimehost/host.go
@@ -65,6 +65,8 @@ type Host struct {
 	sessionCloseOnce bool
 }
 
+var currentWorkingDir = os.Getwd
+
 func Start(ctx context.Context, opts Options) (*Host, error) {
 	if strings.TrimSpace(opts.AgentName) == "" {
 		return nil, errors.New("runtime host requires agent name")
@@ -174,7 +176,11 @@ func Start(ctx context.Context, opts Options) (*Host, error) {
 
 	cwd := opts.CWD
 	if cwd == "" {
-		cwd, _ = os.Getwd()
+		cwd, err = currentWorkingDir()
+		if err != nil {
+			_ = host.Close(context.Background())
+			return nil, fmt.Errorf("resolve current working directory: %w", err)
+		}
 	}
 	if !opts.SkipInitialSession {
 		if _, err := localServer.RuntimeCore().OpenSession(ctx, runtimecore.Session{

--- a/internal/runtimehost/host_test.go
+++ b/internal/runtimehost/host_test.go
@@ -30,6 +30,28 @@ func TestStartWorksOutsideRepoCWD(t *testing.T) {
 	defer host.Close(context.Background())
 }
 
+func TestStartFailsWhenCurrentDirectoryCannotBeResolved(t *testing.T) {
+	original := currentWorkingDir
+	currentWorkingDir = func() (string, error) {
+		return "", os.ErrNotExist
+	}
+	t.Cleanup(func() {
+		currentWorkingDir = original
+	})
+
+	host, err := Start(context.Background(), Options{
+		AgentName: "claude",
+		DBPath:    filepath.Join(t.TempDir(), "guard.db"),
+	})
+	if err == nil {
+		_ = host.Close(context.Background())
+		t.Fatal("Start() error = nil, want current working directory failure")
+	}
+	if !strings.Contains(err.Error(), "resolve current working directory") {
+		t.Fatalf("error = %v, want current working directory failure", err)
+	}
+}
+
 func TestStartUsesFullSessionIDForSessionDir(t *testing.T) {
 	sessionID := "1234567890abcdef1234567890abcdef"
 	host, err := Start(context.Background(), Options{


### PR DESCRIPTION
Summary
This cleans up runtime host startup by failing fast when the current working directory cannot be resolved.

Before this, internal/runtimehost/host.go ignored the os.Getwd error and opened the initial session with an empty cwd, which hid the real startup failure and made session state harder to trust.

Now runtimehost.Start resolves cwd through one testable helper and stops immediately if that lookup fails:

```go
cwd, err = currentWorkingDir()
if err != nil {
    _ = host.Close(context.Background())
    return nil, fmt.Errorf("resolve current working directory: %w", err)
}
```

Why
This gives kontext-cli a cleaner maintenance path for local runtime startup:

runtimehost.Start
-> cwd resolution
-> explicit failure + cleanup
-> no empty session cwd

This PR does not broaden behavior beyond the cleanup scope.

What changed
Added a test seam for current working directory lookup
Removed the hidden fallback that continued with an empty cwd
Strengthened startup failure handling in runtimehost.Start
Updated tests for cwd resolution failure

Verification
go test ./internal/runtimehost -count=1
go test ./internal/managedobserve -count=1
git diff --check
