### PR TITLE
[AUTOMATION] fix: optimize internal/run connectable credential retry scan

### DIFF
--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -344,6 +344,7 @@ func resolveCredentials(
 	resolved := make([]credential.Resolved, 0, len(entries))
 	failures := make(map[string]error)
 	entryByEnvVar := make(map[string]credential.Entry, len(entries))
+	connectableByEnvVar := make(map[string]credential.Entry)
 
 	for _, entry := range entries {
 		entryByEnvVar[entry.EnvVar] = entry
@@ -352,13 +353,19 @@ func resolveCredentials(
 		if err != nil {
 			printCredentialFailure(entry, err, diagnostics)
 			failures[entry.EnvVar] = err
+			if resolutionErr, ok := err.(*credentialResolutionError); ok && resolutionErr.Reason == failureDisconnected {
+				connectableByEnvVar[entry.EnvVar] = entry
+			} else {
+				delete(connectableByEnvVar, entry.EnvVar)
+			}
 			continue
 		}
 		fmt.Fprintln(os.Stderr, "✓")
+		delete(connectableByEnvVar, entry.EnvVar)
 		resolved = append(resolved, resolvedCredential)
 	}
 
-	connectable := unresolvedConnectableEntries(entryByEnvVar, failures)
+	connectable := sortedConnectableEntries(connectableByEnvVar)
 	if len(connectable) == 0 {
 		printLaunchWarnings(entryByEnvVar, failures, diagnostics)
 		return resolved, nil
@@ -435,17 +442,9 @@ func printHostedConnectInstructions(out io.Writer, providerList, connectURL stri
 	return true
 }
 
-func unresolvedConnectableEntries(entryByEnvVar map[string]credential.Entry, failures map[string]error) []credential.Entry {
-	var entries []credential.Entry
-	for envVar, err := range failures {
-		resolutionErr, ok := err.(*credentialResolutionError)
-		if !ok || resolutionErr.Reason != failureDisconnected {
-			continue
-		}
-		entry, ok := entryByEnvVar[envVar]
-		if !ok {
-			continue
-		}
+func sortedConnectableEntries(entriesByEnvVar map[string]credential.Entry) []credential.Entry {
+	entries := make([]credential.Entry, 0, len(entriesByEnvVar))
+	for _, entry := range entriesByEnvVar {
 		entries = append(entries, entry)
 	}
 	slices.SortFunc(entries, func(a, b credential.Entry) int {

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -673,6 +673,30 @@ func TestResolveCredentialsUsesInjectedProvider(t *testing.T) {
 	}
 }
 
+func TestSortedConnectableEntriesOrdersByEnvVar(t *testing.T) {
+	t.Parallel()
+
+	got := sortedConnectableEntries(map[string]credential.Entry{
+		"LINEAR_API_KEY": {
+			EnvVar:   "LINEAR_API_KEY",
+			Provider: "linear",
+		},
+		"GITHUB_TOKEN": {
+			EnvVar:   "GITHUB_TOKEN",
+			Provider: "github",
+		},
+	})
+	if len(got) != 2 {
+		t.Fatalf("len(sortedConnectableEntries()) = %d, want 2", len(got))
+	}
+	if got[0].EnvVar != "GITHUB_TOKEN" {
+		t.Fatalf("got[0].EnvVar = %q, want %q", got[0].EnvVar, "GITHUB_TOKEN")
+	}
+	if got[1].EnvVar != "LINEAR_API_KEY" {
+		t.Fatalf("got[1].EnvVar = %q, want %q", got[1].EnvVar, "LINEAR_API_KEY")
+	}
+}
+
 func TestHostedCredentialProviderConnectURLUsesOwnSessionAndClientID(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Summary
This optimizes internal/run credential resolution by collecting disconnected entries during the first pass.

Before this, resolveCredentials walked every entry once, then scanned the failure map again to rebuild the disconnected subset for hosted connect retries.

Now the first pass is the canonical path:

```go
if resolutionErr, ok := err.(*credentialResolutionError); ok && resolutionErr.Reason == failureDisconnected {
    connectableByEnvVar[entry.EnvVar] = entry
}
```

Why
This gives kontext-cli a cheaper maintenance/runtime path for managed credential startup:

managed env template entries
-> resolveCredentials first-pass tracking
-> hosted connect retry list

This PR does not broaden behavior beyond the optimization scope.

What changed
Optimized connectable credential collection in internal/run
Removed the extra disconnected-failure rescan before hosted connect retries
Preserved retry ordering, provider grouping, and launch warning behavior
Updated tests for connectable entry ordering

Verification
go test ./internal/run -run 'TestResolveCredentialsUsesInjectedProvider|TestSortedConnectableEntriesOrdersByEnvVar|TestResolveCredentialsReturnsIdentityMismatchError'
go test ./internal/guard/judge -run 'TestStartLlamaServerHealthCheckAndStop|TestStartLlamaServerEarlyExitDoesNotWaitForStopTimeout' -count=1 -v
go test ./internal/guard/judge -count=1
go test ./...
go vet ./...
git diff --check

