### PR TITLE
[AUTOMATION] feat: clean up auth and credential helpers

### DIFF
--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -204,21 +204,18 @@ func resolveLoginScopes(scopes []string) []string {
 	}
 
 	resolved := append([]string(nil), baseScopes...)
+	seen := make(map[string]struct{}, len(resolved)+len(scopes))
+	for _, scope := range resolved {
+		seen[scope] = struct{}{}
+	}
 	for _, scope := range scopes {
-		if !hasScope(resolved, scope) {
-			resolved = append(resolved, scope)
+		if _, ok := seen[scope]; ok {
+			continue
 		}
+		seen[scope] = struct{}{}
+		resolved = append(resolved, scope)
 	}
 	return resolved
-}
-
-func hasScope(scopes []string, scope string) bool {
-	for _, existing := range scopes {
-		if existing == scope {
-			return true
-		}
-	}
-	return false
 }
 
 func applyTokenExtraEmailFallback(session *Session, token *oauth2.Token) {

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -67,6 +67,23 @@ func TestResolveLoginScopesDeduplicatesDefaultScopes(t *testing.T) {
 	}
 }
 
+func TestResolveLoginScopesDeduplicatesRepeatedCustomScopes(t *testing.T) {
+	t.Parallel()
+
+	input := []string{"gateway:access", "custom:write", "gateway:access", "custom:write"}
+	got := resolveLoginScopes(input)
+	want := []string{
+		"openid",
+		"email",
+		"profile",
+		"gateway:access",
+		"custom:write",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("resolveLoginScopes(%#v) = %#v, want %#v", input, got, want)
+	}
+}
+
 func TestDecodeJWTClaims(t *testing.T) {
 	t.Parallel()
 

--- a/internal/credential/credential.go
+++ b/internal/credential/credential.go
@@ -104,15 +104,6 @@ type Resolved struct {
 	Value string // The resolved credential value
 }
 
-// ParseTemplate reads an env template file and extracts credential placeholders.
-func ParseTemplate(path string) ([]Entry, error) {
-	doc, err := LoadTemplateFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("parse template: %w", err)
-	}
-	return doc.Entries, nil
-}
-
 // BuildEnv converts resolved credentials into environment variable assignments.
 func BuildEnv(resolved []Resolved, base []string) []string {
 	env := make([]string, len(base))

--- a/internal/credential/credential_test.go
+++ b/internal/credential/credential_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestParseTemplate(t *testing.T) {
+func TestLoadTemplateFileEntries(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -27,13 +27,14 @@ STRIPE_KEY={{kontext:stripe}}
 		t.Fatalf("write template: %v", err)
 	}
 
-	entries, err := ParseTemplate(path)
+	doc, err := LoadTemplateFile(path)
 	if err != nil {
-		t.Fatalf("ParseTemplate() error = %v", err)
+		t.Fatalf("LoadTemplateFile() error = %v", err)
 	}
+	entries := doc.Entries
 
 	if got, want := len(entries), 3; got != want {
-		t.Fatalf("ParseTemplate() len = %d, want %d", got, want)
+		t.Fatalf("LoadTemplateFile() entries len = %d, want %d", got, want)
 	}
 
 	if got, want := entries[0].EnvVar, "GITHUB_TOKEN"; got != want {


### PR DESCRIPTION
## Summary

This cleans up auth and credential helpers by removing redundant scope scans and deleting an unused template helper.

Before this, `resolveLoginScopes` in `internal/auth/oidc.go` rescanned the accumulated slice for every custom scope, and `ParseTemplate` in `internal/credential/credential.go` exposed a dead wrapper that only its own test used. That made the login and template path harder to reason about.

Now one dedupe pass owns login scope resolution, and `LoadTemplateFile` is the only template parsing entry point:

```go
seen := make(map[string]struct{}, len(resolved)+len(scopes))
for _, scope := range scopes {
    if _, ok := seen[scope]; ok {
        continue
    }
    seen[scope] = struct{}{}
    resolved = append(resolved, scope)
}
```

## Why

This gives kontext-cli a cleaner maintenance path for login and env-template handling:

OIDC login scopes
-> resolveLoginScopes
-> single seen map
-> stable scope order without repeated scans

Env template loading
-> LoadTemplateFile
-> canonical template parser
-> no dead wrapper API

This PR does not broaden behavior beyond the cleanup scope.

## What changed

Consolidated login scope deduplication into one pass in `resolveLoginScopes`
Removed unused `ParseTemplate` from the credential package
Updated tests for repeated custom scopes and template entry loading through `LoadTemplateFile`

## Verification

`go test ./internal/auth ./internal/credential`
`go test ./internal/guard/judge`
`git diff --check`
`bash -lc 'rg -n "\\bParseTemplate\\b" .; test $? -eq 1'`

