### PR TITLE
[AUTOMATION] fix(clawpatch): address daily finding

### DIFF
--- a/internal/guard/cli/cli.go
+++ b/internal/guard/cli/cli.go
@@ -440,7 +440,8 @@ func readClaudeSettings() (string, map[string]any, error) {
 }
 
 func backupFile(path, label string) error {
-	if _, err := os.Stat(path); os.IsNotExist(err) {
+	mode, err := fileModeOrDefault(path, 0o600)
+	if os.IsNotExist(err) {
 		return nil
 	} else if err != nil {
 		return err
@@ -450,16 +451,28 @@ func backupFile(path, label string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(backupPath, input, 0o644)
+	return os.WriteFile(backupPath, input, mode)
 }
 
 func writeJSONFile(path string, value any) error {
+	mode, err := fileModeOrDefault(path, 0o600)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
 	bytes, err := json.MarshalIndent(value, "", "  ")
 	if err != nil {
 		return err
 	}
 	bytes = append(bytes, '\n')
-	return os.WriteFile(path, bytes, 0o644)
+	return os.WriteFile(path, bytes, mode)
+}
+
+func fileModeOrDefault(path string, fallback os.FileMode) (os.FileMode, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fallback, err
+	}
+	return info.Mode().Perm(), nil
 }
 
 func mergeHooks(raw any, hookCommand string) map[string]any {

--- a/internal/guard/cli/cli_test.go
+++ b/internal/guard/cli/cli_test.go
@@ -194,6 +194,40 @@ func TestUninstallClaudeHooksPreservesNonGuardHookInMixedGroup(t *testing.T) {
 	if command != "/usr/local/bin/custom-hook" {
 		t.Fatalf("preserved command = %v, want custom hook", command)
 	}
+	assertFileMode(t, settingsPath, 0o600)
+	assertBackupMode(t, settingsPath, 0o600)
+}
+
+func TestInstallClaudeHooksPreservesClaudeSettingsPermissions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	settings := `{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {"type": "command", "command": "/usr/local/bin/custom-hook"}
+        ]
+      }
+    ]
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(settings), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	if err := installClaudeHooks(&stdout, "/tmp/kontext.sock"); err != nil {
+		t.Fatal(err)
+	}
+
+	assertFileMode(t, settingsPath, 0o600)
+	assertBackupMode(t, settingsPath, 0o600)
 }
 
 func TestPrintHookStatusReportsGuardAndHostedConflict(t *testing.T) {
@@ -238,6 +272,31 @@ func TestPrintHookStatusReportsGuardAndHostedConflict(t *testing.T) {
 	if !strings.Contains(got, "Claude Code hook mode: conflict (hosted and Guard hooks are both installed)") {
 		t.Fatalf("PrintHookStatus() = %q, want conflict mode", got)
 	}
+}
+
+func assertFileMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("%s mode = %o, want %o", path, got, want)
+	}
+}
+
+func assertBackupMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+
+	matches, err := filepath.Glob(path + ".kontext-guard-backup-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("backup count = %d, want 1", len(matches))
+	}
+	assertFileMode(t, matches[0], want)
 }
 
 func TestValidateLocalJudgeURLRejectsHostedURL(t *testing.T) {


### PR DESCRIPTION
## Where We Are

Claude hook install and uninstall rewrote `~/.claude/settings.json` and the backup file with `0644`. That makes a private Claude settings file readable by other local users after a guard hook change.

## Where We Want To Go

Keep the existing Claude settings permissions when we rewrite the file. If the file is created fresh, default it to `0600`.

## How do we get there

Read the current file mode before writing `settings.json` or its backup, then reuse that mode instead of hard-coding `0644`. Added regression coverage for both install and uninstall to assert the rewritten settings file and the backup stay `0600`. Verified with `go test ./...`, `go vet ./...`, `npm exec --yes --package pnpm@10.0.0 -- pnpm install --frozen-lockfile`, `npm exec --yes --package pnpm@10.0.0 -- pnpm --dir web/guard-dashboard typecheck`, and `git diff --check`.
