### PR TITLE
fix(managedstream): split hosted ingest batches

### DIFF
--- a/internal/managedstream/stream.go
+++ b/internal/managedstream/stream.go
@@ -6,10 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -23,12 +25,21 @@ const (
 	SchemaVersion   = "authorization-ledger-v1"
 	DefaultEndpoint = "/api/v1/authorization-ledger/batches"
 
-	DefaultBatchLimit = 500
+	DefaultBatchLimit = 100
+	MaxPayloadBytes   = 192 * 1024
 	DefaultInterval   = 10 * time.Second
+
+	maxPayloadSessions = 100
+	maxPayloadActions  = 1000
+	maxPayloadReceipts = 2000
+
+	maxErrorBodyBytes = 4096
 
 	envStatePath = "KONTEXT_MANAGED_STREAM_STATE"
 	envInterval  = "KONTEXT_MANAGED_STREAM_INTERVAL"
 )
+
+var hostedErrorSecretPattern = regexp.MustCompile(`(?i)("(?:[^"]*(?:api[_-]?key|authorization|client[_-]?secret|credential|install[_-]?token|password|secret|token)[^"]*)"\s*:\s*")([^"]*)(")`)
 
 type Options struct {
 	DBPath            string
@@ -123,61 +134,88 @@ func Flush(ctx context.Context, opts Options) error {
 		updatedAfter = &parsed
 	}
 
-	limit := opts.BatchLimit
-	if limit <= 0 {
-		limit = DefaultBatchLimit
-	}
-	batch, err := store.LedgerBatch(ctx, sqlite.LedgerExportOptions{
-		UpdatedAfter:   updatedAfter,
-		UpdatedAfterID: state.ActionID,
-		Limit:          limit,
-	})
-	if err != nil {
-		return err
-	}
-	if len(batch.Actions) == 0 {
+	limit := batchLimit(opts.BatchLimit)
+	for {
+		batch, err := store.LedgerBatch(ctx, sqlite.LedgerExportOptions{
+			UpdatedAfter:   updatedAfter,
+			UpdatedAfterID: state.ActionID,
+			Limit:          limit,
+		})
+		if err != nil {
+			return err
+		}
+		if len(batch.Actions) == 0 {
+			return nil
+		}
+
+		payload := Payload{
+			SchemaVersion:      SchemaVersion,
+			OrganizationID:     opts.OrganizationID,
+			InstallationID:     opts.InstallationID,
+			BatchID:            "batch_" + uuid.NewString(),
+			SentAt:             time.Now().UTC().Format(time.RFC3339Nano),
+			Sessions:           batch.Sessions,
+			Actions:            batch.Actions,
+			Receipts:           batch.Receipts,
+			ReceiptChainAnchor: batch.ReceiptChainAnchor,
+		}
+		// Resolve the deployment version per flush so an in-place package upgrade
+		// is reflected without restarting the daemon.
+		label := strings.TrimSpace(opts.DeviceLabel)
+		deploymentVersion := ""
+		if opts.DeploymentVersion != nil {
+			deploymentVersion = strings.TrimSpace(opts.DeploymentVersion())
+		}
+		if label != "" || deploymentVersion != "" {
+			payload.Device = &Device{Label: label, DeploymentVersion: deploymentVersion}
+		}
+
+		body, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		if reason := payloadLimitViolation(payload, len(body)); reason != "" {
+			if limit == 1 {
+				return advancePastMinimumBatch(statePath, batch, reason, nil)
+			}
+			nextLimit := reducedBatchLimit(limit)
+			opts.Diagnostic.Printf(
+				"managed stream payload exceeds hosted limits (%s); reducing batch limit from %d to %d\n",
+				reason,
+				limit,
+				nextLimit,
+			)
+			limit = nextLimit
+			continue
+		}
+
+		if err := post(ctx, opts, body); err != nil {
+			var hostedErr *hostedIngestError
+			if errors.As(err, &hostedErr) && shouldRetryWithSmallerBatch(hostedErr.StatusCode) {
+				if limit == 1 {
+					return err
+				}
+				nextLimit := reducedBatchLimit(limit)
+				opts.Diagnostic.Printf(
+					"managed stream hosted ingest returned status %d; reducing batch limit from %d to %d\n",
+					hostedErr.StatusCode,
+					limit,
+					nextLimit,
+				)
+				limit = nextLimit
+				continue
+			}
+			return err
+		}
+
+		if batch.Cursor != nil {
+			return saveCursor(statePath, batch)
+		}
 		return nil
 	}
-
-	payload := Payload{
-		SchemaVersion:      SchemaVersion,
-		OrganizationID:     opts.OrganizationID,
-		InstallationID:     opts.InstallationID,
-		BatchID:            "batch_" + uuid.NewString(),
-		SentAt:             time.Now().UTC().Format(time.RFC3339Nano),
-		Sessions:           batch.Sessions,
-		Actions:            batch.Actions,
-		Receipts:           batch.Receipts,
-		ReceiptChainAnchor: batch.ReceiptChainAnchor,
-	}
-	// Resolve the deployment version per flush so an in-place package upgrade
-	// is reflected without restarting the daemon.
-	label := strings.TrimSpace(opts.DeviceLabel)
-	deploymentVersion := ""
-	if opts.DeploymentVersion != nil {
-		deploymentVersion = strings.TrimSpace(opts.DeploymentVersion())
-	}
-	if label != "" || deploymentVersion != "" {
-		payload.Device = &Device{Label: label, DeploymentVersion: deploymentVersion}
-	}
-	if err := post(ctx, opts, payload); err != nil {
-		return err
-	}
-
-	if batch.Cursor != nil {
-		return SaveState(statePath, State{
-			UpdatedAfter: batch.Cursor.UpdatedAt.UTC().Format(time.RFC3339Nano),
-			ActionID:     batch.Cursor.ActionID,
-		})
-	}
-	return nil
 }
 
-func post(ctx context.Context, opts Options, payload Payload) error {
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return err
-	}
+func post(ctx context.Context, opts Options, body []byte) error {
 	endpoint, err := endpointURL(opts.CloudURL)
 	if err != nil {
 		return err
@@ -199,9 +237,108 @@ func post(ctx context.Context, opts Options, payload Payload) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("hosted ledger ingest failed: status %d", resp.StatusCode)
+		return &hostedIngestError{
+			StatusCode: resp.StatusCode,
+			Body:       responseBodySummary(resp.Body),
+		}
 	}
 	return nil
+}
+
+type hostedIngestError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *hostedIngestError) Error() string {
+	body := redactHostedErrorBody(e.Body)
+	if body == "" {
+		return fmt.Sprintf("hosted ledger ingest failed: status %d", e.StatusCode)
+	}
+	return fmt.Sprintf("hosted ledger ingest failed: status %d: %s", e.StatusCode, body)
+}
+
+func redactHostedErrorBody(body string) string {
+	redacted := hostedErrorSecretPattern.ReplaceAllString(strings.TrimSpace(body), `${1}[REDACTED]${3}`)
+	return diagnostic.Redact(redacted)
+}
+
+func batchLimit(limit int) int {
+	if limit <= 0 {
+		return DefaultBatchLimit
+	}
+	if limit > DefaultBatchLimit {
+		return DefaultBatchLimit
+	}
+	return limit
+}
+
+func reducedBatchLimit(limit int) int {
+	next := limit / 2
+	if next < 1 {
+		return 1
+	}
+	return next
+}
+
+func shouldRetryWithSmallerBatch(statusCode int) bool {
+	return statusCode == http.StatusBadRequest ||
+		statusCode == http.StatusRequestEntityTooLarge ||
+		statusCode == http.StatusUnprocessableEntity
+}
+
+func payloadLimitViolation(payload Payload, bodyBytes int) string {
+	switch {
+	case len(payload.Sessions) > maxPayloadSessions:
+		return fmt.Sprintf("agent_sessions=%d exceeds max %d", len(payload.Sessions), maxPayloadSessions)
+	case len(payload.Actions) > maxPayloadActions:
+		return fmt.Sprintf("authorization_actions=%d exceeds max %d", len(payload.Actions), maxPayloadActions)
+	case len(payload.Receipts) > maxPayloadReceipts:
+		return fmt.Sprintf("authorization_receipts=%d exceeds max %d", len(payload.Receipts), maxPayloadReceipts)
+	case bodyBytes > MaxPayloadBytes:
+		return fmt.Sprintf("body_bytes=%d exceeds max %d", bodyBytes, MaxPayloadBytes)
+	default:
+		return ""
+	}
+}
+
+func advancePastMinimumBatch(statePath string, batch sqlite.LedgerBatch, reason string, cause error) error {
+	if batch.Cursor == nil {
+		if cause != nil {
+			return cause
+		}
+		return fmt.Errorf("managed stream minimum batch rejected: %s", reason)
+	}
+	if err := saveCursor(statePath, batch); err != nil {
+		return err
+	}
+	if cause != nil {
+		return fmt.Errorf("managed stream advanced cursor past rejected minimum batch (%s): %w", reason, cause)
+	}
+	return fmt.Errorf("managed stream advanced cursor past oversized minimum batch: %s", reason)
+}
+
+func saveCursor(statePath string, batch sqlite.LedgerBatch) error {
+	return SaveState(statePath, State{
+		UpdatedAfter: batch.Cursor.UpdatedAt.UTC().Format(time.RFC3339Nano),
+		ActionID:     batch.Cursor.ActionID,
+	})
+}
+
+func responseBodySummary(body io.Reader) string {
+	data, err := io.ReadAll(io.LimitReader(body, maxErrorBodyBytes+1))
+	if err != nil {
+		return ""
+	}
+	truncated := len(data) > maxErrorBodyBytes
+	if truncated {
+		data = data[:maxErrorBodyBytes]
+	}
+	summary := strings.Join(strings.Fields(string(data)), " ")
+	if truncated {
+		summary += "..."
+	}
+	return summary
 }
 
 func endpointURL(cloudURL string) (string, error) {

--- a/internal/managedstream/stream_test.go
+++ b/internal/managedstream/stream_test.go
@@ -3,10 +3,12 @@ package managedstream
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -159,6 +161,224 @@ func TestFlushDoesNotAdvanceCursorWhenHostedBackendFails(t *testing.T) {
 	}
 }
 
