### PR TITLE
fix(managedstream): avoid terminal ingest retry storms

### DIFF
--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -110,19 +110,7 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 	defer stopStream()
 	streamErr := make(chan error, 1)
 	go func() {
-		streamErr <- managedstream.Run(streamCtx, managedstream.Options{
-			DBPath:            dbPath,
-			StatePath:         opts.StreamStatePath,
-			CloudURL:          loadedConfig.Config.CloudURL,
-			OrganizationID:    loadedConfig.Config.OrganizationID,
-			InstallationID:    installationState.InstallationID,
-			InstallToken:      installToken,
-			DeviceLabel:       loadedConfig.Config.Device.Label,
-			DeploymentVersion: managedconfig.DeploymentVersion,
-			Interval:          opts.StreamInterval,
-			HTTPClient:        opts.StreamHTTPClient,
-			Diagnostic:        opts.Diagnostic,
-		})
+		streamErr <- runManagedStream(streamCtx, opts, dbPath, installationState.InstallationID)
 	}()
 
 	// Cowork observation runs alongside Claude Code in the same daemon, replaying
@@ -176,6 +164,56 @@ func cleanupStaleSessions(ctx context.Context, dbPath string, idleTimeout time.D
 	}
 	defer store.Close()
 	return store.CloseStaleDaemonObservedSessions(ctx, time.Now().UTC().Add(-idleTimeout))
+}
+
+func runManagedStream(ctx context.Context, opts DaemonOptions, dbPath, installationID string) error {
+	interval := opts.StreamInterval
+	if interval == 0 {
+		interval = managedstream.DefaultIntervalFromEnv()
+	}
+	flush := func() {
+		if err := managedstream.Flush(ctx, managedStreamOptions(ctx, opts, dbPath, installationID)); err != nil {
+			opts.Diagnostic.Printf("managed stream flush: %v\n", err)
+		}
+	}
+
+	flush()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			flush()
+		}
+	}
+}
+
+func managedStreamOptions(ctx context.Context, opts DaemonOptions, dbPath, installationID string) managedstream.Options {
+	streamOpts := managedstream.Options{
+		DBPath:            dbPath,
+		StatePath:         opts.StreamStatePath,
+		InstallationID:    installationID,
+		DeploymentVersion: managedconfig.DeploymentVersion,
+		HTTPClient:        opts.StreamHTTPClient,
+		Diagnostic:        opts.Diagnostic,
+	}
+	loadedConfig, err := managedconfig.Load()
+	if err != nil {
+		opts.Diagnostic.Printf("managed stream config reload: %v\n", err)
+		return streamOpts
+	}
+	installToken, err := managedconfig.ResolveInstallToken(ctx, loadedConfig.Config.Credentials.InstallTokenRef)
+	if err != nil {
+		opts.Diagnostic.Printf("managed stream token reload: %v\n", err)
+		return streamOpts
+	}
+	streamOpts.CloudURL = loadedConfig.Config.CloudURL
+	streamOpts.OrganizationID = loadedConfig.Config.OrganizationID
+	streamOpts.InstallToken = installToken
+	streamOpts.DeviceLabel = loadedConfig.Config.Device.Label
+	return streamOpts
 }
 
 func cleanupInterval(idleTimeout time.Duration) time.Duration {

--- a/internal/managedobserve/daemon_test.go
+++ b/internal/managedobserve/daemon_test.go
@@ -192,6 +192,101 @@ func TestDaemonStreamsLedgerBatches(t *testing.T) {
 	}
 }
 
