### PR TITLE
[AUTOMATION] fix: optimize login scope resolution

### DIFF
--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -204,21 +204,19 @@ func resolveLoginScopes(scopes []string) []string {
 	}
 
 	resolved := append([]string(nil), baseScopes...)
+	seen := make(map[string]struct{}, len(resolved)+len(scopes))
+	for _, scope := range resolved {
+		seen[scope] = struct{}{}
+	}
+
 	for _, scope := range scopes {
-		if !hasScope(resolved, scope) {
-			resolved = append(resolved, scope)
+		if _, ok := seen[scope]; ok {
+			continue
 		}
+		seen[scope] = struct{}{}
+		resolved = append(resolved, scope)
 	}
 	return resolved
-}
-
-func hasScope(scopes []string, scope string) bool {
-	for _, existing := range scopes {
-		if existing == scope {
-			return true
-		}
-	}
-	return false
 }
 
 func applyTokenExtraEmailFallback(session *Session, token *oauth2.Token) {

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -67,6 +67,23 @@ func TestResolveLoginScopesDeduplicatesDefaultScopes(t *testing.T) {
 	}
 }
 
+func TestResolveLoginScopesDeduplicatesCustomScopesInOrder(t *testing.T) {
+	t.Parallel()
+
+	input := []string{"gateway:access", "gateway:access", "profile:read", "profile:read"}
+	got := resolveLoginScopes(input)
+	want := []string{
+		"openid",
+		"email",
+		"profile",
+		"gateway:access",
+		"profile:read",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("resolveLoginScopes(%#v) = %#v, want %#v", input, got, want)
+	}
+}
+
 func TestDecodeJWTClaims(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Summary
This optimizes login scope resolution by deduplicating requested scopes with one pass and a set.

Before this, `resolveLoginScopes` in `internal/auth/oidc.go` scanned the growing result slice for every requested scope, which repeated work as the input list grew.

Now a scope set is the canonical path:

```go
seen := make(map[string]struct{}, len(resolved)+len(scopes))
for _, scope := range resolved {
    seen[scope] = struct{}{}
}
for _, scope := range scopes {
    if _, ok := seen[scope]; ok {
        continue
    }
    seen[scope] = struct{}{}
    resolved = append(resolved, scope)
}
```

Why
This gives kontext-cli a cheaper runtime path for OIDC login scope assembly:

OIDC login request
-> `internal/auth.resolveLoginScopes`
-> deduplicated scope list for the OAuth request

This PR does not broaden behavior beyond the optimization scope.

What changed
Optimized `internal/auth.resolveLoginScopes`
Removed repeated linear scans of the accumulated scope slice
Preserved base-scope precedence, append order, and duplicate filtering
Updated tests for duplicate custom scope handling

Verification
go test ./internal/auth
go test ./internal/guard/judge -run TestStartLlamaServerEarlyExitDoesNotWaitForStopTimeout -count=1
go test ./...
go vet ./...
git diff --check