+func TestFlushCapsBatchLimitBeforePosting(t *testing.T) {
+	store, dbPath := testStore(t)
+	for i := 0; i < 80; i++ {
+		saveTestDecision(t, store, fmt.Sprintf("session-%03d", i), fmt.Sprintf("toolu_%03d", i))
+	}
+
+	var got Payload
+	server := capturePayloadServer(t, &got)
+	t.Cleanup(server.Close)
+
+	if err := Flush(context.Background(), Options{
+		DBPath:         dbPath,
+		StatePath:      filepath.Join(t.TempDir(), "stream-state.json"),
+		CloudURL:       server.URL,
+		OrganizationID: "org_123",
+		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
+		InstallToken:   "test-install-token",
+		BatchLimit:     1000,
+		HTTPClient:     server.Client(),
+	}); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+
+	if len(got.Actions) > DefaultBatchLimit {
+		t.Fatalf("posted %d actions, want at most %d", len(got.Actions), DefaultBatchLimit)
+	}
+}
+
+func TestFlushRetriesWithSmallerBatchWhenHostedBackendRejectsSize(t *testing.T) {
+	store, dbPath := testStore(t)
+	for i := 0; i < 4; i++ {
+		saveTestDecision(t, store, fmt.Sprintf("session-%03d", i), fmt.Sprintf("toolu_%03d", i))
+	}
+
+	var actionCounts []int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var got Payload
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("Decode() error = %v", err)
+		}
+		actionCounts = append(actionCounts, len(got.Actions))
+		if len(actionCounts) == 1 {
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			_, _ = w.Write([]byte(`{"message":"payload too large"}`))
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(server.Close)
+
+	statePath := filepath.Join(t.TempDir(), "stream-state.json")
+	if err := Flush(context.Background(), Options{
+		DBPath:         dbPath,
+		StatePath:      statePath,
+		CloudURL:       server.URL,
+		OrganizationID: "org_123",
+		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
+		InstallToken:   "test-install-token",
+		BatchLimit:     4,
+		HTTPClient:     server.Client(),
+	}); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+
+	if len(actionCounts) != 2 {
+		t.Fatalf("request count = %d, want 2", len(actionCounts))
+	}
+	if actionCounts[0] <= actionCounts[1] {
+		t.Fatalf("action counts = %v, want retry with a smaller batch", actionCounts)
+	}
+	state, err := LoadState(statePath)
+	if err != nil {
+		t.Fatalf("LoadState() error = %v", err)
+	}
+	if state.UpdatedAfter == "" {
+		t.Fatal("updated_after was not persisted after smaller retry")
+	}
+}
+
+func TestFlushReportsHostedValidationBody(t *testing.T) {
+	store, dbPath := testStore(t)
+	saveTestDecision(t, store, "session-1", "toolu_1")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"message":"authorization_actions must contain no more than 1000 records"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	err := Flush(context.Background(), Options{
+		DBPath:         dbPath,
+		StatePath:      filepath.Join(t.TempDir(), "stream-state.json"),
+		CloudURL:       server.URL,
+		OrganizationID: "org_123",
+		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
+		InstallToken:   "test-install-token",
+		BatchLimit:     1,
+		HTTPClient:     server.Client(),
+	})
+	if err == nil {
+		t.Fatal("Flush() error = nil, want hosted validation failure")
+	}
+	if !strings.Contains(err.Error(), "status 400") ||
+		!strings.Contains(err.Error(), "authorization_actions must contain no more than 1000 records") {
+		t.Fatalf("Flush() error = %q, want status and response body", err.Error())
+	}
+}
+
+func TestFlushRedactsHostedValidationBody(t *testing.T) {
+	store, dbPath := testStore(t)
+	saveTestDecision(t, store, "session-1", "toolu_1")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"api_key":"raw-api-key","client_secret":"raw-client-secret","install_token":"raw-install-token","password":"raw-password","secret":"raw-secret","token":"raw-token","message":"Bearer raw-bearer"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	err := Flush(context.Background(), Options{
+		DBPath:         dbPath,
+		StatePath:      filepath.Join(t.TempDir(), "stream-state.json"),
+		CloudURL:       server.URL,
+		OrganizationID: "org_123",
+		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
+		InstallToken:   "test-install-token",
+		BatchLimit:     1,
+		HTTPClient:     server.Client(),
+	})
+	if err == nil {
+		t.Fatal("Flush() error = nil, want hosted validation failure")
+	}
+	for _, secret := range []string{
+		"raw-api-key",
+		"raw-client-secret",
+		"raw-install-token",
+		"raw-password",
+		"raw-secret",
+		"raw-token",
+		"raw-bearer",
+	} {
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("Flush() error = %q, want %q redacted", err.Error(), secret)
+		}
+	}
+	if !strings.Contains(err.Error(), "[REDACTED]") {
+		t.Fatalf("Flush() error = %q, want hosted body secrets redacted", err.Error())
+	}
+}
+
+func TestFlushDoesNotAdvanceCursorPastHostedRejectedMinimumBatch(t *testing.T) {
+	store, dbPath := testStore(t)
+	saveTestDecision(t, store, "session-1", "toolu_1")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"message":"schema validation failed"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	statePath := filepath.Join(t.TempDir(), "stream-state.json")
+	err := Flush(context.Background(), Options{
+		DBPath:         dbPath,
+		StatePath:      statePath,
+		CloudURL:       server.URL,
+		OrganizationID: "org_123",
+		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
+		InstallToken:   "test-install-token",
+		BatchLimit:     1,
+		HTTPClient:     server.Client(),
+	})
+	if err == nil {
+		t.Fatal("Flush() error = nil, want hosted validation failure")
+	}
+	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+		t.Fatalf("state file error = %v, want not exist", err)
+	}
+}
+
+func TestFlushAdvancesCursorPastOversizedMinimumBatch(t *testing.T) {
+	store, dbPath := testStore(t)
+	saveLargeTestDecision(t, store, "session-1", "toolu_1")
+
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(server.Close)
+
+	statePath := filepath.Join(t.TempDir(), "stream-state.json")
+	err := Flush(context.Background(), Options{
+		DBPath:         dbPath,
+		StatePath:      statePath,
+		CloudURL:       server.URL,
+		OrganizationID: "org_123",
+		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
+		InstallToken:   "test-install-token",
+		BatchLimit:     1,
+		HTTPClient:     server.Client(),
+	})
+	if err == nil {
+		t.Fatal("Flush() error = nil, want oversized minimum batch diagnostic")
+	}
+	if !strings.Contains(err.Error(), "advanced cursor past oversized minimum batch") {
+		t.Fatalf("Flush() error = %q, want oversized skip diagnostic", err.Error())
+	}
+	if called {
+		t.Fatal("server was called despite oversized local minimum batch")
+	}
+	state, err := LoadState(statePath)
+	if err != nil {
+		t.Fatalf("LoadState() error = %v", err)
+	}
+	if state.UpdatedAfter == "" || state.ActionID == "" {
+		t.Fatalf("state = %+v, want cursor advanced", state)
+	}
+}
+
 func TestFlushDefaultsStatePathBesideLedgerDB(t *testing.T) {
 	t.Setenv(envStatePath, "")
 	store, dbPath := testStore(t)
@@ -266,6 +486,31 @@ func saveTestDecision(t *testing.T, store *sqlite.Store, sessionID, toolUseID st
 			Operation:      "read",
 			OperationClass: "read",
 			ResourceClass:  "file",
+		},
+	})
+	if err != nil {
+		t.Fatalf("SaveDecision() error = %v", err)
+	}
+}
+
+func saveLargeTestDecision(t *testing.T, store *sqlite.Store, sessionID, toolUseID string) {
+	t.Helper()
+	_, err := store.SaveDecision(context.Background(), risk.HookEvent{
+		SessionID:     sessionID,
+		Agent:         "claude",
+		CWD:           "/tmp/project",
+		HookEventName: "PreToolUse",
+		ToolName:      "Write",
+		ToolUseID:     toolUseID,
+	}, risk.RiskDecision{
+		Decision:   risk.DecisionAllow,
+		ReasonCode: "OBSERVE_MODE",
+		Reason:     "Allowed in observe mode",
+		RiskEvent: risk.RiskEvent{
+			Operation:      "write",
+			OperationClass: "write",
+			ResourceClass:  "file",
+			CommandSummary: strings.Repeat("x", MaxPayloadBytes),
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
## Where We Are

Katana managed observe can get stuck when one ledger cursor produces a hosted ingest payload that is too large or rejected. The daemon retries the same cursor every interval and the local error only says the hosted status code.

## Where We Want To Go

Managed observe should keep draining the backlog in smaller hosted batches. If the backend still rejects a single-action batch, the CLI should show the hosted validation body so the next blocker is visible.

## How do we get there

This caps managed-stream batches at 100 actions, keeps serialized uploads under 192 KiB when possible, retries rejected 400/413/422 batches with smaller limits, and includes a redacted response-body summary in the local error. Covered by managed-stream retry/body tests and verified with `go test ./...`.

