### PR TITLE
[AUTOMATION] fix(clawpatch): address daily finding

### DIFF
--- a/internal/guard/cli/cli.go
+++ b/internal/guard/cli/cli.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -123,9 +124,6 @@ func runDaemon(ctx context.Context, args []string, out io.Writer) error {
 		if err := verifyClaudeCode(); err != nil {
 			return err
 		}
-		if err := installClaudeHooks(out, *socketPath); err != nil {
-			return err
-		}
 	}
 	ui := startupui.New(out)
 	localJudge, closeJudge, _, err := judgeruntime.Configure(ctx, judgeruntime.Config{
@@ -176,6 +174,16 @@ func runDaemon(ctx context.Context, args []string, out io.Writer) error {
 		return fmt.Errorf("local runtime start: %w", err)
 	}
 	defer runtimeService.Stop()
+	listener, err := net.Listen("tcp", *addr)
+	if err != nil {
+		return err
+	}
+	defer listener.Close()
+	if !*skipHookInstall {
+		if err := installClaudeHooks(out, *socketPath); err != nil {
+			return err
+		}
+	}
 	fmt.Fprintf(out, "Kontext Guard local daemon listening on http://%s\n", *addr)
 	fmt.Fprintf(out, "Hook runtime: unix://%s\n", *socketPath)
 	fmt.Fprintln(out, "Mode: observe (Claude Code runs normally; decisions are recorded as would allow / would deny).")
@@ -184,7 +192,11 @@ func runDaemon(ctx context.Context, args []string, out io.Writer) error {
 	if !*noOpen {
 		_ = browser.OpenURL("http://" + *addr)
 	}
-	return localServer.ListenAndServe(*addr)
+	httpServer := &http.Server{
+		Handler:           localServer.Handler(),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	return httpServer.Serve(listener)
 }
 
 func localJudgeStatusLine(localJudge judge.Judge) string {

--- a/internal/guard/cli/cli_test.go
+++ b/internal/guard/cli/cli_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -238,6 +239,45 @@ func TestPrintHookStatusReportsGuardAndHostedConflict(t *testing.T) {
 	if !strings.Contains(got, "Claude Code hook mode: conflict (hosted and Guard hooks are both installed)") {
 		t.Fatalf("PrintHookStatus() = %q, want conflict mode", got)
 	}
+}
+
+func TestRunDaemonDoesNotInstallHooksWhenListenFails(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", fakeClaudePath(t)+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	busy, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer busy.Close()
+
+	var stdout bytes.Buffer
+	err = runDaemon(context.Background(), []string{
+		"--addr", busy.Addr().String(),
+		"--db", filepath.Join(t.TempDir(), "guard.sqlite"),
+		"--socket", filepath.Join(t.TempDir(), "guard.sock"),
+		"--no-open",
+	}, &stdout)
+	if err == nil {
+		t.Fatal("runDaemon() error = nil, want listen failure")
+	}
+
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	if _, statErr := os.Stat(settingsPath); !os.IsNotExist(statErr) {
+		t.Fatalf("settings.json should not be created on listen failure, stat err = %v", statErr)
+	}
+}
+
+func fakeClaudePath(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "claude")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
 }
 
 func TestValidateLocalJudgeURLRejectsHostedURL(t *testing.T) {


### PR DESCRIPTION
## Where We Are

`kontext guard start` could write Claude hook settings before it proved the daemon could bind its HTTP port. If startup failed on the listen step, Claude kept a Guard hook that pointed at a daemon that never came up.

## Where We Want To Go

Only install Claude hooks after the daemon has passed the fail-fast startup checks that can still abort launch. A listen failure must leave `~/.claude/settings.json` unchanged.

## How do we get there

Bind the HTTP listener before installing Claude hooks, then serve that bound listener instead of calling `ListenAndServe` directly. Add a regression test that occupies the target port, runs `runDaemon`, and asserts Claude settings are not created. Validation: `go test ./...`, `go vet ./...`, `npm exec --yes --package pnpm@10.0.0 -- pnpm install --frozen-lockfile`, `npm exec --yes --package pnpm@10.0.0 -- pnpm --dir web/guard-dashboard typecheck`, and `git diff --check`.
