### PR TITLE
fix(managedstream): normalize ledger export timestamps

### DIFF
--- a/internal/guard/store/sqlite/ledger.go
+++ b/internal/guard/store/sqlite/ledger.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 )
@@ -117,24 +118,11 @@ order by created_at, id
 }
 
 func (s *Store) AuthorizationActions(ctx context.Context, opts LedgerExportOptions) ([]LedgerRecord, error) {
-	query := authorizationActionsSelect
-	args := []any{}
-	if opts.UpdatedAfter != nil {
-		if opts.UpdatedAfterID != "" {
-			query += "\nwhere updated_at > ? or (updated_at = ? and id > ?)"
-			updatedAfter := opts.UpdatedAfter.Format(time.RFC3339Nano)
-			args = append(args, updatedAfter, updatedAfter, opts.UpdatedAfterID)
-		} else {
-			query += "\nwhere updated_at > ?"
-			args = append(args, opts.UpdatedAfter.Format(time.RFC3339Nano))
-		}
+	actions, err := queryLedgerRecords(ctx, s.db, authorizationActionsSelect)
+	if err != nil {
+		return nil, err
 	}
-	query += "\norder by updated_at, id"
-	if opts.Limit > 0 {
-		query += "\nlimit ?"
-		args = append(args, opts.Limit)
-	}
-	return queryLedgerRecords(ctx, s.db, query, args...)
+	return filterLedgerActions(actions, opts)
 }
 
 func ledgerCursor(actions []LedgerRecord) (*LedgerCursor, error) {
@@ -164,7 +152,11 @@ func (s *Store) authorizationActionsByIDs(ctx context.Context, ids []string) ([]
 	for _, id := range ids {
 		args = append(args, id)
 	}
-	return queryLedgerRecords(ctx, s.db, fmt.Sprintf("%s\nwhere id in (%s)\norder by updated_at, id", authorizationActionsSelect, placeholders), args...)
+	actions, err := queryLedgerRecords(ctx, s.db, fmt.Sprintf("%s\nwhere id in (%s)", authorizationActionsSelect, placeholders), args...)
+	if err != nil {
+		return nil, err
+	}
+	return orderLedgerActions(actions)
 }
 
 func (s *Store) AuthorizationReceipts(ctx context.Context, opts LedgerExportOptions) ([]LedgerRecord, error) {
@@ -258,7 +250,111 @@ func normalizeLedgerString(column, value string) any {
 			return decoded
 		}
 	}
+	if isLedgerTimeColumn(column) {
+		if normalized, ok := normalizeLedgerTimestamp(value); ok {
+			return normalized
+		}
+	}
 	return value
+}
+
+func isLedgerTimeColumn(column string) bool {
+	return strings.HasSuffix(column, "_at")
+}
+
+func normalizeLedgerTimestamp(value string) (string, bool) {
+	if value == "" {
+		return value, false
+	}
+	if parsed, err := time.Parse(time.RFC3339Nano, value); err == nil {
+		return parsed.UTC().Format(time.RFC3339Nano), true
+	}
+	for _, layout := range []string{
+		"2006-01-02T15:04:05.999999999",
+		"2006-01-02T15:04:05",
+	} {
+		parsed, err := time.Parse(layout, value)
+		if err == nil {
+			return parsed.UTC().Format(time.RFC3339Nano), true
+		}
+	}
+	return value, false
+}
+
+func filterLedgerActions(actions []LedgerRecord, opts LedgerExportOptions) ([]LedgerRecord, error) {
+	ordered, err := orderLedgerActions(actions)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]LedgerRecord, 0, len(ordered))
+	for _, action := range ordered {
+		afterCursor, err := ledgerActionAfterCursor(action, opts)
+		if err != nil {
+			return nil, err
+		}
+		if !afterCursor {
+			continue
+		}
+		out = append(out, action)
+		if opts.Limit > 0 && len(out) >= opts.Limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+func orderLedgerActions(actions []LedgerRecord) ([]LedgerRecord, error) {
+	type sortableAction struct {
+		record    LedgerRecord
+		updatedAt time.Time
+		id        string
+	}
+	sortable := make([]sortableAction, 0, len(actions))
+	for _, action := range actions {
+		updatedAt, id, err := ledgerActionCursorValues(action)
+		if err != nil {
+			return nil, err
+		}
+		sortable = append(sortable, sortableAction{record: action, updatedAt: updatedAt, id: id})
+	}
+	sort.SliceStable(sortable, func(i, j int) bool {
+		if sortable[i].updatedAt.Equal(sortable[j].updatedAt) {
+			return sortable[i].id < sortable[j].id
+		}
+		return sortable[i].updatedAt.Before(sortable[j].updatedAt)
+	})
+	ordered := make([]LedgerRecord, 0, len(sortable))
+	for _, action := range sortable {
+		ordered = append(ordered, action.record)
+	}
+	return ordered, nil
+}
+
+func ledgerActionAfterCursor(action LedgerRecord, opts LedgerExportOptions) (bool, error) {
+	if opts.UpdatedAfter == nil {
+		return true, nil
+	}
+	updatedAt, actionID, err := ledgerActionCursorValues(action)
+	if err != nil {
+		return false, err
+	}
+	if updatedAt.After(*opts.UpdatedAfter) {
+		return true, nil
+	}
+	return updatedAt.Equal(*opts.UpdatedAfter) && opts.UpdatedAfterID != "" && actionID > opts.UpdatedAfterID, nil
+}
+
+func ledgerActionCursorValues(action LedgerRecord) (time.Time, string, error) {
+	rawUpdatedAt, _ := action["updated_at"].(string)
+	actionID, _ := action["id"].(string)
+	if rawUpdatedAt == "" || actionID == "" {
+		return time.Time{}, actionID, nil
+	}
+	updatedAt, err := time.Parse(time.RFC3339Nano, rawUpdatedAt)
+	if err != nil {
+		return time.Time{}, actionID, err
+	}
+	return updatedAt, actionID, nil
 }
 
 func sessionIDs(groups ...[]LedgerRecord) []string {

--- a/internal/guard/store/sqlite/store_test.go
+++ b/internal/guard/store/sqlite/store_test.go
@@ -956,6 +956,214 @@ where id in (?, ?)
 	}
 }
 
