### PR TITLE
[AUTOMATION] fix(clawpatch): address daily finding

### DIFF
--- a/internal/localruntime/socket.go
+++ b/internal/localruntime/socket.go
@@ -1,9 +1,11 @@
 package localruntime
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 )
 
 func DefaultSocketPath() string {
@@ -14,5 +16,31 @@ func DefaultSocketPath() string {
 }
 
 func EnsureSocketDir(socketPath string) error {
-	return os.MkdirAll(filepath.Dir(socketPath), 0o700)
+	dir := filepath.Dir(socketPath)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s is a symlink", dir)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", dir)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return errors.New("socket directory ownership is unavailable")
+	}
+	if int(stat.Uid) != os.Getuid() {
+		return fmt.Errorf("socket directory %s is owned by uid %d, want %d", dir, stat.Uid, os.Getuid())
+	}
+	if info.Mode().Perm() != 0o700 {
+		if err := os.Chmod(dir, 0o700); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/localruntime/socket_test.go
+++ b/internal/localruntime/socket_test.go
@@ -1,0 +1,56 @@
+package localruntime
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestEnsureSocketDirTightensOwnerWritableDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix socket directory permissions are not portable to windows")
+	}
+	dir := filepath.Join(t.TempDir(), "socket-dir")
+	if err := os.Mkdir(dir, 0o777); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+	if err := os.Chmod(dir, 0o777); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+
+	if err := EnsureSocketDir(filepath.Join(dir, "kontext.sock")); err != nil {
+		t.Fatalf("EnsureSocketDir() error = %v", err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Fatalf("socket dir mode = %#o, want 0700", got)
+	}
+}
+
+func TestEnsureSocketDirRejectsNonDirectoryParent(t *testing.T) {
+	parent := filepath.Join(t.TempDir(), "socket-parent")
+	if err := os.WriteFile(parent, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if err := EnsureSocketDir(filepath.Join(parent, "kontext.sock")); err == nil {
+		t.Fatal("EnsureSocketDir() error = nil, want failure for non-directory parent")
+	}
+}
+
+func TestEnsureSocketDirRejectsSymlinkParent(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "target")
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+	link := filepath.Join(t.TempDir(), "socket-link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+	if err := EnsureSocketDir(filepath.Join(link, "kontext.sock")); err == nil {
+		t.Fatal("EnsureSocketDir() error = nil, want failure for symlink parent")
+	}
+}


### PR DESCRIPTION
## Where We Are

The local Guard runtime accepts any existing socket parent directory under `/tmp` as long as `os.MkdirAll` succeeds. If that directory is a symlink or belongs to another uid, the daemon can remove and bind `kontext.sock` inside an untrusted path.

## Where We Want To Go

The local Guard runtime should only bind its socket inside a real directory owned by the current user, with `0700` permissions. That keeps the Guard socket path under the same ownership rules as managed observe.

## How do we get there

Mirror the managed-observe socket-directory checks in `internal/localruntime.EnsureSocketDir`: reject symlink parents, reject non-directories, require the current uid, and tighten permissions back to `0700` when needed. Add focused localruntime tests for writable-directory tightening, non-directory rejection, and symlink rejection. Verified with `go test ./...`, `go vet ./...`, `npm exec --yes --package pnpm@10.0.0 -- pnpm install --frozen-lockfile`, `npm exec --yes --package pnpm@10.0.0 -- pnpm --dir web/guard-dashboard typecheck`, and `git diff --check` from the isolated checkout.
