### PR TITLE
[AUTOMATION] fix: optimize auth login scope deduplication

### DIFF
--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -204,21 +204,18 @@ func resolveLoginScopes(scopes []string) []string {
 	}
 
 	resolved := append([]string(nil), baseScopes...)
+	seen := make(map[string]struct{}, len(baseScopes)+len(scopes))
+	for _, scope := range baseScopes {
+		seen[scope] = struct{}{}
+	}
 	for _, scope := range scopes {
-		if !hasScope(resolved, scope) {
-			resolved = append(resolved, scope)
+		if _, ok := seen[scope]; ok {
+			continue
 		}
+		seen[scope] = struct{}{}
+		resolved = append(resolved, scope)
 	}
 	return resolved
-}
-
-func hasScope(scopes []string, scope string) bool {
-	for _, existing := range scopes {
-		if existing == scope {
-			return true
-		}
-	}
-	return false
 }
 
 func applyTokenExtraEmailFallback(session *Session, token *oauth2.Token) {

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -67,6 +67,23 @@ func TestResolveLoginScopesDeduplicatesDefaultScopes(t *testing.T) {
 	}
 }
 
+func TestResolveLoginScopesDeduplicatesRepeatedCustomScopes(t *testing.T) {
+	t.Parallel()
+
+	input := []string{"gateway:access", "gateway:access", "openid", "org:read", "org:read"}
+	got := resolveLoginScopes(input)
+	want := []string{
+		"openid",
+		"email",
+		"profile",
+		"gateway:access",
+		"org:read",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("resolveLoginScopes(%#v) = %#v, want %#v", input, got, want)
+	}
+}
+
 func TestDecodeJWTClaims(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Summary
This optimizes auth login scope resolution by replacing repeated duplicate scans with one stable dedupe pass.

Before this, `resolveLoginScopes` in `internal/auth/oidc.go` checked every requested scope against the growing result slice, which repeated linear scans as the input list grew.

Now a single `seen` set is the canonical path:

```go
for _, scope := range scopes {
    if _, ok := seen[scope]; ok {
        continue
    }
    seen[scope] = struct{}{}
    resolved = append(resolved, scope)
}
```

Why
This gives kontext-cli a cheaper runtime path for login scope selection:

login scope input
-> `resolveLoginScopes`
-> deduped ordered scope list

This PR does not broaden behavior beyond the optimization scope.

What changed
Optimized auth login scope deduplication
Removed repeated linear scope membership scans
Preserved scope order and default scope behavior
Updated tests for repeated custom scope inputs

Verification
go test ./internal/auth
go test ./internal/auth -run 'TestResolveLoginScopes'
go test ./internal/guard/judge -run TestStartLlamaServerEarlyExitDoesNotWaitForStopTimeout -count=3
go test ./...
go vet ./...
git diff --check
