### PR TITLE
[AUTOMATION] fix: optimize internal/guard/policy evaluation category checks

### DIFF
--- a/internal/guard/policy/engine.go
+++ b/internal/guard/policy/engine.go
@@ -21,9 +21,10 @@ func (e Engine) Evaluate(event risk.RiskEvent, cfg Config) Result {
 	if cfg.RulePack == "" {
 		cfg.RulePack = e.pack.ID
 	}
+	enabledCategories := enabledCategories(cfg.Profile)
 
 	for _, rule := range e.pack.Rules {
-		if !categoryEnabled(cfg.Profile, rule.Category) || !rule.When(event) {
+		if !enabledCategories[rule.Category] || !rule.When(event) {
 			continue
 		}
 		return Result{


### PR DESCRIPTION
Summary
This optimizes internal/guard/policy evaluation by caching the enabled category set once per evaluation.

Before this, every rule check in `internal/guard/policy/engine.go` rebuilt the same enabled-category map for the active profile, which added repeated work across the full rule loop.

Now one cached category map is the canonical path:

`Evaluate -> enabledCategories(cfg.Profile) once -> rule loop`

Why
This gives kontext-cli a cheaper runtime path for deterministic policy evaluation:

risk event
-> `internal/guard/policy.Engine.Evaluate`
-> reused category lookup per rule
-> same allow or deny result

This PR does not broaden behavior beyond the optimization scope.

What changed
Optimized policy evaluation category checks in `internal/guard/policy/engine.go`
Removed per-rule rebuilding of the enabled-category map
Preserved rule order, profile behavior, and match outcomes
Updated tests for specific behavior: no test changes needed because the existing policy evaluation suite already covers profile behavior and deny metadata

Verification
`go test ./internal/guard/policy`
`go test ./internal/guard/judge`
`go test ./...`
`go vet ./...`
`git diff --check`

