### PR TITLE
fix(managedstream): normalize timestamp cursors

### DIFF
--- a/internal/guard/store/sqlite/ledger.go
+++ b/internal/guard/store/sqlite/ledger.go
@@ -12,9 +12,10 @@ import (
 type LedgerRecord map[string]any
 
 type LedgerExportOptions struct {
-	UpdatedAfter   *time.Time
-	UpdatedAfterID string
-	Limit          int
+	UpdatedAfter    *time.Time
+	UpdatedAfterKey string
+	UpdatedAfterID  string
+	Limit           int
 }
 
 type LedgerBatch struct {
@@ -30,9 +31,12 @@ type LedgerReceiptChainAnchor struct {
 }
 
 type LedgerCursor struct {
-	UpdatedAt time.Time
-	ActionID  string
+	UpdatedAt    time.Time
+	UpdatedAtKey string
+	ActionID     string
 }
+
+const ledgerCursorUpdatedAtColumn = "__cursor_updated_at"
 
 const authorizationActionsSelect = `
 select id, session_id, turn_id, tool_use_id, trace_id, span_id, parent_span_id,
@@ -117,19 +121,23 @@ order by created_at, id
 }
 
 func (s *Store) AuthorizationActions(ctx context.Context, opts LedgerExportOptions) ([]LedgerRecord, error) {
-	query := authorizationActionsSelect
+	updatedAtExpr := ledgerUpdatedAtCursorSQL("updated_at")
+	query := authorizationActionsSelectWithCursor()
 	args := []any{}
 	if opts.UpdatedAfter != nil {
+		updatedAfter := opts.UpdatedAfter.UTC().Format(time.RFC3339Nano)
+		if opts.UpdatedAfterKey != "" {
+			updatedAfter = opts.UpdatedAfterKey
+		}
 		if opts.UpdatedAfterID != "" {
-			query += "\nwhere updated_at > ? or (updated_at = ? and id > ?)"
-			updatedAfter := opts.UpdatedAfter.Format(time.RFC3339Nano)
+			query += fmt.Sprintf("\nwhere %s > ? or (%s = ? and id > ?)", updatedAtExpr, updatedAtExpr)
 			args = append(args, updatedAfter, updatedAfter, opts.UpdatedAfterID)
 		} else {
-			query += "\nwhere updated_at > ?"
-			args = append(args, opts.UpdatedAfter.Format(time.RFC3339Nano))
+			query += fmt.Sprintf("\nwhere %s > ?", updatedAtExpr)
+			args = append(args, updatedAfter)
 		}
 	}
-	query += "\norder by updated_at, id"
+	query += fmt.Sprintf("\norder by %s, id", updatedAtExpr)
 	if opts.Limit > 0 {
 		query += "\nlimit ?"
 		args = append(args, opts.Limit)
@@ -143,15 +151,19 @@ func ledgerCursor(actions []LedgerRecord) (*LedgerCursor, error) {
 	}
 	last := actions[len(actions)-1]
 	rawUpdatedAt, _ := last["updated_at"].(string)
+	updatedAtKey, _ := last[ledgerCursorUpdatedAtColumn].(string)
+	if updatedAtKey == "" {
+		updatedAtKey = rawUpdatedAt
+	}
 	actionID, _ := last["id"].(string)
-	if rawUpdatedAt == "" || actionID == "" {
+	if updatedAtKey == "" || actionID == "" {
 		return nil, nil
 	}
-	updatedAt, err := time.Parse(time.RFC3339Nano, rawUpdatedAt)
+	updatedAt, err := time.Parse(time.RFC3339Nano, updatedAtKey)
 	if err != nil {
 		return nil, err
 	}
-	return &LedgerCursor{UpdatedAt: updatedAt, ActionID: actionID}, nil
+	return &LedgerCursor{UpdatedAt: updatedAt, UpdatedAtKey: updatedAtKey, ActionID: actionID}, nil
 }
 
 func (s *Store) authorizationActionsByIDs(ctx context.Context, ids []string) ([]LedgerRecord, error) {
@@ -164,7 +176,11 @@ func (s *Store) authorizationActionsByIDs(ctx context.Context, ids []string) ([]
 	for _, id := range ids {
 		args = append(args, id)
 	}
-	return queryLedgerRecords(ctx, s.db, fmt.Sprintf("%s\nwhere id in (%s)\norder by updated_at, id", authorizationActionsSelect, placeholders), args...)
+	actions, err := queryLedgerRecords(ctx, s.db, fmt.Sprintf("%s\nwhere id in (%s)\norder by %s, id", authorizationActionsSelectWithCursor(), placeholders, ledgerUpdatedAtCursorSQL("updated_at")), args...)
+	if err != nil {
+		return nil, err
+	}
+	return stripLedgerCursorColumns(actions), nil
 }
 
 func (s *Store) AuthorizationReceipts(ctx context.Context, opts LedgerExportOptions) ([]LedgerRecord, error) {
@@ -258,7 +274,58 @@ func normalizeLedgerString(column, value string) any {
 			return decoded
 		}
 	}
+	if isLedgerTimeColumn(column) {
+		if normalized, ok := normalizeLedgerTimestamp(value); ok {
+			return normalized
+		}
+	}
 	return value
+}
+
+func authorizationActionsSelectWithCursor() string {
+	cursorColumn := fmt.Sprintf(",\n  %s as %s", ledgerUpdatedAtCursorSQL("updated_at"), ledgerCursorUpdatedAtColumn)
+	return strings.Replace(authorizationActionsSelect, "\nfrom authorization_actions", cursorColumn+"\nfrom authorization_actions", 1)
+}
+
+func ledgerUpdatedAtCursorSQL(column string) string {
+	offsetSource := fmt.Sprintf("substr(%s, 1, length(%s) - 6)", column, column)
+	offsetFraction := fmt.Sprintf("case when instr(%s, '.') > 0 then substr(%s, instr(%s, '.')) else '' end", offsetSource, offsetSource, offsetSource)
+	return fmt.Sprintf(`case
+	when %s is null or %s = '' then %s
+	when substr(%s, -1) = 'Z' then %s
+	when %s glob '*[+-][0-9][0-9]:[0-9][0-9]' then strftime('%%Y-%%m-%%dT%%H:%%M:%%S', %s) || %s || 'Z'
+	else %s || 'Z'
+end`, column, column, column, column, column, column, column, offsetFraction, column)
+}
+
+func isLedgerTimeColumn(column string) bool {
+	return strings.HasSuffix(column, "_at")
+}
+
+func normalizeLedgerTimestamp(value string) (string, bool) {
+	if value == "" {
+		return value, false
+	}
+	if parsed, err := time.Parse(time.RFC3339Nano, value); err == nil {
+		return parsed.UTC().Format(time.RFC3339Nano), true
+	}
+	for _, layout := range []string{
+		"2006-01-02T15:04:05.999999999",
+		"2006-01-02T15:04:05",
+	} {
+		parsed, err := time.Parse(layout, value)
+		if err == nil {
+			return parsed.UTC().Format(time.RFC3339Nano), true
+		}
+	}
+	return value, false
+}
+
+func stripLedgerCursorColumns(records []LedgerRecord) []LedgerRecord {
+	for _, record := range records {
+		delete(record, ledgerCursorUpdatedAtColumn)
+	}
+	return records
 }
 
 func sessionIDs(groups ...[]LedgerRecord) []string {

--- a/internal/guard/store/sqlite/store_test.go
+++ b/internal/guard/store/sqlite/store_test.go
@@ -956,6 +956,94 @@ where id in (?, ?)
 	}
 }
 
+func TestLedgerBatchNormalizesNaiveTimestampsForHostedExport(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	insertLifecycleActions(t, store)
+	naive := "2026-06-08T12:20:07.853885"
+	if _, err := store.db.ExecContext(context.Background(), `
+update authorization_actions
+set proposed_at = case when proposed_at is null then null else ? end,
+    completed_at = case when completed_at is null then null else ? end,
+    created_at = ?,
+    updated_at = ?
+	`, naive, naive, naive, naive); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(context.Background(), `update authorization_receipts set created_at = ?`, naive); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(context.Background(), `update agent_sessions set closed_at = ?, created_at = ?, updated_at = ?`, naive, naive, naive); err != nil {
+		t.Fatal(err)
+	}
+
+	batch, err := store.LedgerBatch(context.Background(), LedgerExportOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, record := range append(append([]LedgerRecord{}, batch.Sessions...), append(batch.Actions, batch.Receipts...)...) {
+		assertLedgerTimestampHasOffset(t, record, "created_at")
+		assertLedgerTimestampHasOffset(t, record, "updated_at")
+		assertLedgerTimestampHasOffset(t, record, "closed_at")
+		assertLedgerTimestampHasOffset(t, record, "proposed_at")
+		assertLedgerTimestampHasOffset(t, record, "completed_at")
+		if _, ok := record[ledgerCursorUpdatedAtColumn]; ok {
+			t.Fatalf("record leaked cursor column: %+v", record)
+		}
+	}
+}
+
+func TestLedgerBatchCursorComparesNormalizedTimestampKeys(t *testing.T) {
+	for name, values := range map[string][2]string{
+		"naive":  {"2026-06-08T12:20:07.853885", "2026-06-08T12:20:07.853885"},
+		"offset": {"2026-06-08T14:20:07.853885+02:00", "2026-06-08T12:20:07.853885Z"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			store, err := OpenStore(t.TempDir() + "/guard.db")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer store.Close()
+
+			insertLifecycleActions(t, store)
+			ids := ledgerActionIDs(t, store)
+			if len(ids) != 2 {
+				t.Fatalf("action IDs = %+v, want 2", ids)
+			}
+			if _, err := store.db.ExecContext(context.Background(), `
+update authorization_actions
+set updated_at = case id when ? then ? when ? then ? else updated_at end
+			`, ids[0], values[0], ids[1], values[1]); err != nil {
+				t.Fatal(err)
+			}
+
+			firstBatch, err := store.LedgerBatch(context.Background(), LedgerExportOptions{Limit: 1})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if firstBatch.Cursor == nil || firstBatch.Cursor.ActionID != ids[0] {
+				t.Fatalf("first cursor = %+v, want action %s", firstBatch.Cursor, ids[0])
+			}
+			secondBatch, err := store.LedgerBatch(context.Background(), LedgerExportOptions{
+				UpdatedAfter:    &firstBatch.Cursor.UpdatedAt,
+				UpdatedAfterKey: firstBatch.Cursor.UpdatedAtKey,
+				UpdatedAfterID:  firstBatch.Cursor.ActionID,
+				Limit:           1,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(secondBatch.Actions) != 1 || secondBatch.Actions[0]["id"] != ids[1] {
+				t.Fatalf("second batch actions = %+v, want %s", secondBatch.Actions, ids[1])
+			}
+		})
+	}
+}
+
 func TestLedgerBatchIncludesReceiptChainAnchorForIncrementalExports(t *testing.T) {
 	store, err := OpenStore(t.TempDir() + "/guard.db")
 	if err != nil {
@@ -1422,6 +1510,66 @@ func ledgerRecordByField(records []LedgerRecord, field, value string) LedgerReco
 		}
 	}
 	return nil
+}
+
+func insertLifecycleActions(t *testing.T, store *Store) {
+	t.Helper()
+	for _, hookEvent := range []string{"SessionStart", "SessionEnd"} {
+		if _, err := store.SaveDecision(context.Background(), risk.HookEvent{
+			SessionID:     "s1",
+			Agent:         "claude-code",
+			HookEventName: hookEvent,
+			CWD:           "/tmp/project",
+		}, risk.RiskDecision{
+			Decision:   risk.DecisionAllow,
+			Reason:     "async telemetry event recorded",
+			ReasonCode: "async_telemetry",
+			RiskEvent:  risk.RiskEvent{Type: risk.EventNormalToolCall},
+		}); err != nil {
+			t.Fatalf("SaveDecision(%s) error = %v", hookEvent, err)
+		}
+	}
+}
+
+func ledgerActionIDs(t *testing.T, store *Store) []string {
+	t.Helper()
+	rows, err := store.db.QueryContext(context.Background(), `
+select id
+from authorization_actions
+where session_id = 's1'
+order by id
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			t.Fatal(err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return ids
+}
+
+func assertLedgerTimestampHasOffset(t *testing.T, record LedgerRecord, column string) {
+	t.Helper()
+	value, ok := record[column].(string)
+	if !ok || value == "" {
+		return
+	}
+	if _, err := time.Parse(time.RFC3339Nano, value); err != nil {
+		t.Fatalf("%s = %q does not parse as RFC3339Nano: %v", column, value, err)
+	}
+	if !strings.HasSuffix(value, "Z") {
+		t.Fatalf("%s = %q, want normalized UTC timestamp", column, value)
+	}
 }
 
 func receiptCountForTool(t *testing.T, store *Store, receipts []LedgerRecord, toolUseID string) int {

--- a/internal/managedstream/stream.go
+++ b/internal/managedstream/stream.go
@@ -126,20 +126,23 @@ func Flush(ctx context.Context, opts Options) error {
 	}
 
 	var updatedAfter *time.Time
+	updatedAfterKey := ""
 	if state.UpdatedAfter != "" {
-		parsed, err := time.Parse(time.RFC3339Nano, state.UpdatedAfter)
+		parsed, normalized, err := parseStateUpdatedAfter(state.UpdatedAfter)
 		if err != nil {
 			return fmt.Errorf("parse managed stream state: %w", err)
 		}
 		updatedAfter = &parsed
+		updatedAfterKey = normalized
 	}
 
 	limit := batchLimit(opts.BatchLimit)
 	for {
 		batch, err := store.LedgerBatch(ctx, sqlite.LedgerExportOptions{
-			UpdatedAfter:   updatedAfter,
-			UpdatedAfterID: state.ActionID,
-			Limit:          limit,
+			UpdatedAfter:    updatedAfter,
+			UpdatedAfterKey: updatedAfterKey,
+			UpdatedAfterID:  state.ActionID,
+			Limit:           limit,
 		})
 		if err != nil {
 			return err
@@ -319,10 +322,32 @@ func advancePastMinimumBatch(statePath string, batch sqlite.LedgerBatch, reason 
 }
 
 func saveCursor(statePath string, batch sqlite.LedgerBatch) error {
+	updatedAfter := batch.Cursor.UpdatedAt.UTC().Format(time.RFC3339Nano)
+	if batch.Cursor.UpdatedAtKey != "" {
+		updatedAfter = batch.Cursor.UpdatedAtKey
+	}
 	return SaveState(statePath, State{
-		UpdatedAfter: batch.Cursor.UpdatedAt.UTC().Format(time.RFC3339Nano),
+		UpdatedAfter: updatedAfter,
 		ActionID:     batch.Cursor.ActionID,
 	})
+}
+
+func parseStateUpdatedAfter(value string) (time.Time, string, error) {
+	if parsed, err := time.Parse(time.RFC3339Nano, value); err == nil {
+		normalized := parsed.UTC().Format(time.RFC3339Nano)
+		return parsed, normalized, nil
+	}
+	for _, layout := range []string{
+		"2006-01-02T15:04:05.999999999",
+		"2006-01-02T15:04:05",
+	} {
+		parsed, err := time.Parse(layout, value)
+		if err == nil {
+			normalized := parsed.UTC().Format(time.RFC3339Nano)
+			return parsed, normalized, nil
+		}
+	}
+	return time.Time{}, "", fmt.Errorf("invalid timestamp %q", value)
 }
 
 func responseBodySummary(body io.Reader) string {

--- a/internal/managedstream/stream_test.go
+++ b/internal/managedstream/stream_test.go
@@ -442,6 +442,19 @@ func TestFlushUsesUpdatedAfterCursor(t *testing.T) {
 	}
 }
 
+func TestParseStateUpdatedAfterNormalizesNaiveTimestamp(t *testing.T) {
+	parsed, normalized, err := parseStateUpdatedAfter("2026-06-08T12:20:07.853885")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := parsed.UTC().Format(time.RFC3339Nano); got != "2026-06-08T12:20:07.853885Z" {
+		t.Fatalf("parsed = %q", got)
+	}
+	if normalized != "2026-06-08T12:20:07.853885Z" {
+		t.Fatalf("normalized = %q", normalized)
+	}
+}
+
 func testStore(t *testing.T) (*sqlite.Store, string) {
 	t.Helper()
 	dbPath := filepath.Join(t.TempDir(), "guard.db")


### PR DESCRIPTION
## Summary

- normalize ledger timestamp fields before hosted export so no-offset lifecycle rows do not fail API datetime validation
- keep managed-stream cursor filtering bounded in SQLite with a normalized cursor key for `updated_at`
- tolerate existing stream state timestamps that were written without a timezone

## Verification

- [x] go test ./...
