### PR TITLE
feat(observe): surface revoked install tokens; doctor managed-observe section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,10 @@ data/
 *.sqlite
 *.sqlite3
 models/generated/
+
+# Local agent/browser artifacts — never commit
+.playwright-mcp/
+$CODEX_HOME/
+engineering-*.png
+engineering-snapshot.md
+linear-*.png

--- a/cmd/kontext/main.go
+++ b/cmd/kontext/main.go
@@ -66,6 +66,7 @@ func doctorCmd() *cobra.Command {
 		Short: "Inspect local Kontext CLI setup",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			guardcli.PrintHookStatus(cmd.OutOrStdout())
+			managedobserve.PrintStatus(cmd.OutOrStdout())
 			return nil
 		},
 	}

--- a/internal/guard/cli/cli.go
+++ b/internal/guard/cli/cli.go
@@ -296,7 +296,10 @@ func PrintHookStatus(out io.Writer) {
 			case isGuardHookCommand(command):
 				guard = true
 				fmt.Fprintf(out, "Claude Code Guard hook: %s\n", command)
-			case strings.Contains(command, "kontext hook"):
+			// Managed-observe hooks are quoted ('<bin>' hook '<alias>'); use the
+			// shared predicate so wrapper commands containing "kontext" are not
+			// misclassified as hosted hooks.
+			case claudemanaged.IsManagedHookCommand(command):
 				hosted = true
 				fmt.Fprintf(out, "Claude Code hosted hook: %s\n", command)
 			}

