### PR TITLE
[AUTOMATION] feat: clean up guard judge request mapping

### DIFF
--- a/internal/guard/app/server/policy.go
+++ b/internal/guard/app/server/policy.go
@@ -200,9 +200,9 @@ func judgeInputFromRiskEvent(event risk.HookEvent, riskEvent risk.RiskEvent) jud
 	if toolInput.Command == "" {
 		switch {
 		case toolInput.Path != "":
-			toolInput.Request = sanitizedPathRequest(event.ToolName, toolInput.Path)
+			toolInput.Request = judge.SanitizedPathRequest(event.ToolName, toolInput.Path)
 		case strings.EqualFold(event.ToolName, "Skill"):
-			toolInput.Request = skillRequest(event.ToolInput)
+			toolInput.Request = judge.SkillRequest(event.ToolInput)
 		default:
 			toolInput.Request = riskEvent.RequestSummary
 		}
@@ -212,35 +212,6 @@ func judgeInputFromRiskEvent(event risk.HookEvent, riskEvent risk.RiskEvent) jud
 		ExplicitUserIntent: riskEvent.ExplicitUserIntent,
 		ToolInput:          toolInput,
 	}
-}
-
-func sanitizedPathRequest(toolName, pathClass string) string {
-	action := strings.TrimSpace(toolName)
-	if action == "" {
-		action = "Tool"
-	}
-	if isCredentialPathClass(pathClass) {
-		return action + " credential_path " + pathClass
-	}
-	return action + " " + pathClass
-}
-
-func isCredentialPathClass(pathClass string) bool {
-	switch pathClass {
-	case "credential_file", "env_file", "cloud_credentials":
-		return true
-	default:
-		return false
-	}
-}
-
-func skillRequest(input map[string]any) string {
-	name, _ := input["skill"].(string)
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return "Skill"
-	}
-	return "Skill " + name
 }
 
 func pathClassForJudge(input map[string]any, normalizedClass string) string {

--- a/internal/guard/judge/fixtures.go
+++ b/internal/guard/judge/fixtures.go
@@ -80,9 +80,9 @@ func InputFromFixture(fixture Fixture) Input {
 	if toolInput.Command == "" {
 		switch {
 		case toolInput.Path != "":
-			toolInput.Request = sanitizedPathRequest(fixture.HookEvent.ToolName, toolInput.Path)
+			toolInput.Request = SanitizedPathRequest(fixture.HookEvent.ToolName, toolInput.Path)
 		case strings.EqualFold(fixture.HookEvent.ToolName, "Skill"):
-			toolInput.Request = skillRequest(fixture.HookEvent.ToolInput)
+			toolInput.Request = SkillRequest(fixture.HookEvent.ToolInput)
 		default:
 			toolInput.Request = fixture.NormalizedEvent.RequestSummary
 		}
@@ -94,18 +94,18 @@ func InputFromFixture(fixture Fixture) Input {
 	}
 }
 
-func sanitizedPathRequest(toolName, pathClass string) string {
+func SanitizedPathRequest(toolName, pathClass string) string {
 	action := strings.TrimSpace(toolName)
 	if action == "" {
 		action = "Tool"
 	}
-	if isCredentialPathClass(pathClass) {
+	if IsCredentialPathClass(pathClass) {
 		return action + " credential_path " + pathClass
 	}
 	return action + " " + pathClass
 }
 
-func skillRequest(input map[string]any) string {
+func SkillRequest(input map[string]any) string {
 	name, _ := input["skill"].(string)
 	name = strings.TrimSpace(name)
 	if name == "" {
@@ -114,7 +114,7 @@ func skillRequest(input map[string]any) string {
 	return "Skill " + name
 }
 
-func isCredentialPathClass(pathClass string) bool {
+func IsCredentialPathClass(pathClass string) bool {
 	switch pathClass {
 	case "credential_file", "env_file", "cloud_credentials":
 		return true


### PR DESCRIPTION
Summary
This cleans up guard judge request mapping by using one canonical helper path.

Before this, duplicate request-label helpers lived in internal/guard/app/server/policy.go and internal/guard/judge/fixtures.go, which made runtime and fixture judge inputs harder to keep in sync.

Now internal/guard/judge is the canonical path:

`toolInput.Request = judge.SanitizedPathRequest(event.ToolName, toolInput.Path)`

Why
This gives kontext-cli a cleaner maintenance path for Guard judge inputs:

hook event
-> request-label mapping
-> internal/guard/judge helpers
-> consistent runtime and fixture inputs

This PR does not broaden behavior beyond the cleanup scope.

What changed
Consolidated Guard judge request-label helpers in internal/guard/judge
Removed duplicate helper implementations from internal/guard/app/server
Updated fixture and runtime mapping to share the same helper path

Verification
`go test ./internal/guard/judge ./internal/guard/app/server`
`go test ./...`
`go vet ./...`
`git diff --check`
