### PR TITLE
fix(managedstream): use fixed ledger timestamp cursors

### DIFF
--- a/internal/guard/store/sqlite/ledger.go
+++ b/internal/guard/store/sqlite/ledger.go
@@ -34,6 +34,13 @@ type LedgerCursor struct {
 	ActionID  string
 }
 
+const (
+	ledgerCursorUpdatedAtKeyColumn = "__cursor_updated_at_key"
+	ledgerTimestampCursorKeyLayout = "2006-01-02T15:04:05.000000000Z07:00"
+)
+
+var ledgerFallbackTimestamp = time.Unix(0, 0).UTC()
+
 const authorizationActionsSelect = `
 select id, session_id, turn_id, tool_use_id, trace_id, span_id, parent_span_id,
   runtime_kind, runtime_instance_id, adapter_kind, adapter_version,
@@ -59,11 +66,7 @@ select id, action_id, session_id, receipt_type, decision_result, decision_catego
 from authorization_receipts`
 
 func (s *Store) LedgerBatch(ctx context.Context, opts LedgerExportOptions) (LedgerBatch, error) {
-	actions, err := s.AuthorizationActions(ctx, opts)
-	if err != nil {
-		return LedgerBatch{}, err
-	}
-	cursor, err := ledgerCursor(actions)
+	actions, cursor, err := s.authorizationActionCursorPage(ctx, opts)
 	if err != nil {
 		return LedgerBatch{}, err
 	}
@@ -86,6 +89,19 @@ func (s *Store) LedgerBatch(ctx context.Context, opts LedgerExportOptions) (Ledg
 		ReceiptChainAnchor: receiptChainAnchor(receipts),
 		Cursor:             cursor,
 	}, nil
+}
+
+func (s *Store) authorizationActionCursorPage(ctx context.Context, opts LedgerExportOptions) ([]LedgerRecord, *LedgerCursor, error) {
+	actions, err := s.authorizationActions(ctx, opts, true)
+	if err != nil {
+		return nil, nil, err
+	}
+	cursor, err := ledgerCursor(actions)
+	if err != nil {
+		return nil, nil, err
+	}
+	stripLedgerCursorColumns(actions)
+	return actions, cursor, nil
 }
 
 func receiptChainAnchor(receipts []LedgerRecord) *LedgerReceiptChainAnchor {
@@ -117,19 +133,31 @@ order by created_at, id
 }
 
 func (s *Store) AuthorizationActions(ctx context.Context, opts LedgerExportOptions) ([]LedgerRecord, error) {
+	actions, err := s.authorizationActions(ctx, opts, false)
+	if err != nil {
+		return nil, err
+	}
+	stripLedgerCursorColumns(actions)
+	return actions, nil
+}
+
+func (s *Store) authorizationActions(ctx context.Context, opts LedgerExportOptions, includeCursorKey bool) ([]LedgerRecord, error) {
 	query := authorizationActionsSelect
+	if includeCursorKey {
+		query = authorizationActionsSelectWithCursorKey()
+	}
 	args := []any{}
 	if opts.UpdatedAfter != nil {
+		updatedAfter := ledgerTimestampCursorKeyFromTime(*opts.UpdatedAfter)
 		if opts.UpdatedAfterID != "" {
-			query += "\nwhere updated_at > ? or (updated_at = ? and id > ?)"
-			updatedAfter := opts.UpdatedAfter.Format(time.RFC3339Nano)
+			query += "\nwhere updated_at_cursor_key > ? or (updated_at_cursor_key = ? and id > ?)"
 			args = append(args, updatedAfter, updatedAfter, opts.UpdatedAfterID)
 		} else {
-			query += "\nwhere updated_at > ?"
-			args = append(args, opts.UpdatedAfter.Format(time.RFC3339Nano))
+			query += "\nwhere updated_at_cursor_key > ?"
+			args = append(args, updatedAfter)
 		}
 	}
-	query += "\norder by updated_at, id"
+	query += "\norder by updated_at_cursor_key, id"
 	if opts.Limit > 0 {
 		query += "\nlimit ?"
 		args = append(args, opts.Limit)
@@ -143,11 +171,15 @@ func ledgerCursor(actions []LedgerRecord) (*LedgerCursor, error) {
 	}
 	last := actions[len(actions)-1]
 	rawUpdatedAt, _ := last["updated_at"].(string)
+	updatedAtKey, _ := last[ledgerCursorUpdatedAtKeyColumn].(string)
 	actionID, _ := last["id"].(string)
-	if rawUpdatedAt == "" || actionID == "" {
+	if updatedAtKey == "" {
+		updatedAtKey = ledgerTimestampCursorKeyFromValues(rawUpdatedAt)
+	}
+	if updatedAtKey == "" || actionID == "" {
 		return nil, nil
 	}
-	updatedAt, err := time.Parse(time.RFC3339Nano, rawUpdatedAt)
+	updatedAt, err := parseLedgerTimestamp(updatedAtKey)
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +196,7 @@ func (s *Store) authorizationActionsByIDs(ctx context.Context, ids []string) ([]
 	for _, id := range ids {
 		args = append(args, id)
 	}
-	return queryLedgerRecords(ctx, s.db, fmt.Sprintf("%s\nwhere id in (%s)\norder by updated_at, id", authorizationActionsSelect, placeholders), args...)
+	return queryLedgerRecords(ctx, s.db, fmt.Sprintf("%s\nwhere id in (%s)\norder by updated_at_cursor_key, id", authorizationActionsSelect, placeholders), args...)
 }
 
 func (s *Store) AuthorizationReceipts(ctx context.Context, opts LedgerExportOptions) ([]LedgerRecord, error) {
@@ -232,6 +264,7 @@ func queryLedgerRecords(ctx context.Context, db *sql.DB, query string, args ...a
 		for i, column := range columns {
 			record[column] = normalizeLedgerValue(column, values[i])
 		}
+		normalizeLedgerRecord(record)
 		records = append(records, record)
 	}
 	return records, rows.Err()
@@ -259,6 +292,90 @@ func normalizeLedgerString(column, value string) any {
 		}
 	}
 	return value
+}
+
+func normalizeLedgerRecord(record LedgerRecord) {
+	fallback := ledgerRecordFallbackTime(record)
+	for column, value := range record {
+		if !isLedgerTimeColumn(column) {
+			continue
+		}
+		text, ok := value.(string)
+		if !ok {
+			continue
+		}
+		record[column] = normalizeLedgerTimeValue(column, text, fallback)
+	}
+}
+
+func normalizeLedgerTimeValue(column, value string, fallback time.Time) any {
+	if parsed, err := parseLedgerTimestamp(value); err == nil {
+		return parsed.UTC().Format(time.RFC3339Nano)
+	}
+	if isRequiredLedgerTimeColumn(column) {
+		return fallback.UTC().Format(time.RFC3339Nano)
+	}
+	return nil
+}
+
+func ledgerRecordFallbackTime(record LedgerRecord) time.Time {
+	for _, column := range []string{"updated_at", "created_at"} {
+		value, _ := record[column].(string)
+		if parsed, err := parseLedgerTimestamp(value); err == nil {
+			return parsed.UTC()
+		}
+	}
+	return ledgerFallbackTimestamp
+}
+
+func authorizationActionsSelectWithCursorKey() string {
+	cursorColumn := ",\n  updated_at_cursor_key as " + ledgerCursorUpdatedAtKeyColumn
+	return strings.Replace(authorizationActionsSelect, "\nfrom authorization_actions", cursorColumn+"\nfrom authorization_actions", 1)
+}
+
+func stripLedgerCursorColumns(records []LedgerRecord) {
+	for _, record := range records {
+		delete(record, ledgerCursorUpdatedAtKeyColumn)
+	}
+}
+
+func isLedgerTimeColumn(column string) bool {
+	return strings.HasSuffix(column, "_at")
+}
+
+func isRequiredLedgerTimeColumn(column string) bool {
+	return column == "created_at" || column == "updated_at"
+}
+
+func parseLedgerTimestamp(value string) (time.Time, error) {
+	if parsed, err := time.Parse(time.RFC3339Nano, value); err == nil {
+		return parsed, nil
+	}
+	for _, layout := range []string{
+		"2006-01-02T15:04:05.999999999",
+		"2006-01-02T15:04:05",
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02 15:04:05",
+	} {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return parsed, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("invalid timestamp %q", value)
+}
+
+func ledgerTimestampCursorKeyFromTime(value time.Time) string {
+	return value.UTC().Format(ledgerTimestampCursorKeyLayout)
+}
+
+func ledgerTimestampCursorKeyFromValues(values ...string) string {
+	for _, value := range values {
+		parsed, err := parseLedgerTimestamp(value)
+		if err == nil {
+			return ledgerTimestampCursorKeyFromTime(parsed)
+		}
+	}
+	return ledgerTimestampCursorKeyFromTime(ledgerFallbackTimestamp)
 }
 
 func sessionIDs(groups ...[]LedgerRecord) []string {

--- a/internal/guard/store/sqlite/store.go
+++ b/internal/guard/store/sqlite/store.go
@@ -207,7 +207,8 @@ func (s *Store) migrate(ctx context.Context) error {
 	  decision_at text,
 	  completed_at text,
 	  created_at text not null,
-	  updated_at text not null
+	  updated_at text not null,
+	  updated_at_cursor_key text not null default ''
 	);
 
 	create table if not exists authorization_receipts (
@@ -251,9 +252,18 @@ func (s *Store) migrate(ctx context.Context) error {
 	if err := s.ensureAuthorizationActionsDecisionNullable(ctx); err != nil {
 		return err
 	}
+	if err := s.ensureColumn(ctx, "authorization_actions", "updated_at_cursor_key", "text not null default ''"); err != nil {
+		return err
+	}
+	if err := s.backfillAuthorizationActionCursorKeys(ctx); err != nil {
+		return err
+	}
 	if _, err := s.db.ExecContext(ctx, `
 	create index if not exists idx_authorization_actions_session_updated
 	on authorization_actions(session_id, updated_at);
+
+	create index if not exists idx_authorization_actions_cursor
+	on authorization_actions(updated_at_cursor_key, id);
 
 	create index if not exists idx_authorization_actions_session_tool_use
 	on authorization_actions(session_id, tool_use_id);
@@ -427,7 +437,8 @@ func (s *Store) ensureAuthorizationActionsDecisionNullable(ctx context.Context) 
 	  decision_at text,
 	  completed_at text,
 	  created_at text not null,
-	  updated_at text not null
+	  updated_at text not null,
+	  updated_at_cursor_key text not null default ''
 	);
 
 	insert into authorization_actions (
@@ -441,6 +452,9 @@ func (s *Store) ensureAuthorizationActionsDecisionNullable(ctx context.Context) 
 
 	create index if not exists idx_authorization_actions_session_updated
 	on authorization_actions(session_id, updated_at);
+
+	create index if not exists idx_authorization_actions_cursor
+	on authorization_actions(updated_at_cursor_key, id);
 
 	create index if not exists idx_authorization_actions_session_tool_use
 	on authorization_actions(session_id, tool_use_id);
@@ -524,6 +538,7 @@ var authorizationActionColumns = []authorizationActionColumn{
 	{name: "completed_at", defaultExpr: "null"},
 	{name: "created_at", copyExpr: "coalesce(created_at, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))", defaultExpr: "strftime('%Y-%m-%dT%H:%M:%fZ', 'now')"},
 	{name: "updated_at", copyExpr: "coalesce(updated_at, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))", defaultExpr: "strftime('%Y-%m-%dT%H:%M:%fZ', 'now')"},
+	{name: "updated_at_cursor_key", copyExpr: "coalesce(updated_at_cursor_key, '')", defaultExpr: "''"},
 }
 
 func authorizationActionInsertColumns() string {
@@ -547,6 +562,47 @@ func authorizationActionSelectExpressions(existingColumns map[string]bool) strin
 		expressions = append(expressions, fmt.Sprintf("%s as %s", expr, column.name))
 	}
 	return strings.Join(expressions, ",\n\t  ")
+}
+
+func (s *Store) backfillAuthorizationActionCursorKeys(ctx context.Context) error {
+	rows, err := s.db.QueryContext(ctx, `
+select id, updated_at, created_at, updated_at_cursor_key
+from authorization_actions
+	`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	type cursorKeyUpdate struct {
+		id  string
+		key string
+	}
+	updates := []cursorKeyUpdate{}
+	for rows.Next() {
+		var id, updatedAt, createdAt, currentKey string
+		if err := rows.Scan(&id, &updatedAt, &createdAt, &currentKey); err != nil {
+			return err
+		}
+		key := ledgerTimestampCursorKeyFromValues(updatedAt, createdAt)
+		if currentKey == key {
+			continue
+		}
+		updates = append(updates, cursorKeyUpdate{id: id, key: key})
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, update := range updates {
+		if _, err := s.db.ExecContext(ctx, `
+update authorization_actions
+set updated_at_cursor_key = ?
+where id = ?
+		`, update.key, update.id); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *Store) OpenSession(ctx context.Context, sessionID, agent, cwd, source, externalID string) (SessionRecord, error) {
@@ -718,7 +774,7 @@ func (s *Store) insertAction(ctx context.Context, tx *sql.Tx, actionID, sessionI
 		"risk_level", "risk_score", "risk_threshold", "model_version", "confidence", "matched_rules_json", "risk_signals_json", "risk_event_json",
 		"modifications_json", "approval_context_json", "approval_channel", "approval_request_id", "deferral_context_json",
 		"status", "outcome", "output_summary", "output_hash", "error_redacted",
-		"proposed_at", "decision_at", "completed_at", "created_at", "updated_at",
+		"proposed_at", "decision_at", "completed_at", "created_at", "updated_at", "updated_at_cursor_key",
 	}
 	values := []any{
 		action["id"], action["session_id"], action["tool_use_id"], action["canonical_event_type"], action["adapter_event_name"], action["correlation_key"],
@@ -729,7 +785,7 @@ func (s *Store) insertAction(ctx context.Context, tx *sql.Tx, actionID, sessionI
 		action["risk_level"], action["risk_score"], action["risk_threshold"], action["model_version"], action["confidence"], action["matched_rules_json"], action["risk_signals_json"], action["risk_event_json"],
 		action["modifications_json"], action["approval_context_json"], action["approval_channel"], action["approval_request_id"], action["deferral_context_json"],
 		action["status"], action["outcome"], action["output_summary"], action["output_hash"], action["error_redacted"],
-		action["proposed_at"], action["decision_at"], action["completed_at"], action["created_at"], action["updated_at"],
+		action["proposed_at"], action["decision_at"], action["completed_at"], action["created_at"], action["updated_at"], action["updated_at_cursor_key"],
 	}
 	placeholders := strings.TrimRight(strings.Repeat("?,", len(columns)), ",")
 	if _, err := tx.ExecContext(ctx,
@@ -827,6 +883,8 @@ func actionValues(actionID, sessionID string, event risk.HookEvent, decision ris
 		provider = "github"
 	}
 
+	updatedAt := now.Format(time.RFC3339Nano)
+
 	return map[string]any{
 		"id":                       actionID,
 		"session_id":               sessionID,
@@ -876,8 +934,9 @@ func actionValues(actionID, sessionID string, event risk.HookEvent, decision ris
 		"proposed_at":              nullIfEmpty(proposedAt),
 		"decision_at":              nullIfEmpty(decisionAt),
 		"completed_at":             nullIfEmpty(completedAt),
-		"created_at":               now.Format(time.RFC3339Nano),
-		"updated_at":               now.Format(time.RFC3339Nano),
+		"created_at":               updatedAt,
+		"updated_at":               updatedAt,
+		"updated_at_cursor_key":    ledgerTimestampCursorKeyFromValues(updatedAt),
 	}, nil
 }
 

--- a/internal/guard/store/sqlite/store_test.go
+++ b/internal/guard/store/sqlite/store_test.go
@@ -927,11 +927,13 @@ func TestLedgerBatchCursorUsesUpdatedAtAndActionID(t *testing.T) {
 	}
 
 	sharedUpdated := "2026-05-19T10:00:00Z"
+	sharedUpdatedKey := ledgerTimestampCursorKeyFromValues(sharedUpdated)
 	if _, err := store.db.ExecContext(context.Background(), `
 update authorization_actions
-set updated_at = ?
+set updated_at = ?,
+    updated_at_cursor_key = ?
 where id in (?, ?)
-	`, sharedUpdated, first.ID, second.ID); err != nil {
+	`, sharedUpdated, sharedUpdatedKey, first.ID, second.ID); err != nil {
 		t.Fatal(err)
 	}
 
@@ -953,6 +955,157 @@ where id in (?, ?)
 	}
 	if len(secondBatch.Actions) != 1 || secondBatch.Actions[0]["id"] == firstBatch.Cursor.ActionID {
 		t.Fatalf("second batch actions = %+v, cursor = %+v", secondBatch.Actions, firstBatch.Cursor)
+	}
+}
+
+func TestLedgerBatchNormalizesLegacyTimestampsForHostedExport(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	insertLifecycleActions(t, store)
+	naive := "2026-06-08T12:20:07.853885"
+	naiveKey := ledgerTimestampCursorKeyFromValues(naive)
+	if _, err := store.db.ExecContext(context.Background(), `
+update authorization_actions
+set proposed_at = case when proposed_at is null then null else ? end,
+    completed_at = case when completed_at is null then null else ? end,
+    created_at = ?,
+    updated_at = ?,
+    updated_at_cursor_key = ?
+	`, naive, naive, naive, naive, naiveKey); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(context.Background(), `update authorization_receipts set created_at = ?`, naive); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(context.Background(), `update agent_sessions set closed_at = ?, created_at = ?, updated_at = ?`, naive, naive, naive); err != nil {
+		t.Fatal(err)
+	}
+
+	batch, err := store.LedgerBatch(context.Background(), LedgerExportOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, record := range append(append([]LedgerRecord{}, batch.Sessions...), append(batch.Actions, batch.Receipts...)...) {
+		for _, column := range []string{"created_at", "updated_at", "closed_at", "proposed_at", "completed_at"} {
+			assertHostedTimestamp(t, record, column)
+		}
+		if _, ok := record[ledgerCursorUpdatedAtKeyColumn]; ok {
+			t.Fatalf("record leaked cursor key: %+v", record)
+		}
+	}
+}
+
+func TestLedgerBatchToleratesCorruptLegacyActionTimestamps(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	actions := insertLifecycleActions(t, store)
+	actionID := actions[0].ID
+	if _, err := store.db.ExecContext(context.Background(), `
+update authorization_actions
+set proposed_at = 'bad-proposed-at',
+    created_at = 'bad-created-at',
+    updated_at = 'bad-updated-at',
+    updated_at_cursor_key = ?
+where id = ?
+	`, ledgerTimestampCursorKeyFromValues("bad-updated-at", "bad-created-at"), actionID); err != nil {
+		t.Fatal(err)
+	}
+
+	batch, err := store.LedgerBatch(context.Background(), LedgerExportOptions{Limit: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if batch.Cursor == nil || !batch.Cursor.UpdatedAt.Equal(ledgerFallbackTimestamp) {
+		t.Fatalf("cursor = %+v, want fallback timestamp", batch.Cursor)
+	}
+	if len(batch.Actions) != 1 {
+		t.Fatalf("actions = %+v, want one action", batch.Actions)
+	}
+	action := batch.Actions[0]
+	if action["id"] != actionID {
+		t.Fatalf("action id = %v, want %s", action["id"], actionID)
+	}
+	if action["created_at"] != "1970-01-01T00:00:00Z" || action["updated_at"] != "1970-01-01T00:00:00Z" {
+		t.Fatalf("required timestamps = created %v updated %v", action["created_at"], action["updated_at"])
+	}
+	if action["proposed_at"] != nil {
+		t.Fatalf("proposed_at = %v, want nil for corrupt optional timestamp", action["proposed_at"])
+	}
+}
+
+func TestLedgerBatchCursorUsesFixedWidthTimestampKey(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	first, err := store.SaveDecision(context.Background(), risk.HookEvent{
+		SessionID:     "s1",
+		HookEventName: "PreToolUse",
+		ToolName:      "Read",
+		ToolUseID:     "tool-1",
+	}, risk.RiskDecision{
+		Decision:   risk.DecisionAllow,
+		Reason:     "normal",
+		ReasonCode: "normal_tool_call",
+		RiskEvent:  risk.RiskEvent{Type: risk.EventNormalToolCall},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := store.SaveDecision(context.Background(), risk.HookEvent{
+		SessionID:     "s1",
+		HookEventName: "PreToolUse",
+		ToolName:      "Read",
+		ToolUseID:     "tool-2",
+	}, risk.RiskDecision{
+		Decision:   risk.DecisionAllow,
+		Reason:     "normal",
+		ReasonCode: "normal_tool_call",
+		RiskEvent:  risk.RiskEvent{Type: risk.EventNormalToolCall},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstUpdated := "2026-06-08T12:20:07Z"
+	secondUpdated := "2026-06-08T12:20:07.1Z"
+	if _, err := store.db.ExecContext(context.Background(), `
+update authorization_actions
+set updated_at = case id when ? then ? when ? then ? else updated_at end,
+    updated_at_cursor_key = case id when ? then ? when ? then ? else updated_at_cursor_key end
+where id in (?, ?)
+	`, first.ID, firstUpdated, second.ID, secondUpdated, first.ID, ledgerTimestampCursorKeyFromValues(firstUpdated), second.ID, ledgerTimestampCursorKeyFromValues(secondUpdated), first.ID, second.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	firstBatch, err := store.LedgerBatch(context.Background(), LedgerExportOptions{Limit: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstBatch.Cursor == nil || firstBatch.Cursor.ActionID != first.ID {
+		t.Fatalf("first cursor = %+v, want %s", firstBatch.Cursor, first.ID)
+	}
+
+	secondBatch, err := store.LedgerBatch(context.Background(), LedgerExportOptions{
+		UpdatedAfter:   &firstBatch.Cursor.UpdatedAt,
+		UpdatedAfterID: firstBatch.Cursor.ActionID,
+		Limit:          1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(secondBatch.Actions) != 1 || secondBatch.Actions[0]["id"] != second.ID {
+		t.Fatalf("second batch actions = %+v, want %s", secondBatch.Actions, second.ID)
 	}
 }
 
@@ -992,15 +1145,22 @@ func TestLedgerBatchIncludesReceiptChainAnchorForIncrementalExports(t *testing.T
 
 	firstUpdated := "2026-05-19T10:00:00Z"
 	secondUpdated := "2026-05-19T11:00:00Z"
+	firstUpdatedKey := ledgerTimestampCursorKeyFromValues(firstUpdated)
+	secondUpdatedKey := ledgerTimestampCursorKeyFromValues(secondUpdated)
 	if _, err := store.db.ExecContext(context.Background(), `
 	update authorization_actions
 	set updated_at = case tool_use_id
 	  when ? then ?
 	  when ? then ?
 	  else updated_at
+	end,
+	updated_at_cursor_key = case tool_use_id
+	  when ? then ?
+	  when ? then ?
+	  else updated_at_cursor_key
 	end
 	where session_id = ? and tool_use_id in (?, ?)
-		`, "tool-1", firstUpdated, "tool-2", secondUpdated, "s1", "tool-1", "tool-2"); err != nil {
+		`, "tool-1", firstUpdated, "tool-2", secondUpdated, "tool-1", firstUpdatedKey, "tool-2", secondUpdatedKey, "s1", "tool-1", "tool-2"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1085,6 +1245,9 @@ func TestLedgerBatchIncludesContiguousReceiptRangeAndBridgeActions(t *testing.T)
 		t.Fatal(err)
 	}
 
+	firstUpdatedKey := ledgerTimestampCursorKeyFromValues("2026-05-19T11:00:00Z")
+	bridgeUpdatedKey := ledgerTimestampCursorKeyFromValues("2026-05-19T10:00:00Z")
+	secondUpdatedKey := ledgerTimestampCursorKeyFromValues("2026-05-19T12:00:00Z")
 	if _, err := store.db.ExecContext(context.Background(), `
 	update authorization_actions
 	set updated_at = case tool_use_id
@@ -1092,9 +1255,15 @@ func TestLedgerBatchIncludesContiguousReceiptRangeAndBridgeActions(t *testing.T)
 	  when ? then '2026-05-19T10:00:00Z'
 	  when ? then '2026-05-19T12:00:00Z'
 	  else updated_at
+	end,
+	updated_at_cursor_key = case tool_use_id
+	  when ? then ?
+	  when ? then ?
+	  when ? then ?
+	  else updated_at_cursor_key
 	end
 	where session_id = ? and tool_use_id in (?, ?, ?)
-		`, "tool-1", "tool-bridge", "tool-2", "s1", "tool-1", "tool-bridge", "tool-2"); err != nil {
+		`, "tool-1", "tool-bridge", "tool-2", "tool-1", firstUpdatedKey, "tool-bridge", bridgeUpdatedKey, "tool-2", secondUpdatedKey, "s1", "tool-1", "tool-bridge", "tool-2"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1399,6 +1568,43 @@ insert into authorization_actions(
 	_, err = store.Events(context.Background(), "s1")
 	if err == nil || !strings.Contains(err.Error(), "parse decision created_at") {
 		t.Fatalf("err = %v, want invalid created_at parse error", err)
+	}
+}
+
+func insertLifecycleActions(t *testing.T, store *Store) []DecisionRecord {
+	t.Helper()
+	records := []DecisionRecord{}
+	for _, hookEvent := range []string{"SessionStart", "SessionEnd"} {
+		record, err := store.SaveDecision(context.Background(), risk.HookEvent{
+			SessionID:     "s1",
+			Agent:         "claude-code",
+			HookEventName: hookEvent,
+			CWD:           "/tmp/project",
+		}, risk.RiskDecision{
+			Decision:   risk.DecisionAllow,
+			Reason:     "async telemetry event recorded",
+			ReasonCode: "async_telemetry",
+			RiskEvent:  risk.RiskEvent{Type: risk.EventNormalToolCall},
+		})
+		if err != nil {
+			t.Fatalf("SaveDecision(%s) error = %v", hookEvent, err)
+		}
+		records = append(records, record)
+	}
+	return records
+}
+
+func assertHostedTimestamp(t *testing.T, record LedgerRecord, column string) {
+	t.Helper()
+	value, ok := record[column].(string)
+	if !ok || value == "" {
+		return
+	}
+	if _, err := time.Parse(time.RFC3339Nano, value); err != nil {
+		t.Fatalf("%s = %q does not parse as RFC3339Nano: %v", column, value, err)
+	}
+	if !strings.HasSuffix(value, "Z") {
+		t.Fatalf("%s = %q, want UTC timestamp with offset", column, value)
 	}
 }
 

--- a/internal/managedstream/stream.go
+++ b/internal/managedstream/stream.go
@@ -127,7 +127,7 @@ func Flush(ctx context.Context, opts Options) error {
 
 	var updatedAfter *time.Time
 	if state.UpdatedAfter != "" {
-		parsed, err := time.Parse(time.RFC3339Nano, state.UpdatedAfter)
+		parsed, err := parseStateUpdatedAfter(state.UpdatedAfter)
 		if err != nil {
 			return fmt.Errorf("parse managed stream state: %w", err)
 		}
@@ -323,6 +323,23 @@ func saveCursor(statePath string, batch sqlite.LedgerBatch) error {
 		UpdatedAfter: batch.Cursor.UpdatedAt.UTC().Format(time.RFC3339Nano),
 		ActionID:     batch.Cursor.ActionID,
 	})
+}
+
+func parseStateUpdatedAfter(value string) (time.Time, error) {
+	if parsed, err := time.Parse(time.RFC3339Nano, value); err == nil {
+		return parsed, nil
+	}
+	for _, layout := range []string{
+		"2006-01-02T15:04:05.999999999",
+		"2006-01-02T15:04:05",
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02 15:04:05",
+	} {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return parsed, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("invalid timestamp %q", value)
 }
 
 func responseBodySummary(body io.Reader) string {

--- a/internal/managedstream/stream_test.go
+++ b/internal/managedstream/stream_test.go
@@ -442,6 +442,21 @@ func TestFlushUsesUpdatedAfterCursor(t *testing.T) {
 	}
 }
 
+func TestParseStateUpdatedAfterAcceptsLegacyTimestampFormats(t *testing.T) {
+	for _, value := range []string{
+		"2026-06-08T12:20:07.853885",
+		"2026-06-08 12:20:07.853885",
+	} {
+		parsed, err := parseStateUpdatedAfter(value)
+		if err != nil {
+			t.Fatalf("parseStateUpdatedAfter(%q) error = %v", value, err)
+		}
+		if got := parsed.UTC().Format(time.RFC3339Nano); got != "2026-06-08T12:20:07.853885Z" {
+			t.Fatalf("parseStateUpdatedAfter(%q) = %q", value, got)
+		}
+	}
+}
+
 func testStore(t *testing.T) (*sqlite.Store, string) {
 	t.Helper()
 	dbPath := filepath.Join(t.TempDir(), "guard.db")


### PR DESCRIPTION
## Where We Are

Katana managed observe can fail hosted ingest when old local ledger rows contain timestamps without offsets, exact-second timestamps, or corrupt timestamp strings. The old export path used raw timestamp text for both hosted payloads and cursor pagination.

## Where We Want To Go

Managed observe should keep uploading valid ledger batches and keep cursor pagination stable. It should not skip same-second rows, upload invalid datetime strings, leak internal cursor fields, or fail store migration because one legacy timestamp is bad.

## How do we get there

This adds a fixed-width UTC cursor key for authorization actions, backfills it during SQLite migration, and uses it for bounded cursor queries. Exported ledger timestamps are normalized to hosted-valid RFC3339 strings; corrupt optional timestamps become null, and corrupt required timestamps fall back to a valid UTC timestamp. Managed-stream state parsing now accepts old no-offset and SQLite-space timestamp formats. Verified with go test -count=1 ./internal/guard/store/sqlite ./internal/managedstream, go test ./..., and pnpm --dir /Users/michelosswald/cobro/code/workspace/kontext --filter api test -- authorization-ledger.validation.spec.ts --runInBand.

