### PR TITLE
[AUTOMATION] fix(clawpatch): refuse non-socket local runtime paths

### DIFF
--- a/internal/localruntime/service.go
+++ b/internal/localruntime/service.go
@@ -64,8 +64,8 @@ func NewService(opts Options) (*Service, error) {
 func (s *Service) SocketPath() string { return s.socketPath }
 
 func (s *Service) Start(ctx context.Context) error {
-	if err := os.Remove(s.socketPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("remove stale local runtime socket: %w", err)
+	if err := removeStaleSocket(s.socketPath); err != nil {
+		return err
 	}
 	ln, err := net.Listen("unix", s.socketPath)
 	if err != nil {
@@ -76,6 +76,23 @@ func (s *Service) Start(ctx context.Context) error {
 	ctx, s.cancel = context.WithCancel(ctx)
 	s.serveDone = make(chan struct{})
 	go s.acceptLoop(ctx, ln, s.serveDone)
+	return nil
+}
+
+func removeStaleSocket(path string) error {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect local runtime socket path: %w", err)
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return fmt.Errorf("local runtime socket path exists and is not a socket: %s", path)
+	}
+	if err := os.Remove(path); err != nil {
+		return fmt.Errorf("remove stale local runtime socket: %w", err)
+	}
 	return nil
 }
 

--- a/internal/localruntime/service_test.go
+++ b/internal/localruntime/service_test.go
@@ -248,6 +248,42 @@ func TestServiceAllowsNonblockingHookPayloadDecodeFailure(t *testing.T) {
 	}
 }
 
+func TestServiceStartRefusesExistingRegularFile(t *testing.T) {
+	t.Parallel()
+
+	core, err := runtimecore.New(&stubRuntime{})
+	if err != nil {
+		t.Fatalf("runtimecore.New() error = %v", err)
+	}
+	socketPath := filepath.Join(t.TempDir(), "kontext.sock")
+	contents := []byte("keep this file")
+	if err := os.WriteFile(socketPath, contents, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	service, err := NewService(Options{
+		SocketPath: socketPath,
+		Core:       core,
+	})
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	err = service.Start(context.Background())
+	if err == nil {
+		t.Fatal("Start() error = nil, want non-socket path error")
+	}
+	if !strings.Contains(err.Error(), "not a socket") {
+		t.Fatalf("Start() error = %v, want non-socket path error", err)
+	}
+	got, readErr := os.ReadFile(socketPath)
+	if readErr != nil {
+		t.Fatalf("ReadFile() error = %v", readErr)
+	}
+	if string(got) != string(contents) {
+		t.Fatalf("file contents = %q, want %q", got, contents)
+	}
+}
+
 func newTestService(t *testing.T, runtime *stubRuntime, asyncIngest bool) *Service {
 	t.Helper()
 


### PR DESCRIPTION
## Where We Are

`kontext guard start --socket <path>` deletes any existing file at that path before it checks whether the path is actually a Unix socket. A user can point Guard at `~/notes.txt` and lose that file.

## Where We Want To Go

Guard should only remove stale Unix sockets. If the configured path is a regular file, directory, or anything else, startup should stop and leave that path untouched.

## How do we get there

The local runtime now uses `os.Lstat` before unlinking the socket path and returns an error unless the existing path is a socket. A regression test writes a regular file at the configured socket path, starts the service, and verifies startup fails without changing the file contents.

Validation passed with `go test ./internal/guard/judge`, `go test ./...`, `go vet ./...`, `npm exec --yes --package pnpm@10.0.0 -- pnpm install --frozen-lockfile`, `npm exec --yes --package pnpm@10.0.0 -- pnpm --dir web/guard-dashboard typecheck`, and `git diff --check`.