--- a/internal/guard/cli/cli_test.go
+++ b/internal/guard/cli/cli_test.go
@@ -215,7 +215,8 @@ func TestPrintHookStatusReportsGuardAndHostedConflict(t *testing.T) {
     "PostToolUse": [
       {
         "hooks": [
-          {"type": "command", "command": "/usr/local/bin/kontext hook --agent claude"}
+          {"type": "command", "command": "'/usr/local/bin/kontext' hook 'post-tool-use'"},
+          {"type": "command", "command": "/usr/local/bin/not-kontext hook post-tool-use"}
         ]
       }
     ]
@@ -232,8 +233,11 @@ func TestPrintHookStatusReportsGuardAndHostedConflict(t *testing.T) {
 	if !strings.Contains(got, "Claude Code Guard hook: /usr/local/bin/kontext hook --agent claude --mode observe") {
 		t.Fatalf("PrintHookStatus() = %q, want guard hook line", got)
 	}
-	if !strings.Contains(got, "Claude Code hosted hook: /usr/local/bin/kontext hook --agent claude") {
+	if !strings.Contains(got, "Claude Code hosted hook: '/usr/local/bin/kontext' hook 'post-tool-use'") {
 		t.Fatalf("PrintHookStatus() = %q, want hosted hook line", got)
+	}
+	if strings.Contains(got, "not-kontext") {
+		t.Fatalf("PrintHookStatus() = %q, want foreign hook ignored", got)
 	}
 	if !strings.Contains(got, "Claude Code hook mode: conflict (hosted and Guard hooks are both installed)") {
 		t.Fatalf("PrintHookStatus() = %q, want conflict mode", got)

--- a/internal/managedobserve/autherr.go
+++ b/internal/managedobserve/autherr.go
@@ -1,0 +1,104 @@
+package managedobserve
+
+import (
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// AuthError is the on-disk breadcrumb a daemon leaves when it cannot
+// authenticate: kind "auth" for hosted-ledger rejections (revoked token),
+// kind "startup" when the install token could not even be resolved (locked
+// keychain, missing item). The daemon's stderr goes to a log file nobody
+// watches, so `kontext doctor` reads this file to give the user the actual
+// next step.
+type AuthError struct {
+	Kind    string `json:"kind"`
+	Status  int    `json:"status,omitempty"`
+	Message string `json:"message,omitempty"`
+	At      string `json:"at"`
+}
+
+const authErrorKindCorrupt = "corrupt"
+
+// AuthErrorPath puts the breadcrumb next to the observe database — the one
+// directory both the daemon and doctor can always derive.
+func AuthErrorPath(dbPath string) string {
+	return filepath.Join(filepath.Dir(dbPath), "last-auth-error.json")
+}
+
+func WriteAuthError(dbPath string, status int) error {
+	return writeBreadcrumb(dbPath, AuthError{Kind: "auth", Status: status})
+}
+
+// WriteStartupError records that the daemon exited before streaming — e.g.
+// the keychain item was unreadable under launchd. Without it, doctor can only
+// say "daemon: not running" with no cause.
+func WriteStartupError(dbPath string, message string) error {
+	return writeBreadcrumb(dbPath, AuthError{Kind: "startup", Message: message})
+}
+
+func writeBreadcrumb(dbPath string, breadcrumb AuthError) error {
+	breadcrumb.At = time.Now().UTC().Format(time.RFC3339)
+	data, err := json.Marshal(breadcrumb)
+	if err != nil {
+		return err
+	}
+	path := AuthErrorPath(dbPath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	temp, err := os.CreateTemp(filepath.Dir(path), ".last-auth-error-*.tmp")
+	if err != nil {
+		return err
+	}
+	tempPath := temp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tempPath)
+		}
+	}()
+	if err := temp.Chmod(0o600); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if _, err := temp.Write(data); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
+}
+
+func ClearAuthError(dbPath string) {
+	_ = os.Remove(AuthErrorPath(dbPath))
+}
+
+// LoadAuthError returns the breadcrumb, or nil when none exists. Unreadable or
+// corrupt files are returned as a distinct diagnostic kind so doctor never
+// turns a local breadcrumb problem into a false revoked-token warning.
+func LoadAuthError(dbPath string) *AuthError {
+	data, err := os.ReadFile(AuthErrorPath(dbPath))
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return &AuthError{Kind: authErrorKindCorrupt, Message: err.Error()}
+		}
+		return nil
+	}
+	var authErr AuthError
+	if err := json.Unmarshal(data, &authErr); err != nil {
+		return &AuthError{Kind: authErrorKindCorrupt, Message: err.Error()}
+	}
+	return &authErr
+}

--- a/internal/managedobserve/autherr_test.go
+++ b/internal/managedobserve/autherr_test.go
@@ -1,0 +1,60 @@
+package managedobserve
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAuthErrorRoundTrip(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "guard.db")
+
+	if got := LoadAuthError(dbPath); got != nil {
+		t.Fatalf("LoadAuthError before write = %v, want nil", got)
+	}
+
+	if err := WriteAuthError(dbPath, http.StatusUnauthorized); err != nil {
+		t.Fatal(err)
+	}
+	got := LoadAuthError(dbPath)
+	if got == nil || got.Status != http.StatusUnauthorized || got.Kind != "auth" || got.At == "" {
+		t.Fatalf("LoadAuthError = %+v", got)
+	}
+
+	ClearAuthError(dbPath)
+	if got := LoadAuthError(dbPath); got != nil {
+		t.Fatalf("LoadAuthError after clear = %v, want nil", got)
+	}
+	// Clearing again is a no-op.
+	ClearAuthError(dbPath)
+}
+
+func TestStartupErrorRoundTrip(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "nested", "guard.db") // dir created on demand
+
+	if err := WriteStartupError(dbPath, "resolve install token: keychain locked"); err != nil {
+		t.Fatal(err)
+	}
+	got := LoadAuthError(dbPath)
+	if got == nil || got.Kind != "startup" || got.Message == "" || got.At == "" {
+		t.Fatalf("LoadAuthError = %+v", got)
+	}
+
+	ClearAuthError(dbPath)
+	if LoadAuthError(dbPath) != nil {
+		t.Fatal("startup breadcrumb not cleared")
+	}
+}
+
+func TestLoadAuthErrorToleratesCorruptBreadcrumb(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "guard.db")
+	if err := os.WriteFile(AuthErrorPath(dbPath), []byte("{corrupt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Doctor reporting must never fail on a corrupt file, and must not turn a
+	// local breadcrumb problem into a false revoked-token warning.
+	if got := LoadAuthError(dbPath); got == nil || got.Kind != authErrorKindCorrupt || got.Message == "" {
+		t.Fatalf("LoadAuthError(corrupt) = %+v", got)
+	}
+}

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -60,9 +60,25 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 	if err != nil {
 		return fmt.Errorf("ensure installation identity: %w", err)
 	}
+
+	dbPath := opts.DBPath
+	if dbPath == "" {
+		dbPath = DefaultDBPath()
+	}
+
 	installToken, err := managedconfig.ResolveInstallToken(ctx, loadedConfig.Config.Credentials.InstallTokenRef)
 	if err != nil {
+		// Leave a breadcrumb: under launchd this exit is otherwise invisible
+		// (doctor would only see "daemon: not running" with no cause). A
+		// locked login keychain at boot is the typical trigger.
+		if breadcrumbErr := WriteStartupError(dbPath, err.Error()); breadcrumbErr != nil {
+			opts.Diagnostic.Printf("write startup-error breadcrumb: %v\n", breadcrumbErr)
+		}
 		return fmt.Errorf("resolve install token: %w", err)
+	}
+	// Token resolved — clear any stale startup breadcrumb from a prior boot.
+	if previous := LoadAuthError(dbPath); previous != nil && previous.Kind == "startup" {
+		ClearAuthError(dbPath)
 	}
 
 	socketPath := opts.SocketPath
@@ -71,10 +87,6 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 	}
 	if err := EnsureSocketDir(socketPath); err != nil {
 		return fmt.Errorf("prepare managed observe socket dir: %w", err)
-	}
-	dbPath := opts.DBPath
-	if dbPath == "" {
-		dbPath = DefaultDBPath()
 	}
 	if err := cleanupStaleSessions(ctx, dbPath, idleTimeoutOrDefault(opts.IdleTimeout)); err != nil {
 		opts.Diagnostic.Printf("managed observe cleanup: %v\n", err)
@@ -130,7 +142,6 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 			DBPath:            dbPath,
 			StatePath:         opts.StreamStatePath,
 			CloudURL:          loadedConfig.Config.CloudURL,
-			OrganizationID:    loadedConfig.Config.OrganizationID,
 			InstallationID:    installationState.InstallationID,
 			InstallToken:      installToken,
 			DeviceLabel:       loadedConfig.Config.Device.Label,
@@ -138,6 +149,19 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 			Interval:          opts.StreamInterval,
 			HTTPClient:        opts.StreamHTTPClient,
 			Diagnostic:        opts.Diagnostic,
+			OnAuthFailure: func(status int) {
+				// Unconditional stderr (Diagnostic is env-gated and would be
+				// silent under launchd) plus a breadcrumb for `kontext doctor`.
+				fmt.Fprintf(os.Stderr,
+					"Kontext install token rejected by %s (HTTP %d). It may have been revoked — run `kontext setup` with a new token from the dashboard.\n",
+					loadedConfig.Config.CloudURL, status)
+				if err := WriteAuthError(dbPath, status); err != nil {
+					opts.Diagnostic.Printf("write auth-error breadcrumb: %v\n", err)
+				}
+			},
+			OnFlushSuccess: func() {
+				ClearAuthError(dbPath)
+			},
 		})
 	}()
 