+func TestLedgerBatchNormalizesNaiveTimestampsForHostedExport(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	for _, hookEvent := range []string{"SessionStart", "SessionEnd"} {
+		if _, err := store.SaveDecision(context.Background(), risk.HookEvent{
+			SessionID:     "s1",
+			Agent:         "claude-code",
+			HookEventName: hookEvent,
+			CWD:           "/tmp/project",
+		}, risk.RiskDecision{
+			Decision:   risk.DecisionAllow,
+			Reason:     "async telemetry event recorded",
+			ReasonCode: "async_telemetry",
+			RiskEvent:  risk.RiskEvent{Type: risk.EventNormalToolCall},
+		}); err != nil {
+			t.Fatalf("SaveDecision(%s) error = %v", hookEvent, err)
+		}
+	}
+
+	naive := "2026-06-08T12:20:07.853885"
+	if _, err := store.db.ExecContext(context.Background(), `
+update authorization_actions
+set proposed_at = case when proposed_at is null then null else ? end,
+    completed_at = case when completed_at is null then null else ? end,
+    created_at = ?,
+    updated_at = ?
+where session_id = ?
+	`, naive, naive, naive, naive, "s1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(context.Background(), `
+update authorization_receipts
+set created_at = ?
+where session_id = ?
+	`, naive, "s1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(context.Background(), `
+update agent_sessions
+set status = 'closed',
+    closed_at = ?,
+    created_at = ?,
+    updated_at = ?
+where id = ?
+	`, naive, naive, naive, "s1"); err != nil {
+		t.Fatal(err)
+	}
+
+	batch, err := store.LedgerBatch(context.Background(), LedgerExportOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Sessions) != 1 || len(batch.Actions) != 2 || len(batch.Receipts) != 2 {
+		t.Fatalf("batch sizes sessions=%d actions=%d receipts=%d, want 1/2/2", len(batch.Sessions), len(batch.Actions), len(batch.Receipts))
+	}
+	for _, record := range append(append([]LedgerRecord{}, batch.Sessions...), append(batch.Actions, batch.Receipts...)...) {
+		assertLedgerTimestampHasOffset(t, record, "created_at")
+		assertLedgerTimestampHasOffset(t, record, "updated_at")
+		assertLedgerTimestampHasOffset(t, record, "closed_at")
+		assertLedgerTimestampHasOffset(t, record, "proposed_at")
+		assertLedgerTimestampHasOffset(t, record, "completed_at")
+	}
+	if batch.Cursor == nil {
+		t.Fatal("cursor = nil")
+	}
+	if got := batch.Cursor.UpdatedAt.Format(time.RFC3339Nano); got != "2026-06-08T12:20:07.853885Z" {
+		t.Fatalf("cursor updated_at = %q, want normalized UTC timestamp", got)
+	}
+}
+
+func TestLedgerBatchCursorComparesNaiveTimestampsAfterNormalization(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	for _, hookEvent := range []string{"SessionStart", "SessionEnd"} {
+		if _, err := store.SaveDecision(context.Background(), risk.HookEvent{
+			SessionID:     "s1",
+			Agent:         "claude-code",
+			HookEventName: hookEvent,
+			CWD:           "/tmp/project",
+		}, risk.RiskDecision{
+			Decision:   risk.DecisionAllow,
+			Reason:     "async telemetry event recorded",
+			ReasonCode: "async_telemetry",
+			RiskEvent:  risk.RiskEvent{Type: risk.EventNormalToolCall},
+		}); err != nil {
+			t.Fatalf("SaveDecision(%s) error = %v", hookEvent, err)
+		}
+	}
+
+	naive := "2026-06-08T12:20:07.853885"
+	if _, err := store.db.ExecContext(context.Background(), `
+update authorization_actions
+set created_at = ?,
+    updated_at = ?
+where session_id = ?
+	`, naive, naive, "s1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(context.Background(), `
+update authorization_receipts
+set created_at = ?
+where session_id = ?
+	`, naive, "s1"); err != nil {
+		t.Fatal(err)
+	}
+
+	actionIDs := ledgerActionIDs(t, store, "s1")
+	if len(actionIDs) != 2 {
+		t.Fatalf("action IDs = %+v, want 2", actionIDs)
+	}
+	firstBatch, err := store.LedgerBatch(context.Background(), LedgerExportOptions{Limit: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstBatch.Cursor == nil {
+		t.Fatal("first batch cursor = nil")
+	}
+	if firstBatch.Cursor.ActionID != actionIDs[0] {
+		t.Fatalf("first cursor action = %q, want %q", firstBatch.Cursor.ActionID, actionIDs[0])
+	}
+
+	secondBatch, err := store.LedgerBatch(context.Background(), LedgerExportOptions{
+		UpdatedAfter:   &firstBatch.Cursor.UpdatedAt,
+		UpdatedAfterID: firstBatch.Cursor.ActionID,
+		Limit:          1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(secondBatch.Actions) != 1 || secondBatch.Actions[0]["id"] != actionIDs[1] {
+		t.Fatalf("second batch actions = %+v, want %s", secondBatch.Actions, actionIDs[1])
+	}
+}
+
+func TestLedgerBatchCursorComparesOffsetTimestampsAfterNormalization(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	for _, hookEvent := range []string{"SessionStart", "SessionEnd"} {
+		if _, err := store.SaveDecision(context.Background(), risk.HookEvent{
+			SessionID:     "s1",
+			Agent:         "claude-code",
+			HookEventName: hookEvent,
+			CWD:           "/tmp/project",
+		}, risk.RiskDecision{
+			Decision:   risk.DecisionAllow,
+			Reason:     "async telemetry event recorded",
+			ReasonCode: "async_telemetry",
+			RiskEvent:  risk.RiskEvent{Type: risk.EventNormalToolCall},
+		}); err != nil {
+			t.Fatalf("SaveDecision(%s) error = %v", hookEvent, err)
+		}
+	}
+
+	actionIDs := ledgerActionIDs(t, store, "s1")
+	if len(actionIDs) != 2 {
+		t.Fatalf("action IDs = %+v, want 2", actionIDs)
+	}
+	if _, err := store.db.ExecContext(context.Background(), `
+update authorization_actions
+set updated_at = case id
+  when ? then ?
+  when ? then ?
+  else updated_at
+end
+where session_id = ?
+	`, actionIDs[0], "2026-06-08T14:20:07.853885+02:00", actionIDs[1], "2026-06-08T12:20:07.853885Z", "s1"); err != nil {
+		t.Fatal(err)
+	}
+
+	firstBatch, err := store.LedgerBatch(context.Background(), LedgerExportOptions{Limit: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstBatch.Cursor == nil {
+		t.Fatal("first batch cursor = nil")
+	}
+	if firstBatch.Cursor.ActionID != actionIDs[0] {
+		t.Fatalf("first cursor action = %q, want %q", firstBatch.Cursor.ActionID, actionIDs[0])
+	}
+	if got := firstBatch.Cursor.UpdatedAt.UTC().Format(time.RFC3339Nano); got != "2026-06-08T12:20:07.853885Z" {
+		t.Fatalf("first cursor updated_at = %q, want normalized UTC timestamp", got)
+	}
+
+	secondBatch, err := store.LedgerBatch(context.Background(), LedgerExportOptions{
+		UpdatedAfter:   &firstBatch.Cursor.UpdatedAt,
+		UpdatedAfterID: firstBatch.Cursor.ActionID,
+		Limit:          1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(secondBatch.Actions) != 1 || secondBatch.Actions[0]["id"] != actionIDs[1] {
+		t.Fatalf("second batch actions = %+v, want %s", secondBatch.Actions, actionIDs[1])
+	}
+}
+
 func TestLedgerBatchIncludesReceiptChainAnchorForIncrementalExports(t *testing.T) {
 	store, err := OpenStore(t.TempDir() + "/guard.db")
 	if err != nil {
@@ -1424,6 +1632,33 @@ func ledgerRecordByField(records []LedgerRecord, field, value string) LedgerReco
 	return nil
 }
 
+func ledgerActionIDs(t *testing.T, store *Store, sessionID string) []string {
+	t.Helper()
+	rows, err := store.db.QueryContext(context.Background(), `
+select id
+from authorization_actions
+where session_id = ?
+order by id
+	`, sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			t.Fatal(err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return ids
+}
+
 func receiptCountForTool(t *testing.T, store *Store, receipts []LedgerRecord, toolUseID string) int {
 	t.Helper()
 	count := 0
@@ -1442,6 +1677,25 @@ func receiptCountForTool(t *testing.T, store *Store, receipts []LedgerRecord, to
 		}
 	}
 	return count
+}
+
+func assertLedgerTimestampHasOffset(t *testing.T, record LedgerRecord, column string) {
+	t.Helper()
+	value, ok := record[column]
+	if !ok || value == nil {
+		return
+	}
+	raw, ok := value.(string)
+	if !ok || raw == "" {
+		return
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		t.Fatalf("%s = %q does not parse as RFC3339Nano: %v", column, raw, err)
+	}
+	if !strings.HasSuffix(raw, "Z") {
+		t.Fatalf("%s = %q has offset %s, want normalized UTC", column, raw, parsed.Format("-07:00"))
+	}
 }
 
 func assertRecordIDs(t *testing.T, records []LedgerRecord, want map[string]bool) {


### PR DESCRIPTION
## Summary

- normalize hosted ledger export timestamps to RFC3339 UTC before upload
- handles existing local rows that were stored without a timezone offset
- prevents hosted ingest from rejecting lifecycle batches with datetime validation 400s

## Verification

- [x] go test ./...
