### PR TITLE
feat(githubpolicy): evaluate synced GitHub policy locally in observer mode (ENG-426)

### DIFF
--- a/internal/githubpolicy/cache.go
+++ b/internal/githubpolicy/cache.go
@@ -1,0 +1,231 @@
+package githubpolicy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/diagnostic"
+)
+
+// DefaultRefreshInterval is how often the managed daemon re-fetches the
+// snapshot. Hash-unchanged responses are cheap: they only bump freshness.
+const DefaultRefreshInterval = 60 * time.Second
+
+const envRefreshInterval = "KONTEXT_GITHUB_POLICY_REFRESH_INTERVAL"
+
+// Status describes how trustworthy the cached snapshot currently is. A stale
+// snapshot keeps being evaluated — stale-but-deterministic beats unavailable —
+// and the staleness is recorded on every decision.
+type Status struct {
+	// FetchedAt is when the cached snapshot was last confirmed by the cloud
+	// (fetch succeeded, whether or not the hash changed).
+	FetchedAt time.Time `json:"fetched_at"`
+	// Stale is true when the most recent fetch attempt failed and the cache
+	// is serving the last known snapshot.
+	Stale bool `json:"stale"`
+	// LastError holds the most recent fetch failure, if any.
+	LastError string `json:"last_error,omitempty"`
+}
+
+// SnapshotProvider is what the guard runtime consumes: the current snapshot,
+// its freshness, and whether a snapshot exists at all.
+type SnapshotProvider interface {
+	CurrentSnapshot() (Snapshot, Status, bool)
+}
+
+// Cache holds the per-installation snapshot in memory and mirrors it to disk
+// so the policy survives daemon restarts and cloud outages.
+type Cache struct {
+	path string
+
+	mu       sync.RWMutex
+	snapshot Snapshot
+	status   Status
+	loaded   bool
+}
+
+type cacheFile struct {
+	SchemaVersion string   `json:"schema_version"`
+	FetchedAt     string   `json:"fetched_at"`
+	Snapshot      Snapshot `json:"snapshot"`
+}
+
+func NewCache(path string) *Cache {
+	return &Cache{path: path}
+}
+
+// DefaultCachePathForDB stores the snapshot next to the guard database, the
+// same convention managedstream uses for its cursor state.
+func DefaultCachePathForDB(dbPath string) string {
+	if dbPath = strings.TrimSpace(dbPath); dbPath != "" {
+		return filepath.Join(filepath.Dir(dbPath), "github-policy-snapshot.json")
+	}
+	return "github-policy-snapshot.json"
+}
+
+func (c *Cache) CurrentSnapshot() (Snapshot, Status, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.snapshot, c.status, c.loaded
+}
+
+// LoadPersisted primes the cache from disk so evaluation works before the
+// first fetch completes. The persisted snapshot starts out stale until the
+// cloud confirms it.
+func (c *Cache) LoadPersisted() error {
+	if c.path == "" {
+		return nil
+	}
+	data, err := os.ReadFile(c.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	var file cacheFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		return err
+	}
+	if file.Snapshot.SchemaVersion != SchemaVersion {
+		return nil
+	}
+	fetchedAt, _ := time.Parse(time.RFC3339Nano, file.FetchedAt)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.snapshot = file.Snapshot
+	c.status = Status{FetchedAt: fetchedAt, Stale: true, LastError: "persisted snapshot not yet confirmed by cloud"}
+	c.loaded = true
+	return nil
+}
+
+// Apply installs a freshly fetched snapshot. When the hash is unchanged the
+// rules are not re-applied or re-persisted; only freshness is updated.
+func (c *Cache) Apply(snapshot Snapshot, fetchedAt time.Time) error {
+	c.mu.Lock()
+	unchanged := c.loaded && c.snapshot.Hash == snapshot.Hash
+	if !unchanged {
+		c.snapshot = snapshot
+	}
+	c.status = Status{FetchedAt: fetchedAt}
+	c.loaded = true
+	c.mu.Unlock()
+	if unchanged {
+		return nil
+	}
+	return c.persist(snapshot, fetchedAt)
+}
+
+// MarkFetchFailed records that the latest refresh failed; the cached snapshot
+// keeps serving evaluations.
+func (c *Cache) MarkFetchFailed(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.status.Stale = true
+	if err != nil {
+		c.status.LastError = err.Error()
+	}
+}
+
+func (c *Cache) persist(snapshot Snapshot, fetchedAt time.Time) error {
+	if c.path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(c.path), 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(cacheFile{
+		SchemaVersion: SchemaVersion,
+		FetchedAt:     fetchedAt.UTC().Format(time.RFC3339Nano),
+		Snapshot:      snapshot,
+	}, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	temp, err := os.CreateTemp(filepath.Dir(c.path), ".github-policy-*.tmp")
+	if err != nil {
+		return err
+	}
+	tempPath := temp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tempPath)
+		}
+	}()
+	if err := temp.Chmod(0o600); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if _, err := temp.Write(data); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tempPath, c.path); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
+}
+
+type RunOptions struct {
+	Cache        *Cache
+	CloudURL     string
+	InstallToken string
+	Interval     time.Duration
+	HTTPClient   *http.Client
+	Diagnostic   diagnostic.Logger
+}
+
+// Run fetches the snapshot once at start and then on every interval tick
+// until the context is cancelled. Fetch failures are logged and leave the
+// last cached snapshot in place.
+func Run(ctx context.Context, opts RunOptions) {
+	interval := opts.Interval
+	if interval == 0 {
+		interval = DefaultIntervalFromEnv()
+	}
+	refresh(ctx, opts)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			refresh(ctx, opts)
+		}
+	}
+}
+
+func refresh(ctx context.Context, opts RunOptions) {
+	snapshot, err := FetchSnapshot(ctx, opts.HTTPClient, opts.CloudURL, opts.InstallToken)
+	if err != nil {
+		opts.Cache.MarkFetchFailed(err)
+		opts.Diagnostic.Printf("github policy refresh: %v\n", err)
+		return
+	}
+	if err := opts.Cache.Apply(snapshot, time.Now().UTC()); err != nil {
+		opts.Diagnostic.Printf("github policy persist: %v\n", err)
+	}
+}
+
+func DefaultIntervalFromEnv() time.Duration {
+	if value := strings.TrimSpace(os.Getenv(envRefreshInterval)); value != "" {
+		if parsed, err := time.ParseDuration(value); err == nil && parsed > 0 {
+			return parsed
+		}
+	}
+	return DefaultRefreshInterval
+}

--- a/internal/githubpolicy/cache_test.go
+++ b/internal/githubpolicy/cache_test.go
@@ -1,0 +1,155 @@
+package githubpolicy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func testSnapshot(epoch int, hash string) Snapshot {
+	return Snapshot{
+		SchemaVersion:  SchemaVersion,
+		OrganizationID: testOrgID,
+		ProviderKey:    "github",
+		Mode:           ModeObserve,
+		Epoch:          epoch,
+		Hash:           hash,
+		Rules:          []Rule{{ID: "rule-1", Layer: LayerOrg, SubjectID: testOrgID, Effect: EffectAllow}},
+		GeneratedAt:    "2026-06-11T00:00:00.000Z",
+	}
+}
+
+func TestFetchSnapshotSendsInstallTokenAndDecodes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != SnapshotEndpoint {
+			t.Fatalf("path = %q, want %q", r.URL.Path, SnapshotEndpoint)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-install-token" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(testSnapshot(3, "hash-3"))
+	}))
+	t.Cleanup(server.Close)
+
+	snapshot, err := FetchSnapshot(context.Background(), server.Client(), server.URL, "test-install-token")
+	if err != nil {
+		t.Fatalf("FetchSnapshot() error = %v", err)
+	}
+	if snapshot.Epoch != 3 || snapshot.Hash != "hash-3" || len(snapshot.Rules) != 1 {
+		t.Fatalf("snapshot = %+v", snapshot)
+	}
+}
+
+func TestFetchSnapshotRejectsUnauthorized(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(server.Close)
+
+	if _, err := FetchSnapshot(context.Background(), server.Client(), server.URL, "revoked"); err == nil {
+		t.Fatal("FetchSnapshot() with revoked token should fail")
+	}
+}
+
+func TestCacheApplyPersistsAndReloads(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "github-policy-snapshot.json")
+	cache := NewCache(path)
+	if err := cache.Apply(testSnapshot(3, "hash-3"), time.Now().UTC()); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	reloaded := NewCache(path)
+	if err := reloaded.LoadPersisted(); err != nil {
+		t.Fatalf("LoadPersisted() error = %v", err)
+	}
+	snapshot, status, ok := reloaded.CurrentSnapshot()
+	if !ok || snapshot.Hash != "hash-3" {
+		t.Fatalf("CurrentSnapshot() = %+v, %v", snapshot, ok)
+	}
+	if !status.Stale {
+		t.Fatal("persisted snapshot should start stale until the cloud confirms it")
+	}
+}
+
+func TestCacheUnchangedHashSkipsReapply(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "github-policy-snapshot.json")
+	cache := NewCache(path)
+	if err := cache.Apply(testSnapshot(3, "hash-3"), time.Now().UTC()); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	// A second fetch with the same hash only refreshes status; the snapshot
+	// (including its rule slice) stays in place.
+	unchanged := testSnapshot(3, "hash-3")
+	unchanged.Rules = nil // would wipe rules if re-applied
+	if err := cache.Apply(unchanged, time.Now().UTC()); err != nil {
+		t.Fatalf("Apply() unchanged error = %v", err)
+	}
+	snapshot, status, _ := cache.CurrentSnapshot()
+	if len(snapshot.Rules) != 1 {
+		t.Fatalf("rules were re-applied on unchanged hash: %+v", snapshot.Rules)
+	}
+	if status.Stale {
+		t.Fatal("status should be fresh after a confirmed fetch")
+	}
+}
+
+func TestCacheKeepsServingStaleSnapshotOnFetchFailure(t *testing.T) {
+	cache := NewCache(filepath.Join(t.TempDir(), "github-policy-snapshot.json"))
+	if err := cache.Apply(testSnapshot(3, "hash-3"), time.Now().UTC()); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	cache.MarkFetchFailed(context.DeadlineExceeded)
+
+	snapshot, status, ok := cache.CurrentSnapshot()
+	if !ok || snapshot.Hash != "hash-3" {
+		t.Fatalf("CurrentSnapshot() after failure = %+v, %v", snapshot, ok)
+	}
+	if !status.Stale || status.LastError == "" {
+		t.Fatalf("status = %+v, want stale with recorded error", status)
+	}
+}
+
+func TestRunRefreshesUntilCancelled(t *testing.T) {
+	fetches := make(chan struct{}, 8)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fetches <- struct{}{}
+		_ = json.NewEncoder(w).Encode(testSnapshot(3, "hash-3"))
+	}))
+	t.Cleanup(server.Close)
+
+	cache := NewCache(filepath.Join(t.TempDir(), "github-policy-snapshot.json"))
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		Run(ctx, RunOptions{
+			Cache:        cache,
+			CloudURL:     server.URL,
+			InstallToken: "test-install-token",
+			Interval:     10 * time.Millisecond,
+			HTTPClient:   server.Client(),
+		})
+		close(done)
+	}()
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-fetches:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for refresh fetches")
+		}
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run() did not stop on context cancellation")
+	}
+
+	if _, _, ok := cache.CurrentSnapshot(); !ok {
+		t.Fatal("cache should hold a snapshot after refresh")
+	}
+}

--- a/internal/githubpolicy/cache_test.go
+++ b/internal/githubpolicy/cache_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -41,6 +42,18 @@ func TestFetchSnapshotSendsInstallTokenAndDecodes(t *testing.T) {
 	}
 	if snapshot.Epoch != 3 || snapshot.Hash != "hash-3" || len(snapshot.Rules) != 1 {
 		t.Fatalf("snapshot = %+v", snapshot)
+	}
+}
+
+func TestFetchSnapshotRejectsOversizedBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(make([]byte, maxSnapshotBodyBytes+1))
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := FetchSnapshot(context.Background(), server.Client(), server.URL, "test-install-token")
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("FetchSnapshot() error = %v, want explicit size-limit failure", err)
 	}
 }
 