--- a/internal/managedobserve/daemon_test.go
+++ b/internal/managedobserve/daemon_test.go
@@ -169,8 +169,8 @@ func TestDaemonStreamsLedgerBatches(t *testing.T) {
 
 	select {
 	case body := <-requests:
-		if body.OrganizationID != "org_123" {
-			t.Fatalf("organization_id = %q", body.OrganizationID)
+		if body.OrganizationID != "" {
+			t.Fatalf("organization_id sent = %q, want omitted (token binds the org)", body.OrganizationID)
 		}
 		if body.InstallationID != "ins_0123456789abcdefghijklmnopqrstuv" {
 			t.Fatalf("installation_id = %q", body.InstallationID)

--- a/internal/managedobserve/doctor.go
+++ b/internal/managedobserve/doctor.go
@@ -1,0 +1,105 @@
+package managedobserve
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/installation"
+	"github.com/kontext-security/kontext-cli/internal/managedconfig"
+)
+
+// PrintStatus reports the managed-observe state for `kontext doctor`:
+// which managed config (if any) this machine resolves, the installation
+// identity, whether the daemon is reachable, the self-serve LaunchAgent, and
+// any token-rejection breadcrumb the daemon left behind.
+func PrintStatus(out io.Writer) {
+	fmt.Fprintln(out, "Managed observe:")
+
+	loaded, err := managedconfig.Load()
+	if errors.Is(err, managedconfig.ErrNotManaged) {
+		fmt.Fprintln(out, "  config: not configured (run `kontext setup` to connect this Mac to a workspace)")
+		return
+	}
+	if err != nil {
+		fmt.Fprintf(out, "  config: ERROR %v\n", err)
+		return
+	}
+
+	fmt.Fprintf(out, "  config: %s (%s)\n", loaded.Path, describeScope(loaded.Scope))
+	fmt.Fprintf(out, "  organization: %s\n", loaded.Config.OrganizationID)
+
+	identityPath := installationPathForScope(loaded.Scope)
+	if state, err := installation.LoadFile(identityPath); err == nil {
+		fmt.Fprintf(out, "  installation: %s\n", state.InstallationID)
+	} else {
+		fmt.Fprintf(out, "  installation: not created yet (%s)\n", identityPath)
+	}
+
+	// Resolve the token through the daemon's exact read path: a locked or
+	// missing keychain item is THE silent killer under launchd, and "daemon:
+	// not running" alone points the user in the wrong direction.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := managedconfig.ResolveInstallToken(ctx, loaded.Config.Credentials.InstallTokenRef); err == nil {
+		fmt.Fprintf(out, "  install token: readable (%s)\n", loaded.Config.Credentials.InstallTokenRef)
+	} else {
+		fmt.Fprintf(out, "  WARNING: install token is not readable (%v) — the agent cannot stream; re-run `kontext setup` or unlock your login keychain\n", err)
+	}
+
+	if conn, err := net.DialTimeout("unix", DefaultSocketPath(), 500*time.Millisecond); err == nil {
+		conn.Close()
+		fmt.Fprintln(out, "  daemon: running")
+	} else {
+		fmt.Fprintln(out, "  daemon: not running (it starts with your next Claude Code session)")
+	}
+
+	// Self-serve installs have a user LaunchAgent; MDM installs manage theirs
+	// under /Library. Having BOTH scopes on one Mac deserves a callout — the
+	// system config wins and the user agent should be removed.
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		userPlist := filepath.Join(home, "Library", "LaunchAgents", DefaultLaunchdLabel+".plist")
+		if _, err := os.Lstat(userPlist); err == nil {
+			fmt.Fprintf(out, "  launch agent: %s\n", userPlist)
+			if loaded.Scope == managedconfig.ScopeSystem {
+				fmt.Fprintln(out, "  WARNING: this Mac is organization-managed but a self-serve agent is also installed; run `kontext setup --uninstall` to remove it")
+			}
+		}
+	}
+
+	// The LaunchAgent runs the daemon without --db, so the breadcrumb always
+	// sits next to the default database. A custom --db (dev-only hidden flag)
+	// is invisible here — acceptable for a diagnostics readout.
+	if authErr := LoadAuthError(DefaultDBPath()); authErr != nil {
+		switch authErr.Kind {
+		case "startup":
+			fmt.Fprintf(out, "  WARNING: the agent failed to start — %s (%s)\n", authErr.Message, authErr.At)
+		case authErrorKindCorrupt:
+			fmt.Fprintf(out, "  WARNING: auth breadcrumb is unreadable — %s\n", authErr.Message)
+		default:
+			detail := ""
+			if authErr.Status > 0 {
+				detail = fmt.Sprintf(" (HTTP %d, %s)", authErr.Status, authErr.At)
+			}
+			fmt.Fprintf(out, "  WARNING: hosted ingest is failing — install token rejected%s; run `kontext setup` with a new token from the dashboard\n", detail)
+		}
+	}
+}
+
+func describeScope(scope managedconfig.Scope) string {
+	switch scope {
+	case managedconfig.ScopeSystem:
+		return "system, managed by your organization"
+	case managedconfig.ScopeUser:
+		return "user, installed by kontext setup"
+	case managedconfig.ScopeEnv:
+		return "env override"
+	default:
+		return string(scope)
+	}
+}

--- a/internal/managedstream/authfailure_test.go
+++ b/internal/managedstream/authfailure_test.go
@@ -1,0 +1,155 @@
+package managedstream
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/diagnostic"
+)
+
+// A store with one decision so every Flush actually posts — an empty store
+// short-circuits before hitting the server, which would reset the
+// auth-failure counter without exercising it.
+func seededStore(t *testing.T) string {
+	t.Helper()
+	store, dbPath := testStore(t)
+	saveTestDecision(t, store, "sess-auth-test", "tool-use-auth-test")
+	return dbPath
+}
+
+func TestFlushDoesNotFireOnFlushSuccessWithoutPosting(t *testing.T) {
+	// An empty flush never contacts the server and therefore proves nothing
+	// about the token — it must not clear a "token rejected" breadcrumb on an
+	// idle machine whose token is still revoked.
+	_, dbPath := testStore(t)
+
+	fired := false
+	err := Flush(context.Background(), Options{
+		DBPath:         dbPath,
+		StatePath:      filepath.Join(filepath.Dir(dbPath), "state.json"),
+		CloudURL:       "https://unreachable.invalid",
+		InstallationID: "ins_test",
+		InstallToken:   "any",
+		Diagnostic:     diagnostic.New(nil, false),
+		OnFlushSuccess: func() { fired = true },
+	})
+	if err != nil {
+		t.Fatalf("Flush(empty store) error = %v", err)
+	}
+	if fired {
+		t.Fatal("OnFlushSuccess fired for an empty flush that never posted")
+	}
+}
+
+func TestRunFiresOnAuthFailureAfterConsecutive401s(t *testing.T) {
+	dbPath := seededStore(t)
+	dir := filepath.Dir(dbPath)
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "valid install token is required"})
+	}))
+	defer server.Close()
+
+	authFired := make(chan int, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- Run(ctx, Options{
+			DBPath:         dbPath,
+			StatePath:      filepath.Join(dir, "state.json"),
+			CloudURL:       server.URL,
+			InstallationID: "ins_test",
+			InstallToken:   "revoked-token",
+			Interval:       5 * time.Millisecond,
+			HTTPClient:     server.Client(),
+			Diagnostic:     diagnostic.New(nil, false),
+			OnAuthFailure: func(status int) {
+				select {
+				case authFired <- status:
+				default:
+				}
+			},
+		})
+	}()
+
+	select {
+	case status := <-authFired:
+		if status != http.StatusUnauthorized {
+			t.Fatalf("OnAuthFailure status = %d, want 401", status)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("OnAuthFailure never fired despite consecutive 401s")
+	}
+	// The threshold means it must NOT have fired on the very first rejection.
+	if requests.Load() < authFailureThreshold {
+		t.Fatalf("fired after %d requests, want >= %d", requests.Load(), authFailureThreshold)
+	}
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+}
+
+func TestRunRecoveryFiresOnFlushSuccess(t *testing.T) {
+	dbPath := seededStore(t)
+	dir := filepath.Dir(dbPath)
+
+	// Reject the first N requests, then accept — emulating a token that gets
+	// un-revoked / replaced server-side.
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requests.Add(1) <= authFailureThreshold {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"success": true})
+	}))
+	defer server.Close()
+
+	recovered := make(chan struct{}, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- Run(ctx, Options{
+			DBPath:         dbPath,
+			StatePath:      filepath.Join(dir, "state.json"),
+			CloudURL:       server.URL,
+			InstallationID: "ins_test",
+			InstallToken:   "rotating-token",
+			Interval:       5 * time.Millisecond,
+			HTTPClient:     server.Client(),
+			Diagnostic:     diagnostic.New(nil, false),
+			OnFlushSuccess: func() {
+				select {
+				case recovered <- struct{}{}:
+				default:
+				}
+			},
+		})
+	}()
+
+	select {
+	case <-recovered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("OnFlushSuccess never fired after recovery")
+	}
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+}

