### PR TITLE
[AUTOMATION] feat: clean up hook payload JSON helpers

### DIFF
--- a/internal/hook/json.go
+++ b/internal/hook/json.go
@@ -1,0 +1,30 @@
+package hook
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+func MarshalMapJSON(value map[string]any) (json.RawMessage, error) {
+	if value == nil {
+		return nil, nil
+	}
+	return json.Marshal(value)
+}
+
+func UnmarshalMapJSON(data json.RawMessage) (map[string]any, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var value map[string]any
+	if err := UnmarshalJSONUseNumber(data, &value); err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+func UnmarshalJSONUseNumber(data []byte, dst any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	return decoder.Decode(dst)
+}

--- a/internal/hook/json_test.go
+++ b/internal/hook/json_test.go
@@ -1,0 +1,51 @@
+package hook
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMarshalMapJSONNil(t *testing.T) {
+	t.Parallel()
+
+	data, err := MarshalMapJSON(nil)
+	if err != nil {
+		t.Fatalf("MarshalMapJSON(nil) error = %v", err)
+	}
+	if data != nil {
+		t.Fatalf("MarshalMapJSON(nil) = %v, want nil", data)
+	}
+}
+
+func TestUnmarshalMapJSONPreservesLargeNumbers(t *testing.T) {
+	t.Parallel()
+
+	value, err := UnmarshalMapJSON(json.RawMessage(`{"id":9007199254740993}`))
+	if err != nil {
+		t.Fatalf("UnmarshalMapJSON() error = %v", err)
+	}
+	got, ok := value["id"].(json.Number)
+	if !ok {
+		t.Fatalf("id type = %T, want json.Number", value["id"])
+	}
+	if got.String() != "9007199254740993" {
+		t.Fatalf("id = %s, want exact large number", got.String())
+	}
+}
+
+func TestUnmarshalJSONUseNumberPreservesLargeNumbersInArrays(t *testing.T) {
+	t.Parallel()
+
+	var value any
+	if err := UnmarshalJSONUseNumber([]byte(`[{"id":9007199254740993}]`), &value); err != nil {
+		t.Fatalf("UnmarshalJSONUseNumber() error = %v", err)
+	}
+	got := value.([]any)[0].(map[string]any)["id"]
+	num, ok := got.(json.Number)
+	if !ok {
+		t.Fatalf("id type = %T, want json.Number", got)
+	}
+	if num.String() != "9007199254740993" {
+		t.Fatalf("id = %s, want exact large number", num.String())
+	}
+}

--- a/internal/hookruntime/claude.go
+++ b/internal/hookruntime/claude.go
@@ -98,23 +98,15 @@ func normalizeToolResponse(values ...json.RawMessage) map[string]any {
 			continue
 		}
 		var obj map[string]any
-		if err := decodeUseNumber(trimmed, &obj); err == nil {
+		if err := hook.UnmarshalJSONUseNumber(trimmed, &obj); err == nil {
 			return obj
 		}
 		var v any
-		if err := decodeUseNumber(trimmed, &v); err == nil {
+		if err := hook.UnmarshalJSONUseNumber(trimmed, &v); err == nil {
 			return map[string]any{"content": v}
 		}
 	}
 	return nil
-}
-
-// decodeUseNumber unmarshals JSON while preserving numeric precision, so large
-// integer IDs beyond float64's exact range survive recording and hashing.
-func decodeUseNumber(data []byte, dst any) error {
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.UseNumber()
-	return decoder.Decode(dst)
 }
 
 func EncodeClaudeResult(hookEventName string, result hook.Result) ([]byte, error) {

--- a/internal/localruntime/conversions.go
+++ b/internal/localruntime/conversions.go
@@ -1,8 +1,6 @@
 package localruntime
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -26,14 +24,14 @@ func EvaluateRequestFromEvent(event hook.Event) (EvaluateRequest, error) {
 	}
 
 	if event.ToolInput != nil {
-		data, err := marshalMap(event.ToolInput)
+		data, err := hook.MarshalMapJSON(event.ToolInput)
 		if err != nil {
 			return EvaluateRequest{}, fmt.Errorf("marshal tool input: %w", err)
 		}
 		req.ToolInput = data
 	}
 	if event.ToolResponse != nil {
-		data, err := marshalMap(event.ToolResponse)
+		data, err := hook.MarshalMapJSON(event.ToolResponse)
 		if err != nil {
 			return EvaluateRequest{}, fmt.Errorf("marshal tool response: %w", err)
 		}
@@ -74,11 +72,11 @@ func EventFromEvaluateRequest(sessionID, fallbackAgent string, req *EvaluateRequ
 	}
 
 	var err error
-	event.ToolInput, err = rawMap(req.ToolInput)
+	event.ToolInput, err = hook.UnmarshalMapJSON(req.ToolInput)
 	if err != nil {
 		return hook.Event{}, fmt.Errorf("decode tool input: %w", err)
 	}
-	event.ToolResponse, err = rawMap(req.ToolResponse)
+	event.ToolResponse, err = hook.UnmarshalMapJSON(req.ToolResponse)
 	if err != nil {
 		return hook.Event{}, fmt.Errorf("decode tool response: %w", err)
 	}
@@ -88,7 +86,7 @@ func EventFromEvaluateRequest(sessionID, fallbackAgent string, req *EvaluateRequ
 func EvaluateResultFromResult(result hook.Result) EvaluateResult {
 	return EvaluateResult{
 		Type:         "result",
-		Decision:     string(result.Decision),
+		Decision:     result.Decision,
 		Allowed:      result.Allowed(),
 		Reason:       result.Reason,
 		ReasonCode:   result.ReasonCode,
@@ -100,7 +98,7 @@ func EvaluateResultFromResult(result hook.Result) EvaluateResult {
 }
 
 func ResultFromEvaluateResult(result EvaluateResult) hook.Result {
-	decision, ok := hook.NormalizeDecision(result.Decision)
+	decision, ok := hook.NormalizeDecision(string(result.Decision))
 	if !ok {
 		decision = resultFromBool(result.Allowed).Decision
 	}
@@ -120,26 +118,6 @@ func resultFromBool(allowed bool) hook.Result {
 		return hook.Result{Decision: hook.DecisionAllow}
 	}
 	return hook.Result{Decision: hook.DecisionDeny}
-}
-
-func marshalMap(value map[string]any) (json.RawMessage, error) {
-	if value == nil {
-		return nil, nil
-	}
-	return json.Marshal(value)
-}
-
-func rawMap(data json.RawMessage) (map[string]any, error) {
-	if len(data) == 0 {
-		return nil, nil
-	}
-	var value map[string]any
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.UseNumber()
-	if err := decoder.Decode(&value); err != nil {
-		return nil, err
-	}
-	return value, nil
 }
 
 func normalizeHookName(value string) (hook.HookName, bool) {

--- a/internal/localruntime/conversions_test.go
+++ b/internal/localruntime/conversions_test.go
@@ -126,6 +126,19 @@ func TestEventFromEvaluateRequestPreservesLargeJSONNumbers(t *testing.T) {
 	}
 }
 
+func TestEvaluateResultFromResultPreservesDecision(t *testing.T) {
+	t.Parallel()
+
+	result := EvaluateResultFromResult(hook.Result{
+		Decision: hook.DecisionDeny,
+		Reason:   "blocked",
+	})
+
+	if result.Decision != hook.DecisionDeny {
+		t.Fatalf("decision = %q, want deny", result.Decision)
+	}
+}
+
 func TestResultFromEvaluateResultNormalizesLegacyDecision(t *testing.T) {
 	t.Parallel()
 

--- a/internal/localruntime/protocol.go
+++ b/internal/localruntime/protocol.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net"
+
+	"github.com/kontext-security/kontext-cli/internal/hook"
 )
 
 type EvaluateRequest struct {
@@ -26,7 +28,7 @@ type EvaluateRequest struct {
 
 type EvaluateResult struct {
 	Type         string         `json:"type"`
-	Decision     string         `json:"decision,omitempty"`
+	Decision     hook.Decision  `json:"decision,omitempty"`
 	Allowed      bool           `json:"allowed"`
 	Reason       string         `json:"reason"`
 	ReasonCode   string         `json:"reason_code,omitempty"`

--- a/internal/localruntime/service_test.go
+++ b/internal/localruntime/service_test.go
@@ -226,7 +226,7 @@ func TestServiceFailsClosedWhenBlockingHookPayloadCannotDecode(t *testing.T) {
 	if result.Allowed {
 		t.Fatal("result.Allowed = true, want false")
 	}
-	if result.Decision != string(hook.DecisionDeny) {
+	if result.Decision != hook.DecisionDeny {
 		t.Fatalf("result.Decision = %q, want deny", result.Decision)
 	}
 }
@@ -243,7 +243,7 @@ func TestServiceAllowsNonblockingHookPayloadDecodeFailure(t *testing.T) {
 	if !result.Allowed {
 		t.Fatal("result.Allowed = false, want true")
 	}
-	if result.Decision != string(hook.DecisionAllow) {
+	if result.Decision != hook.DecisionAllow {
 		t.Fatalf("result.Decision = %q, want allow", result.Decision)
 	}
 }

--- a/internal/sidecar/conversions.go
+++ b/internal/sidecar/conversions.go
@@ -1,8 +1,6 @@
 package sidecar
 
 import (
-	"encoding/json"
-
 	agentv1 "github.com/kontext-security/kontext-cli/gen/kontext/agent/v1"
 	"github.com/kontext-security/kontext-cli/internal/backend"
 	"github.com/kontext-security/kontext-cli/internal/hook"
@@ -37,11 +35,4 @@ func HookResultFromHostedResult(result *backend.ProcessHookEventResult, accessMo
 		out.Decision = hook.DecisionDeny
 	}
 	return out
-}
-
-func marshalMap(value map[string]any) (json.RawMessage, error) {
-	if value == nil {
-		return nil, nil
-	}
-	return json.Marshal(value)
 }

--- a/internal/sidecar/sidecar.go
+++ b/internal/sidecar/sidecar.go
@@ -251,7 +251,7 @@ func buildHookEventRequestFromEvent(event hook.Event) *agentv1.ProcessHookEventR
 		hookEvent.ToolInput = enrichToolInput(event)
 	}
 	if event.ToolResponse != nil {
-		hookEvent.ToolResponse, _ = marshalMap(event.ToolResponse)
+		hookEvent.ToolResponse, _ = hook.MarshalMapJSON(event.ToolResponse)
 	}
 
 	return hookEvent
@@ -259,7 +259,7 @@ func buildHookEventRequestFromEvent(event hook.Event) *agentv1.ProcessHookEventR
 
 func enrichToolInput(event hook.Event) []byte {
 	input := cloneMap(event.ToolInput)
-	data, err := marshalMap(input)
+	data, err := hook.MarshalMapJSON(input)
 	if err != nil {
 		return nil
 	}

--- a/internal/sidecar/sidecar_test.go
+++ b/internal/sidecar/sidecar_test.go
@@ -323,7 +323,7 @@ func TestEvaluatePreToolUseAllowsBackendBlocksWhenNotEnforcing(t *testing.T) {
 			if !result.Allowed {
 				t.Fatalf("evaluate().Allowed = false, want true for %s in no_policy mode", tc.name)
 			}
-			if result.Decision != string(hook.DecisionAllow) {
+			if result.Decision != hook.DecisionAllow {
 				t.Fatalf("evaluate().Decision = %q, want allow", result.Decision)
 			}
 			if result.Reason != "backend observed a block" {
@@ -365,7 +365,7 @@ func TestEvaluatePreToolUseUsesCachedModeWhenBackendOmitsMode(t *testing.T) {
 	if result.Allowed {
 		t.Fatal("evaluate().Allowed = true, want false")
 	}
-	if result.Decision != string(hook.DecisionDeny) {
+	if result.Decision != hook.DecisionDeny {
 		t.Fatalf("evaluate().Decision = %q, want deny", result.Decision)
 	}
 	if result.Mode != string(backend.HostedAccessModeEnforce) {


### PR DESCRIPTION
Summary
This cleans up hook payload JSON helpers by moving map encode/decode and numeric-preserving JSON parsing into one canonical hook helper.

Before this, localruntime, sidecar, and hookruntime each carried their own JSON map helpers or decode path, which made hook payload handling easier to drift.

Now `internal/hook/json.go` is the canonical path:

```go
data, err := hook.MarshalMapJSON(event.ToolInput)
value, err := hook.UnmarshalMapJSON(req.ToolInput)
```

Why
This gives kontext-cli a cleaner maintenance path for hook payload handling:

hook event/result
-> internal/hook/json.go
-> localruntime, sidecar, hookruntime
-> one typed decision path and one JSON codec

This PR does not broaden behavior beyond the cleanup scope.

What changed
Added `internal/hook/json.go` and regression tests for nil-map handling and large-number preservation
Removed duplicate JSON map helpers from `internal/localruntime` and `internal/sidecar`
Consolidated Claude tool-response decoding onto the shared helper
Strengthened `localruntime.EvaluateResult.Decision` to use `hook.Decision`
Updated localruntime and sidecar tests for the typed decision path

Verification
`go test ./internal/hook ./internal/hookruntime ./internal/localruntime ./internal/sidecar -count=1`
`go test ./...`
`go vet ./...`
