### PR TITLE
fix(managedstream): add stored timestamp cursor keys

### DIFF
--- a/internal/guard/store/sqlite/ledger.go
+++ b/internal/guard/store/sqlite/ledger.go
@@ -12,9 +12,10 @@ import (
 type LedgerRecord map[string]any
 
 type LedgerExportOptions struct {
-	UpdatedAfter   *time.Time
-	UpdatedAfterID string
-	Limit          int
+	UpdatedAfter    *time.Time
+	UpdatedAfterKey string
+	UpdatedAfterID  string
+	Limit           int
 }
 
 type LedgerBatch struct {
@@ -30,9 +31,15 @@ type LedgerReceiptChainAnchor struct {
 }
 
 type LedgerCursor struct {
-	UpdatedAt time.Time
-	ActionID  string
+	UpdatedAt    time.Time
+	UpdatedAtKey string
+	ActionID     string
 }
+
+const (
+	ledgerCursorUpdatedAtKeyColumn = "__cursor_updated_at_key"
+	ledgerTimestampCursorKeyLayout = "2006-01-02T15:04:05.000000000Z07:00"
+)
 
 const authorizationActionsSelect = `
 select id, session_id, turn_id, tool_use_id, trace_id, span_id, parent_span_id,
@@ -117,19 +124,22 @@ order by created_at, id
 }
 
 func (s *Store) AuthorizationActions(ctx context.Context, opts LedgerExportOptions) ([]LedgerRecord, error) {
-	query := authorizationActionsSelect
+	query := authorizationActionsSelectWithCursorKey()
 	args := []any{}
 	if opts.UpdatedAfter != nil {
+		updatedAfter := opts.UpdatedAfter.UTC().Format(ledgerTimestampCursorKeyLayout)
+		if opts.UpdatedAfterKey != "" {
+			updatedAfter = opts.UpdatedAfterKey
+		}
 		if opts.UpdatedAfterID != "" {
-			query += "\nwhere updated_at > ? or (updated_at = ? and id > ?)"
-			updatedAfter := opts.UpdatedAfter.Format(time.RFC3339Nano)
+			query += "\nwhere updated_at_cursor_key > ? or (updated_at_cursor_key = ? and id > ?)"
 			args = append(args, updatedAfter, updatedAfter, opts.UpdatedAfterID)
 		} else {
-			query += "\nwhere updated_at > ?"
-			args = append(args, opts.UpdatedAfter.Format(time.RFC3339Nano))
+			query += "\nwhere updated_at_cursor_key > ?"
+			args = append(args, updatedAfter)
 		}
 	}
-	query += "\norder by updated_at, id"
+	query += "\norder by updated_at_cursor_key, id"
 	if opts.Limit > 0 {
 		query += "\nlimit ?"
 		args = append(args, opts.Limit)
@@ -143,15 +153,19 @@ func ledgerCursor(actions []LedgerRecord) (*LedgerCursor, error) {
 	}
 	last := actions[len(actions)-1]
 	rawUpdatedAt, _ := last["updated_at"].(string)
+	updatedAtKey, _ := last[ledgerCursorUpdatedAtKeyColumn].(string)
+	if updatedAtKey == "" {
+		updatedAtKey = rawUpdatedAt
+	}
 	actionID, _ := last["id"].(string)
-	if rawUpdatedAt == "" || actionID == "" {
+	if updatedAtKey == "" || actionID == "" {
 		return nil, nil
 	}
-	updatedAt, err := time.Parse(time.RFC3339Nano, rawUpdatedAt)
+	updatedAt, err := parseLedgerTimestamp(updatedAtKey)
 	if err != nil {
 		return nil, err
 	}
-	return &LedgerCursor{UpdatedAt: updatedAt, ActionID: actionID}, nil
+	return &LedgerCursor{UpdatedAt: updatedAt, UpdatedAtKey: updatedAtKey, ActionID: actionID}, nil
 }
 
 func (s *Store) authorizationActionsByIDs(ctx context.Context, ids []string) ([]LedgerRecord, error) {
@@ -164,7 +178,7 @@ func (s *Store) authorizationActionsByIDs(ctx context.Context, ids []string) ([]
 	for _, id := range ids {
 		args = append(args, id)
 	}
-	return queryLedgerRecords(ctx, s.db, fmt.Sprintf("%s\nwhere id in (%s)\norder by updated_at, id", authorizationActionsSelect, placeholders), args...)
+	return queryLedgerRecords(ctx, s.db, fmt.Sprintf("%s\nwhere id in (%s)\norder by updated_at_cursor_key, id", authorizationActionsSelect, placeholders), args...)
 }
 
 func (s *Store) AuthorizationReceipts(ctx context.Context, opts LedgerExportOptions) ([]LedgerRecord, error) {
@@ -258,7 +272,46 @@ func normalizeLedgerString(column, value string) any {
 			return decoded
 		}
 	}
+	if isLedgerTimeColumn(column) {
+		if parsed, err := parseLedgerTimestamp(value); err == nil {
+			return parsed.UTC().Format(time.RFC3339Nano)
+		}
+	}
 	return value
+}
+
+func authorizationActionsSelectWithCursorKey() string {
+	cursorColumn := ",\n  updated_at_cursor_key as " + ledgerCursorUpdatedAtKeyColumn
+	return strings.Replace(authorizationActionsSelect, "\nfrom authorization_actions", cursorColumn+"\nfrom authorization_actions", 1)
+}
+
+func isLedgerTimeColumn(column string) bool {
+	return strings.HasSuffix(column, "_at")
+}
+
+func parseLedgerTimestamp(value string) (time.Time, error) {
+	if parsed, err := time.Parse(time.RFC3339Nano, value); err == nil {
+		return parsed, nil
+	}
+	for _, layout := range []string{
+		"2006-01-02T15:04:05.999999999",
+		"2006-01-02T15:04:05",
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02 15:04:05",
+	} {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return parsed, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("invalid timestamp %q", value)
+}
+
+func ledgerTimestampCursorKey(value string) (string, error) {
+	parsed, err := parseLedgerTimestamp(value)
+	if err != nil {
+		return "", err
+	}
+	return parsed.UTC().Format(ledgerTimestampCursorKeyLayout), nil
 }
 
 func sessionIDs(groups ...[]LedgerRecord) []string {

--- a/internal/guard/store/sqlite/store.go
+++ b/internal/guard/store/sqlite/store.go
@@ -207,7 +207,8 @@ func (s *Store) migrate(ctx context.Context) error {
 	  decision_at text,
 	  completed_at text,
 	  created_at text not null,
-	  updated_at text not null
+	  updated_at text not null,
+	  updated_at_cursor_key text not null default ''
 	);
 
 	create table if not exists authorization_receipts (
@@ -251,9 +252,18 @@ func (s *Store) migrate(ctx context.Context) error {
 	if err := s.ensureAuthorizationActionsDecisionNullable(ctx); err != nil {
 		return err
 	}
+	if err := s.ensureColumn(ctx, "authorization_actions", "updated_at_cursor_key", "text not null default ''"); err != nil {
+		return err
+	}
+	if err := s.backfillAuthorizationActionCursorKeys(ctx); err != nil {
+		return err
+	}
 	if _, err := s.db.ExecContext(ctx, `
 	create index if not exists idx_authorization_actions_session_updated
 	on authorization_actions(session_id, updated_at);
+
+	create index if not exists idx_authorization_actions_cursor
+	on authorization_actions(updated_at_cursor_key, id);
 
 	create index if not exists idx_authorization_actions_session_tool_use
 	on authorization_actions(session_id, tool_use_id);
@@ -427,7 +437,8 @@ func (s *Store) ensureAuthorizationActionsDecisionNullable(ctx context.Context) 
 	  decision_at text,
 	  completed_at text,
 	  created_at text not null,
-	  updated_at text not null
+	  updated_at text not null,
+	  updated_at_cursor_key text not null default ''
 	);
 
 	insert into authorization_actions (
@@ -441,6 +452,9 @@ func (s *Store) ensureAuthorizationActionsDecisionNullable(ctx context.Context) 
 
 	create index if not exists idx_authorization_actions_session_updated
 	on authorization_actions(session_id, updated_at);
+
+	create index if not exists idx_authorization_actions_cursor
+	on authorization_actions(updated_at_cursor_key, id);
 
 	create index if not exists idx_authorization_actions_session_tool_use
 	on authorization_actions(session_id, tool_use_id);
@@ -524,6 +538,7 @@ var authorizationActionColumns = []authorizationActionColumn{
 	{name: "completed_at", defaultExpr: "null"},
 	{name: "created_at", copyExpr: "coalesce(created_at, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))", defaultExpr: "strftime('%Y-%m-%dT%H:%M:%fZ', 'now')"},
 	{name: "updated_at", copyExpr: "coalesce(updated_at, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))", defaultExpr: "strftime('%Y-%m-%dT%H:%M:%fZ', 'now')"},
+	{name: "updated_at_cursor_key", copyExpr: "coalesce(nullif(updated_at_cursor_key, ''), updated_at, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))", defaultExpr: "''"},
 }
 
 func authorizationActionInsertColumns() string {
@@ -547,6 +562,55 @@ func authorizationActionSelectExpressions(existingColumns map[string]bool) strin
 		expressions = append(expressions, fmt.Sprintf("%s as %s", expr, column.name))
 	}
 	return strings.Join(expressions, ",\n\t  ")
+}
+
+func (s *Store) backfillAuthorizationActionCursorKeys(ctx context.Context) error {
+	rows, err := s.db.QueryContext(ctx, `
+select id, updated_at, updated_at_cursor_key
+from authorization_actions
+	`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	type rowValue struct {
+		id  string
+		key string
+	}
+	updates := []rowValue{}
+	for rows.Next() {
+		var id, updatedAt, currentKey string
+		if err := rows.Scan(&id, &updatedAt, &currentKey); err != nil {
+			return err
+		}
+		key := legacyAuthorizationActionCursorKey(updatedAt)
+		if currentKey == key {
+			continue
+		}
+		updates = append(updates, rowValue{id: id, key: key})
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, update := range updates {
+		if _, err := s.db.ExecContext(ctx, `
+update authorization_actions
+set updated_at_cursor_key = ?
+where id = ?
+		`, update.key, update.id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func legacyAuthorizationActionCursorKey(updatedAt string) string {
+	key, err := ledgerTimestampCursorKey(updatedAt)
+	if err != nil {
+		return updatedAt
+	}
+	return key
 }
 
 func (s *Store) OpenSession(ctx context.Context, sessionID, agent, cwd, source, externalID string) (SessionRecord, error) {
@@ -718,7 +782,7 @@ func (s *Store) insertAction(ctx context.Context, tx *sql.Tx, actionID, sessionI
 		"risk_level", "risk_score", "risk_threshold", "model_version", "confidence", "matched_rules_json", "risk_signals_json", "risk_event_json",
 		"modifications_json", "approval_context_json", "approval_channel", "approval_request_id", "deferral_context_json",
 		"status", "outcome", "output_summary", "output_hash", "error_redacted",
-		"proposed_at", "decision_at", "completed_at", "created_at", "updated_at",
+		"proposed_at", "decision_at", "completed_at", "created_at", "updated_at", "updated_at_cursor_key",
 	}
 	values := []any{
 		action["id"], action["session_id"], action["tool_use_id"], action["canonical_event_type"], action["adapter_event_name"], action["correlation_key"],
@@ -729,7 +793,7 @@ func (s *Store) insertAction(ctx context.Context, tx *sql.Tx, actionID, sessionI
 		action["risk_level"], action["risk_score"], action["risk_threshold"], action["model_version"], action["confidence"], action["matched_rules_json"], action["risk_signals_json"], action["risk_event_json"],
 		action["modifications_json"], action["approval_context_json"], action["approval_channel"], action["approval_request_id"], action["deferral_context_json"],
 		action["status"], action["outcome"], action["output_summary"], action["output_hash"], action["error_redacted"],
-		action["proposed_at"], action["decision_at"], action["completed_at"], action["created_at"], action["updated_at"],
+		action["proposed_at"], action["decision_at"], action["completed_at"], action["created_at"], action["updated_at"], action["updated_at_cursor_key"],
 	}
 	placeholders := strings.TrimRight(strings.Repeat("?,", len(columns)), ",")
 	if _, err := tx.ExecContext(ctx,
@@ -827,6 +891,12 @@ func actionValues(actionID, sessionID string, event risk.HookEvent, decision ris
 		provider = "github"
 	}
 
+	updatedAt := now.Format(time.RFC3339Nano)
+	updatedAtCursorKey, err := ledgerTimestampCursorKey(updatedAt)
+	if err != nil {
+		return nil, err
+	}
+
 	return map[string]any{
 		"id":                       actionID,
 		"session_id":               sessionID,
@@ -876,8 +946,9 @@ func actionValues(actionID, sessionID string, event risk.HookEvent, decision ris
 		"proposed_at":              nullIfEmpty(proposedAt),
 		"decision_at":              nullIfEmpty(decisionAt),
 		"completed_at":             nullIfEmpty(completedAt),
-		"created_at":               now.Format(time.RFC3339Nano),
-		"updated_at":               now.Format(time.RFC3339Nano),
+		"created_at":               updatedAt,
+		"updated_at":               updatedAt,
+		"updated_at_cursor_key":    updatedAtCursorKey,
 	}, nil
 }
 

--- a/internal/guard/store/sqlite/store_test.go
+++ b/internal/guard/store/sqlite/store_test.go
@@ -142,6 +142,74 @@ where id = 'act_legacy_deny'
 	}
 }
 
+func TestMigrationToleratesLegacyActionCursorKeyTimestamps(t *testing.T) {
+	path := t.TempDir() + "/guard.db"
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.ExecContext(context.Background(), `
+create table authorization_actions (
+  id text primary key,
+  session_id text not null,
+  canonical_event_type text not null,
+  decision_result text not null,
+  status text not null,
+  created_at text not null,
+  updated_at text not null
+);
+insert into authorization_actions (
+  id, session_id, canonical_event_type, decision_result, status, created_at, updated_at
+) values (
+  'act_sqlite_space', 's1', 'request.decided', 'allow', 'authorized',
+  '2026-06-08 12:20:07.853885', '2026-06-08 12:20:07.853885'
+), (
+  'act_bad_timestamp', 's1', 'request.decided', 'allow', 'authorized',
+  'not-a-timestamp', 'not-a-timestamp'
+);
+`)
+	if err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := OpenStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	keys := map[string]string{}
+	rows, err := store.db.QueryContext(context.Background(), `
+select id, updated_at_cursor_key
+from authorization_actions
+where id in ('act_sqlite_space', 'act_bad_timestamp')
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id, key string
+		if err := rows.Scan(&id, &key); err != nil {
+			t.Fatal(err)
+		}
+		keys[id] = key
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if keys["act_sqlite_space"] != "2026-06-08T12:20:07.853885000Z" {
+		t.Fatalf("sqlite space cursor key = %q", keys["act_sqlite_space"])
+	}
+	if keys["act_bad_timestamp"] != "not-a-timestamp" {
+		t.Fatalf("bad timestamp cursor key = %q", keys["act_bad_timestamp"])
+	}
+}
+
 func TestSaveDecisionGeneratesUniqueIDsConcurrently(t *testing.T) {
 	store, err := OpenStore(t.TempDir() + "/guard.db")
 	if err != nil {
@@ -927,11 +995,16 @@ func TestLedgerBatchCursorUsesUpdatedAtAndActionID(t *testing.T) {
 	}
 
 	sharedUpdated := "2026-05-19T10:00:00Z"
+	sharedUpdatedKey, err := ledgerTimestampCursorKey(sharedUpdated)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if _, err := store.db.ExecContext(context.Background(), `
 update authorization_actions
-set updated_at = ?
+set updated_at = ?,
+    updated_at_cursor_key = ?
 where id in (?, ?)
-	`, sharedUpdated, first.ID, second.ID); err != nil {
+	`, sharedUpdated, sharedUpdatedKey, first.ID, second.ID); err != nil {
 		t.Fatal(err)
 	}
 
@@ -953,6 +1026,122 @@ where id in (?, ?)
 	}
 	if len(secondBatch.Actions) != 1 || secondBatch.Actions[0]["id"] == firstBatch.Cursor.ActionID {
 		t.Fatalf("second batch actions = %+v, cursor = %+v", secondBatch.Actions, firstBatch.Cursor)
+	}
+}
+
+func TestLedgerBatchNormalizesNaiveTimestampsForHostedExport(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	insertLifecycleActions(t, store)
+	naive := "2026-06-08T12:20:07.853885"
+	if _, err := store.db.ExecContext(context.Background(), `
+update authorization_actions
+set proposed_at = case when proposed_at is null then null else ? end,
+    completed_at = case when completed_at is null then null else ? end,
+    created_at = ?,
+    updated_at = ?
+	`, naive, naive, naive, naive); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(context.Background(), `update authorization_receipts set created_at = ?`, naive); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(context.Background(), `update agent_sessions set closed_at = ?, created_at = ?, updated_at = ?`, naive, naive, naive); err != nil {
+		t.Fatal(err)
+	}
+
+	batch, err := store.LedgerBatch(context.Background(), LedgerExportOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, record := range append(append([]LedgerRecord{}, batch.Sessions...), append(batch.Actions, batch.Receipts...)...) {
+		assertLedgerTimestampHasOffset(t, record, "created_at")
+		assertLedgerTimestampHasOffset(t, record, "updated_at")
+		assertLedgerTimestampHasOffset(t, record, "closed_at")
+		assertLedgerTimestampHasOffset(t, record, "proposed_at")
+		assertLedgerTimestampHasOffset(t, record, "completed_at")
+		if _, ok := record[ledgerCursorUpdatedAtKeyColumn]; ok {
+			t.Fatalf("record leaked cursor key: %+v", record)
+		}
+	}
+}
+
+func TestLedgerBatchCursorUsesNormalizedTimestampKey(t *testing.T) {
+	for name, timestamps := range map[string][2]string{
+		"naive":                  {"2026-06-08T12:20:07.853885", "2026-06-08T12:20:07.853885"},
+		"offset":                 {"2026-06-08T14:20:07.999999999+02:00", "2026-06-08T14:20:07.999999999+02:00"},
+		"mixed_utc":              {"2026-06-08T14:20:07.999999999+02:00", "2026-06-08T12:30:00Z"},
+		"same_second_fractional": {"2026-06-08T12:20:07Z", "2026-06-08T12:20:07.1Z"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			store, err := OpenStore(t.TempDir() + "/guard.db")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer store.Close()
+
+			insertLifecycleActions(t, store)
+			ids := ledgerActionIDs(t, store)
+			if len(ids) != 2 {
+				t.Fatalf("action IDs = %+v, want 2", ids)
+			}
+			firstKey, err := ledgerTimestampCursorKey(timestamps[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+			secondKey, err := ledgerTimestampCursorKey(timestamps[1])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := store.db.ExecContext(context.Background(), `
+update authorization_actions
+set updated_at = case id when ? then ? when ? then ? else updated_at end,
+    updated_at_cursor_key = case id when ? then ? when ? then ? else updated_at_cursor_key end
+where id in (?, ?)
+			`, ids[0], timestamps[0], ids[1], timestamps[1], ids[0], firstKey, ids[1], secondKey, ids[0], ids[1]); err != nil {
+				t.Fatal(err)
+			}
+
+			firstBatch, err := store.LedgerBatch(context.Background(), LedgerExportOptions{Limit: 1})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if firstBatch.Cursor == nil {
+				t.Fatal("first cursor = nil")
+			}
+			if firstBatch.Cursor.ActionID != ids[0] || firstBatch.Cursor.UpdatedAtKey != firstKey {
+				t.Fatalf("first cursor = %+v, want action %s and cursor key %q", firstBatch.Cursor, ids[0], firstKey)
+			}
+
+			secondBatch, err := store.LedgerBatch(context.Background(), LedgerExportOptions{
+				UpdatedAfter:    &firstBatch.Cursor.UpdatedAt,
+				UpdatedAfterKey: firstBatch.Cursor.UpdatedAtKey,
+				UpdatedAfterID:  firstBatch.Cursor.ActionID,
+				Limit:           1,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(secondBatch.Actions) != 1 || secondBatch.Actions[0]["id"] != ids[1] {
+				t.Fatalf("second batch actions = %+v, want %s", secondBatch.Actions, ids[1])
+			}
+
+			fallbackBatch, err := store.LedgerBatch(context.Background(), LedgerExportOptions{
+				UpdatedAfter:   &firstBatch.Cursor.UpdatedAt,
+				UpdatedAfterID: firstBatch.Cursor.ActionID,
+				Limit:          1,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(fallbackBatch.Actions) != 1 || fallbackBatch.Actions[0]["id"] != ids[1] {
+				t.Fatalf("fallback batch actions = %+v, want %s", fallbackBatch.Actions, ids[1])
+			}
+		})
 	}
 }
 
@@ -992,15 +1181,28 @@ func TestLedgerBatchIncludesReceiptChainAnchorForIncrementalExports(t *testing.T
 
 	firstUpdated := "2026-05-19T10:00:00Z"
 	secondUpdated := "2026-05-19T11:00:00Z"
+	firstUpdatedKey, err := ledgerTimestampCursorKey(firstUpdated)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondUpdatedKey, err := ledgerTimestampCursorKey(secondUpdated)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if _, err := store.db.ExecContext(context.Background(), `
 	update authorization_actions
 	set updated_at = case tool_use_id
 	  when ? then ?
 	  when ? then ?
 	  else updated_at
+	end,
+	updated_at_cursor_key = case tool_use_id
+	  when ? then ?
+	  when ? then ?
+	  else updated_at_cursor_key
 	end
 	where session_id = ? and tool_use_id in (?, ?)
-		`, "tool-1", firstUpdated, "tool-2", secondUpdated, "s1", "tool-1", "tool-2"); err != nil {
+		`, "tool-1", firstUpdated, "tool-2", secondUpdated, "tool-1", firstUpdatedKey, "tool-2", secondUpdatedKey, "s1", "tool-1", "tool-2"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1085,16 +1287,34 @@ func TestLedgerBatchIncludesContiguousReceiptRangeAndBridgeActions(t *testing.T)
 		t.Fatal(err)
 	}
 
+	firstUpdatedKey, err := ledgerTimestampCursorKey("2026-05-19T11:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bridgeUpdatedKey, err := ledgerTimestampCursorKey("2026-05-19T10:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondUpdatedKey, err := ledgerTimestampCursorKey("2026-05-19T12:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if _, err := store.db.ExecContext(context.Background(), `
-	update authorization_actions
-	set updated_at = case tool_use_id
-	  when ? then '2026-05-19T11:00:00Z'
-	  when ? then '2026-05-19T10:00:00Z'
-	  when ? then '2026-05-19T12:00:00Z'
-	  else updated_at
-	end
-	where session_id = ? and tool_use_id in (?, ?, ?)
-		`, "tool-1", "tool-bridge", "tool-2", "s1", "tool-1", "tool-bridge", "tool-2"); err != nil {
+		update authorization_actions
+		set updated_at = case tool_use_id
+		  when ? then '2026-05-19T11:00:00Z'
+		  when ? then '2026-05-19T10:00:00Z'
+		  when ? then '2026-05-19T12:00:00Z'
+		  else updated_at
+		end,
+		updated_at_cursor_key = case tool_use_id
+		  when ? then ?
+		  when ? then ?
+		  when ? then ?
+		  else updated_at_cursor_key
+		end
+		where session_id = ? and tool_use_id in (?, ?, ?)
+			`, "tool-1", "tool-bridge", "tool-2", "tool-1", firstUpdatedKey, "tool-bridge", bridgeUpdatedKey, "tool-2", secondUpdatedKey, "s1", "tool-1", "tool-bridge", "tool-2"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1422,6 +1642,66 @@ func ledgerRecordByField(records []LedgerRecord, field, value string) LedgerReco
 		}
 	}
 	return nil
+}
+
+func insertLifecycleActions(t *testing.T, store *Store) {
+	t.Helper()
+	for _, hookEvent := range []string{"SessionStart", "SessionEnd"} {
+		if _, err := store.SaveDecision(context.Background(), risk.HookEvent{
+			SessionID:     "s1",
+			Agent:         "claude-code",
+			HookEventName: hookEvent,
+			CWD:           "/tmp/project",
+		}, risk.RiskDecision{
+			Decision:   risk.DecisionAllow,
+			Reason:     "async telemetry event recorded",
+			ReasonCode: "async_telemetry",
+			RiskEvent:  risk.RiskEvent{Type: risk.EventNormalToolCall},
+		}); err != nil {
+			t.Fatalf("SaveDecision(%s) error = %v", hookEvent, err)
+		}
+	}
+}
+
+func ledgerActionIDs(t *testing.T, store *Store) []string {
+	t.Helper()
+	rows, err := store.db.QueryContext(context.Background(), `
+select id
+from authorization_actions
+where session_id = 's1'
+order by id
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			t.Fatal(err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return ids
+}
+
+func assertLedgerTimestampHasOffset(t *testing.T, record LedgerRecord, column string) {
+	t.Helper()
+	value, ok := record[column].(string)
+	if !ok || value == "" {
+		return
+	}
+	if _, err := time.Parse(time.RFC3339Nano, value); err != nil {
+		t.Fatalf("%s = %q does not parse as RFC3339Nano: %v", column, value, err)
+	}
+	if !strings.HasSuffix(value, "Z") {
+		t.Fatalf("%s = %q, want normalized UTC timestamp", column, value)
+	}
 }
 
 func receiptCountForTool(t *testing.T, store *Store, receipts []LedgerRecord, toolUseID string) int {

--- a/internal/managedstream/stream.go
+++ b/internal/managedstream/stream.go
@@ -33,7 +33,8 @@ const (
 	maxPayloadActions  = 1000
 	maxPayloadReceipts = 2000
 
-	maxErrorBodyBytes = 4096
+	maxErrorBodyBytes             = 4096
+	stateTimestampCursorKeyLayout = "2006-01-02T15:04:05.000000000Z07:00"
 
 	envStatePath = "KONTEXT_MANAGED_STREAM_STATE"
 	envInterval  = "KONTEXT_MANAGED_STREAM_INTERVAL"
@@ -126,20 +127,23 @@ func Flush(ctx context.Context, opts Options) error {
 	}
 
 	var updatedAfter *time.Time
+	updatedAfterKey := ""
 	if state.UpdatedAfter != "" {
-		parsed, err := time.Parse(time.RFC3339Nano, state.UpdatedAfter)
+		parsed, err := parseStateUpdatedAfter(state.UpdatedAfter)
 		if err != nil {
 			return fmt.Errorf("parse managed stream state: %w", err)
 		}
 		updatedAfter = &parsed
+		updatedAfterKey = parsed.UTC().Format(stateTimestampCursorKeyLayout)
 	}
 
 	limit := batchLimit(opts.BatchLimit)
 	for {
 		batch, err := store.LedgerBatch(ctx, sqlite.LedgerExportOptions{
-			UpdatedAfter:   updatedAfter,
-			UpdatedAfterID: state.ActionID,
-			Limit:          limit,
+			UpdatedAfter:    updatedAfter,
+			UpdatedAfterKey: updatedAfterKey,
+			UpdatedAfterID:  state.ActionID,
+			Limit:           limit,
 		})
 		if err != nil {
 			return err
@@ -319,10 +323,31 @@ func advancePastMinimumBatch(statePath string, batch sqlite.LedgerBatch, reason 
 }
 
 func saveCursor(statePath string, batch sqlite.LedgerBatch) error {
+	updatedAfter := batch.Cursor.UpdatedAt.UTC().Format(time.RFC3339Nano)
+	if batch.Cursor.UpdatedAtKey != "" {
+		updatedAfter = batch.Cursor.UpdatedAtKey
+	}
 	return SaveState(statePath, State{
-		UpdatedAfter: batch.Cursor.UpdatedAt.UTC().Format(time.RFC3339Nano),
+		UpdatedAfter: updatedAfter,
 		ActionID:     batch.Cursor.ActionID,
 	})
+}
+
+func parseStateUpdatedAfter(value string) (time.Time, error) {
+	if parsed, err := time.Parse(time.RFC3339Nano, value); err == nil {
+		return parsed, nil
+	}
+	for _, layout := range []string{
+		"2006-01-02T15:04:05.999999999",
+		"2006-01-02T15:04:05",
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02 15:04:05",
+	} {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return parsed, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("invalid timestamp %q", value)
 }
 
 func responseBodySummary(body io.Reader) string {

--- a/internal/managedstream/stream_test.go
+++ b/internal/managedstream/stream_test.go
@@ -442,6 +442,49 @@ func TestFlushUsesUpdatedAfterCursor(t *testing.T) {
 	}
 }
 
+func TestParseStateUpdatedAfterAcceptsNaiveTimestamp(t *testing.T) {
+	parsed, err := parseStateUpdatedAfter("2026-06-08T12:20:07.853885")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := parsed.UTC().Format(time.RFC3339Nano); got != "2026-06-08T12:20:07.853885Z" {
+		t.Fatalf("parsed = %q", got)
+	}
+	if got := parsed.UTC().Format(stateTimestampCursorKeyLayout); got != "2026-06-08T12:20:07.853885000Z" {
+		t.Fatalf("cursor key = %q", got)
+	}
+
+	parsed, err = parseStateUpdatedAfter("2026-06-08 12:20:07.853885")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := parsed.UTC().Format(time.RFC3339Nano); got != "2026-06-08T12:20:07.853885Z" {
+		t.Fatalf("space parsed = %q", got)
+	}
+}
+
+func TestSaveCursorPersistsTimestampCursorKey(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "stream-state.json")
+	updatedAt, err := time.Parse(time.RFC3339Nano, "2026-06-08T12:20:07.999999999Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := saveCursor(statePath, sqlite.LedgerBatch{Cursor: &sqlite.LedgerCursor{
+		UpdatedAt:    updatedAt,
+		UpdatedAtKey: "2026-06-08T12:20:07.999999999Z",
+		ActionID:     "act_1",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	state, err := LoadState(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.UpdatedAfter != "2026-06-08T12:20:07.999999999Z" || state.ActionID != "act_1" {
+		t.Fatalf("state = %+v", state)
+	}
+}
+
 func testStore(t *testing.T) (*sqlite.Store, string) {
 	t.Helper()
 	dbPath := filepath.Join(t.TempDir(), "guard.db")


### PR DESCRIPTION
## Where We Are

Katana managed observe can still fail hosted ingest when legacy ledger rows contain timestamps without a timezone, like 2026-06-08T12:20:07.853885. Hosted expects offset-aware timestamps, so those rows turn into 400 responses.

## Where We Want To Go

Managed observe should upload the same ledger rows with valid UTC timestamps and keep cursor pagination stable. It must not skip rows, leak internal cursor fields into the payload, or rely on SQLite timestamp rounding.

## How do we get there

This adds a stored Go-computed updated_at cursor key, backfills it during SQLite migration, uses it for bounded cursor filtering, and normalizes exported *_at fields to RFC3339 UTC. Covered by focused ledger/managed-stream tests and verified with go test -count=1 ./internal/guard/store/sqlite ./internal/managedstream plus go test ./...