+func TestDaemonStreamsWithRefreshedInstallToken(t *testing.T) {
+	type ledgerBatchRequest struct {
+		Actions []struct {
+			SessionID string `json:"session_id"`
+		} `json:"authorization_actions"`
+	}
+
+	requests := make(chan string, 4)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := r.Header.Get("Authorization")
+		requests <- token
+		if token != "Bearer refreshed-install-token" {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"message":"install token is stale"}`))
+			return
+		}
+		var body ledgerBatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("Decode() error = %v", err)
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	dir := t.TempDir()
+	socketDir, err := os.MkdirTemp("/tmp", "kontext-managedobserve-stream-refresh-test-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp() error = %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	socketPath := filepath.Join(socketDir, "kontext.sock")
+	dbPath := filepath.Join(dir, "guard.db")
+	writeTestManagedConfigWithCloudURL(t, filepath.Join(dir, "managed.json"), server.URL)
+	t.Setenv("KONTEXT_INSTALL_TOKEN", "stale-install-token")
+	writeTestInstallation(t, filepath.Join(dir, "installation.json"))
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- RunDaemon(ctx, DaemonOptions{
+			SocketPath:       socketPath,
+			DBPath:           dbPath,
+			IdleTimeout:      time.Hour,
+			StreamStatePath:  filepath.Join(dir, "stream-state.json"),
+			StreamInterval:   20 * time.Millisecond,
+			StreamHTTPClient: server.Client(),
+		})
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Fatalf("RunDaemon() error = %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("RunDaemon did not stop")
+		}
+	})
+	waitForSocket(t, socketPath, errCh)
+
+	client := localruntime.NewClient(socketPath)
+	client.Timeout = time.Second
+	if _, err := client.Process(context.Background(), hook.Event{
+		SessionID: "claude-stream-refresh-session",
+		Agent:     "claude",
+		HookName:  hook.HookPreToolUse,
+		ToolName:  "Read",
+		CWD:       "/tmp/project",
+	}); err != nil {
+		t.Fatalf("Process() error = %v", err)
+	}
+
+	select {
+	case token := <-requests:
+		if token != "Bearer stale-install-token" {
+			t.Fatalf("first token = %q, want stale token", token)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for stale token request")
+	}
+	if err := os.Setenv("KONTEXT_INSTALL_TOKEN", "refreshed-install-token"); err != nil {
+		t.Fatalf("Setenv() error = %v", err)
+	}
+
+	select {
+	case token := <-requests:
+		if token != "Bearer refreshed-install-token" {
+			t.Fatalf("second token = %q, want refreshed token", token)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for refreshed token request")
+	}
+}
+
 func TestCleanupIntervalNeverReturnsZero(t *testing.T) {
 	if got := cleanupInterval(time.Nanosecond); got != time.Nanosecond {
 		t.Fatalf("cleanupInterval(1ns) = %s, want 1ns", got)

--- a/internal/managedstream/stream.go
+++ b/internal/managedstream/stream.go
@@ -191,7 +191,7 @@ func Flush(ctx context.Context, opts Options) error {
 
 		if err := post(ctx, opts, body); err != nil {
 			var hostedErr *hostedIngestError
-			if errors.As(err, &hostedErr) && shouldRetryWithSmallerBatch(hostedErr.StatusCode) {
+			if errors.As(err, &hostedErr) && shouldRetryWithSmallerBatch(hostedErr) {
 				if limit == 1 {
 					return err
 				}
@@ -281,10 +281,28 @@ func reducedBatchLimit(limit int) int {
 	return next
 }
 
-func shouldRetryWithSmallerBatch(statusCode int) bool {
-	return statusCode == http.StatusBadRequest ||
-		statusCode == http.StatusRequestEntityTooLarge ||
-		statusCode == http.StatusUnprocessableEntity
+func shouldRetryWithSmallerBatch(err *hostedIngestError) bool {
+	if err.StatusCode == http.StatusRequestEntityTooLarge {
+		return true
+	}
+	if err.StatusCode != http.StatusBadRequest && err.StatusCode != http.StatusUnprocessableEntity {
+		return false
+	}
+	return isHostedPayloadSizeError(err.Body)
+}
+
+func isHostedPayloadSizeError(body string) bool {
+	body = strings.ToLower(body)
+	if strings.Contains(body, "payload too large") || strings.Contains(body, "request entity too large") {
+		return true
+	}
+	if !strings.Contains(body, "must contain no more than") && !strings.Contains(body, "exceeds max") {
+		return false
+	}
+	return strings.Contains(body, "agent_sessions") ||
+		strings.Contains(body, "authorization_actions") ||
+		strings.Contains(body, "authorization_receipts") ||
+		strings.Contains(body, "body_bytes")
 }
 
 func payloadLimitViolation(payload Payload, bodyBytes int) string {

--- a/internal/managedstream/stream_test.go
+++ b/internal/managedstream/stream_test.go
@@ -240,6 +240,81 @@ func TestFlushRetriesWithSmallerBatchWhenHostedBackendRejectsSize(t *testing.T) 
 	}
 }
 
+func TestFlushDoesNotRetrySmallerBatchForTerminalHostedValidation(t *testing.T) {
+	store, dbPath := testStore(t)
+	for i := 0; i < 4; i++ {
+		saveTestDecision(t, store, fmt.Sprintf("session-%03d", i), fmt.Sprintf("toolu_%03d", i))
+	}
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"message":"organization_id does not match installation"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	statePath := filepath.Join(t.TempDir(), "stream-state.json")
+	err := Flush(context.Background(), Options{
+		DBPath:         dbPath,
+		StatePath:      statePath,
+		CloudURL:       server.URL,
+		OrganizationID: "org_wrong",
+		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
+		InstallToken:   "test-install-token",
+		BatchLimit:     4,
+		HTTPClient:     server.Client(),
+	})
+	if err == nil {
+		t.Fatal("Flush() error = nil, want hosted validation failure")
+	}
+	if requests != 1 {
+		t.Fatalf("request count = %d, want 1 terminal attempt", requests)
+	}
+	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+		t.Fatalf("state file error = %v, want not exist", err)
+	}
+}
+
+func TestFlushRetriesWithSmallerBatchForSizeLikeHostedValidation(t *testing.T) {
+	store, dbPath := testStore(t)
+	for i := 0; i < 4; i++ {
+		saveTestDecision(t, store, fmt.Sprintf("session-%03d", i), fmt.Sprintf("toolu_%03d", i))
+	}
+
+	var actionCounts []int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var got Payload
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("Decode() error = %v", err)
+		}
+		actionCounts = append(actionCounts, len(got.Actions))
+		if len(actionCounts) == 1 {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = w.Write([]byte(`{"message":"authorization_actions must contain no more than 1000 records"}`))
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(server.Close)
+
+	if err := Flush(context.Background(), Options{
+		DBPath:         dbPath,
+		StatePath:      filepath.Join(t.TempDir(), "stream-state.json"),
+		CloudURL:       server.URL,
+		OrganizationID: "org_123",
+		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
+		InstallToken:   "test-install-token",
+		BatchLimit:     4,
+		HTTPClient:     server.Client(),
+	}); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if len(actionCounts) != 2 || actionCounts[0] <= actionCounts[1] {
+		t.Fatalf("action counts = %v, want one smaller retry", actionCounts)
+	}
+}
+
 func TestFlushReportsHostedValidationBody(t *testing.T) {
 	store, dbPath := testStore(t)
 	saveTestDecision(t, store, "session-1", "toolu_1")


### PR DESCRIPTION
## Where We Are

PR #294 tried to stop terminal hosted ingest failures with persisted cooldown state. Greptile found that unchanged terminal failures could still replay after cooldown expiry, some config changes did not clear the pause, and the daemon kept a fixed credential/config snapshot.

## Where We Want To Go

Terminal hosted 400/422 validation failures should stop the smaller-batch retry path without advancing the cursor. Real payload-size responses should still retry with a smaller batch. A running daemon should use refreshed managed config and install tokens on the next stream flush.

## How do we get there

Classify hosted 400/422 responses by body before shrinking batches. Generic validation failures now return after one hosted attempt and leave stream state untouched. The daemon now rebuilds managed stream upload options for each flush, so refreshed config and install tokens are used without restarting.

Verified with:

- go test ./internal/managedstream ./internal/managedobserve
- go test ./...
- go vet ./...
- go test -race ./internal/managedstream ./internal/managedobserve
