### PR TITLE
[AUTOMATION] feat: clean up redundant runtime helpers

### DIFF
--- a/cmd/kontext/main.go
+++ b/cmd/kontext/main.go
@@ -423,10 +423,6 @@ func evaluateHookWithSidecarForMode(socketPath string, event hook.Event, mode st
 	return evaluateViaSidecarForMode(socketPath, event, mode)
 }
 
-func evaluateViaSidecar(socketPath string, event hook.Event) (hook.Result, error) {
-	return evaluateViaSidecarForMode(socketPath, event, "")
-}
-
 func evaluateViaSidecarForMode(socketPath string, event hook.Event, mode string) (hook.Result, error) {
 	conn, err := net.DialTimeout("unix", socketPath, 5*time.Second)
 	if err != nil {

--- a/cmd/kontext/main_test.go
+++ b/cmd/kontext/main_test.go
@@ -354,15 +354,15 @@ func TestEvaluateViaSidecarFailsOpenOnMarshalErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := evaluateViaSidecar(socketPath, tt.event)
+			result, err := evaluateViaSidecarForMode(socketPath, tt.event, "")
 			if err != nil {
-				t.Fatalf("evaluateViaSidecar() error = %v", err)
+				t.Fatalf("evaluateViaSidecarForMode() error = %v", err)
 			}
 			if !result.Allowed() {
-				t.Fatal("evaluateViaSidecar() allowed = false, want true")
+				t.Fatal("evaluateViaSidecarForMode() allowed = false, want true")
 			}
 			if result.Reason != "sidecar marshal error" {
-				t.Fatalf("evaluateViaSidecar() reason = %q, want sidecar marshal error", result.Reason)
+				t.Fatalf("evaluateViaSidecarForMode() reason = %q, want sidecar marshal error", result.Reason)
 			}
 		})
 	}
