### PR TITLE
[AUTOMATION] fix: optimize internal/auth login scope resolution

### DIFF
--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -204,21 +204,18 @@ func resolveLoginScopes(scopes []string) []string {
 	}
 
 	resolved := append([]string(nil), baseScopes...)
+	seen := make(map[string]struct{}, len(resolved)+len(scopes))
+	for _, scope := range resolved {
+		seen[scope] = struct{}{}
+	}
 	for _, scope := range scopes {
-		if !hasScope(resolved, scope) {
-			resolved = append(resolved, scope)
+		if _, exists := seen[scope]; exists {
+			continue
 		}
+		seen[scope] = struct{}{}
+		resolved = append(resolved, scope)
 	}
 	return resolved
-}
-
-func hasScope(scopes []string, scope string) bool {
-	for _, existing := range scopes {
-		if existing == scope {
-			return true
-		}
-	}
-	return false
 }
 
 func applyTokenExtraEmailFallback(session *Session, token *oauth2.Token) {

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -67,6 +67,23 @@ func TestResolveLoginScopesDeduplicatesDefaultScopes(t *testing.T) {
 	}
 }
 
+func TestResolveLoginScopesDeduplicatesRepeatedCustomScopesInOrder(t *testing.T) {
+	t.Parallel()
+
+	input := []string{"gateway:access", "openid", "gateway:access", "profile", "audit:read"}
+	got := resolveLoginScopes(input)
+	want := []string{
+		"openid",
+		"email",
+		"profile",
+		"gateway:access",
+		"audit:read",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("resolveLoginScopes(%#v) = %#v, want %#v", input, got, want)
+	}
+}
+
 func TestDecodeJWTClaims(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Summary
This optimizes internal/auth login scope resolution by deduplicating custom scopes in one pass.

Before this, `resolveLoginScopes` in `internal/auth/oidc.go` rescanned the growing `resolved` slice for every custom scope, which made repeated scope lists do extra work.

Now one seen-map is the canonical path:

```go
seen := make(map[string]struct{}, len(resolved)+len(scopes))
for _, scope := range resolved {
    seen[scope] = struct{}{}
}
```

Why
This gives kontext-cli a cheaper runtime path for login scope assembly:

custom scope input
-> `resolveLoginScopes`
-> stable deduplicated OAuth scope list

This PR does not broaden behavior beyond the optimization scope.

What changed
Optimized `resolveLoginScopes`
Removed repeated slice scans during scope deduplication
Preserved scope order and default identity scopes
Updated tests for repeated custom scopes and order

Verification
`go test ./internal/auth`
`go test ./internal/guard/judge -run 'TestStartLlamaServerHealthCheckAndStop|TestStartLlamaServerEarlyExitDoesNotWaitForStopTimeout' -count=1`
`go test ./...`
`go vet ./...`
`git diff --check`
