### PR TITLE
[AUTOMATION] fix: optimize internal/guard/policy evaluation category checks

### DIFF
--- a/internal/guard/policy/engine.go
+++ b/internal/guard/policy/engine.go
@@ -21,9 +21,10 @@ func (e Engine) Evaluate(event risk.RiskEvent, cfg Config) Result {
 	if cfg.RulePack == "" {
 		cfg.RulePack = e.pack.ID
 	}
+	enabledCategories := enabledCategories(cfg.Profile)
 
 	for _, rule := range e.pack.Rules {
-		if !categoryEnabled(cfg.Profile, rule.Category) || !rule.When(event) {
+		if !enabledCategories[rule.Category] || !rule.When(event) {
 			continue
 		}
 		return Result{

--- a/internal/guard/policy/profiles.go
+++ b/internal/guard/policy/profiles.go
@@ -29,7 +29,3 @@ func enabledCategories(profile Profile) map[RuleCategory]bool {
 	}
 	return categories
 }
-
-func categoryEnabled(profile Profile, category RuleCategory) bool {
-	return enabledCategories(profile)[category]
-}


### PR DESCRIPTION
Summary
This optimizes internal/guard/policy evaluation by building the enabled-category lookup once per event.

Before this, Evaluate rebuilt the same profile category map for every rule in the pack, which repeated the same work across a single policy scan.

Now one cached lookup is the canonical path:

enabled := enabledCategories(cfg.Profile)
for _, rule := range e.pack.Rules {
    if !enabled[rule.Category] || !rule.When(event) {
        continue
    }
}

Why
This gives kontext-cli a cheaper runtime path for deterministic Guard policy checks:

risk event
-> internal/guard/policy.Engine.Evaluate
-> one cached category lookup across the rule scan

This PR does not broaden behavior beyond the optimization scope.

What changed
Optimized internal/guard/policy.Engine.Evaluate
Removed per-rule enabledCategories(profile) recomputation
Preserved rule ordering and profile-based category filtering

Verification
go test ./internal/guard/policy
go test ./...
go vet ./...
git diff --check

