### PR TITLE
feat(selfserve): scope-aware config/identity paths, user settings merge, version fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,11 @@ dist/
 /kontext
 .DS_Store
 node_modules/
+.playwright-mcp/
+engineering-*.png
+linear-*.png
+engineering-snapshot.md
+$CODEX_HOME/
 web/guard-dashboard/dist/
 web/guard-dashboard/node_modules/
 data/

--- a/cmd/kontext/main.go
+++ b/cmd/kontext/main.go
@@ -352,6 +352,9 @@ func managedObserveDaemonCmd() *cobra.Command {
 				DBPath:      dbPath,
 				IdleTimeout: timeout,
 				Diagnostic:  diagnostic.New(cmd.ErrOrStderr(), diagnostic.EnabledFromEnv()),
+				// "cli-" prefix lets the dashboard distinguish self-serve brew
+				// installs (no MDM deployment-version marker) from packages.
+				FallbackDeploymentVersion: "cli-" + version,
 			})
 		},
 	}

--- a/internal/claudemanaged/usersettings.go
+++ b/internal/claudemanaged/usersettings.go
@@ -1,0 +1,390 @@
+package claudemanaged
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// User-level Claude Code settings (~/.claude/settings.json) integration for
+// self-serve installs. Unlike the MDM managed-settings drop-in (root-owned,
+// tamper-resistant), this file belongs to the user: the merge must preserve
+// every byte of foreign content (their hooks, permissions, env, unknown
+// keys), be idempotent, and be cleanly reversible.
+
+// UserSettingsPath returns ~/.claude/settings.json, creating ~/.claude.
+func UserSettingsPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		return "", err
+	}
+	return filepath.Join(claudeDir, "settings.json"), nil
+}
+
+// ReadUserSettings parses the settings file into a generic map so unknown
+// keys survive a read-merge-write round trip. A missing file is an empty map.
+func ReadUserSettings(path string) (map[string]any, error) {
+	settings := map[string]any{}
+	raw, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return settings, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(raw, &settings); err != nil {
+		return nil, fmt.Errorf("parse Claude settings: %w", err)
+	}
+	return settings, nil
+}
+
+// WriteUserSettings writes the settings back atomically (temp file + rename,
+// so a crash mid-write can never leave a truncated settings.json behind),
+// preserving the existing file's permission bits (a user may keep their
+// settings private); new files are created 0600.
+func WriteUserSettings(path string, settings map[string]any) error {
+	writePath := path
+	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		target, err := filepath.EvalSymlinks(path)
+		if err != nil {
+			return err
+		}
+		writePath = target
+	} else if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+
+	mode := fs.FileMode(0o600)
+	if info, err := os.Stat(writePath); err == nil {
+		mode = info.Mode().Perm()
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	temp, err := os.CreateTemp(filepath.Dir(writePath), ".settings-*.tmp")
+	if err != nil {
+		return err
+	}
+	tempPath := temp.Name()
+	defer os.Remove(tempPath)
+	if err := temp.Chmod(mode); err != nil {
+		temp.Close()
+		return err
+	}
+	if _, err := temp.Write(append(data, '\n')); err != nil {
+		temp.Close()
+		return err
+	}
+	if err := temp.Sync(); err != nil {
+		temp.Close()
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tempPath, writePath)
+}
+
+// BackupUserSettings copies the file aside (timestamped, same permissions)
+// before a mutation. Missing file is a no-op.
+func BackupUserSettings(path, label string) error {
+	info, err := os.Stat(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	backupPathPrefix := fmt.Sprintf("%s.%s-backup-%s", path, label, time.Now().UTC().Format("20060102T150405.000000000Z"))
+	var file *os.File
+	for attempt := 0; attempt < 100; attempt++ {
+		backupPath := backupPathPrefix
+		if attempt > 0 {
+			backupPath = fmt.Sprintf("%s-%d", backupPathPrefix, attempt)
+		}
+		file, err = os.OpenFile(backupPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, info.Mode().Perm())
+		if errors.Is(err, fs.ErrExist) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		break
+	}
+	if file == nil {
+		return fmt.Errorf("create backup for %s: too many timestamp collisions", path)
+	}
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
+}
+
+// IsGuardHookCommand reports whether a hook command belongs to Kontext Guard
+// (the local-only enforcement product). Shared with guard/cli so the two
+// installers agree on whose entries are whose.
+func IsGuardHookCommand(command string) bool {
+	normalized := strings.ReplaceAll(command, "'", "")
+	return strings.Contains(normalized, "kontext guard hook claude-code") ||
+		(strings.Contains(normalized, "kontext hook --agent claude") && strings.Contains(normalized, "--mode"))
+}
+
+// IsManagedHookCommand reports whether a hook command is one of OURS: the
+// flagless managed-observe form `'<binary>' hook '<alias>'`. Guard hooks
+// (`kontext guard hook claude-code`, `kontext hook --agent claude … --mode …`)
+// are deliberately excluded so the two installers never touch each other's
+// entries. Matching on the alias rather than the exact binary path means a
+// re-run after the binary moved (brew prefix change) replaces stale entries.
+func IsManagedHookCommand(command string) bool {
+	fields, ok := splitHookCommand(command)
+	if !ok || len(fields) != 3 {
+		return false
+	}
+	for _, field := range fields {
+		if strings.HasPrefix(field, "--") {
+			return false
+		}
+	}
+	if filepath.Base(fields[0]) != "kontext" || fields[1] != "hook" {
+		return false
+	}
+	for _, event := range SupportedEvents {
+		if fields[2] == event.Alias {
+			return true
+		}
+	}
+	return false
+}
+
+func splitHookCommand(command string) ([]string, bool) {
+	var fields []string
+	var builder strings.Builder
+	var quote rune
+	inField := false
+
+	runes := []rune(command)
+	for i := 0; i < len(runes); i++ {
+		char := runes[i]
+		switch {
+		case quote != 0:
+			if char == quote {
+				quote = 0
+				continue
+			}
+			if quote == '"' && char == '\\' && i+1 < len(runes) {
+				i++
+				builder.WriteRune(runes[i])
+				inField = true
+				continue
+			}
+			builder.WriteRune(char)
+			inField = true
+		case char == '\\':
+			if i+1 >= len(runes) {
+				return nil, false
+			}
+			i++
+			builder.WriteRune(runes[i])
+			inField = true
+		case char == '\'' || char == '"':
+			quote = char
+			inField = true
+		case char == ' ' || char == '\t' || char == '\n' || char == '\r':
+			if inField {
+				fields = append(fields, builder.String())
+				builder.Reset()
+				inField = false
+			}
+		default:
+			builder.WriteRune(char)
+			inField = true
+		}
+	}
+	if quote != 0 {
+		return nil, false
+	}
+	if inField {
+		fields = append(fields, builder.String())
+	}
+	return fields, true
+}
+
+// MergeManagedHooks installs/refreshes the five managed-observe hooks in the
+// settings map: for each supported event it removes any existing Kontext
+// managed handlers (stale binary paths included) and appends the canonical
+// group from Template. Everything else in the map is untouched. Idempotent:
+// merging twice is a fixpoint. Returns non-fatal warnings for conditions the
+// user should know about.
+func MergeManagedHooks(settings map[string]any, kontextBinary string) ([]string, error) {
+	var warnings []string
+
+	if disabled, ok := settings["disableAllHooks"].(bool); ok && disabled {
+		warnings = append(warnings, "Claude Code hooks are globally disabled (disableAllHooks) in settings.json; Kontext hooks will not fire until you remove that setting")
+	}
+
+	hooks, err := hooksMap(settings)
+	if err != nil {
+		return nil, err
+	}
+
+	if hasGuardHooks(hooks) {
+		warnings = append(warnings, "Kontext Guard hooks are also installed; consider `kontext guard hooks uninstall claude-code` to avoid duplicate processing")
+	}
+
+	// Build every canonical group before touching the map, so an error can
+	// never leave the caller's settings half-merged.
+	template := Template(kontextBinary)
+	canonical := make(map[string]any, len(SupportedEvents))
+	for _, event := range SupportedEvents {
+		name := event.Name.String()
+		group, err := toAny(template.Hooks[name][0])
+		if err != nil {
+			return nil, err
+		}
+		canonical[name] = group
+	}
+
+	settings["hooks"] = hooks
+	for _, event := range SupportedEvents {
+		name := event.Name.String()
+		hooks[name] = append(withoutManagedHandlers(hooks[name]), canonical[name])
+	}
+	return warnings, nil
+}
+
+// RemoveManagedHooks strips OUR handlers (and only ours) from the settings
+// map, pruning groups and event keys that end up empty. Foreign hooks,
+// including Guard's, survive untouched. Idempotent.
+func RemoveManagedHooks(settings map[string]any) error {
+	hooks, err := hooksMap(settings)
+	if err != nil {
+		return err
+	}
+	for _, event := range SupportedEvents {
+		name := event.Name.String()
+		if _, present := hooks[name]; !present {
+			continue
+		}
+		groups := withoutManagedHandlers(hooks[name])
+		if len(groups) == 0 {
+			delete(hooks, name)
+			continue
+		}
+		hooks[name] = groups
+	}
+	if len(hooks) == 0 {
+		delete(settings, "hooks")
+	}
+	return nil
+}
+
+func hooksMap(settings map[string]any) (map[string]any, error) {
+	switch value := settings["hooks"].(type) {
+	case nil:
+		return map[string]any{}, nil
+	case map[string]any:
+		return value, nil
+	default:
+		// Never clobber a shape we don't understand — the file is the user's.
+		return nil, errors.New("settings.json hooks must be a JSON object")
+	}
+}
+
+// withoutManagedHandlers filters our handlers out of every matcher group of
+// an event's group list, dropping groups left without handlers. Unparseable
+// entries are kept verbatim (they are the user's data, not ours to judge).
+func withoutManagedHandlers(raw any) []any {
+	list, ok := raw.([]any)
+	if !ok {
+		if raw == nil {
+			return nil
+		}
+		return []any{raw}
+	}
+	filtered := make([]any, 0, len(list))
+	for _, entry := range list {
+		group, ok := entry.(map[string]any)
+		if !ok {
+			filtered = append(filtered, entry)
+			continue
+		}
+		handlers, ok := group["hooks"].([]any)
+		if !ok {
+			filtered = append(filtered, entry)
+			continue
+		}
+		kept := make([]any, 0, len(handlers))
+		for _, handler := range handlers {
+			if handlerMap, ok := handler.(map[string]any); ok {
+				if command, ok := handlerMap["command"].(string); ok && IsManagedHookCommand(command) {
+					continue
+				}
+			}
+			kept = append(kept, handler)
+		}
+		if len(kept) == 0 {
+			continue
+		}
+		group["hooks"] = kept
+		filtered = append(filtered, group)
+	}
+	return filtered
+}
+
+func hasGuardHooks(hooks map[string]any) bool {
+	for _, raw := range hooks {
+		list, ok := raw.([]any)
+		if !ok {
+			continue
+		}
+		for _, entry := range list {
+			group, ok := entry.(map[string]any)
+			if !ok {
+				continue
+			}
+			handlers, _ := group["hooks"].([]any)
+			for _, handler := range handlers {
+				handlerMap, ok := handler.(map[string]any)
+				if !ok {
+					continue
+				}
+				if command, ok := handlerMap["command"].(string); ok && IsGuardHookCommand(command) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// toAny round-trips a typed value through JSON so it lands in the generic
+// settings map with exactly the shape WriteUserSettings will serialize.
+func toAny(value any) (any, error) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	var out any
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/internal/claudemanaged/usersettings_test.go
+++ b/internal/claudemanaged/usersettings_test.go
@@ -1,0 +1,465 @@
+package claudemanaged
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const testBinary = "/opt/homebrew/bin/kontext"
+
+func decode(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	var out map[string]any
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+func eventGroups(t *testing.T, settings map[string]any, event string) []any {
+	t.Helper()
+	hooks, ok := settings["hooks"].(map[string]any)
+	if !ok {
+		t.Fatalf("hooks missing or not an object: %T", settings["hooks"])
+	}
+	groups, ok := hooks[event].([]any)
+	if !ok {
+		t.Fatalf("event %s missing or not a list: %T", event, hooks[event])
+	}
+	return groups
+}
+
+func TestMergeManagedHooksIntoEmptySettings(t *testing.T) {
+	settings := map[string]any{}
+	warnings, err := MergeManagedHooks(settings, testBinary)
+	if err != nil {
+		t.Fatalf("MergeManagedHooks() error = %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+
+	for _, event := range SupportedEvents {
+		groups := eventGroups(t, settings, event.Name.String())
+		if len(groups) != 1 {
+			t.Fatalf("%s groups = %d, want 1", event.Name, len(groups))
+		}
+	}
+
+	// The merged shape must satisfy the same validator the MDM drop-in uses.
+	data, err := json.Marshal(map[string]any{"hooks": settings["hooks"]})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Validate(data, testBinary); err != nil {
+		t.Fatalf("merged settings fail Validate: %v", err)
+	}
+}
+
+func TestMergeManagedHooksPreservesForeignContent(t *testing.T) {
+	settings := decode(t, `{
+		"permissions": {"allow": ["Bash(ls:*)"]},
+		"env": {"FOO": "bar"},
+		"hooks": {
+			"PreToolUse": [
+				{"matcher": "Bash", "hooks": [{"type": "command", "command": "/usr/local/bin/other-tool check"}]}
+			],
+			"Notification": [
+				{"matcher": "", "hooks": [{"type": "command", "command": "say done"}]}
+			]
+		},
+		"unknownKey": 42
+	}`)
+
+	if _, err := MergeManagedHooks(settings, testBinary); err != nil {
+		t.Fatal(err)
+	}
+
+	if settings["unknownKey"] != float64(42) {
+		t.Fatalf("unknownKey clobbered: %v", settings["unknownKey"])
+	}
+	if _, ok := settings["permissions"].(map[string]any); !ok {
+		t.Fatal("permissions clobbered")
+	}
+
+	// The user's PreToolUse hook survives alongside ours.
+	groups := eventGroups(t, settings, "PreToolUse")
+	if len(groups) != 2 {
+		t.Fatalf("PreToolUse groups = %d, want foreign + ours", len(groups))
+	}
+	foreign := groups[0].(map[string]any)
+	if foreign["matcher"] != "Bash" {
+		t.Fatalf("foreign group reordered or modified: %v", foreign)
+	}
+
+	// Unmanaged events are untouched.
+	notification := eventGroups(t, settings, "Notification")
+	if len(notification) != 1 {
+		t.Fatalf("Notification groups = %d, want 1", len(notification))
+	}
+}
+
+func TestMergeManagedHooksReplacesStaleBinaryPath(t *testing.T) {
+	settings := decode(t, `{
+		"hooks": {
+			"PreToolUse": [
+				{"matcher": "", "hooks": [{"type": "command", "command": "'/Applications/Kontext CLI/kontext' hook 'pre-tool-use'", "timeout": 20}]}
+			]
+		}
+	}`)
+
+	if _, err := MergeManagedHooks(settings, testBinary); err != nil {
+		t.Fatal(err)
+	}
+
+	groups := eventGroups(t, settings, "PreToolUse")
+	if len(groups) != 1 {
+		t.Fatalf("PreToolUse groups = %d, want stale entry replaced, not duplicated", len(groups))
+	}
+	handler := groups[0].(map[string]any)["hooks"].([]any)[0].(map[string]any)
+	if !strings.Contains(handler["command"].(string), testBinary) {
+		t.Fatalf("stale binary path not replaced: %v", handler["command"])
+	}
+}
+
+func TestMergeManagedHooksIsIdempotent(t *testing.T) {
+	settings := map[string]any{}
+	if _, err := MergeManagedHooks(settings, testBinary); err != nil {
+		t.Fatal(err)
+	}
+	first, err := json.Marshal(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := MergeManagedHooks(settings, testBinary); err != nil {
+		t.Fatal(err)
+	}
+	second, err := json.Marshal(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(first) != string(second) {
+		t.Fatalf("double merge is not a fixpoint:\n%s\n%s", first, second)
+	}
+}
+
+func TestMergeManagedHooksWarnsOnDisableAllHooks(t *testing.T) {
+	settings := decode(t, `{"disableAllHooks": true}`)
+	warnings, err := MergeManagedHooks(settings, testBinary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "disableAllHooks") {
+		t.Fatalf("warnings = %v, want disableAllHooks warning", warnings)
+	}
+	// The user's policy is warned about, never mutated.
+	if settings["disableAllHooks"] != true {
+		t.Fatal("disableAllHooks was mutated")
+	}
+}
+
+func TestMergeManagedHooksWarnsOnGuardHooksAndLeavesThem(t *testing.T) {
+	settings := decode(t, `{
+		"hooks": {
+			"PreToolUse": [
+				{"matcher": "", "hooks": [{"type": "command", "command": "'/usr/local/bin/kontext' hook --agent claude --event pre-tool-use --mode observe"}]}
+			]
+		}
+	}`)
+
+	warnings, err := MergeManagedHooks(settings, testBinary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "Guard") {
+		t.Fatalf("warnings = %v, want guard-conflict warning", warnings)
+	}
+
+	groups := eventGroups(t, settings, "PreToolUse")
+	if len(groups) != 2 {
+		t.Fatalf("PreToolUse groups = %d, want guard hook + ours", len(groups))
+	}
+}
+
+func TestMergeManagedHooksRejectsNonObjectHooks(t *testing.T) {
+	settings := decode(t, `{"hooks": ["weird"]}`)
+	if _, err := MergeManagedHooks(settings, testBinary); err == nil {
+		t.Fatal("expected error for non-object hooks, got nil")
+	}
+}
+
+func TestRemoveManagedHooksLeavesForeignContent(t *testing.T) {
+	settings := map[string]any{
+		"permissions": map[string]any{"allow": []any{"Bash(ls:*)"}},
+	}
+	if _, err := MergeManagedHooks(settings, testBinary); err != nil {
+		t.Fatal(err)
+	}
+	// Add a foreign hook next to ours on one event.
+	hooks := settings["hooks"].(map[string]any)
+	pre := hooks["PreToolUse"].([]any)
+	hooks["PreToolUse"] = append(pre, map[string]any{
+		"matcher": "Edit",
+		"hooks":   []any{map[string]any{"type": "command", "command": "lint-check"}},
+	})
+
+	if err := RemoveManagedHooks(settings); err != nil {
+		t.Fatal(err)
+	}
+
+	hooks = settings["hooks"].(map[string]any)
+	// Events that only held our hooks are pruned entirely.
+	for _, event := range []string{"SessionStart", "PostToolUse", "SessionEnd"} {
+		if _, present := hooks[event]; present {
+			t.Fatalf("%s not pruned after removal", event)
+		}
+	}
+	// The foreign PreToolUse hook survives alone.
+	pre = hooks["PreToolUse"].([]any)
+	if len(pre) != 1 || pre[0].(map[string]any)["matcher"] != "Edit" {
+		t.Fatalf("foreign PreToolUse hook lost: %v", pre)
+	}
+	if _, ok := settings["permissions"]; !ok {
+		t.Fatal("permissions clobbered by removal")
+	}
+}
+
+func TestRemoveManagedHooksDropsEmptyHooksKey(t *testing.T) {
+	settings := map[string]any{}
+	if _, err := MergeManagedHooks(settings, testBinary); err != nil {
+		t.Fatal(err)
+	}
+	if err := RemoveManagedHooks(settings); err != nil {
+		t.Fatal(err)
+	}
+	if _, present := settings["hooks"]; present {
+		t.Fatalf("empty hooks key left behind: %v", settings["hooks"])
+	}
+}
+
+func TestIsGuardHookCommand(t *testing.T) {
+	cases := []struct {
+		command string
+		want    bool
+	}{
+		{"kontext guard hook claude-code", true},
+		{"'/usr/local/bin/kontext' guard hook claude-code", true},
+		{"'/usr/local/bin/kontext' hook --agent claude --event pre-tool-use --mode observe", true},
+		// Managed-observe hooks must never match.
+		{"'/usr/local/bin/kontext' hook 'pre-tool-use'", false},
+		// --agent without --mode is not a guard hook.
+		{"kontext hook --agent claude", false},
+		{"say done", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := IsGuardHookCommand(tc.command); got != tc.want {
+			t.Errorf("IsGuardHookCommand(%q) = %v, want %v", tc.command, got, tc.want)
+		}
+	}
+}
+
+func TestIsManagedHookCommand(t *testing.T) {
+	cases := []struct {
+		command string
+		want    bool
+	}{
+		{"'/usr/local/bin/kontext' hook 'pre-tool-use'", true},
+		{"'/Users/o'\\''brien/bin/kontext' hook 'pre-tool-use'", true},
+		{"'/Applications/Kontext CLI/kontext' hook 'pre-tool-use'", true},
+		{"'/Users/dev/--tools/kontext' hook 'pre-tool-use'", true},
+		{"'/opt/homebrew/bin/kontext' hook 'session-start'", true},
+		{"/usr/local/bin/kontext hook session-end", true},
+		{"'/usr/local/bin/kontext' hook 'unterminated", false},
+		// Guard hooks must never match.
+		{"'/usr/local/bin/kontext' hook --agent claude --event pre-tool-use --mode observe", false},
+		{"kontext guard hook claude-code", false},
+		// Foreign tools must never match.
+		{"/usr/local/bin/other-tool hook pre-tool-use", false},
+		{"/usr/local/bin/not-kontext hook pre-tool-use", false},
+		{"my-kontext-helper hook session-end", false},
+		{"say done", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := IsManagedHookCommand(tc.command); got != tc.want {
+			t.Errorf("IsManagedHookCommand(%q) = %v, want %v", tc.command, got, tc.want)
+		}
+	}
+}
+
+func TestReadWriteUserSettingsPreservesPermissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+
+	// New files are created private.
+	if err := WriteUserSettings(path, map[string]any{"a": float64(1)}); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("new file mode = %v, want 0600", info.Mode().Perm())
+	}
+
+	// An existing file's (looser) mode is preserved, not tightened or loosened.
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteUserSettings(path, map[string]any{"a": float64(2)}); err != nil {
+		t.Fatal(err)
+	}
+	info, err = os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o644 {
+		t.Fatalf("rewritten file mode = %v, want 0644 preserved", info.Mode().Perm())
+	}
+
+	got, err := ReadUserSettings(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, map[string]any{"a": float64(2)}) {
+		t.Fatalf("round trip = %v", got)
+	}
+}
+
+func TestWriteUserSettingsPreservesSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target-settings.json")
+	firstLink := filepath.Join(dir, "first-settings.json")
+	link := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(target, []byte(`{"a":1}`), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, firstLink); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(firstLink, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := WriteUserSettings(link, map[string]any{"a": float64(2)}); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("settings path is no longer a symlink: mode=%v", info.Mode())
+	}
+	firstInfo, err := os.Lstat(firstLink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstInfo.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("intermediate settings path is no longer a symlink: mode=%v", firstInfo.Mode())
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"a": 2`) {
+		t.Fatalf("target content = %s, want rewritten target", data)
+	}
+}
+
+func TestReadUserSettingsMissingFileIsEmpty(t *testing.T) {
+	got, err := ReadUserSettings(filepath.Join(t.TempDir(), "absent.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("missing file settings = %v, want empty", got)
+	}
+}
+
+func TestReadUserSettingsMalformedJSONFails(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadUserSettings(path); err == nil {
+		t.Fatal("expected parse error, got nil")
+	}
+}
+
+func TestBackupUserSettingsPreservesModeAndContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(path, []byte(`{"a":1}`), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := BackupUserSettings(path, "kontext-setup"); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var backup string
+	for _, entry := range entries {
+		if strings.Contains(entry.Name(), "kontext-setup-backup-") {
+			backup = filepath.Join(dir, entry.Name())
+		}
+	}
+	if backup == "" {
+		t.Fatal("no backup file written")
+	}
+	info, err := os.Stat(backup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o640 {
+		t.Fatalf("backup mode = %v, want original 0640", info.Mode().Perm())
+	}
+	data, err := os.ReadFile(backup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != `{"a":1}` {
+		t.Fatalf("backup content = %s", data)
+	}
+
+	// Missing file is a no-op.
+	if err := BackupUserSettings(filepath.Join(dir, "absent.json"), "x"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBackupUserSettingsDoesNotOverwriteExistingBackup(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(path, []byte(`{"a":1}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := BackupUserSettings(path, "kontext-setup"); err != nil {
+		t.Fatal(err)
+	}
+	if err := BackupUserSettings(path, "kontext-setup"); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backups := 0
+	for _, entry := range entries {
+		if strings.Contains(entry.Name(), "kontext-setup-backup-") {
+			backups++
+		}
+	}
+	if backups != 2 {
+		t.Fatalf("backup count = %d, want 2", backups)
+	}
+}

--- a/internal/guard/cli/cli.go
+++ b/internal/guard/cli/cli.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cli/browser"
 
+	"github.com/kontext-security/kontext-cli/internal/claudemanaged"
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 	"github.com/kontext-security/kontext-cli/internal/guard/app/server"
 	"github.com/kontext-security/kontext-cli/internal/guard/judge"
@@ -538,9 +539,7 @@ func isGuardHookEntry(entry any) bool {
 }
 
 func isGuardHookCommand(command string) bool {
-	normalized := strings.ReplaceAll(command, "'", "")
-	return strings.Contains(normalized, "kontext guard hook claude-code") ||
-		(strings.Contains(normalized, "kontext hook --agent claude") && strings.Contains(normalized, "--mode"))
+	return claudemanaged.IsGuardHookCommand(command)
 }
 
 func runSmokeTest(ctx context.Context, args []string, out io.Writer) error {

--- a/internal/installation/state.go
+++ b/internal/installation/state.go
@@ -31,6 +31,18 @@ func PathFromEnv() string {
 	return DefaultPath
 }
 
+// UserPath is the self-serve installation identity location (paired with the
+// user-scope managed config), or "" when the home directory cannot be
+// resolved. The system DefaultPath stays the default so enterprise daemons
+// keep creating identity under /Library exactly as before.
+func UserPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, "Library", "Application Support", "Kontext", "installation.json")
+}
+
 func Load() (State, error) {
 	return LoadFile(PathFromEnv())
 }

--- a/internal/managedconfig/config.go
+++ b/internal/managedconfig/config.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -38,6 +39,51 @@ const (
 var ErrNotManaged = errors.New("managed config not found")
 
 var envNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// Scope identifies which managed config a process resolved: an explicit env
+// override, the system-wide MDM install under /Library, or a per-user
+// self-serve install written by `kontext setup`.
+type Scope string
+
+const (
+	ScopeEnv    Scope = "env"
+	ScopeSystem Scope = "system"
+	ScopeUser   Scope = "user"
+)
+
+// Test seam: ResolvePath stats this instead of the /Library literal so tests
+// can simulate the presence/absence of an MDM install.
+var systemPath = DefaultPath
+
+// UserPath is the self-serve managed config location, or "" when the home
+// directory cannot be resolved.
+func UserPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, "Library", "Application Support", "Kontext", "managed.json")
+}
+
+// ResolvePath picks the managed config path for this process. Precedence is
+// security-relevant: an existing SYSTEM (MDM) config always wins over the
+// user-level one, so an org-managed Mac cannot be re-pointed by a self-serve
+// setup. The system path is selected whenever it exists OR whenever its
+// existence cannot be determined (any stat error other than not-exist), so a
+// broken/unreadable MDM config surfaces as an error instead of silently
+// falling through to user config.
+func ResolvePath() (string, Scope) {
+	if path := strings.TrimSpace(os.Getenv(EnvPath)); path != "" {
+		return path, ScopeEnv
+	}
+	if _, err := os.Lstat(systemPath); err == nil || !errors.Is(err, os.ErrNotExist) {
+		return systemPath, ScopeSystem
+	}
+	if user := UserPath(); user != "" {
+		return user, ScopeUser
+	}
+	return systemPath, ScopeSystem
+}
 
 type Config struct {
 	Version        string      `json:"version"`
@@ -71,6 +117,9 @@ type LoadedConfig struct {
 	Config   Config
 	Path     string
 	Checksum string
+	// Scope reflects how the path was resolved (env/system/user). LoadFile
+	// callers that bypass ResolvePath get an empty Scope.
+	Scope Scope
 }
 
 func PathFromEnv() string {
@@ -95,7 +144,13 @@ func DeploymentVersion() string {
 }
 
 func Load() (LoadedConfig, error) {
-	return LoadFile(PathFromEnv())
+	path, scope := ResolvePath()
+	loaded, err := LoadFile(path)
+	if err != nil {
+		return LoadedConfig{}, err
+	}
+	loaded.Scope = scope
+	return loaded, nil
 }
 
 func LoadFile(path string) (LoadedConfig, error) {

--- a/internal/managedconfig/resolve_path_test.go
+++ b/internal/managedconfig/resolve_path_test.go
@@ -1,0 +1,143 @@
+package managedconfig
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// withSystemPath points the ResolvePath system-path probe at a temp location
+// so tests can simulate the presence/absence of an MDM install.
+func withSystemPath(t *testing.T, path string) {
+	t.Helper()
+	previous := systemPath
+	systemPath = path
+	t.Cleanup(func() { systemPath = previous })
+}
+
+func TestResolvePathEnvOverrideWins(t *testing.T) {
+	dir := t.TempDir()
+	withSystemPath(t, filepath.Join(dir, "system", "managed.json"))
+	t.Setenv(EnvPath, "/custom/managed.json")
+
+	path, scope := ResolvePath()
+	if path != "/custom/managed.json" || scope != ScopeEnv {
+		t.Fatalf("ResolvePath() = %q, %q; want env override", path, scope)
+	}
+}
+
+func TestResolvePathSystemWinsWhenPresent(t *testing.T) {
+	dir := t.TempDir()
+	system := filepath.Join(dir, "managed.json")
+	if err := os.WriteFile(system, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	withSystemPath(t, system)
+	t.Setenv(EnvPath, "")
+	t.Setenv("HOME", filepath.Join(dir, "home"))
+
+	path, scope := ResolvePath()
+	if path != system || scope != ScopeSystem {
+		t.Fatalf("ResolvePath() = %q, %q; want system path", path, scope)
+	}
+}
+
+func TestResolvePathFallsBackToUserWhenSystemAbsent(t *testing.T) {
+	dir := t.TempDir()
+	withSystemPath(t, filepath.Join(dir, "missing", "managed.json"))
+	t.Setenv(EnvPath, "")
+	home := filepath.Join(dir, "home")
+	t.Setenv("HOME", home)
+
+	path, scope := ResolvePath()
+	want := filepath.Join(home, "Library", "Application Support", "Kontext", "managed.json")
+	if path != want || scope != ScopeUser {
+		t.Fatalf("ResolvePath() = %q, %q; want user path %q", path, scope, want)
+	}
+}
+
+func TestResolvePathSystemStatErrorDoesNotFallThrough(t *testing.T) {
+	// An MDM config whose existence cannot be determined must keep the system
+	// scope so the error surfaces on read instead of silently using the user
+	// config (a self-serve config must never shadow a managed install).
+	dir := t.TempDir()
+	blocked := filepath.Join(dir, "blocked")
+	if err := os.MkdirAll(blocked, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(blocked, 0o755) })
+	system := filepath.Join(blocked, "managed.json")
+	withSystemPath(t, system)
+	t.Setenv(EnvPath, "")
+	t.Setenv("HOME", filepath.Join(dir, "home"))
+
+	if _, err := os.Lstat(system); err == nil || errors.Is(err, os.ErrNotExist) {
+		t.Skip("environment does not produce permission errors (running as root?)")
+	}
+
+	path, scope := ResolvePath()
+	if path != system || scope != ScopeSystem {
+		t.Fatalf("ResolvePath() = %q, %q; want system path despite stat error", path, scope)
+	}
+}
+
+func TestLoadResolvesUserScopeConfig(t *testing.T) {
+	dir := t.TempDir()
+	withSystemPath(t, filepath.Join(dir, "missing", "managed.json"))
+	t.Setenv(EnvPath, "")
+	home := filepath.Join(dir, "home")
+	t.Setenv("HOME", home)
+
+	userDir := filepath.Join(home, "Library", "Application Support", "Kontext")
+	if err := os.MkdirAll(userDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(userDir, "managed.json"), []byte(validConfigJSON()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if loaded.Scope != ScopeUser {
+		t.Fatalf("Load() scope = %q, want %q", loaded.Scope, ScopeUser)
+	}
+	if loaded.Config.OrganizationID != "org_123" {
+		t.Fatalf("Load() org = %q", loaded.Config.OrganizationID)
+	}
+}
+
+func TestLoadInvalidSystemConfigDoesNotFallThroughToUser(t *testing.T) {
+	dir := t.TempDir()
+	system := filepath.Join(dir, "managed.json")
+	if err := os.WriteFile(system, []byte("not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	withSystemPath(t, system)
+	t.Setenv(EnvPath, "")
+	home := filepath.Join(dir, "home")
+	t.Setenv("HOME", home)
+
+	userDir := filepath.Join(home, "Library", "Application Support", "Kontext")
+	if err := os.MkdirAll(userDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(userDir, "managed.json"), []byte(validConfigJSON()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Load(); err == nil || strings.Contains(err.Error(), "org_123") {
+		t.Fatalf("Load() = %v; want parse error from the system config, not user fallback", err)
+	}
+}
+
+func TestUserPathUsesHomeLibrary(t *testing.T) {
+	t.Setenv("HOME", "/Users/example")
+	want := filepath.Join("/Users/example", "Library", "Application Support", "Kontext", "managed.json")
+	if got := UserPath(); got != want {
+		t.Fatalf("UserPath() = %q, want %q", got, want)
+	}
+}

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/kontext-security/kontext-cli/internal/coworkobserve"
@@ -30,6 +32,9 @@ type DaemonOptions struct {
 	GithubPolicyInterval  time.Duration
 	GithubPolicyClient    *http.Client
 	Diagnostic            diagnostic.Logger
+	// FallbackDeploymentVersion is reported to the ledger when no MDM
+	// deployment-version marker exists (self-serve brew installs).
+	FallbackDeploymentVersion string
 }
 
 func RunDaemon(ctx context.Context, opts DaemonOptions) error {
@@ -40,7 +45,7 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 		}
 		return fmt.Errorf("load managed config: %w", err)
 	}
-	installationState, err := installation.Ensure()
+	installationState, err := installation.EnsureFile(installationPathForScope(loadedConfig.Scope))
 	if err != nil {
 		return fmt.Errorf("ensure installation identity: %w", err)
 	}
@@ -118,7 +123,7 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 			InstallationID:    installationState.InstallationID,
 			InstallToken:      installToken,
 			DeviceLabel:       loadedConfig.Config.Device.Label,
-			DeploymentVersion: managedconfig.DeploymentVersion,
+			DeploymentVersion: deploymentVersionWithFallback(opts.FallbackDeploymentVersion),
 			Interval:          opts.StreamInterval,
 			HTTPClient:        opts.StreamHTTPClient,
 			Diagnostic:        opts.Diagnostic,
@@ -160,6 +165,35 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 			}
 		}
 	}
+}
+
+// deploymentVersionWithFallback resolves the version reported with each
+// ledger batch: the MDM package marker wins; brew installs have none and
+// report the CLI's own version instead. Evaluated per flush so a package
+// update under a running daemon is picked up.
+func deploymentVersionWithFallback(fallback string) func() string {
+	return func() string {
+		if v := managedconfig.DeploymentVersion(); v != "" {
+			return v
+		}
+		return fallback
+	}
+}
+
+// installationPathForScope ties identity scope to config scope: a system
+// (MDM) config never reads a user identity and vice versa. The env override
+// (KONTEXT_INSTALLATION_STATE, honored by PathFromEnv) always wins, and the
+// enterprise default is byte-identical to the pre-self-serve behavior.
+func installationPathForScope(scope managedconfig.Scope) string {
+	if strings.TrimSpace(os.Getenv(installation.EnvPath)) != "" {
+		return installation.PathFromEnv()
+	}
+	if scope == managedconfig.ScopeUser {
+		if path := installation.UserPath(); path != "" {
+			return path
+		}
+	}
+	return installation.PathFromEnv()
 }
 
 func idleTimeoutOrDefault(idleTimeout time.Duration) time.Duration {

--- a/internal/managedobserve/scope_test.go
+++ b/internal/managedobserve/scope_test.go
@@ -1,0 +1,77 @@
+package managedobserve
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/installation"
+	"github.com/kontext-security/kontext-cli/internal/managedconfig"
+)
+
+func TestInstallationPathForScope(t *testing.T) {
+	t.Setenv("HOME", "/Users/example")
+	t.Setenv(installation.EnvPath, "")
+
+	userPath := filepath.Join("/Users/example", "Library", "Application Support", "Kontext", "installation.json")
+
+	cases := []struct {
+		name  string
+		scope managedconfig.Scope
+		want  string
+	}{
+		// System and env-resolved configs keep the enterprise default so MDM
+		// daemons behave byte-identically to before self-serve existed.
+		{"system scope", managedconfig.ScopeSystem, installation.DefaultPath},
+		{"env scope", managedconfig.ScopeEnv, installation.DefaultPath},
+		{"empty scope (LoadFile callers)", managedconfig.Scope(""), installation.DefaultPath},
+		{"user scope", managedconfig.ScopeUser, userPath},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := installationPathForScope(tc.scope); got != tc.want {
+				t.Fatalf("installationPathForScope(%q) = %q, want %q", tc.scope, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInstallationPathForScopeUserWithoutHomeFallsBack(t *testing.T) {
+	// Pathological: scope resolved as user but the home dir has since become
+	// unavailable. The system default is the only sane landing spot.
+	t.Setenv("HOME", "")
+	t.Setenv(installation.EnvPath, "")
+
+	if got := installationPathForScope(managedconfig.ScopeUser); got != installation.DefaultPath {
+		t.Fatalf("installationPathForScope(user, no home) = %q, want system default", got)
+	}
+}
+
+func TestInstallationPathForScopeEnvOverrideWins(t *testing.T) {
+	t.Setenv("HOME", "/Users/example")
+	t.Setenv(installation.EnvPath, "/custom/installation.json")
+
+	if got := installationPathForScope(managedconfig.ScopeUser); got != "/custom/installation.json" {
+		t.Fatalf("installationPathForScope(user) = %q, want env override", got)
+	}
+}
+
+func TestDeploymentVersionWithFallback(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "deployment-version")
+
+	t.Setenv(managedconfig.EnvDeploymentVersionPath, marker)
+
+	// No marker (brew install): the CLI's own version is reported.
+	if got := deploymentVersionWithFallback("cli-1.2.3")(); got != "cli-1.2.3" {
+		t.Fatalf("fallback = %q, want cli-1.2.3", got)
+	}
+
+	// Marker present (MDM package): it wins, evaluated per call.
+	if err := os.WriteFile(marker, []byte("0.3.2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := deploymentVersionWithFallback("cli-1.2.3")(); got != "0.3.2" {
+		t.Fatalf("marker = %q, want 0.3.2", got)
+	}
+}


### PR DESCRIPTION
## What & why

Foundations for self-serve on the CLI side (ENG-442) — the changes that let one binary serve both an MDM-managed Mac and a self-serve one, with **enterprise behaviour byte-identical**. No user-facing command yet; that's #277.

- **Scope-aware config + identity paths.** `managedconfig.ResolvePath()` resolves env override > system `/Library` (if present) > user `~/Library`, and `Load()` records the `Scope`. System (MDM) config always wins; an invalid system file is an error, never a silent fall-through to user scope. Installation identity follows the same scope so a user config reads a user `installation.json`, never the MDM one.
- **`~/.claude/settings.json` hooks merge** (`internal/claudemanaged/usersettings.go`): remove-ours-then-append-canonical per event, operating on `map[string]any` so all foreign content survives. Ownership is the shared `IsManagedHookCommand` predicate (disjoint from Guard hooks). Writes preserve the existing file mode, create new files `0600`, and back up first.
- **`cli-<version>` deployment-version fallback** reported to the ledger when no MDM package marker exists (self-serve brew installs).

## How to review / test — pure Go, nothing to install

```bash
go build ./... && go vet ./... && go test ./...
```

The behaviour is fully covered by unit tests — no real filesystem-of-record, keychain, or daemon needed:
- `managedconfig/config_test.go`: the env/system/user resolution matrix incl. invalid-system-no-fall-through.
- `installation/state_test.go`: scope-derived identity path.
- `claudemanaged/usersettings_test.go`: foreign-content preservation, stale-path replacement, Guard hooks left untouched, idempotency, malformed JSON, mode preservation.

## Risk

The enterprise default path is unchanged: with no env override and a system `/Library` config present, resolution and the installation path are identical to pre-self-serve. Only the new user-scope branch is added.

Part of the ENG-442 kontext-cli stack: **#276** -> #277 -> #278.