@@ -372,13 +372,13 @@ func TestEvaluateViaSidecarFailsClosedWhenEnforceSidecarUnavailable(t *testing.T
 	t.Setenv("KONTEXT_ACCESS_MODE", "enforce")
 
 	socketPath := fmt.Sprintf("/tmp/kontext-missing-%d.sock", time.Now().UnixNano())
-	result, err := evaluateViaSidecar(socketPath, hook.Event{
+	result, err := evaluateViaSidecarForMode(socketPath, hook.Event{
 		Agent:    "claude",
 		HookName: hook.HookPreToolUse,
 		ToolName: "Bash",
-	})
+	}, "")
 	if err != nil {
-		t.Fatalf("evaluateViaSidecar() error = %v", err)
+		t.Fatalf("evaluateViaSidecarForMode() error = %v", err)
 	}
 	if result.Decision != hook.DecisionDeny {
 		t.Fatalf("decision = %q, want DENY", result.Decision)
@@ -412,13 +412,13 @@ func TestEvaluateViaSidecarFailsClosedWhenAccessModePathSet(t *testing.T) {
 	t.Setenv("KONTEXT_ACCESS_MODE_PATH", "/tmp/kontext-missing-mode")
 
 	socketPath := fmt.Sprintf("/tmp/kontext-missing-%d.sock", time.Now().UnixNano())
-	result, err := evaluateViaSidecar(socketPath, hook.Event{
+	result, err := evaluateViaSidecarForMode(socketPath, hook.Event{
 		Agent:    "claude",
 		HookName: hook.HookPreToolUse,
 		ToolName: "Bash",
-	})
+	}, "")
 	if err != nil {
-		t.Fatalf("evaluateViaSidecar() error = %v", err)
+		t.Fatalf("evaluateViaSidecarForMode() error = %v", err)
 	}
 	if result.Decision != hook.DecisionDeny {
 		t.Fatalf("decision = %q, want DENY", result.Decision)
@@ -441,13 +441,13 @@ func TestEvaluateViaSidecarFailsOpenWhenNoPolicyModePathSet(t *testing.T) {
 	t.Setenv("KONTEXT_ACCESS_MODE_PATH", modePath)
 
 	socketPath := fmt.Sprintf("/tmp/kontext-missing-%d.sock", time.Now().UnixNano())
-	result, err := evaluateViaSidecar(socketPath, hook.Event{
+	result, err := evaluateViaSidecarForMode(socketPath, hook.Event{
 		Agent:    "claude",
 		HookName: hook.HookPreToolUse,
 		ToolName: "Bash",
-	})
+	}, "")
 	if err != nil {
-		t.Fatalf("evaluateViaSidecar() error = %v", err)
+		t.Fatalf("evaluateViaSidecarForMode() error = %v", err)
 	}
 	if result.Decision != hook.DecisionAllow {
 		t.Fatalf("decision = %q, want ALLOW", result.Decision)
@@ -464,13 +464,13 @@ func TestEvaluateViaSidecarUsesRefreshedEnforceModeFromPath(t *testing.T) {
 	t.Setenv("KONTEXT_ACCESS_MODE_PATH", modePath)
 
 	socketPath := fmt.Sprintf("/tmp/kontext-missing-%d.sock", time.Now().UnixNano())
-	result, err := evaluateViaSidecar(socketPath, hook.Event{
+	result, err := evaluateViaSidecarForMode(socketPath, hook.Event{
 		Agent:    "claude",
 		HookName: hook.HookPreToolUse,
 		ToolName: "Bash",
-	})
+	}, "")
 	if err != nil {
-		t.Fatalf("evaluateViaSidecar() error = %v", err)
+		t.Fatalf("evaluateViaSidecarForMode() error = %v", err)
 	}
 	if result.Decision != hook.DecisionDeny {
 		t.Fatalf("decision = %q, want DENY", result.Decision)
@@ -548,13 +548,13 @@ func TestEvaluateViaSidecarUsesRefreshedNoPolicyModeFromPath(t *testing.T) {
 	t.Setenv("KONTEXT_ACCESS_MODE_PATH", modePath)
 
 	socketPath := fmt.Sprintf("/tmp/kontext-missing-%d.sock", time.Now().UnixNano())
-	result, err := evaluateViaSidecar(socketPath, hook.Event{
+	result, err := evaluateViaSidecarForMode(socketPath, hook.Event{
 		Agent:    "claude",
 		HookName: hook.HookPreToolUse,
 		ToolName: "Bash",
-	})
+	}, "")
 	if err != nil {
-		t.Fatalf("evaluateViaSidecar() error = %v", err)
+		t.Fatalf("evaluateViaSidecarForMode() error = %v", err)
 	}
 	if result.Decision != hook.DecisionAllow {
 		t.Fatalf("decision = %q, want ALLOW", result.Decision)
@@ -565,13 +565,13 @@ func TestEvaluateViaSidecarFailsOpenWhenObserveSidecarUnavailable(t *testing.T) 
 	t.Setenv("KONTEXT_ACCESS_MODE", "no_policy")
 
 	socketPath := fmt.Sprintf("/tmp/kontext-missing-%d.sock", time.Now().UnixNano())
-	result, err := evaluateViaSidecar(socketPath, hook.Event{
+	result, err := evaluateViaSidecarForMode(socketPath, hook.Event{
 		Agent:    "claude",
 		HookName: hook.HookPreToolUse,
 		ToolName: "Bash",
-	})
+	}, "")
 	if err != nil {
-		t.Fatalf("evaluateViaSidecar() error = %v", err)
+		t.Fatalf("evaluateViaSidecarForMode() error = %v", err)
 	}
 	if result.Decision != hook.DecisionAllow {
 		t.Fatalf("decision = %q, want ALLOW", result.Decision)

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -60,12 +60,6 @@ func NewClient(baseURL string, ts TokenSource) *Client {
 	}
 }
 
-// StaticToken returns a TokenSource that always returns the same token.
-// Useful for tests or short-lived commands.
-func StaticToken(token string) TokenSource {
-	return func(_ bool) (string, error) { return token, nil }
-}
-
 // BaseURL returns the API base URL from env or default.
 func BaseURL() string {
 	if v := os.Getenv("KONTEXT_API_URL"); v != "" {

--- a/internal/hook/domain_test.go
+++ b/internal/hook/domain_test.go
@@ -79,3 +79,32 @@ func TestHookNameCanBlock(t *testing.T) {
 		t.Fatalf("HookUserPromptSubmit.CanBlock() = true, want false")
 	}
 }
+
+func TestHookNameIsKnown(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name HookName
+		want bool
+	}{
+		{name: HookSessionStart, want: true},
+		{name: HookPreToolUse, want: true},
+		{name: HookPostToolUse, want: true},
+		{name: HookPostToolUseFailed, want: true},
+		{name: HookSessionEnd, want: true},
+		{name: HookUserPromptSubmit, want: true},
+		{name: HookName("pretooluse"), want: false},
+		{name: HookName(""), want: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name.String(), func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.name.IsKnown(); got != tt.want {
+				t.Fatalf("HookName(%q).IsKnown() = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/localruntime/conversions.go
+++ b/internal/localruntime/conversions.go
@@ -143,10 +143,9 @@ func rawMap(data json.RawMessage) (map[string]any, error) {
 }
 
 func normalizeHookName(value string) (hook.HookName, bool) {
-	switch hookName := hook.HookName(strings.TrimSpace(value)); hookName {
-	case hook.HookSessionStart, hook.HookPreToolUse, hook.HookPostToolUse, hook.HookPostToolUseFailed, hook.HookSessionEnd, hook.HookUserPromptSubmit:
-		return hookName, true
-	default:
+	hookName := hook.HookName(strings.TrimSpace(value))
+	if !hookName.IsKnown() {
 		return "", false
 	}
+	return hookName, true
 }


### PR DESCRIPTION
Summary
This cleans up redundant runtime helpers by deleting dead wrappers and using one canonical hook-name check.

Before this, the sidecar path and local runtime kept extra helper code in cmd/kontext, internal/backend, and internal/localruntime, which made the runtime path harder to reason about and left one hook allowlist duplicated.

Now one canonical path remains:

```go
if !hookName.IsKnown() {
	return "", false
}
```

Why
This gives kontext-cli a cleaner maintenance path for local runtime evaluation:

EvaluateRequest
-> internal/localruntime normalizeHookName
-> hook.HookName.IsKnown
-> canonical hook validation

This PR does not broaden behavior beyond the cleanup scope.

What changed
Removed the dead evaluateViaSidecar wrapper
Removed the unused backend StaticToken helper
Consolidated local runtime hook-name validation onto hook.HookName.IsKnown
Updated tests for the canonical hook-name contract and sidecar callers

Verification
go test ./cmd/kontext ./internal/backend ./internal/hook ./internal/localruntime
go vet ./cmd/kontext ./internal/backend ./internal/hook ./internal/localruntime