--- a/internal/managedstream/stream.go
+++ b/internal/managedstream/stream.go
@@ -45,7 +45,6 @@ type Options struct {
 	DBPath            string
 	StatePath         string
 	CloudURL          string
-	OrganizationID    string
 	InstallationID    string
 	InstallToken      string
 	DeviceLabel       string
@@ -54,11 +53,33 @@ type Options struct {
 	BatchLimit        int
 	HTTPClient        *http.Client
 	Diagnostic        diagnostic.Logger
+	// OnAuthFailure fires (nil-safe) after several consecutive 401/403
+	// rejections — the signature of a revoked or rotated install token,
+	// which would otherwise spin silently under launchd. Re-fires
+	// periodically so a long-running daemon keeps surfacing it without
+	// spamming every flush.
+	OnAuthFailure func(status int)
+	// OnFlushSuccess fires (nil-safe) after every ACCEPTED hosted post, so
+	// callers can clear "token rejected" breadcrumbs. It deliberately does
+	// not depend on this process's failure counter (a breadcrumb can outlive
+	// a daemon restart) and deliberately does NOT fire on empty flushes that
+	// never contacted the server — an idle machine with a revoked token must
+	// keep its breadcrumb.
+	OnFlushSuccess func()
 }
+
+const (
+	// authFailureThreshold avoids alerting on a transient 401 during a
+	// server-side deploy; three consecutive rejections (~30s at the default
+	// interval) means the credential itself is the problem.
+	authFailureThreshold = 3
+	// authFailureRefire re-surfaces the condition roughly every 8 minutes at
+	// the default interval.
+	authFailureRefire = 50
+)
 
 type Payload struct {
 	SchemaVersion      string                           `json:"schema_version"`
-	OrganizationID     string                           `json:"organization_id"`
 	InstallationID     string                           `json:"installation_id"`
 	BatchID            string                           `json:"batch_id"`
 	SentAt             string                           `json:"sent_at"`
@@ -88,10 +109,31 @@ func Run(ctx context.Context, opts Options) error {
 		interval = DefaultIntervalFromEnv()
 	}
 
-	if err := Flush(ctx, opts); err != nil {
+	var consecutiveAuthFailures int
+	flush := func() {
+		// OnFlushSuccess is invoked inside Flush (only after an accepted
+		// post); here we only track consecutive auth rejections.
+		err := Flush(ctx, opts)
+		if err == nil {
+			consecutiveAuthFailures = 0
+			return
+		}
 		opts.Diagnostic.Printf("managed stream flush: %v\n", err)
+
+		var hostedErr *hostedIngestError
+		if !errors.As(err, &hostedErr) || !isAuthStatus(hostedErr.StatusCode) {
+			consecutiveAuthFailures = 0
+			return
+		}
+		consecutiveAuthFailures++
+		if opts.OnAuthFailure != nil &&
+			(consecutiveAuthFailures == authFailureThreshold ||
+				consecutiveAuthFailures%authFailureRefire == 0) {
+			opts.OnAuthFailure(hostedErr.StatusCode)
+		}
 	}
 
+	flush()
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
@@ -99,11 +141,13 @@ func Run(ctx context.Context, opts Options) error {
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			if err := Flush(ctx, opts); err != nil {
-				opts.Diagnostic.Printf("managed stream flush: %v\n", err)
-			}
+			flush()
 		}
 	}
+}
+
+func isAuthStatus(status int) bool {
+	return status == http.StatusUnauthorized || status == http.StatusForbidden
 }
 
 func Flush(ctx context.Context, opts Options) error {
@@ -150,7 +194,6 @@ func Flush(ctx context.Context, opts Options) error {
 
 		payload := Payload{
 			SchemaVersion:      SchemaVersion,
-			OrganizationID:     opts.OrganizationID,
 			InstallationID:     opts.InstallationID,
 			BatchID:            "batch_" + uuid.NewString(),
 			SentAt:             time.Now().UTC().Format(time.RFC3339Nano),
@@ -206,6 +249,12 @@ func Flush(ctx context.Context, opts Options) error {
 				continue
 			}
 			return err
+		}
+
+		// The hosted ledger accepted a post with this token — proof the
+		// credential works, which is what breadcrumb-clearing needs.
+		if opts.OnFlushSuccess != nil {
+			opts.OnFlushSuccess()
 		}
 
 		if batch.Cursor != nil {
@@ -459,9 +508,6 @@ func validateOptions(opts Options) error {
 	}
 	if strings.TrimSpace(opts.CloudURL) == "" {
 		return errors.New("managed stream requires cloud url")
-	}
-	if strings.TrimSpace(opts.OrganizationID) == "" {
-		return errors.New("managed stream requires organization id")
 	}
 	if strings.TrimSpace(opts.InstallationID) == "" {
 		return errors.New("managed stream requires installation id")

--- a/internal/managedstream/stream_test.go
+++ b/internal/managedstream/stream_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -29,7 +30,6 @@ func TestFlushPostsLedgerBatchWithInstallationIdentity(t *testing.T) {
 		DBPath:         dbPath,
 		StatePath:      statePath,
 		CloudURL:       server.URL,
-		OrganizationID: "org_123",
 		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
 		InstallToken:   "test-install-token",
 		DeviceLabel:    "michel-macbook",
@@ -40,9 +40,6 @@ func TestFlushPostsLedgerBatchWithInstallationIdentity(t *testing.T) {
 
 	if got.SchemaVersion != SchemaVersion {
 		t.Fatalf("schema_version = %q, want %q", got.SchemaVersion, SchemaVersion)
-	}
-	if got.OrganizationID != "org_123" {
-		t.Fatalf("organization_id = %q", got.OrganizationID)
 	}
 	if got.InstallationID != "ins_0123456789abcdefghijklmnopqrstuv" {
 		t.Fatalf("installation_id = %q", got.InstallationID)
@@ -80,7 +77,6 @@ func TestFlushOmitsBlankDeviceLabel(t *testing.T) {
 		DBPath:         dbPath,
 		StatePath:      filepath.Join(t.TempDir(), "stream-state.json"),
 		CloudURL:       server.URL,
-		OrganizationID: "org_123",
 		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
 		InstallToken:   "test-install-token",
 		DeviceLabel:    " \t\n ",
@@ -108,7 +104,6 @@ func TestFlushResolvesDeploymentVersionPerFlush(t *testing.T) {
 			DBPath:            dbPath,
 			StatePath:         filepath.Join(t.TempDir(), "stream-state.json"),
 			CloudURL:          server.URL,
-			OrganizationID:    "org_123",
 			InstallationID:    "ins_0123456789abcdefghijklmnopqrstuv",
 			InstallToken:      "test-install-token",
 			DeploymentVersion: func() string { return version },
@@ -148,7 +143,6 @@ func TestFlushDoesNotAdvanceCursorWhenHostedBackendFails(t *testing.T) {
 		DBPath:         dbPath,
 		StatePath:      statePath,
 		CloudURL:       server.URL,
-		OrganizationID: "org_123",
 		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
 		InstallToken:   "test-install-token",
 		HTTPClient:     server.Client(),
@@ -175,7 +169,6 @@ func TestFlushCapsBatchLimitBeforePosting(t *testing.T) {
 		DBPath:         dbPath,
 		StatePath:      filepath.Join(t.TempDir(), "stream-state.json"),
 		CloudURL:       server.URL,
-		OrganizationID: "org_123",
 		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
 		InstallToken:   "test-install-token",
 		BatchLimit:     1000,
@@ -216,7 +209,6 @@ func TestFlushRetriesWithSmallerBatchWhenHostedBackendRejectsSize(t *testing.T) 
 		DBPath:         dbPath,
 		StatePath:      statePath,
 		CloudURL:       server.URL,
-		OrganizationID: "org_123",
 		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
 		InstallToken:   "test-install-token",
 		BatchLimit:     4,
@@ -254,7 +246,6 @@ func TestFlushReportsHostedValidationBody(t *testing.T) {
 		DBPath:         dbPath,
 		StatePath:      filepath.Join(t.TempDir(), "stream-state.json"),
 		CloudURL:       server.URL,
-		OrganizationID: "org_123",
 		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
 		InstallToken:   "test-install-token",
 		BatchLimit:     1,
@@ -283,7 +274,6 @@ func TestFlushRedactsHostedValidationBody(t *testing.T) {
 		DBPath:         dbPath,
 		StatePath:      filepath.Join(t.TempDir(), "stream-state.json"),
 		CloudURL:       server.URL,
-		OrganizationID: "org_123",
 		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
 		InstallToken:   "test-install-token",
 		BatchLimit:     1,
@@ -325,7 +315,6 @@ func TestFlushDoesNotAdvanceCursorPastHostedRejectedMinimumBatch(t *testing.T) {
 		DBPath:         dbPath,
 		StatePath:      statePath,
 		CloudURL:       server.URL,
-		OrganizationID: "org_123",
 		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
 		InstallToken:   "test-install-token",
 		BatchLimit:     1,
@@ -355,7 +344,6 @@ func TestFlushAdvancesCursorPastOversizedMinimumBatch(t *testing.T) {
 		DBPath:         dbPath,
 		StatePath:      statePath,
 		CloudURL:       server.URL,
-		OrganizationID: "org_123",
 		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
 		InstallToken:   "test-install-token",
 		BatchLimit:     1,
@@ -392,7 +380,6 @@ func TestFlushDefaultsStatePathBesideLedgerDB(t *testing.T) {
 	if err := Flush(context.Background(), Options{
 		DBPath:         dbPath,
 		CloudURL:       server.URL,
-		OrganizationID: "org_123",
 		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
 		InstallToken:   "test-install-token",
 		HTTPClient:     server.Client(),
@@ -430,7 +417,6 @@ func TestFlushUsesUpdatedAfterCursor(t *testing.T) {
 		DBPath:         dbPath,
 		StatePath:      statePath,
 		CloudURL:       server.URL,
-		OrganizationID: "org_123",
 		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
 		InstallToken:   "test-install-token",
 		HTTPClient:     server.Client(),
@@ -477,8 +463,17 @@ func capturePayloadServer(t *testing.T, got *Payload) *httptest.Server {
 		if got := r.Header.Get("Authorization"); got != "Bearer test-install-token" {
 			t.Fatalf("Authorization = %q, want bearer install token", got)
 		}
-		if err := json.NewDecoder(r.Body).Decode(got); err != nil {
-			t.Fatalf("Decode() error = %v", err)
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("ReadAll() error = %v", err)
+		}
+		// New agents must not send the legacy organization_id claim — the
+		// install token alone binds the batch to its org.
+		if strings.Contains(string(raw), `"organization_id"`) {
+			t.Fatalf("payload contains organization_id claim: %s", raw)
+		}
+		if err := json.Unmarshal(raw, got); err != nil {
+			t.Fatalf("Unmarshal() error = %v", err)
 		}
 		w.WriteHeader(http.StatusAccepted)
 	}))


### PR DESCRIPTION
## What & why

Revoked-token DevX + `kontext doctor`, and the final wire-format change (ENG-442). Closes the loop so a self-serve operator whose key was revoked gets an actionable message instead of a silently-dead daemon. Builds on #277.

- **Consecutive-401 detection**: `managedstream` fires `OnAuthFailure` after 3 straight 401/403s (re-fires periodically), and `OnFlushSuccess` only after an accepted post. The daemon turns that into a stderr line ("token rejected — run `kontext setup` with a new token") and a `last-auth-error.json` breadcrumb next to the guard DB; a later success clears it.
- **`kontext doctor` managed-observe section**: config path + scope (system MDM / user / env), org, installation id, live token-resolve check through the daemon's read path, socket probe, LaunchAgent presence + MDM-coexistence warning, and the breadcrumb (kind-aware: auth vs startup).
- **Batches no longer send `organization_id`.** The install token is the only org binding (server resolves it per request, see #574); `managed.json` keeps the org id purely as a local label for doctor/setup output. Stream `Options`/`Payload` drop the field and tests assert it is absent from the wire.

## How to review / test — pure Go

```bash
go build ./... && go vet ./... && go test ./... && go test -race ./...
```
- `managedstream/stream_test.go`: the 401 counter + refire, `OnFlushSuccess` only on accepted post, and **assertion that `organization_id` is absent** from the posted payload.
- `managedobserve/autherr_test.go` + `doctor_test.go`: breadcrumb round-trip, corrupt-file tolerance, doctor section rendering.

To see the live revoked-token behaviour, use the branch-built binary from #277 against the local stack, then revoke the key in the dashboard: within a few flushes the daemon logs the actionable message and the breadcrumb appears; `kontext doctor` shows it; seeding a fresh key clears it on the next accepted flush. (No brew required.)

## Risk

The claim removal is forward-safe: old deployed agents keep sending `organization_id` and the server keeps verifying it (#574); only new agents omit it. **Rollout: the kontext API change (#574) must be deployed before a CLI release that omits the claim.**

Part of the ENG-442 kontext-cli stack: #276 -> #277 -> **#278**.
