### PR TITLE
[AUTOMATION] fix: optimize build env assembly

### DIFF
--- a/internal/credential/credential.go
+++ b/internal/credential/credential.go
@@ -115,8 +115,8 @@ func ParseTemplate(path string) ([]Entry, error) {
 
 // BuildEnv converts resolved credentials into environment variable assignments.
 func BuildEnv(resolved []Resolved, base []string) []string {
-	env := make([]string, len(base))
-	copy(env, base)
+	env := make([]string, 0, len(base)+len(resolved))
+	env = append(env, base...)
 	for _, r := range resolved {
 		env = append(env, fmt.Sprintf("%s=%s", r.EnvVar, r.Value))
 	}

--- a/internal/credential/credential_test.go
+++ b/internal/credential/credential_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -85,5 +86,37 @@ func TestNoopProviderReportsUnavailable(t *testing.T) {
 	})
 	if !errors.Is(err, ErrNoopProvider) {
 		t.Fatalf("err = %v, want ErrNoopProvider", err)
+	}
+}
+
+func TestBuildEnvAppendsResolvedValuesWithoutMutatingBase(t *testing.T) {
+	t.Parallel()
+
+	base := []string{"PATH=/usr/bin", "HOME=/tmp/test"}
+	got := BuildEnv([]Resolved{
+		{
+			Entry: Entry{EnvVar: "GITHUB_TOKEN"},
+			Value: "token-1",
+		},
+		{
+			Entry: Entry{EnvVar: "LINEAR_API_KEY"},
+			Value: "token-2",
+		},
+	}, base)
+
+	want := []string{
+		"PATH=/usr/bin",
+		"HOME=/tmp/test",
+		"GITHUB_TOKEN=token-1",
+		"LINEAR_API_KEY=token-2",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("BuildEnv() = %#v, want %#v", got, want)
+	}
+	if !reflect.DeepEqual(base, []string{"PATH=/usr/bin", "HOME=/tmp/test"}) {
+		t.Fatalf("BuildEnv() mutated base = %#v", base)
+	}
+	if len(got) > 0 && len(base) > 0 && &got[0] == &base[0] {
+		t.Fatal("BuildEnv() reused base backing array")
 	}
 }


### PR DESCRIPTION
Summary
This optimizes build env assembly by preallocating the final slice once.

Before this, resolved credential entries were appended onto a copied base slice in internal/credential/credential.go, which left the runtime env path doing extra growth work on every run.

Now one pre-sized slice is the canonical path:

env := make([]string, 0, len(base)+len(resolved))
env = append(env, base...)

Why
This gives kontext-cli a cheaper runtime path for env setup:

run startup
-> credential.BuildEnv
-> final agent env slice

This PR does not broaden behavior beyond the optimization scope.

What changed
Optimized env slice assembly in internal/credential/credential.go
Removed repeated slice growth while appending resolved credentials
Preserved env ordering and base-slice isolation
Updated tests for base-slice mutation and output order

Verification
go test ./internal/credential
go test ./internal/run
go test ./...
go vet ./...
git diff --check