--- a/internal/githubpolicy/classifier.go
+++ b/internal/githubpolicy/classifier.go
@@ -1,6 +1,7 @@
 package githubpolicy
 
 import (
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -57,39 +58,61 @@ var githubHostRE = regexp.MustCompile(`(?i)(^|[\s"'(<])((https?://)?(api\.)?gith
 // branch resolution — because deriving it shells out to git.
 func ClassifyProviderActions(toolName string, toolInput map[string]any, gitContext func() GitContext) []ProviderAction {
 	if gitContext == nil {
-		gitContext = func() GitContext { return GitContext{} }
+		return ClassifyProviderActionsWithCWD(toolName, toolInput, "", nil)
 	}
+	return ClassifyProviderActionsWithCWD(toolName, toolInput, "", func(string) GitContext {
+		return gitContext()
+	})
+}
+
+// ClassifyProviderActionsWithCWD maps a tool invocation to canonical GitHub
+// actions, using cwd as the base for git -C context resolution.
+func ClassifyProviderActionsWithCWD(toolName string, toolInput map[string]any, cwd string, gitContext func(string) GitContext) []ProviderAction {
+	if gitContext == nil {
+		gitContext = func(string) GitContext { return GitContext{} }
+	}
+	loadGitContext := memoizedGitContext(gitContext)
 	switch strings.ToLower(toolName) {
 	case "bash", "shell":
-		command, _ := stringField(toolInput, "command")
-		if command == "" {
-			command, _ = stringField(toolInput, "cmd")
-		}
+		command := commandFromToolInput(toolInput)
 		if command == "" {
 			return nil
 		}
-		return classifyCommand(command, memoizedGitContext(gitContext))
+		return classifyCommand(command, cwd, loadGitContext)
 	case "webfetch", "web_fetch":
 		url, _ := stringField(toolInput, "url")
 		if url != "" && isGithubURL(url) {
 			return []ProviderAction{{Action: "github.api.read", Resource: normalizeGithubRepo(url)}}
 		}
 	}
+	if action, ok := classifyGithubMCPTool(toolName, toolInput); ok {
+		return []ProviderAction{action}
+	}
 	return nil
 }
 
-func memoizedGitContext(load func() GitContext) func() GitContext {
-	var cached *GitContext
-	return func() GitContext {
-		if cached == nil {
-			context := load()
-			cached = &context
+func commandFromToolInput(input map[string]any) string {
+	for _, key := range []string{"command", "cmd", "script"} {
+		if value, _ := stringField(input, key); value != "" {
+			return value
 		}
-		return *cached
+	}
+	return ""
+}
+
+func memoizedGitContext(load func(string) GitContext) func(string) GitContext {
+	cached := map[string]GitContext{}
+	return func(cwd string) GitContext {
+		if context, ok := cached[cwd]; ok {
+			return context
+		}
+		context := load(cwd)
+		cached[cwd] = context
+		return context
 	}
 }
 
-func classifyCommand(command string, gitContext func() GitContext) []ProviderAction {
+func classifyCommand(command string, cwd string, gitContext func(string) GitContext) []ProviderAction {
 	trimmed := strings.TrimSpace(command)
 	if trimmed == "" {
 		return nil
@@ -98,15 +121,17 @@ func classifyCommand(command string, gitContext func() GitContext) []ProviderAct
 	for _, segment := range splitCommandSegments(trimmed) {
 		invocation, args := commandInvocation(segment)
 		if unwrapped, ok := unwrapShellLauncher(invocation, args); ok {
-			actions = append(actions, classifyCommand(unwrapped, gitContext)...)
+			actions = append(actions, classifyCommand(unwrapped, cwd, gitContext)...)
 			continue
 		}
 		switch invocation {
 		case "gh":
-			actions = append(actions, classifyGhCommand(args, segment, gitContext))
+			actions = append(actions, classifyGhCommand(args, segment, func() GitContext {
+				return gitContext(cwd)
+			}))
 			continue
 		case "git":
-			actions = append(actions, classifyGitCommand(args, segment, gitContext)...)
+			actions = append(actions, classifyGitCommand(args, segment, cwd, gitContext)...)
 			continue
 		case "curl", "wget", "http", "https", "httpie":
 			if isGithubURL(segment) {
@@ -173,8 +198,10 @@ func classifyGhCommand(args []string, raw string, gitContext func() GitContext) 
 	case "workflow":
 		mutating := verb == "run" || verb == "enable" || verb == "disable"
 		return ProviderAction{Action: apiAction(mutating), Resource: resource}
+	case "release", "secret", "gist":
+		return ProviderAction{Action: readWriteAction("github.api", isReadVerb(verb)), Resource: resource}
 	}
-	return ProviderAction{Action: apiAction(commandLooksMutating(raw)), Resource: resource}
+	return ProviderAction{Action: apiAction(commandLooksMutating(raw) || !isKnownReadOnlyGhCommand(area, verb)), Resource: resource}
 }
 
 func readWriteAction(prefix string, read bool) string {
@@ -184,18 +211,82 @@ func readWriteAction(prefix string, read bool) string {
 	return prefix + ".write"
 }
 
-func classifyGitCommand(args []string, raw string, gitContext func() GitContext) []ProviderAction {
+func isKnownReadOnlyGhCommand(area, verb string) bool {
+	switch area {
+	case "auth":
+		return verb == "status" || verb == "token"
+	case "config", "alias", "extension":
+		return verb == "get" || verb == "list"
+	}
+	return false
+}
+
+func classifyGithubMCPTool(toolName string, toolInput map[string]any) (ProviderAction, bool) {
+	name := strings.ToLower(toolName)
+	const prefix = "mcp__github__"
+	if !strings.HasPrefix(name, prefix) {
+		return ProviderAction{}, false
+	}
+	operation := strings.TrimPrefix(name, prefix)
+	read := githubMCPOperationLooksRead(operation)
+	actionPrefix := "github.api"
+	if strings.Contains(operation, "pull_request") {
+		actionPrefix = "github.pr"
+	} else if strings.Contains(operation, "issue") {
+		actionPrefix = "github.issue"
+	} else if strings.Contains(operation, "repo") || strings.Contains(operation, "repository") {
+		actionPrefix = "github.repo"
+	}
+	return ProviderAction{
+		Action:   readWriteAction(actionPrefix, read),
+		Resource: githubRepoFromMCPInput(toolInput),
+	}, true
+}
+
+func githubMCPOperationLooksRead(operation string) bool {
+	verb := operation
+	if index := strings.IndexByte(operation, '_'); index >= 0 {
+		verb = operation[:index]
+	}
+	switch verb {
+	case "get", "list", "read", "search", "view":
+		return true
+	}
+	return false
+}
+
+func githubRepoFromMCPInput(input map[string]any) string {
+	for _, key := range []string{"repository", "nameWithOwner", "name_with_owner"} {
+		if value, _ := stringField(input, key); value != "" {
+			if repo := normalizeGithubRepo(value); repo != "" {
+				return repo
+			}
+		}
+	}
+	repo, _ := stringField(input, "repo")
+	if repo == "" {
+		repo, _ = stringField(input, "repository_name")
+	}
+	owner, _ := stringField(input, "owner")
+	if owner != "" && repo != "" {
+		return normalizeGithubRepo(owner + "/" + repo)
+	}
+	return normalizeGithubRepo(repo)
+}
+
+func classifyGitCommand(args []string, raw string, cwd string, gitContext func(string) GitContext) []ProviderAction {
 	positionals := gitPositionals(args)
 	if len(positionals) == 0 {
 		return nil
 	}
 	verb := positionals[0]
+	targetCWD := gitContextCWD(args, cwd)
 
 	var context GitContext
 	contextLoaded := false
 	loadContext := func() GitContext {
 		if !contextLoaded {
-			context = gitContext()
+			context = gitContext(targetCWD)
 			contextLoaded = true
 		}
 		return context
@@ -397,7 +488,7 @@ func githubRepoFromGhArgs(args []string) string {
 
 var ghValueOptions = map[string]bool{
 	"-R": true, "--repo": true, "--hostname": true, "--jq": true, "-q": true,
-	"--template": true, "-t": true, "--paginate": true, "--cache": true, "--preview": true,
+	"--template": true, "-t": true, "--cache": true, "--preview": true,
 	"--limit": true, "--state": true, "--base": true, "--head": true,
 	"--label": true, "--author": true, "--assignee": true, "--milestone": true,
 	"--search": true, "--json": true, "--field": true, "-F": true,
@@ -497,6 +588,44 @@ func gitBranchFallback(verb string, args []string, gitContext func() GitContext)
 		return gitFlagValue(args, "-b", "--branch")
 	}
 	return gitContext().Branch
+}
+
+func gitContextCWD(args []string, base string) string {
+	cwd := strings.TrimSpace(base)
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			break
+		}
+		if arg == "-C" {
+			if i+1 < len(args) {
+				cwd = joinGitCWD(cwd, args[i+1])
+				i++
+			}
+			continue
+		}
+		if strings.HasPrefix(arg, "-C") && arg != "-c" {
+			if value := strings.TrimPrefix(arg, "-C"); value != "" {
+				cwd = joinGitCWD(cwd, value)
+			}
+			continue
+		}
+		if !strings.HasPrefix(arg, "-") {
+			break
+		}
+	}
+	return cwd
+}
+
+func joinGitCWD(base, next string) string {
+	next = strings.TrimSpace(next)
+	if next == "" {
+		return base
+	}
+	if filepath.IsAbs(next) || strings.TrimSpace(base) == "" {
+		return filepath.Clean(next)
+	}
+	return filepath.Clean(filepath.Join(base, next))
 }
 
 func gitFlagValue(args []string, flags ...string) string {

--- a/internal/githubpolicy/classifier.go
+++ b/internal/githubpolicy/classifier.go
@@ -396,12 +396,13 @@ func githubRepoFromGhArgs(args []string) string {
 }
 
 var ghValueOptions = map[string]bool{
-	"-R": true, "--repo": true, "--hostname": true, "--jq": true,
-	"--template": true, "--paginate": true, "--cache": true, "--preview": true,
+	"-R": true, "--repo": true, "--hostname": true, "--jq": true, "-q": true,
+	"--template": true, "-t": true, "--paginate": true, "--cache": true, "--preview": true,
 	"--limit": true, "--state": true, "--base": true, "--head": true,
 	"--label": true, "--author": true, "--assignee": true, "--milestone": true,
 	"--search": true, "--json": true, "--field": true, "-F": true,
-	"--raw-field": true, "-f": true,
+	"--raw-field": true, "-f": true, "--input": true,
+	"-X": true, "--method": true, "--request": true, "-H": true, "--header": true,
 }
 
 var gitValueOptions = map[string]bool{

--- a/internal/githubpolicy/classifier.go
+++ b/internal/githubpolicy/classifier.go
@@ -72,7 +72,7 @@ func ClassifyProviderActions(toolName string, toolInput map[string]any, gitConte
 	case "webfetch", "web_fetch":
 		url, _ := stringField(toolInput, "url")
 		if url != "" && isGithubURL(url) {
-			return []ProviderAction{{Action: "github.api.read"}}
+			return []ProviderAction{{Action: "github.api.read", Resource: normalizeGithubRepo(url)}}
 		}
 	}
 	return nil
@@ -110,12 +110,18 @@ func classifyCommand(command string, gitContext func() GitContext) []ProviderAct
 			continue
 		case "curl", "wget", "http", "https", "httpie":
 			if isGithubURL(segment) {
-				actions = append(actions, ProviderAction{Action: apiAction(commandLooksMutating(segment))})
+				actions = append(actions, ProviderAction{
+					Action:   apiAction(commandLooksMutating(segment)),
+					Resource: normalizeGithubRepo(segment),
+				})
 			}
 			continue
 		}
 		if isGithubURL(segment) {
-			actions = append(actions, ProviderAction{Action: apiAction(commandLooksMutating(segment))})
+			actions = append(actions, ProviderAction{
+				Action:   apiAction(commandLooksMutating(segment)),
+				Resource: normalizeGithubRepo(segment),
+			})
 		}
 	}
 	return actions
@@ -139,6 +145,15 @@ func classifyGhCommand(args []string, raw string, gitContext func() GitContext) 
 		verb = positional[1]
 	}
 	resource := githubRepoFromGhArgs(args)
+	if resource == "" && area == "api" && len(positional) > 1 {
+		// A literal REST endpoint names the repository it targets; -R only
+		// fills {owner}/{repo} placeholders.
+		resource = githubRepoFromAPIEndpoint(positional[1])
+	}
+	if resource == "" && area == "repo" && len(positional) > 2 {
+		// gh repo verbs take the target repository as a positional argument.
+		resource = normalizeGithubRepo(positional[2])
+	}
 	if resource == "" {
 		// Local extension over the cloud classifier: gh acts on the current
 		// repository when -R/--repo is absent, and the endpoint knows its cwd
@@ -347,6 +362,23 @@ func tokenize(command string) []string {
 	return tokens
 }
 
+// githubRepoFromAPIEndpoint extracts the repository slug from a gh api
+// endpoint argument: "repos/<owner>/<repo>/..." or a full API URL. Endpoints
+// with {owner}/{repo} placeholders resolve through -R or the cwd instead.
+func githubRepoFromAPIEndpoint(endpoint string) string {
+	if strings.Contains(endpoint, "{") {
+		return ""
+	}
+	if isGithubURL(endpoint) {
+		return normalizeGithubRepo(endpoint)
+	}
+	segments := strings.Split(strings.TrimPrefix(strings.Trim(endpoint, "/"), "repos/"), "/")
+	if !strings.HasPrefix(strings.Trim(endpoint, "/"), "repos/") || len(segments) < 2 {
+		return ""
+	}
+	return normalizeGithubRepo(segments[0] + "/" + segments[1])
+}
+
 func githubRepoFromGhArgs(args []string) string {
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
@@ -377,6 +409,7 @@ var gitValueOptions = map[string]bool{
 	"--work-tree": true, "--namespace": true, "--exec-path": true,
 	"--super-prefix": true, "--repo": true, "-o": true, "--push-option": true,
 	"--receive-pack": true, "--exec": true, "--recurse-submodules": true,
+	"-b": true, "--branch": true,
 }
 
 func ghPositionals(args []string) []string {
@@ -457,7 +490,26 @@ func gitBranchFallback(verb string, args []string, gitContext func() GitContext)
 			}
 		}
 	}
+	// clone targets a fresh checkout, not the branch the cwd happens to be
+	// on; only an explicit -b/--branch pins it.
+	if verb == "clone" {
+		return gitFlagValue(args, "-b", "--branch")
+	}
 	return gitContext().Branch
+}
+
+func gitFlagValue(args []string, flags ...string) string {
+	for i, arg := range args {
+		for _, flag := range flags {
+			if arg == flag && i+1 < len(args) {
+				return args[i+1]
+			}
+			if strings.HasPrefix(arg, flag+"=") {
+				return strings.TrimPrefix(arg, flag+"=")
+			}
+		}
+	}
+	return ""
 }
 
 func selectedGitRemoteURL(verb string, args []string, gitContext func() GitContext) string {
@@ -469,6 +521,11 @@ func selectedGitRemoteURL(verb string, args []string, gitContext func() GitConte
 		return ""
 	}
 	if len(positionals) < 2 {
+		// push/fetch/pull without an explicit remote still hit the network —
+		// they default to origin, so the policy evaluation must too.
+		if verb == "push" || verb == "fetch" || verb == "pull" {
+			return gitContext().RemoteByName["origin"]
+		}
 		return ""
 	}
 	remote := positionals[1]
@@ -515,6 +572,7 @@ func normalizeGitPushRef(value string) string {
 
 var (
 	githubSSHRepoRE  = regexp.MustCompile(`(?i)^git@github\.com:([^/\s]+/[^/\s]+)$`)
+	githubAPIRepoRE  = regexp.MustCompile(`(?i)api\.github\.com/repos/([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)`)
 	githubURLRepoRE  = regexp.MustCompile(`(?i)github\.com[:/]([^/\s]+/[^/\s?#]+)`)
 	githubSlugRepoRE = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
 	dotGitSuffixRE   = regexp.MustCompile(`(?i)\.git$`)
@@ -527,6 +585,15 @@ func normalizeGithubRepo(value string) string {
 	}
 	if match := githubSSHRepoRE.FindStringSubmatch(trimmed); match != nil {
 		return match[1]
+	}
+	// REST API URLs nest the slug under /repos/; the generic URL pattern
+	// would capture "repos/<owner>" instead. Non-repos API paths (orgs,
+	// search, ...) carry no repository.
+	if match := githubAPIRepoRE.FindStringSubmatch(trimmed); match != nil {
+		return dotGitSuffixRE.ReplaceAllString(match[1], "")
+	}
+	if strings.Contains(strings.ToLower(trimmed), "api.github.com") {
+		return ""
 	}
 	if match := githubURLRepoRE.FindStringSubmatch(trimmed); match != nil {
 		return dotGitSuffixRE.ReplaceAllString(match[1], "")

--- a/internal/githubpolicy/classifier.go
+++ b/internal/githubpolicy/classifier.go
@@ -1,0 +1,617 @@
+package githubpolicy
+
+import (
+	"regexp"
+	"strings"
+)
+
+// This classifier mirrors the cloud reference implementation in
+// apps/api/src/agent-service/provider-action-classifier.ts so local dry-run
+// decisions match what the cloud would decide for the same activity.
+//
+// Canonical action names emitted: github.repo.read|write, github.pr.read|write,
+// github.issue.read|write, github.api.read|write. The release/workflow/secret/
+// gist catalog buckets are not classified yet.
+//
+// Policy matching uses repo + branch + action only; file paths and API
+// endpoint details are audit context.
+
+// ProviderAction is one classified GitHub action extracted from a tool call.
+type ProviderAction struct {
+	// Action is the canonical action name, e.g. "github.pr.write".
+	Action string
+	// Resource is the repository slug "owner/repo" when derivable.
+	Resource string
+	// BranchOrRef is the branch or ref when derivable (push refspecs,
+	// fetch/pull positionals, current branch fallback).
+	BranchOrRef string
+}
+
+// GitContext carries repository context derived from the session working
+// directory (current branch and configured remotes). It mirrors the
+// toolInput.kontext.git enrichment the cloud classifier consumes.
+type GitContext struct {
+	Branch       string
+	RemoteByName map[string]string
+}
+
+func (c GitContext) githubRemotes() []string {
+	remotes := make([]string, 0, len(c.RemoteByName))
+	// Prefer origin so the fallback repo is deterministic.
+	if url, ok := c.RemoteByName["origin"]; ok && isGithubURL(url) {
+		remotes = append(remotes, url)
+	}
+	for name, url := range c.RemoteByName {
+		if name == "origin" || !isGithubURL(url) {
+			continue
+		}
+		remotes = append(remotes, url)
+	}
+	return remotes
+}
+
+var githubHostRE = regexp.MustCompile(`(?i)(^|[\s"'(<])((https?://)?(api\.)?github\.com[/:]|(ssh://)?git@github\.com[:/])`)
+
+// ClassifyProviderActions maps a tool invocation to canonical GitHub actions.
+// gitContext is invoked lazily — only when a git command needs remote or
+// branch resolution — because deriving it shells out to git.
+func ClassifyProviderActions(toolName string, toolInput map[string]any, gitContext func() GitContext) []ProviderAction {
+	if gitContext == nil {
+		gitContext = func() GitContext { return GitContext{} }
+	}
+	switch strings.ToLower(toolName) {
+	case "bash", "shell":
+		command, _ := stringField(toolInput, "command")
+		if command == "" {
+			command, _ = stringField(toolInput, "cmd")
+		}
+		if command == "" {
+			return nil
+		}
+		return classifyCommand(command, memoizedGitContext(gitContext))
+	case "webfetch", "web_fetch":
+		url, _ := stringField(toolInput, "url")
+		if url != "" && isGithubURL(url) {
+			return []ProviderAction{{Action: "github.api.read"}}
+		}
+	}
+	return nil
+}
+
+func memoizedGitContext(load func() GitContext) func() GitContext {
+	var cached *GitContext
+	return func() GitContext {
+		if cached == nil {
+			context := load()
+			cached = &context
+		}
+		return *cached
+	}
+}
+
+func classifyCommand(command string, gitContext func() GitContext) []ProviderAction {
+	trimmed := strings.TrimSpace(command)
+	if trimmed == "" {
+		return nil
+	}
+	var actions []ProviderAction
+	for _, segment := range splitCommandSegments(trimmed) {
+		invocation, args := commandInvocation(segment)
+		if unwrapped, ok := unwrapShellLauncher(invocation, args); ok {
+			actions = append(actions, classifyCommand(unwrapped, gitContext)...)
+			continue
+		}
+		switch invocation {
+		case "gh":
+			actions = append(actions, classifyGhCommand(args, segment, gitContext))
+			continue
+		case "git":
+			actions = append(actions, classifyGitCommand(args, segment, gitContext)...)
+			continue
+		case "curl", "wget", "http", "https", "httpie":
+			if isGithubURL(segment) {
+				actions = append(actions, ProviderAction{Action: apiAction(commandLooksMutating(segment))})
+			}
+			continue
+		}
+		if isGithubURL(segment) {
+			actions = append(actions, ProviderAction{Action: apiAction(commandLooksMutating(segment))})
+		}
+	}
+	return actions
+}
+
+func apiAction(mutating bool) string {
+	if mutating {
+		return "github.api.write"
+	}
+	return "github.api.read"
+}
+
+func classifyGhCommand(args []string, raw string, gitContext func() GitContext) ProviderAction {
+	positional := ghPositionals(args)
+	area := "api"
+	if len(positional) > 0 {
+		area = positional[0]
+	}
+	verb := ""
+	if len(positional) > 1 {
+		verb = positional[1]
+	}
+	resource := githubRepoFromGhArgs(args)
+	if resource == "" {
+		// Local extension over the cloud classifier: gh acts on the current
+		// repository when -R/--repo is absent, and the endpoint knows its cwd
+		// remotes, so resolve the policy anchor from them.
+		resource = githubRepoFromGitContext(gitContext())
+	}
+
+	switch area {
+	case "api":
+		return ProviderAction{Action: apiAction(ghAPILooksMutating(args, raw)), Resource: resource}
+	case "pr":
+		return ProviderAction{Action: readWriteAction("github.pr", isReadVerb(verb)), Resource: resource}
+	case "issue":
+		return ProviderAction{Action: readWriteAction("github.issue", isReadVerb(verb)), Resource: resource}
+	case "repo":
+		return ProviderAction{Action: readWriteAction("github.repo", isReadVerb(verb)), Resource: resource}
+	case "workflow":
+		mutating := verb == "run" || verb == "enable" || verb == "disable"
+		return ProviderAction{Action: apiAction(mutating), Resource: resource}
+	}
+	return ProviderAction{Action: apiAction(commandLooksMutating(raw)), Resource: resource}
+}
+
+func readWriteAction(prefix string, read bool) string {
+	if read {
+		return prefix + ".read"
+	}
+	return prefix + ".write"
+}
+
+func classifyGitCommand(args []string, raw string, gitContext func() GitContext) []ProviderAction {
+	positionals := gitPositionals(args)
+	if len(positionals) == 0 {
+		return nil
+	}
+	verb := positionals[0]
+
+	var context GitContext
+	contextLoaded := false
+	loadContext := func() GitContext {
+		if !contextLoaded {
+			context = gitContext()
+			contextLoaded = true
+		}
+		return context
+	}
+
+	selectedRemote := selectedGitRemoteURL(verb, args, loadContext)
+	if !isGithubURL(raw) && !isGithubURL(selectedRemote) {
+		return nil
+	}
+
+	action := "github.repo.read"
+	if isGitWriteVerb(verb) {
+		action = "github.repo.write"
+	}
+	resource := normalizeGithubRepo(raw)
+	if resource == "" {
+		resource = normalizeGithubRepo(selectedRemote)
+	}
+	if resource == "" {
+		resource = githubRepoFromGitContext(loadContext())
+	}
+
+	base := ProviderAction{Action: action, Resource: resource}
+	branchOrRefs := gitBranchOrRefsFromArgs(verb, args)
+	if len(branchOrRefs) > 0 {
+		actions := make([]ProviderAction, 0, len(branchOrRefs))
+		for _, branchOrRef := range branchOrRefs {
+			withBranch := base
+			withBranch.BranchOrRef = branchOrRef
+			actions = append(actions, withBranch)
+		}
+		return actions
+	}
+	if fallback := gitBranchFallback(verb, args, loadContext); fallback != "" {
+		base.BranchOrRef = fallback
+	}
+	return []ProviderAction{base}
+}
+
+func stringField(input map[string]any, key string) (string, bool) {
+	value, ok := input[key].(string)
+	return value, ok
+}
+
+var assignmentPrefixRE = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*=`)
+
+func commandInvocation(command string) (string, []string) {
+	tokens := tokenize(command)
+	index := 0
+	for ; index < len(tokens); index++ {
+		if !assignmentPrefixRE.MatchString(tokens[index]) {
+			break
+		}
+	}
+	if index >= len(tokens) {
+		return "", nil
+	}
+	return tokens[index], tokens[index+1:]
+}
+
+var dashCFlagRE = regexp.MustCompile(`^-[A-Za-z]*c[A-Za-z]*$`)
+
+func unwrapShellLauncher(command string, args []string) (string, bool) {
+	switch command {
+	case "bash", "sh", "zsh":
+		for i, arg := range args {
+			if dashCFlagRE.MatchString(arg) {
+				if i+1 < len(args) && args[i+1] != "" {
+					return args[i+1], true
+				}
+				return "", false
+			}
+		}
+		return "", false
+	case "sudo":
+		payload := sudoPayloadArgs(args)
+		if len(payload) == 0 {
+			return "", false
+		}
+		quoted := make([]string, len(payload))
+		for i, value := range payload {
+			quoted[i] = shellToken(value)
+		}
+		return strings.Join(quoted, " "), true
+	}
+	return "", false
+}
+
+var sudoValueOptions = map[string]bool{
+	"-u": true, "--user": true,
+	"-g": true, "--group": true,
+	"-h": true, "--host": true,
+}
+
+func sudoPayloadArgs(args []string) []string {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			return args[i+1:]
+		}
+		if sudoValueOptions[arg] {
+			i++
+			continue
+		}
+		if hasOptionValuePrefix(arg, sudoValueOptions) {
+			continue
+		}
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		return args[i:]
+	}
+	return nil
+}
+
+func hasOptionValuePrefix(arg string, options map[string]bool) bool {
+	for option := range options {
+		if strings.HasPrefix(arg, option+"=") {
+			return true
+		}
+	}
+	return false
+}
+
+var unsafeShellTokenRE = regexp.MustCompile(`[\s'"\\]`)
+
+func shellToken(value string) string {
+	if !unsafeShellTokenRE.MatchString(value) {
+		return value
+	}
+	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
+}
+
+func tokenize(command string) []string {
+	var tokens []string
+	var current strings.Builder
+	var quote rune
+
+	for _, char := range command {
+		if quote != 0 {
+			if char == quote {
+				quote = 0
+			} else {
+				current.WriteRune(char)
+			}
+			continue
+		}
+		if char == '"' || char == '\'' {
+			quote = char
+			continue
+		}
+		if char == ' ' || char == '\t' || char == '\n' || char == '\r' {
+			if current.Len() > 0 {
+				tokens = append(tokens, current.String())
+				current.Reset()
+			}
+			continue
+		}
+		current.WriteRune(char)
+	}
+	if current.Len() > 0 {
+		tokens = append(tokens, current.String())
+	}
+	return tokens
+}
+
+func githubRepoFromGhArgs(args []string) string {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "-R" || arg == "--repo" {
+			if i+1 < len(args) {
+				return normalizeGithubRepo(args[i+1])
+			}
+			return ""
+		}
+		if strings.HasPrefix(arg, "--repo=") {
+			return normalizeGithubRepo(strings.TrimPrefix(arg, "--repo="))
+		}
+	}
+	return ""
+}
+
+var ghValueOptions = map[string]bool{
+	"-R": true, "--repo": true, "--hostname": true, "--jq": true,
+	"--template": true, "--paginate": true, "--cache": true, "--preview": true,
+	"--limit": true, "--state": true, "--base": true, "--head": true,
+	"--label": true, "--author": true, "--assignee": true, "--milestone": true,
+	"--search": true, "--json": true, "--field": true, "-F": true,
+	"--raw-field": true, "-f": true,
+}
+
+var gitValueOptions = map[string]bool{
+	"-C": true, "-c": true, "--config": true, "--git-dir": true,
+	"--work-tree": true, "--namespace": true, "--exec-path": true,
+	"--super-prefix": true, "--repo": true, "-o": true, "--push-option": true,
+	"--receive-pack": true, "--exec": true, "--recurse-submodules": true,
+}
+
+func ghPositionals(args []string) []string {
+	return positionalsSkippingOptionValues(args, ghValueOptions)
+}
+
+func gitPositionals(args []string) []string {
+	return positionalsSkippingOptionValues(args, gitValueOptions)
+}
+
+func positionalsSkippingOptionValues(args []string, valueOptions map[string]bool) []string {
+	var positionals []string
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			positionals = append(positionals, args[i+1:]...)
+			break
+		}
+		if valueOptions[arg] {
+			i++
+			continue
+		}
+		if hasOptionValuePrefix(arg, valueOptions) {
+			continue
+		}
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		positionals = append(positionals, arg)
+	}
+	return positionals
+}
+
+func githubRepoFromGitContext(context GitContext) string {
+	remotes := context.githubRemotes()
+	if len(remotes) == 0 {
+		return ""
+	}
+	return normalizeGithubRepo(remotes[0])
+}
+
+func gitBranchOrRefsFromArgs(verb string, args []string) []string {
+	positionals := gitPositionals(args)
+	if len(positionals) == 0 || positionals[0] != verb {
+		return nil
+	}
+	switch verb {
+	case "push":
+		refspecStart := 2
+		if gitRepoFromArgs(args) != "" {
+			refspecStart = 1
+		}
+		if refspecStart >= len(positionals) {
+			return nil
+		}
+		var refs []string
+		for _, refspec := range positionals[refspecStart:] {
+			if ref := normalizeGitPushRef(refspec); ref != "" {
+				refs = append(refs, ref)
+			}
+		}
+		return refs
+	case "fetch", "pull":
+		if len(positionals) > 2 {
+			if ref := normalizeGitRef(positionals[2]); ref != "" {
+				return []string{ref}
+			}
+		}
+	}
+	return nil
+}
+
+func gitBranchFallback(verb string, args []string, gitContext func() GitContext) string {
+	if verb == "push" {
+		for _, arg := range args {
+			if arg == "--all" || arg == "--mirror" || arg == "--tags" {
+				return ""
+			}
+		}
+	}
+	return gitContext().Branch
+}
+
+func selectedGitRemoteURL(verb string, args []string, gitContext func() GitContext) string {
+	if repo := gitRepoFromArgs(args); repo != "" {
+		return repo
+	}
+	positionals := gitPositionals(args)
+	if len(positionals) == 0 || positionals[0] != verb {
+		return ""
+	}
+	if len(positionals) < 2 {
+		return ""
+	}
+	remote := positionals[1]
+	if normalizeGithubRepo(remote) != "" {
+		return remote
+	}
+	return gitContext().RemoteByName[remote]
+}
+
+func gitRepoFromArgs(args []string) string {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--repo" {
+			if i+1 < len(args) {
+				return args[i+1]
+			}
+			return ""
+		}
+		if strings.HasPrefix(arg, "--repo=") {
+			return strings.TrimPrefix(arg, "--repo=")
+		}
+	}
+	return ""
+}
+
+func normalizeGitRef(value string) string {
+	if value == "" {
+		return ""
+	}
+	source := strings.SplitN(value, ":", 2)[0]
+	return strings.TrimPrefix(source, "refs/heads/")
+}
+
+func normalizeGitPushRef(value string) string {
+	if value == "" {
+		return ""
+	}
+	parts := strings.SplitN(value, ":", 2)
+	if len(parts) == 2 && parts[1] != "" {
+		return normalizeGitRef(parts[1])
+	}
+	return normalizeGitRef(parts[0])
+}
+
+var (
+	githubSSHRepoRE  = regexp.MustCompile(`(?i)^git@github\.com:([^/\s]+/[^/\s]+)$`)
+	githubURLRepoRE  = regexp.MustCompile(`(?i)github\.com[:/]([^/\s]+/[^/\s?#]+)`)
+	githubSlugRepoRE = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
+	dotGitSuffixRE   = regexp.MustCompile(`(?i)\.git$`)
+)
+
+func normalizeGithubRepo(value string) string {
+	trimmed := dotGitSuffixRE.ReplaceAllString(strings.TrimSpace(value), "")
+	if trimmed == "" {
+		return ""
+	}
+	if match := githubSSHRepoRE.FindStringSubmatch(trimmed); match != nil {
+		return match[1]
+	}
+	if match := githubURLRepoRE.FindStringSubmatch(trimmed); match != nil {
+		return dotGitSuffixRE.ReplaceAllString(match[1], "")
+	}
+	if githubSlugRepoRE.MatchString(trimmed) {
+		return trimmed
+	}
+	return ""
+}
+
+var commandSegmentSplitRE = regexp.MustCompile(`\s*(?:&&|\|\||;|\|)\s*`)
+
+func splitCommandSegments(command string) []string {
+	var segments []string
+	for _, segment := range commandSegmentSplitRE.Split(command, -1) {
+		segment = strings.TrimSpace(segment)
+		if segment != "" {
+			segments = append(segments, segment)
+		}
+	}
+	return segments
+}
+
+func isGithubURL(value string) bool {
+	return githubHostRE.MatchString(value)
+}
+
+func isReadVerb(verb string) bool {
+	switch verb {
+	case "", "view", "list", "status", "diff", "checks", "clone":
+		return true
+	}
+	return false
+}
+
+func isGitWriteVerb(verb string) bool {
+	switch verb {
+	case "push", "commit", "tag":
+		return true
+	}
+	return false
+}
+
+var (
+	mutatingDataFlagRE   = regexp.MustCompile(`(?i)\s(-d|--data|--data-raw|--data-binary|--data-urlencode|--json|--form)(=|\s)`)
+	mutatingMethodRE     = regexp.MustCompile(`(?i)(^|\s)(-X|--method|--request)(=|\s+)?(POST|PUT|PATCH|DELETE)\b`)
+	mutatingURLMethodRE  = regexp.MustCompile(`(?i)\b(POST|PUT|PATCH|DELETE)\s+https?://(api\.)?github\.com[/:]`)
+	mutatingHTTPCmdRE    = regexp.MustCompile(`(?i)\b(http|https)\s+(POST|PUT|PATCH|DELETE)\b`)
+	explicitMethodFlagRE = regexp.MustCompile(`(?i)(^|\s)(-X|--method|--request)(=|\s+)?(GET|HEAD)\b`)
+)
+
+func commandLooksMutating(command string) bool {
+	return mutatingDataFlagRE.MatchString(command) ||
+		mutatingMethodRE.MatchString(command) ||
+		mutatingURLMethodRE.MatchString(command) ||
+		mutatingHTTPCmdRE.MatchString(command)
+}
+
+var ghAPIBodyFlags = []string{"-f", "-F", "--field", "--raw-field", "--input"}
+
+func ghAPILooksMutating(args []string, raw string) bool {
+	if commandLooksMutating(raw) {
+		return true
+	}
+	for _, arg := range args {
+		for _, flag := range ghAPIBodyFlags {
+			if arg == flag || strings.HasPrefix(arg, flag+"=") {
+				return true
+			}
+		}
+	}
+	// A method override we cannot prove to be GET/HEAD defaults to write:
+	// unprovable gh api calls are treated as mutating.
+	if hasMethodFlag(args) && !explicitMethodFlagRE.MatchString(raw) && !mutatingMethodRE.MatchString(raw) {
+		return true
+	}
+	return false
+}
+
+func hasMethodFlag(args []string) bool {
+	for _, arg := range args {
+		if arg == "-X" || arg == "--method" || arg == "--request" ||
+			strings.HasPrefix(arg, "-X=") || strings.HasPrefix(arg, "--method=") || strings.HasPrefix(arg, "--request=") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/githubpolicy/classifier_test.go
+++ b/internal/githubpolicy/classifier_test.go
@@ -1,0 +1,182 @@
+package githubpolicy
+
+import (
+	"reflect"
+	"testing"
+)
+
+func classifyBash(t *testing.T, command string, context GitContext) []ProviderAction {
+	t.Helper()
+	return ClassifyProviderActions("Bash", map[string]any{"command": command}, func() GitContext {
+		return context
+	})
+}
+
+func projectContext() GitContext {
+	return GitContext{
+		Branch: "feature/x",
+		RemoteByName: map[string]string{
+			"origin":   "git@github.com:acme/api.git",
+			"upstream": "https://github.com/acme-upstream/api.git",
+		},
+	}
+}
+
+func TestClassifyGitPush(t *testing.T) {
+	cases := []struct {
+		command string
+		want    []ProviderAction
+	}{
+		{
+			command: "git push origin main",
+			want:    []ProviderAction{{Action: "github.repo.write", Resource: "acme/api", BranchOrRef: "main"}},
+		},
+		{
+			command: "git push origin local:refs/heads/release",
+			want:    []ProviderAction{{Action: "github.repo.write", Resource: "acme/api", BranchOrRef: "release"}},
+		},
+		{
+			// No refspec: falls back to the current branch.
+			command: "git push origin",
+			want:    []ProviderAction{{Action: "github.repo.write", Resource: "acme/api", BranchOrRef: "feature/x"}},
+		},
+		{
+			// --tags push has no single branch.
+			command: "git push --tags origin",
+			want:    []ProviderAction{{Action: "github.repo.write", Resource: "acme/api"}},
+		},
+		{
+			command: "git push upstream main",
+			want:    []ProviderAction{{Action: "github.repo.write", Resource: "acme-upstream/api", BranchOrRef: "main"}},
+		},
+		{
+			command: "git fetch origin main",
+			want:    []ProviderAction{{Action: "github.repo.read", Resource: "acme/api", BranchOrRef: "main"}},
+		},
+		{
+			command: "git clone https://github.com/acme/api.git",
+			want:    []ProviderAction{{Action: "github.repo.read", Resource: "acme/api", BranchOrRef: "feature/x"}},
+		},
+	}
+	for _, testCase := range cases {
+		got := classifyBash(t, testCase.command, projectContext())
+		if !reflect.DeepEqual(got, testCase.want) {
+			t.Errorf("classify(%q) = %+v, want %+v", testCase.command, got, testCase.want)
+		}
+	}
+}
+
+func TestClassifyGitWithoutGithubRemoteIsNotProviderAction(t *testing.T) {
+	context := GitContext{Branch: "main", RemoteByName: map[string]string{"origin": "git@gitlab.com:acme/api.git"}}
+	if got := classifyBash(t, "git push origin main", context); got != nil {
+		t.Fatalf("classify() = %+v, want nil for non-GitHub remote", got)
+	}
+	// Local-only git commands never classify.
+	if got := classifyBash(t, "git status", projectContext()); got != nil {
+		t.Fatalf("classify(git status) = %+v, want nil", got)
+	}
+}
+
+func TestClassifyGhCommands(t *testing.T) {
+	cases := []struct {
+		command string
+		want    []ProviderAction
+	}{
+		{"gh pr create --title x", []ProviderAction{{Action: "github.pr.write", Resource: "acme/api"}}},
+		{"gh pr view 42", []ProviderAction{{Action: "github.pr.read", Resource: "acme/api"}}},
+		{"gh pr merge 42 -R acme/web", []ProviderAction{{Action: "github.pr.write", Resource: "acme/web"}}},
+		{"gh issue list --repo=acme/web", []ProviderAction{{Action: "github.issue.read", Resource: "acme/web"}}},
+		{"gh issue comment 7", []ProviderAction{{Action: "github.issue.write", Resource: "acme/api"}}},
+		{"gh repo view acme/api", []ProviderAction{{Action: "github.repo.read", Resource: "acme/api"}}},
+		{"gh repo delete acme/api", []ProviderAction{{Action: "github.repo.write", Resource: "acme/api"}}},
+		{"gh workflow run deploy.yml", []ProviderAction{{Action: "github.api.write", Resource: "acme/api"}}},
+		{"gh workflow view deploy.yml", []ProviderAction{{Action: "github.api.read", Resource: "acme/api"}}},
+	}
+	for _, testCase := range cases {
+		got := classifyBash(t, testCase.command, projectContext())
+		if !reflect.DeepEqual(got, testCase.want) {
+			t.Errorf("classify(%q) = %+v, want %+v", testCase.command, got, testCase.want)
+		}
+	}
+}
+
+func TestClassifyGhAPIHeuristic(t *testing.T) {
+	cases := []struct {
+		command string
+		want    string
+	}{
+		{"gh api repos/acme/api/pulls", "github.api.read"},
+		{"gh api -X POST repos/acme/api/pulls", "github.api.write"},
+		{"gh api --method=DELETE repos/acme/api", "github.api.write"},
+		{"gh api repos/acme/api/issues -f title=hello", "github.api.write"},
+		{"gh api repos/acme/api/issues -F title=@file", "github.api.write"},
+		{"gh api repos/acme/api/issues --raw-field title=x", "github.api.write"},
+		{"gh api graphql --input mutation.json", "github.api.write"},
+		// Unprovable method defaults to write.
+		{"gh api -X \"$METHOD\" repos/acme/api", "github.api.write"},
+		{"gh api -X GET repos/acme/api", "github.api.read"},
+	}
+	for _, testCase := range cases {
+		got := classifyBash(t, testCase.command, projectContext())
+		if len(got) != 1 || got[0].Action != testCase.want {
+			t.Errorf("classify(%q) = %+v, want action %s", testCase.command, got, testCase.want)
+		}
+	}
+}
+
+func TestClassifyHTTPAndWebFetch(t *testing.T) {
+	got := classifyBash(t, "curl https://api.github.com/repos/acme/api", GitContext{})
+	if len(got) != 1 || got[0].Action != "github.api.read" {
+		t.Fatalf("curl GET = %+v, want github.api.read", got)
+	}
+	got = classifyBash(t, "curl -X POST https://api.github.com/repos/acme/api/issues -d '{}'", GitContext{})
+	if len(got) != 1 || got[0].Action != "github.api.write" {
+		t.Fatalf("curl POST = %+v, want github.api.write", got)
+	}
+	got = ClassifyProviderActions("WebFetch", map[string]any{"url": "https://github.com/acme/api/pull/1"}, nil)
+	if len(got) != 1 || got[0].Action != "github.api.read" {
+		t.Fatalf("WebFetch = %+v, want github.api.read", got)
+	}
+	if got := ClassifyProviderActions("WebFetch", map[string]any{"url": "https://example.com"}, nil); got != nil {
+		t.Fatalf("WebFetch non-GitHub = %+v, want nil", got)
+	}
+}
+
+func TestClassifyChainedAndWrappedCommands(t *testing.T) {
+	// add/commit stay local; only the push segment reaches GitHub.
+	got := classifyBash(t, "git add -A && git commit -m x && git push origin main", projectContext())
+	want := []ProviderAction{{Action: "github.repo.write", Resource: "acme/api", BranchOrRef: "main"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("chained = %+v, want %+v", got, want)
+	}
+
+	got = classifyBash(t, `bash -c "git push origin main"`, projectContext())
+	if !reflect.DeepEqual(got, []ProviderAction{{Action: "github.repo.write", Resource: "acme/api", BranchOrRef: "main"}}) {
+		t.Fatalf("bash -c wrapped = %+v", got)
+	}
+
+	got = classifyBash(t, "sudo gh pr merge 42 -R acme/web", projectContext())
+	if !reflect.DeepEqual(got, []ProviderAction{{Action: "github.pr.write", Resource: "acme/web"}}) {
+		t.Fatalf("sudo wrapped = %+v", got)
+	}
+}
+
+func TestClassifyNonGithubCommandsAreIgnored(t *testing.T) {
+	for _, command := range []string{"ls -la", "npm test", "curl https://example.com"} {
+		if got := classifyBash(t, command, projectContext()); got != nil {
+			t.Errorf("classify(%q) = %+v, want nil", command, got)
+		}
+	}
+	if got := ClassifyProviderActions("Read", map[string]any{"file_path": "/tmp/x"}, nil); got != nil {
+		t.Fatalf("Read tool = %+v, want nil", got)
+	}
+}
+
+func TestClassifyGitCommitDoesNotReachGithub(t *testing.T) {
+	// Mirrors the cloud classifier: commit/tag are local until pushed, so
+	// without a github.com mention or a selected GitHub remote they do not
+	// classify as provider actions.
+	if got := classifyBash(t, "git commit -m 'msg'", projectContext()); got != nil {
+		t.Fatalf("git commit = %+v, want nil", got)
+	}
+}

--- a/internal/githubpolicy/classifier_test.go
+++ b/internal/githubpolicy/classifier_test.go
@@ -257,6 +257,23 @@ func TestClassifyGhAPIEndpointRepo(t *testing.T) {
 			command: "gh api orgs/acme/teams",
 			want:    ProviderAction{Action: "github.api.read", Resource: "acme/api"},
 		},
+		{
+			// Value flags before the endpoint must not shift the positional.
+			command: "gh api -X DELETE repos/acme/admin/issues/1",
+			want:    ProviderAction{Action: "github.api.write", Resource: "acme/admin"},
+		},
+		{
+			command: "gh api --method=DELETE repos/acme/admin/issues/1",
+			want:    ProviderAction{Action: "github.api.write", Resource: "acme/admin"},
+		},
+		{
+			command: "gh api -H 'Accept: application/vnd.github+json' repos/acme/admin/pulls",
+			want:    ProviderAction{Action: "github.api.read", Resource: "acme/admin"},
+		},
+		{
+			command: "gh api --input payload.json repos/acme/admin/issues",
+			want:    ProviderAction{Action: "github.api.write", Resource: "acme/admin"},
+		},
 	}
 	for _, testCase := range cases {
 		got := classifyBash(t, testCase.command, projectContext())

--- a/internal/githubpolicy/classifier_test.go
+++ b/internal/githubpolicy/classifier_test.go
@@ -55,7 +55,7 @@ func TestClassifyGitPush(t *testing.T) {
 		},
 		{
 			command: "git clone https://github.com/acme/api.git",
-			want:    []ProviderAction{{Action: "github.repo.read", Resource: "acme/api", BranchOrRef: "feature/x"}},
+			want:    []ProviderAction{{Action: "github.repo.read", Resource: "acme/api"}},
 		},
 	}
 	for _, testCase := range cases {
@@ -169,6 +169,119 @@ func TestClassifyNonGithubCommandsAreIgnored(t *testing.T) {
 	}
 	if got := ClassifyProviderActions("Read", map[string]any{"file_path": "/tmp/x"}, nil); got != nil {
 		t.Fatalf("Read tool = %+v, want nil", got)
+	}
+}
+
+func TestClassifyGitImplicitRemoteDefaultsToOrigin(t *testing.T) {
+	cases := []struct {
+		command string
+		want    []ProviderAction
+	}{
+		{
+			command: "git push",
+			want:    []ProviderAction{{Action: "github.repo.write", Resource: "acme/api", BranchOrRef: "feature/x"}},
+		},
+		{
+			command: "git pull",
+			want:    []ProviderAction{{Action: "github.repo.read", Resource: "acme/api", BranchOrRef: "feature/x"}},
+		},
+		{
+			command: "git fetch",
+			want:    []ProviderAction{{Action: "github.repo.read", Resource: "acme/api", BranchOrRef: "feature/x"}},
+		},
+	}
+	for _, testCase := range cases {
+		got := classifyBash(t, testCase.command, projectContext())
+		if !reflect.DeepEqual(got, testCase.want) {
+			t.Errorf("classify(%q) = %+v, want %+v", testCase.command, got, testCase.want)
+		}
+	}
+	// No origin remote configured: nothing to evaluate.
+	if got := classifyBash(t, "git push", GitContext{Branch: "main"}); got != nil {
+		t.Fatalf("classify(git push) without remotes = %+v, want nil", got)
+	}
+}
+
+func TestClassifyGitCloneDoesNotInheritCwdBranch(t *testing.T) {
+	got := classifyBash(t, "git clone https://github.com/acme/api.git", projectContext())
+	want := []ProviderAction{{Action: "github.repo.read", Resource: "acme/api"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("clone = %+v, want no branch from cwd", got)
+	}
+	got = classifyBash(t, "git clone -b release https://github.com/acme/api.git", projectContext())
+	want = []ProviderAction{{Action: "github.repo.read", Resource: "acme/api", BranchOrRef: "release"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("clone -b = %+v, want explicit branch", got)
+	}
+}
+
+func TestClassifyGhRepoPositionalArgument(t *testing.T) {
+	// The positional repo argument names the target even when the cwd is a
+	// different repository.
+	got := classifyBash(t, "gh repo delete acme/admin --yes", projectContext())
+	want := []ProviderAction{{Action: "github.repo.write", Resource: "acme/admin"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("gh repo delete = %+v, want %+v", got, want)
+	}
+	got = classifyBash(t, "gh repo clone https://github.com/acme/admin.git", projectContext())
+	want = []ProviderAction{{Action: "github.repo.read", Resource: "acme/admin"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("gh repo clone = %+v, want %+v", got, want)
+	}
+}
+
+func TestClassifyGhAPIEndpointRepo(t *testing.T) {
+	cases := []struct {
+		command string
+		want    ProviderAction
+	}{
+		{
+			command: "gh api repos/acme/admin/issues -f title=x",
+			want:    ProviderAction{Action: "github.api.write", Resource: "acme/admin"},
+		},
+		{
+			command: "gh api /repos/acme/admin/pulls",
+			want:    ProviderAction{Action: "github.api.read", Resource: "acme/admin"},
+		},
+		{
+			command: "gh api https://api.github.com/repos/acme/admin",
+			want:    ProviderAction{Action: "github.api.read", Resource: "acme/admin"},
+		},
+		{
+			// Placeholders resolve through -R, not the literal path.
+			command: "gh api repos/{owner}/{repo}/issues -R acme/web",
+			want:    ProviderAction{Action: "github.api.read", Resource: "acme/web"},
+		},
+		{
+			// Non-repos endpoints carry no repository: cwd fallback applies.
+			command: "gh api orgs/acme/teams",
+			want:    ProviderAction{Action: "github.api.read", Resource: "acme/api"},
+		},
+	}
+	for _, testCase := range cases {
+		got := classifyBash(t, testCase.command, projectContext())
+		if len(got) != 1 || got[0] != testCase.want {
+			t.Errorf("classify(%q) = %+v, want %+v", testCase.command, got, testCase.want)
+		}
+	}
+}
+
+func TestClassifyURLResources(t *testing.T) {
+	got := classifyBash(t, "curl -X DELETE https://api.github.com/repos/acme/admin/issues/1", GitContext{})
+	want := []ProviderAction{{Action: "github.api.write", Resource: "acme/admin"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("curl api = %+v, want %+v", got, want)
+	}
+	// Non-repos API paths have no repository to anchor on.
+	got = classifyBash(t, "curl https://api.github.com/orgs/acme/teams", GitContext{})
+	want = []ProviderAction{{Action: "github.api.read"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("curl orgs = %+v, want no resource", got)
+	}
+	got = ClassifyProviderActions("WebFetch", map[string]any{"url": "https://github.com/acme/admin/pull/1"}, nil)
+	want = []ProviderAction{{Action: "github.api.read", Resource: "acme/admin"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("WebFetch = %+v, want %+v", got, want)
 	}
 }
 

--- a/internal/githubpolicy/classifier_test.go
+++ b/internal/githubpolicy/classifier_test.go
@@ -91,6 +91,11 @@ func TestClassifyGhCommands(t *testing.T) {
 		{"gh repo delete acme/api", []ProviderAction{{Action: "github.repo.write", Resource: "acme/api"}}},
 		{"gh workflow run deploy.yml", []ProviderAction{{Action: "github.api.write", Resource: "acme/api"}}},
 		{"gh workflow view deploy.yml", []ProviderAction{{Action: "github.api.read", Resource: "acme/api"}}},
+		{"gh release create v1.0.0", []ProviderAction{{Action: "github.api.write", Resource: "acme/api"}}},
+		{"gh release view v1.0.0", []ProviderAction{{Action: "github.api.read", Resource: "acme/api"}}},
+		{"gh secret set TOKEN --body x", []ProviderAction{{Action: "github.api.write", Resource: "acme/api"}}},
+		{"gh auth status", []ProviderAction{{Action: "github.api.read", Resource: "acme/api"}}},
+		{"gh unknown subcommand", []ProviderAction{{Action: "github.api.write", Resource: "acme/api"}}},
 	}
 	for _, testCase := range cases {
 		got := classifyBash(t, testCase.command, projectContext())
@@ -274,6 +279,10 @@ func TestClassifyGhAPIEndpointRepo(t *testing.T) {
 			command: "gh api --input payload.json repos/acme/admin/issues",
 			want:    ProviderAction{Action: "github.api.write", Resource: "acme/admin"},
 		},
+		{
+			command: "gh api --paginate repos/acme/admin/pulls",
+			want:    ProviderAction{Action: "github.api.read", Resource: "acme/admin"},
+		},
 	}
 	for _, testCase := range cases {
 		got := classifyBash(t, testCase.command, projectContext())
@@ -308,5 +317,52 @@ func TestClassifyGitCommitDoesNotReachGithub(t *testing.T) {
 	// classify as provider actions.
 	if got := classifyBash(t, "git commit -m 'msg'", projectContext()); got != nil {
 		t.Fatalf("git commit = %+v, want nil", got)
+	}
+}
+
+func TestClassifyScriptInput(t *testing.T) {
+	got := ClassifyProviderActions("Bash", map[string]any{"script": "git push origin main"}, func() GitContext {
+		return projectContext()
+	})
+	want := []ProviderAction{{Action: "github.repo.write", Resource: "acme/api", BranchOrRef: "main"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("script input = %+v, want %+v", got, want)
+	}
+}
+
+func TestClassifyGithubMCPTool(t *testing.T) {
+	got := ClassifyProviderActions("mcp__github__get_pull_request", map[string]any{
+		"owner":       "acme",
+		"repo":        "admin",
+		"pull_number": 42,
+	}, nil)
+	want := []ProviderAction{{Action: "github.pr.read", Resource: "acme/admin"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("github mcp get_pull_request = %+v, want %+v", got, want)
+	}
+
+	got = ClassifyProviderActions("mcp__github__merge_pull_request", map[string]any{"repository": "acme/admin"}, nil)
+	want = []ProviderAction{{Action: "github.pr.write", Resource: "acme/admin"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("github mcp merge_pull_request = %+v, want %+v", got, want)
+	}
+}
+
+func TestClassifyGitDashCUsesTargetContext(t *testing.T) {
+	contexts := map[string]GitContext{
+		"/work/current": projectContext(),
+		"/work/other-repo": {
+			Branch: "main",
+			RemoteByName: map[string]string{
+				"origin": "git@github.com:acme/admin.git",
+			},
+		},
+	}
+	got := ClassifyProviderActionsWithCWD("Bash", map[string]any{"command": "git -C ../other-repo push"}, "/work/current", func(cwd string) GitContext {
+		return contexts[cwd]
+	})
+	want := []ProviderAction{{Action: "github.repo.write", Resource: "acme/admin", BranchOrRef: "main"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("git -C push = %+v, want %+v", got, want)
 	}
 }

--- a/internal/githubpolicy/client.go
+++ b/internal/githubpolicy/client.go
@@ -1,0 +1,93 @@
+package githubpolicy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// SnapshotEndpoint is the cloud path serving the policy snapshot. Tenancy is
+// resolved from the install token; missing/unknown/revoked tokens get 401.
+const SnapshotEndpoint = "/api/v1/policy/github/snapshot"
+
+const maxSnapshotBodyBytes = 4 << 20
+
+// FetchSnapshot retrieves the GitHub policy snapshot from the cloud using the
+// same per-customer install token as the authorization-ledger ingest.
+func FetchSnapshot(ctx context.Context, client *http.Client, cloudURL, installToken string) (Snapshot, error) {
+	endpoint, err := snapshotURL(cloudURL)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(installToken))
+
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Second}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return Snapshot{}, fmt.Errorf("github policy snapshot fetch failed: status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxSnapshotBodyBytes))
+	if err != nil {
+		return Snapshot{}, err
+	}
+	var snapshot Snapshot
+	if err := json.Unmarshal(body, &snapshot); err != nil {
+		return Snapshot{}, fmt.Errorf("decode github policy snapshot: %w", err)
+	}
+	if snapshot.SchemaVersion != SchemaVersion {
+		return Snapshot{}, fmt.Errorf("unsupported github policy snapshot schema %q", snapshot.SchemaVersion)
+	}
+	if err := validateSnapshot(snapshot); err != nil {
+		return Snapshot{}, err
+	}
+	return snapshot, nil
+}
+
+func validateSnapshot(snapshot Snapshot) error {
+	if snapshot.Hash == "" {
+		return fmt.Errorf("github policy snapshot is missing hash")
+	}
+	for _, rule := range snapshot.Rules {
+		switch rule.Layer {
+		case LayerOrg, LayerUser, LayerAgent:
+		default:
+			return fmt.Errorf("github policy rule %s has unknown layer %q", rule.ID, rule.Layer)
+		}
+		switch rule.Effect {
+		case EffectAllow, EffectDeny:
+		default:
+			return fmt.Errorf("github policy rule %s has unknown effect %q", rule.ID, rule.Effect)
+		}
+		if rule.ID == "" || rule.SubjectID == "" {
+			return fmt.Errorf("github policy rule is missing id or subject")
+		}
+	}
+	return nil
+}
+
+func snapshotURL(cloudURL string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(cloudURL))
+	if err != nil {
+		return "", err
+	}
+	parsed.Path = SnapshotEndpoint
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String(), nil
+}

--- a/internal/githubpolicy/client.go
+++ b/internal/githubpolicy/client.go
@@ -42,9 +42,12 @@ func FetchSnapshot(ctx context.Context, client *http.Client, cloudURL, installTo
 		return Snapshot{}, fmt.Errorf("github policy snapshot fetch failed: status %d", resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxSnapshotBodyBytes))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxSnapshotBodyBytes+1))
 	if err != nil {
 		return Snapshot{}, err
+	}
+	if len(body) > maxSnapshotBodyBytes {
+		return Snapshot{}, fmt.Errorf("github policy snapshot exceeds %d bytes", maxSnapshotBodyBytes)
 	}
 	var snapshot Snapshot
 	if err := json.Unmarshal(body, &snapshot); err != nil {

--- a/internal/githubpolicy/evaluate.go
+++ b/internal/githubpolicy/evaluate.go
@@ -1,0 +1,201 @@
+package githubpolicy
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Reason codes shared with the cloud evaluator.
+const (
+	ReasonCodeAllow = "ALLOWED_POLICY_CHECK"
+	ReasonCodeDeny  = "DENY_POLICY_CHECK"
+)
+
+// Request is one classified GitHub action to evaluate. UserID and
+// ApplicationID are the Kontext user and application subjects; the managed
+// endpoint's trusted identity is the service account + installation, so both
+// are typically empty (unresolved) and user/agent-layer rules then never
+// match their subject.
+type Request struct {
+	Action        string
+	Resource      string
+	BranchOrRef   string
+	UserID        string
+	ApplicationID string
+}
+
+// MatchedRule records one rule that matched the request, and whether it was
+// the rule that decided the outcome.
+type MatchedRule struct {
+	ID      string `json:"id"`
+	Layer   string `json:"layer"`
+	Effect  string `json:"effect"`
+	Decided bool   `json:"decided,omitempty"`
+}
+
+// Evaluation is the would-be decision for one request under one snapshot.
+type Evaluation struct {
+	Request      Request
+	Result       string // "allow" | "deny"
+	ReasonCode   string
+	Reason       string
+	MatchedRules []MatchedRule
+	// DecidingRuleID is the rule that determined the outcome: the first
+	// matching deny, or the org-layer allow that anchored an allow. Empty
+	// when a layer vetoed by silence.
+	DecidingRuleID string
+	Mode           string
+	Epoch          int
+	Hash           string
+	// Stale is true when the snapshot used was not confirmed by the cloud on
+	// the most recent refresh attempt.
+	Stale bool
+	// SubjectsResolved is false when no Kontext user/application identity was
+	// available, so user/agent-layer rules could not match their subject.
+	SubjectsResolved bool
+}
+
+// Evaluate mirrors the cloud evaluator exactly:
+//
+//  1. A rule matches when its layer subject matches and each non-null
+//     dimension equals the request value exactly (null = wildcard, no globs).
+//  2. Any matching deny ⇒ deny, regardless of specificity.
+//  3. Otherwise allow only if every layer consents. The org layer is strict:
+//     it needs a matching allow. The user and agent layers abstain (consent)
+//     while the snapshot has zero rules in that layer; once a layer has any
+//     rule it is active and silence vetoes again.
+//
+// The boolean result is false when the snapshot carries no rules at all (no
+// active policy authored yet) — there is nothing to dry-run.
+func Evaluate(snapshot Snapshot, status Status, request Request) (Evaluation, bool) {
+	if len(snapshot.Rules) == 0 {
+		return Evaluation{}, false
+	}
+
+	evaluation := Evaluation{
+		Request:          request,
+		Mode:             snapshot.Mode,
+		Epoch:            snapshot.Epoch,
+		Hash:             snapshot.Hash,
+		Stale:            status.Stale,
+		SubjectsResolved: request.UserID != "" || request.ApplicationID != "",
+	}
+
+	layerSubjects := map[string]string{
+		LayerOrg:   snapshot.OrganizationID,
+		LayerUser:  request.UserID,
+		LayerAgent: request.ApplicationID,
+	}
+
+	var matched []MatchedRule
+	var decidingDeny *Rule
+	allowLayers := map[string]bool{}
+	var firstOrgAllow *Rule
+	for i := range snapshot.Rules {
+		rule := &snapshot.Rules[i]
+		subject := layerSubjects[rule.Layer]
+		if subject == "" || rule.SubjectID != subject || !ruleMatchesRequest(rule, request) {
+			continue
+		}
+		matched = append(matched, MatchedRule{ID: rule.ID, Layer: rule.Layer, Effect: rule.Effect})
+		if rule.Effect == EffectDeny {
+			if decidingDeny == nil {
+				decidingDeny = rule
+			}
+			continue
+		}
+		allowLayers[rule.Layer] = true
+		if rule.Layer == LayerOrg && firstOrgAllow == nil {
+			firstOrgAllow = rule
+		}
+	}
+
+	if decidingDeny != nil {
+		markDecided(matched, decidingDeny.ID)
+		evaluation.Result = EffectDeny
+		evaluation.ReasonCode = ReasonCodeDeny
+		evaluation.Reason = fmt.Sprintf("denied by %s-layer deny rule on %s", decidingDeny.Layer, ruleScopeSummary(*decidingDeny))
+		evaluation.MatchedRules = matched
+		evaluation.DecidingRuleID = decidingDeny.ID
+		return evaluation, true
+	}
+
+	// User and agent layers consent by abstention while they hold no rules at
+	// all; the org layer is the mandatory ceiling and stays strict.
+	for _, layer := range []string{LayerUser, LayerAgent} {
+		if !snapshotHasLayerRules(snapshot, layer) {
+			allowLayers[layer] = true
+		}
+	}
+
+	var vetoLayers []string
+	for _, layer := range []string{LayerOrg, LayerUser, LayerAgent} {
+		if !allowLayers[layer] {
+			vetoLayers = append(vetoLayers, layer)
+		}
+	}
+	if len(vetoLayers) > 0 {
+		evaluation.Result = EffectDeny
+		evaluation.ReasonCode = ReasonCodeDeny
+		evaluation.Reason = fmt.Sprintf("no matching allow rule in active layer(s): %s", strings.Join(vetoLayers, ", "))
+		evaluation.MatchedRules = matched
+		return evaluation, true
+	}
+
+	if firstOrgAllow != nil {
+		markDecided(matched, firstOrgAllow.ID)
+		evaluation.DecidingRuleID = firstOrgAllow.ID
+	}
+	evaluation.Result = EffectAllow
+	evaluation.ReasonCode = ReasonCodeAllow
+	evaluation.Reason = "allowed by policy: every layer consents"
+	evaluation.MatchedRules = matched
+	return evaluation, true
+}
+
+func ruleMatchesRequest(rule *Rule, request Request) bool {
+	if rule.ActionName != nil && *rule.ActionName != request.Action {
+		return false
+	}
+	if rule.ResourceID != nil && *rule.ResourceID != request.Resource {
+		return false
+	}
+	if rule.BranchOrRef != nil && *rule.BranchOrRef != request.BranchOrRef {
+		return false
+	}
+	return true
+}
+
+func snapshotHasLayerRules(snapshot Snapshot, layer string) bool {
+	for i := range snapshot.Rules {
+		if snapshot.Rules[i].Layer == layer {
+			return true
+		}
+	}
+	return false
+}
+
+func markDecided(matched []MatchedRule, ruleID string) {
+	for i := range matched {
+		if matched[i].ID == ruleID {
+			matched[i].Decided = true
+			return
+		}
+	}
+}
+
+func ruleScopeSummary(rule Rule) string {
+	action := "any action"
+	if rule.ActionName != nil {
+		action = *rule.ActionName
+	}
+	resource := "any repo"
+	if rule.ResourceID != nil {
+		resource = *rule.ResourceID
+	}
+	summary := action + " @ " + resource
+	if rule.BranchOrRef != nil {
+		summary += " (" + *rule.BranchOrRef + ")"
+	}
+	return summary
+}

--- a/internal/githubpolicy/evaluate_test.go
+++ b/internal/githubpolicy/evaluate_test.go
@@ -1,0 +1,195 @@
+package githubpolicy
+
+import (
+	"testing"
+)
+
+const testOrgID = "org_test"
+
+func ptr(value string) *string {
+	return &value
+}
+
+func orgAllowAll(id string) Rule {
+	return Rule{ID: id, Layer: LayerOrg, SubjectID: testOrgID, Effect: EffectAllow}
+}
+
+func snapshotWithRules(rules ...Rule) Snapshot {
+	return Snapshot{
+		SchemaVersion:  SchemaVersion,
+		OrganizationID: testOrgID,
+		ProviderKey:    "github",
+		Mode:           ModeObserve,
+		Epoch:          5,
+		Hash:           "hash-5",
+		Rules:          rules,
+	}
+}
+
+func TestEvaluateNoRulesMeansNothingToDryRun(t *testing.T) {
+	_, ok := Evaluate(snapshotWithRules(), Status{}, Request{Action: "github.pr.write"})
+	if ok {
+		t.Fatal("Evaluate() with zero rules should not produce a decision")
+	}
+}
+
+func TestEvaluateOrgAllowAloneAllowsOrgWide(t *testing.T) {
+	snapshot := snapshotWithRules(orgAllowAll("rule-allow"))
+	for _, request := range []Request{
+		{Action: "github.pr.write", Resource: "acme/api", BranchOrRef: "main"},
+		{Action: "github.repo.read"},
+	} {
+		evaluation, ok := Evaluate(snapshot, Status{}, request)
+		if !ok || evaluation.Result != EffectAllow {
+			t.Fatalf("Evaluate(%+v) = %+v, want org-wide allow", request, evaluation)
+		}
+		if evaluation.ReasonCode != ReasonCodeAllow {
+			t.Fatalf("ReasonCode = %q, want %q", evaluation.ReasonCode, ReasonCodeAllow)
+		}
+		if evaluation.DecidingRuleID != "rule-allow" {
+			t.Fatalf("DecidingRuleID = %q, want rule-allow", evaluation.DecidingRuleID)
+		}
+	}
+}
+
+func TestEvaluateDenyBeatsAllowRegardlessOfSpecificity(t *testing.T) {
+	snapshot := snapshotWithRules(
+		Rule{
+			ID: "rule-deny", Layer: LayerOrg, SubjectID: testOrgID,
+			ResourceID: ptr("acme/api"), ActionName: ptr("github.pr.write"), Effect: EffectDeny, Specificity: 5,
+		},
+		orgAllowAll("rule-allow"),
+	)
+
+	denied, ok := Evaluate(snapshot, Status{}, Request{Action: "github.pr.write", Resource: "acme/api"})
+	if !ok || denied.Result != EffectDeny || denied.ReasonCode != ReasonCodeDeny {
+		t.Fatalf("targeted request = %+v, want deny", denied)
+	}
+	if denied.DecidingRuleID != "rule-deny" {
+		t.Fatalf("DecidingRuleID = %q, want rule-deny", denied.DecidingRuleID)
+	}
+	var decidedMarked bool
+	for _, rule := range denied.MatchedRules {
+		if rule.ID == "rule-deny" && rule.Decided {
+			decidedMarked = true
+		}
+	}
+	if !decidedMarked {
+		t.Fatalf("MatchedRules = %+v, want rule-deny marked decided", denied.MatchedRules)
+	}
+
+	// The deny is scoped: everything off-target still allows.
+	allowed, ok := Evaluate(snapshot, Status{}, Request{Action: "github.pr.write", Resource: "acme/web"})
+	if !ok || allowed.Result != EffectAllow {
+		t.Fatalf("off-target request = %+v, want allow", allowed)
+	}
+}
+
+func TestEvaluateOrgLayerIsStrict(t *testing.T) {
+	// A user-layer rule alone activates nothing for the org layer: zero org
+	// rules deny everything.
+	snapshot := snapshotWithRules(
+		Rule{ID: "rule-user", Layer: LayerUser, SubjectID: "user-1", Effect: EffectAllow},
+	)
+	evaluation, ok := Evaluate(snapshot, Status{}, Request{Action: "github.repo.read", UserID: "user-1"})
+	if !ok || evaluation.Result != EffectDeny {
+		t.Fatalf("Evaluate() = %+v, want deny from strict org layer", evaluation)
+	}
+}
+
+func TestEvaluateUserLayerAbstainsUntilItHasRulesThenSilenceVetoes(t *testing.T) {
+	// No user rules: layer abstains, org allow carries the decision.
+	abstaining := snapshotWithRules(orgAllowAll("rule-org"))
+	evaluation, ok := Evaluate(abstaining, Status{}, Request{Action: "github.pr.write", UserID: "user-1"})
+	if !ok || evaluation.Result != EffectAllow {
+		t.Fatalf("abstaining user layer = %+v, want allow", evaluation)
+	}
+
+	// One user rule for someone else: the layer is active, silence vetoes.
+	active := snapshotWithRules(
+		orgAllowAll("rule-org"),
+		Rule{ID: "rule-user", Layer: LayerUser, SubjectID: "user-2", Effect: EffectAllow},
+	)
+	evaluation, ok = Evaluate(active, Status{}, Request{Action: "github.pr.write", UserID: "user-1"})
+	if !ok || evaluation.Result != EffectDeny {
+		t.Fatalf("active user layer without matching allow = %+v, want deny", evaluation)
+	}
+
+	// The covered user is allowed.
+	evaluation, ok = Evaluate(active, Status{}, Request{Action: "github.pr.write", UserID: "user-2"})
+	if !ok || evaluation.Result != EffectAllow {
+		t.Fatalf("active user layer with matching allow = %+v, want allow", evaluation)
+	}
+}
+
+func TestEvaluateAgentLayerMirrorsUserLayer(t *testing.T) {
+	snapshot := snapshotWithRules(
+		orgAllowAll("rule-org"),
+		Rule{ID: "rule-agent", Layer: LayerAgent, SubjectID: "app-1", Effect: EffectAllow},
+	)
+	evaluation, ok := Evaluate(snapshot, Status{}, Request{Action: "github.pr.write", ApplicationID: "app-2"})
+	if !ok || evaluation.Result != EffectDeny {
+		t.Fatalf("agent layer veto = %+v, want deny", evaluation)
+	}
+}
+
+func TestEvaluateUnresolvedSubjectsCannotMatchUserOrAgentRules(t *testing.T) {
+	snapshot := snapshotWithRules(
+		orgAllowAll("rule-org"),
+		Rule{ID: "rule-user", Layer: LayerUser, SubjectID: "user-1", Effect: EffectAllow},
+	)
+	// The managed endpoint resolves no Kontext user: the user layer is active
+	// and silence vetoes, flagged as unresolved subject on the evaluation.
+	evaluation, ok := Evaluate(snapshot, Status{}, Request{Action: "github.pr.write"})
+	if !ok || evaluation.Result != EffectDeny {
+		t.Fatalf("unresolved user subject = %+v, want deny", evaluation)
+	}
+	if evaluation.SubjectsResolved {
+		t.Fatal("SubjectsResolved = true, want false for unresolved identity")
+	}
+}
+
+func TestEvaluateExactDimensionMatchingWithNullWildcards(t *testing.T) {
+	snapshot := snapshotWithRules(Rule{
+		ID: "rule-main", Layer: LayerOrg, SubjectID: testOrgID,
+		ResourceID:  ptr("acme/api"),
+		ActionName:  ptr("github.repo.write"),
+		BranchOrRef: ptr("main"),
+		Effect:      EffectAllow,
+	})
+
+	cases := []struct {
+		request Request
+		want    string
+	}{
+		{Request{Action: "github.repo.write", Resource: "acme/api", BranchOrRef: "main"}, EffectAllow},
+		{Request{Action: "github.repo.write", Resource: "acme/api", BranchOrRef: "dev"}, EffectDeny},
+		{Request{Action: "github.repo.write", Resource: "acme/api"}, EffectDeny},
+		{Request{Action: "github.repo.read", Resource: "acme/api", BranchOrRef: "main"}, EffectDeny},
+		// No globs: a prefix of the slug must not match.
+		{Request{Action: "github.repo.write", Resource: "acme/api-v2", BranchOrRef: "main"}, EffectDeny},
+	}
+	for _, testCase := range cases {
+		evaluation, ok := Evaluate(snapshot, Status{}, testCase.request)
+		if !ok || evaluation.Result != testCase.want {
+			t.Fatalf("Evaluate(%+v) = %+v, want %s", testCase.request, evaluation, testCase.want)
+		}
+	}
+}
+
+func TestEvaluateRecordsSnapshotVersionAndStaleness(t *testing.T) {
+	snapshot := snapshotWithRules(orgAllowAll("rule-org"))
+	evaluation, ok := Evaluate(snapshot, Status{Stale: true}, Request{Action: "github.pr.read"})
+	if !ok {
+		t.Fatal("Evaluate() returned no decision")
+	}
+	if evaluation.Epoch != 5 || evaluation.Hash != "hash-5" {
+		t.Fatalf("Epoch/Hash = %d/%q, want 5/hash-5", evaluation.Epoch, evaluation.Hash)
+	}
+	if !evaluation.Stale {
+		t.Fatal("Stale = false, want true when serving an unconfirmed snapshot")
+	}
+	if evaluation.Mode != ModeObserve {
+		t.Fatalf("Mode = %q, want observe", evaluation.Mode)
+	}
+}

--- a/internal/githubpolicy/gitcontext.go
+++ b/internal/githubpolicy/gitcontext.go
@@ -1,0 +1,46 @@
+package githubpolicy
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const gitContextTimeout = 500 * time.Millisecond
+
+// GitContextFromCWD derives the current branch and configured remotes from
+// the session working directory. This stands in for the toolInput.kontext.git
+// enrichment the cloud classifier receives.
+func GitContextFromCWD(cwd string) GitContext {
+	if strings.TrimSpace(cwd) == "" {
+		return GitContext{}
+	}
+	context := GitContext{RemoteByName: map[string]string{}}
+	if branch := gitOutput(cwd, "rev-parse", "--abbrev-ref", "HEAD"); branch != "HEAD" {
+		context.Branch = branch
+	}
+	for _, line := range strings.Split(gitOutput(cwd, "config", "--get-regexp", `^remote\..*\.url$`), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		name := strings.TrimSuffix(strings.TrimPrefix(fields[0], "remote."), ".url")
+		if name == "" {
+			continue
+		}
+		context.RemoteByName[name] = fields[1]
+	}
+	return context
+}
+
+func gitOutput(cwd string, args ...string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), gitContextTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", cwd}, args...)...)
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(output))
+}

--- a/internal/githubpolicy/snapshot.go
+++ b/internal/githubpolicy/snapshot.go
@@ -1,0 +1,95 @@
+// Package githubpolicy syncs the cloud-hosted GitHub access-control policy
+// down to the managed endpoint and evaluates classified GitHub activity
+// against it locally.
+//
+// The cloud authors GitHub policy as versioned, epoched rules. The managed
+// endpoint fetches the snapshot, caches it by epoch/hash, and evaluates
+// GitHub CLI / MCP / API activity locally. For ENG-426 the directive is
+// observe-only: the engine records what it *would* allow or deny, but never
+// blocks.
+//
+// Precedence in the local engine is: general deterministic guardrails >
+// this synced policy > probabilistic signals.
+//
+// The contract mirrors packages/shared/src/github-policy-snapshot.ts in the
+// kontext cloud repository.
+package githubpolicy
+
+// SchemaVersion identifies the snapshot wire format.
+const SchemaVersion = "github-policy-snapshot-v1"
+
+// Enforcement directive for the local engine.
+//
+//   - ModeObserve — evaluate every action and record a dry-run decision, but
+//     never block. Anything other than an explicit "enforce" is treated as
+//     observe.
+//   - ModeEnforce — block denied actions. Reserved for a later, careful step;
+//     not emitted during the observer-mode pilot.
+const (
+	ModeObserve = "observe"
+	ModeEnforce = "enforce"
+)
+
+// Policy layers. Each rule binds a subject in exactly one layer.
+const (
+	LayerOrg   = "org"
+	LayerUser  = "user"
+	LayerAgent = "agent"
+)
+
+// Rule effects.
+const (
+	EffectAllow = "allow"
+	EffectDeny  = "deny"
+)
+
+// Rule is a single matchable rule. nil on ResourceID / ActionName /
+// BranchOrRef means "matches any" for that dimension; non-nil dimensions are
+// exact string matches. For the first GitHub pilot, policy matching uses repo
+// (ResourceID) + branch (BranchOrRef) + action; file path and API endpoint
+// details are audit context only.
+type Rule struct {
+	ID    string `json:"id"`
+	Layer string `json:"layer"`
+	// SubjectID is the org id, kontext user id, or application id depending
+	// on Layer.
+	SubjectID string `json:"subjectId"`
+	// ResourceID is a repository slug "owner/repo", or nil for any repository.
+	ResourceID *string `json:"resourceId"`
+	// ActionName is a canonical action name (e.g. "github.pr.write"), or nil
+	// for any action.
+	ActionName *string `json:"actionName"`
+	// BranchOrRef is a branch or ref constraint, or nil for any branch.
+	BranchOrRef *string `json:"branchOrRef"`
+	Effect      string  `json:"effect"`
+	// Specificity is higher for more pinned rules. Ordering/diagnostic hint
+	// only — evaluation is NOT most-specific-wins; any matching deny beats
+	// any matching allow.
+	Specificity int `json:"specificity"`
+}
+
+// Snapshot is the response body of GET /api/v1/policy/github/snapshot. The
+// server resolves the organization from the install token; there is no
+// organization parameter.
+type Snapshot struct {
+	SchemaVersion  string `json:"schemaVersion"`
+	OrganizationID string `json:"organizationId"`
+	// ProviderID is the GitHub provider id, or nil when the org has no GitHub
+	// provider configured.
+	ProviderID  *string `json:"providerId"`
+	ProviderKey string  `json:"providerKey"`
+	Mode        string  `json:"mode"`
+	// Epoch is the active policy epoch; 0 when the org has no active policy.
+	Epoch int `json:"epoch"`
+	// Hash is a stable content hash over {epoch, rules}, independent of
+	// GeneratedAt, so an unchanged policy keeps an unchanged hash.
+	Hash        string `json:"hash"`
+	Rules       []Rule `json:"rules"`
+	GeneratedAt string `json:"generatedAt"`
+}
+
+// Enforce reports whether the snapshot explicitly directs enforcement.
+// Anything other than the literal "enforce" is observe.
+func (s Snapshot) Enforce() bool {
+	return s.Mode == ModeEnforce
+}

--- a/internal/guard/app/server/githubpolicy_test.go
+++ b/internal/guard/app/server/githubpolicy_test.go
@@ -1,0 +1,155 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/githubpolicy"
+	"github.com/kontext-security/kontext-cli/internal/guard/risk"
+)
+
+type staticGithubPolicy struct {
+	snapshot githubpolicy.Snapshot
+	status   githubpolicy.Status
+	loaded   bool
+}
+
+func (p staticGithubPolicy) CurrentSnapshot() (githubpolicy.Snapshot, githubpolicy.Status, bool) {
+	return p.snapshot, p.status, p.loaded
+}
+
+func githubTestSnapshot(mode string, rules ...githubpolicy.Rule) githubpolicy.Snapshot {
+	return githubpolicy.Snapshot{
+		SchemaVersion:  githubpolicy.SchemaVersion,
+		OrganizationID: "org_test",
+		ProviderKey:    "github",
+		Mode:           mode,
+		Epoch:          5,
+		Hash:           "hash-5",
+		Rules:          rules,
+	}
+}
+
+func githubPushEvent() risk.HookEvent {
+	return risk.HookEvent{
+		SessionID:     "session-1",
+		HookEventName: "PreToolUse",
+		ToolName:      "Bash",
+		// The github.com mention makes the classification self-contained; no
+		// git context is needed from the (nonexistent) cwd.
+		ToolInput: map[string]any{"command": "git push https://github.com/acme/api.git main"},
+	}
+}
+
+func TestDecideHookRecordsGithubDryRunWithoutBlocking(t *testing.T) {
+	denyResource := "acme/api"
+	provider := NewRiskPolicyProviderWithOptions(RiskPolicyProviderOptions{
+		GithubPolicy: staticGithubPolicy{
+			snapshot: githubTestSnapshot(githubpolicy.ModeObserve,
+				githubpolicy.Rule{ID: "rule-deny", Layer: githubpolicy.LayerOrg, SubjectID: "org_test", ResourceID: &denyResource, Effect: githubpolicy.EffectDeny},
+			),
+			loaded: true,
+		},
+	})
+
+	decision, err := provider.DecideHook(context.Background(), githubPushEvent())
+	if err != nil {
+		t.Fatalf("DecideHook() error = %v", err)
+	}
+	// Observe mode: the policy would deny, but the runtime decision is
+	// untouched — nothing is ever blocked.
+	if decision.Decision != risk.DecisionAllow {
+		t.Fatalf("Decision = %v, want allow in observe mode", decision.Decision)
+	}
+	if len(decision.GithubPolicy) != 1 {
+		t.Fatalf("GithubPolicy evaluations = %d, want 1", len(decision.GithubPolicy))
+	}
+	evaluation := decision.GithubPolicy[0]
+	if evaluation.Result != githubpolicy.EffectDeny || evaluation.ReasonCode != githubpolicy.ReasonCodeDeny {
+		t.Fatalf("evaluation = %+v, want would-deny", evaluation)
+	}
+	if evaluation.Request.Action != "github.repo.write" || evaluation.Request.Resource != "acme/api" {
+		t.Fatalf("classified request = %+v", evaluation.Request)
+	}
+}
+
+func TestDecideHookEnforceModeDeniesBeforeJudge(t *testing.T) {
+	denyResource := "acme/api"
+	provider := NewRiskPolicyProviderWithOptions(RiskPolicyProviderOptions{
+		GithubPolicy: staticGithubPolicy{
+			snapshot: githubTestSnapshot(githubpolicy.ModeEnforce,
+				githubpolicy.Rule{ID: "rule-deny", Layer: githubpolicy.LayerOrg, SubjectID: "org_test", ResourceID: &denyResource, Effect: githubpolicy.EffectDeny},
+			),
+			loaded: true,
+		},
+	})
+
+	decision, err := provider.DecideHook(context.Background(), githubPushEvent())
+	if err != nil {
+		t.Fatalf("DecideHook() error = %v", err)
+	}
+	if decision.Decision != risk.DecisionDeny {
+		t.Fatalf("Decision = %v, want deny when the snapshot directs enforcement", decision.Decision)
+	}
+	if decision.ReasonCode != githubpolicy.ReasonCodeDeny {
+		t.Fatalf("ReasonCode = %q", decision.ReasonCode)
+	}
+}
+
+func TestDecideHookUnknownModeIsTreatedAsObserve(t *testing.T) {
+	denyResource := "acme/api"
+	provider := NewRiskPolicyProviderWithOptions(RiskPolicyProviderOptions{
+		GithubPolicy: staticGithubPolicy{
+			snapshot: githubTestSnapshot("enforce-later-maybe",
+				githubpolicy.Rule{ID: "rule-deny", Layer: githubpolicy.LayerOrg, SubjectID: "org_test", ResourceID: &denyResource, Effect: githubpolicy.EffectDeny},
+			),
+			loaded: true,
+		},
+	})
+
+	decision, err := provider.DecideHook(context.Background(), githubPushEvent())
+	if err != nil {
+		t.Fatalf("DecideHook() error = %v", err)
+	}
+	if decision.Decision != risk.DecisionAllow {
+		t.Fatalf("Decision = %v, want allow: only an explicit enforce mode may block", decision.Decision)
+	}
+	if len(decision.GithubPolicy) != 1 {
+		t.Fatalf("evaluations = %d, want dry-run recorded regardless of mode", len(decision.GithubPolicy))
+	}
+}
+
+func TestDecideHookNonGithubEventsCarryNoEvaluations(t *testing.T) {
+	provider := NewRiskPolicyProviderWithOptions(RiskPolicyProviderOptions{
+		GithubPolicy: staticGithubPolicy{
+			snapshot: githubTestSnapshot(githubpolicy.ModeObserve,
+				githubpolicy.Rule{ID: "rule-allow", Layer: githubpolicy.LayerOrg, SubjectID: "org_test", Effect: githubpolicy.EffectAllow},
+			),
+			loaded: true,
+		},
+	})
+
+	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{
+		SessionID:     "session-1",
+		HookEventName: "PreToolUse",
+		ToolName:      "Bash",
+		ToolInput:     map[string]any{"command": "ls -la"},
+	})
+	if err != nil {
+		t.Fatalf("DecideHook() error = %v", err)
+	}
+	if len(decision.GithubPolicy) != 0 {
+		t.Fatalf("evaluations = %+v, want none for non-GitHub activity", decision.GithubPolicy)
+	}
+}
+
+func TestDecideHookWithoutSnapshotProviderIsUnchanged(t *testing.T) {
+	provider := NewRiskPolicyProviderWithOptions(RiskPolicyProviderOptions{})
+	decision, err := provider.DecideHook(context.Background(), githubPushEvent())
+	if err != nil {
+		t.Fatalf("DecideHook() error = %v", err)
+	}
+	if decision.Decision != risk.DecisionAllow || len(decision.GithubPolicy) != 0 {
+		t.Fatalf("decision = %+v, want plain allow with no evaluations", decision)
+	}
+}

--- a/internal/guard/app/server/policy.go
+++ b/internal/guard/app/server/policy.go
@@ -111,8 +111,8 @@ func (p RiskPolicyProvider) evaluateGithubPolicy(event risk.HookEvent) ([]github
 	if !ok || len(snapshot.Rules) == 0 {
 		return nil, false
 	}
-	actions := githubpolicy.ClassifyProviderActions(event.ToolName, event.ToolInput, func() githubpolicy.GitContext {
-		return githubpolicy.GitContextFromCWD(event.CWD)
+	actions := githubpolicy.ClassifyProviderActionsWithCWD(event.ToolName, event.ToolInput, event.CWD, func(cwd string) githubpolicy.GitContext {
+		return githubpolicy.GitContextFromCWD(cwd)
 	})
 	if len(actions) == 0 {
 		return nil, false

--- a/internal/guard/app/server/policy.go
+++ b/internal/guard/app/server/policy.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/kontext-security/kontext-cli/internal/githubpolicy"
 	"github.com/kontext-security/kontext-cli/internal/guard/judge"
 	guardpolicy "github.com/kontext-security/kontext-cli/internal/guard/policy"
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
@@ -22,6 +23,7 @@ type RiskPolicyProvider struct {
 	judge        judge.Judge
 	policyEngine guardpolicy.Engine
 	policyConfig PolicyConfigProvider
+	githubPolicy githubpolicy.SnapshotProvider
 }
 
 type RiskPolicyProviderOptions struct {
@@ -29,6 +31,7 @@ type RiskPolicyProviderOptions struct {
 	PolicyEngine         guardpolicy.Engine
 	PolicyConfig         guardpolicy.Config
 	PolicyConfigProvider PolicyConfigProvider
+	GithubPolicy         githubpolicy.SnapshotProvider
 }
 
 type staticPolicyConfigProvider struct {
@@ -58,6 +61,7 @@ func NewRiskPolicyProviderWithOptions(opts RiskPolicyProviderOptions) RiskPolicy
 		judge:        opts.Judge,
 		policyEngine: opts.PolicyEngine,
 		policyConfig: configProvider,
+		githubPolicy: opts.GithubPolicy,
 	}
 }
 
@@ -68,18 +72,99 @@ func (p RiskPolicyProvider) DecideHook(ctx context.Context, event risk.HookEvent
 	riskEvent := risk.NormalizeHookEvent(event)
 	policyResult := p.policyEngine.Evaluate(riskEvent, p.activePolicyConfig(ctx))
 	applyPolicyMetadata(&riskEvent, policyResult)
+	// Local layering: deterministic guardrails > synced GitHub policy >
+	// probabilistic signals. A guardrail deny stands regardless of what the
+	// synced policy would have said; the synced policy (when enforcing)
+	// pre-empts the judge.
+	githubEvaluations, githubEnforce := p.evaluateGithubPolicy(event)
 	if policyResult.Decision == guardpolicy.DecisionDeny {
-		return deterministicDenyDecision(riskEvent, policyResult), nil
+		return withGithubPolicy(deterministicDenyDecision(riskEvent, policyResult), githubEvaluations), nil
+	}
+	if githubEnforce && len(githubEvaluations) > 0 {
+		return withGithubPolicy(githubPolicyDecision(riskEvent, githubEvaluations), githubEvaluations), nil
 	}
 	if p.judge == nil {
-		return deterministicAllowDecision(riskEvent, policyResult), nil
+		return withGithubPolicy(deterministicAllowDecision(riskEvent, policyResult), githubEvaluations), nil
 	}
 
 	result, err := p.judge.Decide(ctx, judgeInputFromRiskEvent(event, riskEvent))
 	if err != nil {
-		return judgeFailOpenDecision(riskEvent, p.judge, err), nil
+		return withGithubPolicy(judgeFailOpenDecision(riskEvent, p.judge, err), githubEvaluations), nil
 	}
-	return judgeDecision(riskEvent, result), nil
+	return withGithubPolicy(judgeDecision(riskEvent, result), githubEvaluations), nil
+}
+
+// evaluateGithubPolicy classifies the event into canonical GitHub actions and
+// evaluates each against the synced policy snapshot. The managed endpoint's
+// trusted identity is the service account + installation — Claude hook
+// payloads are not trusted human identity — so requests carry no Kontext
+// user/application subject and user/agent-layer rules cannot match their
+// subject (the evaluation flags this via SubjectsResolved).
+//
+// The boolean result reports whether the snapshot explicitly directs
+// enforcement; anything else is observe and never influences the decision.
+func (p RiskPolicyProvider) evaluateGithubPolicy(event risk.HookEvent) ([]githubpolicy.Evaluation, bool) {
+	if p.githubPolicy == nil {
+		return nil, false
+	}
+	snapshot, status, ok := p.githubPolicy.CurrentSnapshot()
+	if !ok || len(snapshot.Rules) == 0 {
+		return nil, false
+	}
+	actions := githubpolicy.ClassifyProviderActions(event.ToolName, event.ToolInput, func() githubpolicy.GitContext {
+		return githubpolicy.GitContextFromCWD(event.CWD)
+	})
+	if len(actions) == 0 {
+		return nil, false
+	}
+	evaluations := make([]githubpolicy.Evaluation, 0, len(actions))
+	for _, action := range actions {
+		evaluation, ok := githubpolicy.Evaluate(snapshot, status, githubpolicy.Request{
+			Action:      action.Action,
+			Resource:    action.Resource,
+			BranchOrRef: action.BranchOrRef,
+		})
+		if ok {
+			evaluations = append(evaluations, evaluation)
+		}
+	}
+	return evaluations, snapshot.Enforce()
+}
+
+func withGithubPolicy(decision risk.RiskDecision, evaluations []githubpolicy.Evaluation) risk.RiskDecision {
+	decision.GithubPolicy = evaluations
+	return decision
+}
+
+// githubPolicyDecision is the enforce-mode path, reserved for after the
+// observer pilot: the synced policy outranks probabilistic signals, so its
+// verdict decides instead of the judge. Any denied action denies the event.
+func githubPolicyDecision(riskEvent risk.RiskEvent, evaluations []githubpolicy.Evaluation) risk.RiskDecision {
+	for _, evaluation := range evaluations {
+		if evaluation.Result == githubpolicy.EffectDeny {
+			riskEvent.Decision = risk.DecisionDeny
+			riskEvent.ReasonCode = evaluation.ReasonCode
+			riskEvent.DecisionStage = "github_policy_deny"
+			return risk.RiskDecision{
+				Decision:   risk.DecisionDeny,
+				Reason:     evaluation.Reason,
+				ReasonCode: evaluation.ReasonCode,
+				GuardID:    evaluation.DecidingRuleID,
+				RiskEvent:  riskEvent,
+			}
+		}
+	}
+	allowed := evaluations[0]
+	riskEvent.Decision = risk.DecisionAllow
+	riskEvent.ReasonCode = allowed.ReasonCode
+	riskEvent.DecisionStage = "github_policy_allow"
+	return risk.RiskDecision{
+		Decision:   risk.DecisionAllow,
+		Reason:     allowed.Reason,
+		ReasonCode: allowed.ReasonCode,
+		GuardID:    allowed.DecidingRuleID,
+		RiskEvent:  riskEvent,
+	}
 }
 
 func (p RiskPolicyProvider) asyncTelemetryDecision(event risk.HookEvent) risk.RiskDecision {

--- a/internal/guard/app/server/server.go
+++ b/internal/guard/app/server/server.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kontext-security/kontext-cli/internal/githubpolicy"
 	"github.com/kontext-security/kontext-cli/internal/guard/judge"
 	"github.com/kontext-security/kontext-cli/internal/guard/policy"
 	"github.com/kontext-security/kontext-cli/internal/guard/policyconfig"
@@ -49,6 +50,7 @@ type Options struct {
 	Judge                judge.Judge
 	PolicyConfig         policy.Config
 	PolicyConfigProvider PolicyConfigProvider
+	GithubPolicy         githubpolicy.SnapshotProvider
 	CurrentSessionID     string
 	Mode                 string
 }
@@ -90,6 +92,7 @@ func NewServerWithOptions(store *sqlite.Store, opts Options) (*Server, error) {
 	return NewServerWithPolicyConfigAndOptions(store, NewRiskPolicyProviderWithOptions(RiskPolicyProviderOptions{
 		Judge:                opts.Judge,
 		PolicyConfigProvider: configProvider,
+		GithubPolicy:         opts.GithubPolicy,
 	}), policyStore, opts)
 }
 

--- a/internal/guard/risk/types.go
+++ b/internal/guard/risk/types.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/kontext-security/kontext-cli/internal/githubpolicy"
 	"github.com/kontext-security/kontext-cli/internal/guard/decision"
 )
 
@@ -102,6 +103,9 @@ type RiskDecision struct {
 	ModelVersion string    `json:"model_version,omitempty"`
 	GuardID      string    `json:"guard_id,omitempty"`
 	RiskEvent    RiskEvent `json:"risk_event"`
+	// GithubPolicy carries the synced-policy dry-run evaluations for this
+	// event; each one is recorded as a separate request.decided ledger row.
+	GithubPolicy []githubpolicy.Evaluation `json:"github_policy,omitempty"`
 }
 
 func MarshalInput(value map[string]any) string {

--- a/internal/guard/store/sqlite/githubdryrun.go
+++ b/internal/guard/store/sqlite/githubdryrun.go
@@ -1,0 +1,148 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kontext-security/kontext-cli/internal/githubpolicy"
+	"github.com/kontext-security/kontext-cli/internal/guard/risk"
+)
+
+// insertGithubDryRunActions records the synced GitHub policy's would-be
+// decisions. Each evaluated action gets its own request.decided row with
+// decision_category "dry_run", separate from the runtime's own decided row —
+// in observe mode nothing is ever blocked, the dry-run row only documents
+// what the policy would have done.
+func (s *Store) insertGithubDryRunActions(ctx context.Context, tx *sql.Tx, sessionID string, event risk.HookEvent, decision risk.RiskDecision, now time.Time) error {
+	for i, evaluation := range decision.GithubPolicy {
+		action, err := githubDryRunActionValues("act_"+uuid.NewString(), sessionID, event, decision, evaluation, now.Add(time.Duration(i)*time.Millisecond))
+		if err != nil {
+			return err
+		}
+		if err := s.insertActionRecord(ctx, tx, action, "decision", now); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func githubDryRunActionValues(actionID, sessionID string, event risk.HookEvent, decision risk.RiskDecision, evaluation githubpolicy.Evaluation, now time.Time) (map[string]any, error) {
+	riskEvent := decision.RiskEvent
+	parametersJSON, parametersHash := mustHashJSON(map[string]any{
+		"command_summary": riskEvent.CommandSummary,
+		"request_summary": riskEvent.RequestSummary,
+		"path_class":      riskEvent.PathClass,
+	})
+	// The managed endpoint's trusted identity is the service account +
+	// installation; hook payloads are session telemetry, not human identity.
+	identityJSON, identityHash := mustHashJSON(map[string]any{
+		"agent":          event.Agent,
+		"principal_kind": "service_account",
+	})
+
+	githubContext := map[string]any{}
+	if owner, repo, ok := splitRepoSlug(evaluation.Request.Resource); ok {
+		githubContext["owner"] = owner
+		githubContext["repo"] = repo
+	}
+	if evaluation.Request.BranchOrRef != "" {
+		githubContext["branch_or_ref"] = evaluation.Request.BranchOrRef
+	}
+	contextPayload := map[string]any{
+		"cwd":             event.CWD,
+		"hook_event_name": event.HookEventName,
+		"github_policy": map[string]any{
+			"schema_version":    githubpolicy.SchemaVersion,
+			"mode":              evaluation.Mode,
+			"epoch":             evaluation.Epoch,
+			"hash":              evaluation.Hash,
+			"stale":             evaluation.Stale,
+			"subjects_resolved": evaluation.SubjectsResolved,
+		},
+	}
+	if len(githubContext) > 0 {
+		contextPayload["github"] = githubContext
+	}
+	contextJSON, contextHash := mustHashJSON(contextPayload)
+
+	matchedRules := evaluation.MatchedRules
+	if matchedRules == nil {
+		matchedRules = []githubpolicy.MatchedRule{}
+	}
+	matchedRulesJSON := mustJSONText(matchedRules)
+
+	timestamp := now.Format(time.RFC3339Nano)
+	return map[string]any{
+		"id":                       actionID,
+		"session_id":               sessionID,
+		"tool_use_id":              event.ToolUseID,
+		"canonical_event_type":     canonicalEventRequestDecided,
+		"adapter_event_name":       event.HookEventName,
+		"correlation_key":          correlationKey(event),
+		"tool_name":                event.ToolName,
+		"provider":                 "github",
+		"operation":                evaluation.Request.Action,
+		"operation_class":          operationClassFromAction(evaluation.Request.Action),
+		"resource_class":           "repo",
+		"resource_id":              nullIfEmpty(evaluation.Request.Resource),
+		"parameters_redacted_json": parametersJSON,
+		"parameters_hash":          parametersHash,
+		"identity_context_json":    identityJSON,
+		"identity_hash":            identityHash,
+		"context_json":             contextJSON,
+		"context_hash":             contextHash,
+		"policy_id":                evaluation.DecidingRuleID,
+		"policy_version":           strconv.Itoa(evaluation.Epoch),
+		"policy_hash":              evaluation.Hash,
+		"default_posture":          "",
+		"decision_result":          evaluation.Result,
+		"decision_category":        "dry_run",
+		"adapter_decision":         "",
+		"reason_code":              evaluation.ReasonCode,
+		"reason":                   evaluation.Reason,
+		"risk_level":               "",
+		"risk_score":               nil,
+		"risk_threshold":           nil,
+		"model_version":            "",
+		"confidence":               0.0,
+		"matched_rules_json":       matchedRulesJSON,
+		"risk_signals_json":        "[]",
+		"risk_event_json":          "{}",
+		"modifications_json":       "{}",
+		"approval_context_json":    "{}",
+		"approval_channel":         "",
+		"approval_request_id":      "",
+		"deferral_context_json":    "{}",
+		"status":                   "evaluated",
+		"outcome":                  "",
+		"output_summary":           "",
+		"output_hash":              "",
+		"error_redacted":           "",
+		"proposed_at":              nil,
+		"decision_at":              nullIfEmpty(timestamp),
+		"completed_at":             nil,
+		"created_at":               timestamp,
+		"updated_at":               timestamp,
+		"updated_at_cursor_key":    ledgerTimestampCursorKeyFromValues(timestamp),
+	}, nil
+}
+
+func operationClassFromAction(action string) string {
+	if index := strings.LastIndex(action, "."); index >= 0 {
+		return action[index+1:]
+	}
+	return ""
+}
+
+func splitRepoSlug(resource string) (owner, repo string, ok bool) {
+	owner, repo, found := strings.Cut(resource, "/")
+	if !found || owner == "" || repo == "" {
+		return "", "", false
+	}
+	return owner, repo, true
+}

--- a/internal/guard/store/sqlite/githubdryrun_test.go
+++ b/internal/guard/store/sqlite/githubdryrun_test.go
@@ -139,6 +139,58 @@ func TestSaveDecisionRecordsGithubDryRunRows(t *testing.T) {
 	}
 }
 
+func TestDryRunRowsDoNotCountAsCriticalActions(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatalf("OpenStore() error = %v", err)
+	}
+	defer store.Close()
+
+	event := risk.HookEvent{
+		SessionID:     "session-1",
+		Agent:         "claude",
+		HookEventName: "PreToolUse",
+		ToolName:      "Bash",
+		ToolInput:     map[string]any{"command": "git push origin main"},
+		ToolUseID:     "toolu_1",
+	}
+	decision := risk.RiskDecision{
+		Decision: risk.DecisionAllow,
+		GithubPolicy: []githubpolicy.Evaluation{{
+			Request:    githubpolicy.Request{Action: "github.repo.write", Resource: "acme/api"},
+			Result:     "deny",
+			ReasonCode: githubpolicy.ReasonCodeDeny,
+			Reason:     "would deny",
+			Epoch:      5,
+			Hash:       "hash-5",
+		}},
+	}
+	if _, err := store.SaveDecision(context.Background(), event, decision); err != nil {
+		t.Fatalf("SaveDecision() error = %v", err)
+	}
+
+	summary, err := store.Summary(context.Background())
+	if err != nil {
+		t.Fatalf("Summary() error = %v", err)
+	}
+	// The runtime decision was allow; the observer-mode would-deny must not
+	// surface as a real critical action.
+	if summary.Critical != 0 {
+		t.Fatalf("Summary.Critical = %d, want 0", summary.Critical)
+	}
+	if summary.Actions != 1 {
+		t.Fatalf("Summary.Actions = %d, want only the runtime decision", summary.Actions)
+	}
+
+	sessions, err := store.Sessions(context.Background())
+	if err != nil {
+		t.Fatalf("Sessions() error = %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].Critical != 0 {
+		t.Fatalf("Sessions() = %+v, want zero critical", sessions)
+	}
+}
+
 func TestSaveDecisionWithoutGithubPolicyAddsNoExtraRows(t *testing.T) {
 	store, err := OpenStore(t.TempDir() + "/guard.db")
 	if err != nil {

--- a/internal/guard/store/sqlite/githubdryrun_test.go
+++ b/internal/guard/store/sqlite/githubdryrun_test.go
@@ -1,0 +1,167 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/githubpolicy"
+	"github.com/kontext-security/kontext-cli/internal/guard/risk"
+)
+
+func TestSaveDecisionRecordsGithubDryRunRows(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatalf("OpenStore() error = %v", err)
+	}
+	defer store.Close()
+
+	event := risk.HookEvent{
+		SessionID:     "session-1",
+		Agent:         "claude",
+		HookEventName: "PreToolUse",
+		ToolName:      "Bash",
+		ToolInput:     map[string]any{"command": "git push origin main"},
+		ToolUseID:     "toolu_1",
+		CWD:           "/tmp/project",
+	}
+	decision := risk.RiskDecision{
+		Decision:   risk.DecisionAllow,
+		Reason:     "observed",
+		ReasonCode: "deterministic_allow",
+		RiskEvent:  risk.RiskEvent{CommandSummary: "git push origin main"},
+		GithubPolicy: []githubpolicy.Evaluation{{
+			Request:    githubpolicy.Request{Action: "github.repo.write", Resource: "acme/api", BranchOrRef: "main"},
+			Result:     "deny",
+			ReasonCode: githubpolicy.ReasonCodeDeny,
+			Reason:     "denied by org-layer deny rule on github.repo.write @ acme/api",
+			MatchedRules: []githubpolicy.MatchedRule{
+				{ID: "rule-deny", Layer: "org", Effect: "deny", Decided: true},
+				{ID: "rule-allow", Layer: "org", Effect: "allow"},
+			},
+			DecidingRuleID: "rule-deny",
+			Mode:           githubpolicy.ModeObserve,
+			Epoch:          5,
+			Hash:           "hash-5",
+		}},
+	}
+	if _, err := store.SaveDecision(context.Background(), event, decision); err != nil {
+		t.Fatalf("SaveDecision() error = %v", err)
+	}
+
+	batch, err := store.LedgerBatch(context.Background(), LedgerExportOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("LedgerBatch() error = %v", err)
+	}
+
+	var dryRun LedgerRecord
+	decidedRows := 0
+	for _, action := range batch.Actions {
+		if action["canonical_event_type"] != "request.decided" {
+			continue
+		}
+		decidedRows++
+		if action["decision_category"] == "dry_run" {
+			dryRun = action
+		}
+	}
+	if decidedRows != 2 {
+		t.Fatalf("decided rows = %d, want runtime decision + dry-run decision", decidedRows)
+	}
+	if dryRun == nil {
+		t.Fatal("no dry_run request.decided row found")
+	}
+
+	expectations := map[string]any{
+		"decision_result": "deny",
+		"reason_code":     githubpolicy.ReasonCodeDeny,
+		"provider":        "github",
+		"resource_class":  "repo",
+		"resource_id":     "acme/api",
+		"operation":       "github.repo.write",
+		"operation_class": "write",
+		"policy_id":       "rule-deny",
+		"policy_version":  "5",
+		"policy_hash":     "hash-5",
+		"tool_name":       "Bash",
+		"status":          "evaluated",
+	}
+	for key, want := range expectations {
+		if got := dryRun[key]; got != want {
+			t.Errorf("dry run %s = %v, want %v", key, got, want)
+		}
+	}
+
+	matchedRules, ok := dryRun["matched_rules_json"].([]any)
+	if !ok || len(matchedRules) != 2 {
+		t.Fatalf("matched_rules_json = %v, want two matched rules", dryRun["matched_rules_json"])
+	}
+	first, _ := matchedRules[0].(map[string]any)
+	if first["id"] != "rule-deny" || first["decided"] != true {
+		t.Fatalf("matched rule = %v, want deciding rule-deny", first)
+	}
+
+	contextJSON, _ := dryRun["context_json"].(map[string]any)
+	githubContext, _ := contextJSON["github"].(map[string]any)
+	if githubContext["owner"] != "acme" || githubContext["repo"] != "api" || githubContext["branch_or_ref"] != "main" {
+		t.Fatalf("context_json.github = %v", githubContext)
+	}
+	policyContext, _ := contextJSON["github_policy"].(map[string]any)
+	if policyContext["mode"] != "observe" || policyContext["hash"] != "hash-5" {
+		t.Fatalf("context_json.github_policy = %v", policyContext)
+	}
+	if policyContext["subjects_resolved"] != false {
+		t.Fatalf("subjects_resolved = %v, want false", policyContext["subjects_resolved"])
+	}
+
+	identityJSON, _ := dryRun["identity_context_json"].(map[string]any)
+	if identityJSON["principal_kind"] != "service_account" {
+		t.Fatalf("identity_context_json = %v, want service_account principal", identityJSON)
+	}
+
+	if decisionAt, _ := dryRun["decision_at"].(string); decisionAt == "" {
+		t.Fatal("dry run decision_at is empty")
+	}
+	if _, err := time.Parse(time.RFC3339Nano, dryRun["updated_at"].(string)); err != nil {
+		t.Fatalf("updated_at = %v: %v", dryRun["updated_at"], err)
+	}
+
+	// Every action row appends a chained receipt; dry-run rows must too or
+	// the ledger export references break.
+	receiptForDryRun := false
+	for _, receipt := range batch.Receipts {
+		if receipt["action_id"] == dryRun["id"] {
+			receiptForDryRun = true
+		}
+	}
+	if !receiptForDryRun {
+		t.Fatal("dry run row has no receipt")
+	}
+}
+
+func TestSaveDecisionWithoutGithubPolicyAddsNoExtraRows(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatalf("OpenStore() error = %v", err)
+	}
+	defer store.Close()
+
+	event := risk.HookEvent{
+		SessionID:     "session-1",
+		Agent:         "claude",
+		HookEventName: "PreToolUse",
+		ToolName:      "Bash",
+		ToolInput:     map[string]any{"command": "ls"},
+		ToolUseID:     "toolu_1",
+	}
+	if _, err := store.SaveDecision(context.Background(), event, risk.RiskDecision{Decision: risk.DecisionAllow}); err != nil {
+		t.Fatalf("SaveDecision() error = %v", err)
+	}
+	batch, err := store.LedgerBatch(context.Background(), LedgerExportOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("LedgerBatch() error = %v", err)
+	}
+	if len(batch.Actions) != 2 {
+		t.Fatalf("actions = %d, want proposed + decided only", len(batch.Actions))
+	}
+}

--- a/internal/guard/store/sqlite/githubdryrun_test.go
+++ b/internal/guard/store/sqlite/githubdryrun_test.go
@@ -181,6 +181,13 @@ func TestDryRunRowsDoNotCountAsCriticalActions(t *testing.T) {
 	if summary.Actions != 1 {
 		t.Fatalf("Summary.Actions = %d, want only the runtime decision", summary.Actions)
 	}
+	events, err := store.Events(context.Background(), "session-1")
+	if err != nil {
+		t.Fatalf("Events() error = %v", err)
+	}
+	if len(events) != 1 || events[0].Decision != risk.DecisionAllow {
+		t.Fatalf("Events() = %+v, want only the runtime allow decision", events)
+	}
 
 	sessions, err := store.Sessions(context.Background())
 	if err != nil {

--- a/internal/guard/store/sqlite/store.go
+++ b/internal/guard/store/sqlite/store.go
@@ -733,6 +733,9 @@ on conflict(id) do update set
 		if err := s.insertAction(ctx, tx, actionID, sessionID, event, decision, canonicalEventRequestDecided, "decision", now.Add(time.Millisecond)); err != nil {
 			return DecisionRecord{}, err
 		}
+		if err := s.insertGithubDryRunActions(ctx, tx, sessionID, event, decision, now.Add(2*time.Millisecond)); err != nil {
+			return DecisionRecord{}, err
+		}
 	} else {
 		if err := s.insertAction(ctx, tx, actionID, sessionID, event, decision, canonicalEventType(event.HookEventName), "outcome", now); err != nil {
 			return DecisionRecord{}, err
@@ -765,6 +768,10 @@ func (s *Store) insertAction(ctx context.Context, tx *sql.Tx, actionID, sessionI
 	if err != nil {
 		return err
 	}
+	return s.insertActionRecord(ctx, tx, action, receiptType, now)
+}
+
+func (s *Store) insertActionRecord(ctx context.Context, tx *sql.Tx, action map[string]any, receiptType string, now time.Time) error {
 	columns := []string{
 		"id", "session_id", "tool_use_id", "canonical_event_type", "adapter_event_name", "correlation_key",
 		"tool_name", "provider", "operation", "operation_class", "resource_class", "resource_id", "parameters_redacted_json", "parameters_hash",

--- a/internal/guard/store/sqlite/store.go
+++ b/internal/guard/store/sqlite/store.go
@@ -1424,6 +1424,7 @@ select
 	  select case when decision_result = 'deny' then 1 else 0 end as critical, 1 as actions
 	  from authorization_actions
 	  where canonical_event_type <> 'request.proposed'
+	    and coalesce(decision_category, '') <> 'dry_run'
 	)
 	`)
 	if err := row.Scan(&summary.Critical, &summary.Warnings, &summary.Actions, &summary.Sessions); err != nil {
@@ -1448,6 +1449,7 @@ select actions.session_id,
 	  select session_id, case when decision_result = 'deny' then 1 else 0 end as critical, updated_at as latest_at
 	  from authorization_actions
 	  where canonical_event_type <> 'request.proposed'
+	    and coalesce(decision_category, '') <> 'dry_run'
 		) actions
 left join agent_sessions on agent_sessions.id = actions.session_id
 group by actions.session_id, agent_sessions.mode, agent_sessions.status, agent_sessions.created_at, agent_sessions.updated_at, agent_sessions.closed_at
@@ -1492,6 +1494,7 @@ select actions.session_id,
 	  select session_id, case when decision_result = 'deny' then 1 else 0 end as critical, updated_at as latest_at
 	  from authorization_actions
 	  where session_id = ? and canonical_event_type <> 'request.proposed'
+	    and coalesce(decision_category, '') <> 'dry_run'
 		) actions
 left join agent_sessions on agent_sessions.id = actions.session_id
 group by actions.session_id, agent_sessions.mode, agent_sessions.status, agent_sessions.created_at, agent_sessions.updated_at, agent_sessions.closed_at

--- a/internal/guard/store/sqlite/store.go
+++ b/internal/guard/store/sqlite/store.go
@@ -1519,8 +1519,9 @@ select id, session_id, coalesce(tool_use_id, ''), hook_event_name, coalesce(tool
 	    coalesce(reason_code, '') as reason_code, coalesce(reason, '') as reason, risk_score, risk_threshold as threshold, model_version, risk_event_json, updated_at as created_at
 	  from authorization_actions
 	  where canonical_event_type = 'request.decided'
-	)
-where session_id = ?
+	    and coalesce(decision_category, '') <> 'dry_run'
+		)
+	where session_id = ?
 order by created_at desc
 	`, sessionID)
 	if err != nil {

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kontext-security/kontext-cli/internal/coworkobserve"
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
+	"github.com/kontext-security/kontext-cli/internal/githubpolicy"
 	guardhookruntime "github.com/kontext-security/kontext-cli/internal/guard/hookruntime"
 	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
 	"github.com/kontext-security/kontext-cli/internal/installation"
@@ -19,13 +20,16 @@ import (
 )
 
 type DaemonOptions struct {
-	SocketPath       string
-	DBPath           string
-	IdleTimeout      time.Duration
-	StreamStatePath  string
-	StreamInterval   time.Duration
-	StreamHTTPClient *http.Client
-	Diagnostic       diagnostic.Logger
+	SocketPath            string
+	DBPath                string
+	IdleTimeout           time.Duration
+	StreamStatePath       string
+	StreamInterval        time.Duration
+	StreamHTTPClient      *http.Client
+	GithubPolicyCachePath string
+	GithubPolicyInterval  time.Duration
+	GithubPolicyClient    *http.Client
+	Diagnostic            diagnostic.Logger
 }
 
 func RunDaemon(ctx context.Context, opts DaemonOptions) error {
@@ -67,10 +71,20 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 		return fmt.Errorf("parse managed mode: %w", err)
 	}
 
+	policyCachePath := opts.GithubPolicyCachePath
+	if policyCachePath == "" {
+		policyCachePath = githubpolicy.DefaultCachePathForDB(dbPath)
+	}
+	policyCache := githubpolicy.NewCache(policyCachePath)
+	if err := policyCache.LoadPersisted(); err != nil {
+		opts.Diagnostic.Printf("github policy cache load: %v\n", err)
+	}
+
 	host, err := runtimehost.Start(ctx, runtimehost.Options{
 		AgentName:          managedconfig.Agent,
 		DBPath:             dbPath,
 		SocketPath:         socketPath,
+		GithubPolicy:       policyCache,
 		Mode:               mode,
 		Diagnostic:         opts.Diagnostic,
 		SkipInitialSession: true,
@@ -80,6 +94,17 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 		return err
 	}
 	defer host.Close(context.Background())
+
+	policyCtx, stopPolicyRefresh := context.WithCancel(ctx)
+	defer stopPolicyRefresh()
+	go githubpolicy.Run(policyCtx, githubpolicy.RunOptions{
+		Cache:        policyCache,
+		CloudURL:     loadedConfig.Config.CloudURL,
+		InstallToken: installToken,
+		Interval:     opts.GithubPolicyInterval,
+		HTTPClient:   opts.GithubPolicyClient,
+		Diagnostic:   opts.Diagnostic,
+	})
 
 	streamCtx, stopStream := context.WithCancel(ctx)
 	defer stopStream()

--- a/internal/runtimehost/host.go
+++ b/internal/runtimehost/host.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
+	"github.com/kontext-security/kontext-cli/internal/githubpolicy"
 	"github.com/kontext-security/kontext-cli/internal/guard/app/server"
 	guardhookruntime "github.com/kontext-security/kontext-cli/internal/guard/hookruntime"
 	"github.com/kontext-security/kontext-cli/internal/guard/judge"
@@ -37,6 +38,7 @@ type Options struct {
 	JudgeConfigFromEnv        bool
 	JudgeManagedDefault       bool
 	JudgeDownloadProgress     judge.DownloadProgressHandler
+	GithubPolicy              githubpolicy.SnapshotProvider
 	Mode                      guardhookruntime.Mode
 	Diagnostic                diagnostic.Logger
 	Out                       io.Writer
@@ -111,6 +113,7 @@ func Start(ctx context.Context, opts Options) (*Host, error) {
 	}
 	localServer, closeStore, err := server.OpenDefaultServerWithOptions(dbPath, server.Options{
 		Judge:            localJudge,
+		GithubPolicy:     opts.GithubPolicy,
 		CurrentSessionID: serverSessionID,
 		Mode:             string(mode),
 	})


### PR DESCRIPTION
## Summary

Consumer side of ENG-426: managed endpoints now fetch the cloud GitHub access-control policy snapshot (`github-policy-snapshot-v1`, served by kontext PR #551), cache it per installation, evaluate classified GitHub activity against it locally, and record would-allow/would-deny decisions — without ever blocking anything (observer mode).

Local decision layering: **general deterministic guardrails > synced policy > probabilistic signals** (`RiskPolicyProvider.DecideHook` evaluates the snapshot after the deterministic policy engine and before the judge; the enforce path is implemented but only an explicit `mode: "enforce"` can ever block — anything else is observe).

## What's in here

- **`internal/githubpolicy`** (new): vendored snapshot types mirroring `packages/shared/src/github-policy-snapshot.ts`; HTTP client for `GET /api/v1/policy/github/snapshot` (same install token as ledger ingest, no org parameter); per-installation disk cache + 60s refresh loop (`KONTEXT_GITHUB_POLICY_REFRESH_INTERVAL` to override); Go port of the cloud classifier (`provider-action-classifier.ts`); local evaluator mirroring the cloud semantics exactly (deny beats allow; org layer strict; user/agent layers abstain while empty, veto once active; exact matching, null = wildcard, no globs).
- **Ledger**: each evaluated action gets its own `request.decided` row with `decision_category: "dry_run"`, `reason_code` `ALLOWED_POLICY_CHECK`/`DENY_POLICY_CHECK`, `matched_rules_json` (rule ids + which one decided), `policy_version` = snapshot epoch, `policy_hash` = snapshot hash, `provider: github`, `resource_class: repo`, `resource_id: owner/name`, and `context_json.github.{owner,repo,branch_or_ref}` + `context_json.github_policy.{mode,epoch,hash,stale,subjects_resolved}`. Rows flow through the existing `POST /api/v1/authorization-ledger/batches` pipeline with chained receipts. Existing `request.proposed`/`observed` rows are untouched.
- **Cache resilience**: on fetch failure the last cached snapshot keeps evaluating (stale-but-deterministic beats unavailable) and staleness is recorded on every decision; unchanged `hash` skips re-applying; the persisted snapshot survives daemon restarts and starts out marked stale until the cloud confirms it.

## Identity decision (pilot caveat)

Per `docs/guides/access-control-event-schema.md`, the managed endpoint's trusted identity is the **service account + installation** — Claude hook payloads are not trusted human identity, and this repo has no enrolled Kontext user/application identity. So requests are evaluated **org-layer-first with unresolved user/agent subjects**: user/agent-layer rules never match their subject (unresolved subject = no match), which means a snapshot containing any user/agent-layer rule makes that layer active and silence vetoes — exactly what the cloud evaluator does for an unknown user id. Every dry-run row flags this via `context_json.github_policy.subjects_resolved: false`, and `identity_context_json.principal_kind` is `service_account`.

## Deliberate local extensions over the cloud classifier

- `gh` commands without `-R/--repo` fall back to the cwd's GitHub origin remote for the policy anchor (the task spec lists "current branch + remotes" as a derivation source; the cloud classifier only uses `-R` because it can't see the endpoint's cwd).
- `gh api --input …` counts as mutating, and a method override that can't be proven `GET/HEAD` defaults to write ("default to write when unprovable").

## Verification (cloud repo on PR #551 branch, localhost:4000, katana-local profile)

1. `curl` with the install token returns the snapshot; missing token → 401. Rule edits changed `epoch 6 / 60593dfb…` → `epoch 7 / a3e06c34…` and the daemon picked the change up on its own refresh tick (no restart).
2. Real `PreToolUse` hook events through the launchd daemon (`git push …enterprise-deployments.git main`, `gh pr create -R kontext-security/kontext`) produced `request.decided` `dry_run` rows in local `guard.db` **and** in `hosted_ledger_actions` via the existing stream.
3. Semantics table verified live: org allow alone ⇒ org-wide would-allow (`ALLOWED_POLICY_CHECK`); org allow + targeted deny ⇒ would-deny only on `kontext-security/enterprise-deployments` with the deny rule id marked as deciding; user-layer rule present ⇒ user layer strict (would-deny `no matching allow rule in active layer(s): user` with unresolved subject).
4. Every hook response stayed `permissionDecision: allow` — nothing was blocked, regardless of the would-be decision.

Unit tests cover the evaluator semantics table, classifier parity cases (incl. chained/wrapped commands and the `gh api` heuristic), cache staleness/refresh, the dry-run ledger rows + receipts, and the DecideHook layering (observe never blocks, unknown modes treated as observe, enforce reserved path denies before the judge).