### PR TITLE
fix(managedobserve): refresh rotated install tokens

### DIFF
--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -33,20 +33,13 @@ type DaemonOptions struct {
 }
 
 func RunDaemon(ctx context.Context, opts DaemonOptions) error {
-	loadedConfig, err := managedconfig.Load()
+	runtimeConfig, err := loadManagedRuntimeConfig(ctx)
 	if err != nil {
-		if errors.Is(err, managedconfig.ErrNotManaged) {
-			return err
-		}
-		return fmt.Errorf("load managed config: %w", err)
+		return err
 	}
 	installationState, err := installation.Ensure()
 	if err != nil {
 		return fmt.Errorf("ensure installation identity: %w", err)
-	}
-	installToken, err := managedconfig.ResolveInstallToken(ctx, loadedConfig.Config.Credentials.InstallTokenRef)
-	if err != nil {
-		return fmt.Errorf("resolve install token: %w", err)
 	}
 
 	socketPath := opts.SocketPath
@@ -66,7 +59,7 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 
 	// The deployment-level mode from managed.json drives every hook edge:
 	// observe records would-decisions, enforce returns real denies.
-	mode, err := guardhookruntime.ParseMode(loadedConfig.Config.Mode)
+	mode, err := guardhookruntime.ParseMode(runtimeConfig.Mode)
 	if err != nil {
 		return fmt.Errorf("parse managed mode: %w", err)
 	}
@@ -97,38 +90,19 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 
 	policyCtx, stopPolicyRefresh := context.WithCancel(ctx)
 	defer stopPolicyRefresh()
-	go githubpolicy.Run(policyCtx, githubpolicy.RunOptions{
-		Cache:        policyCache,
-		CloudURL:     loadedConfig.Config.CloudURL,
-		InstallToken: installToken,
-		Interval:     opts.GithubPolicyInterval,
-		HTTPClient:   opts.GithubPolicyClient,
-		Diagnostic:   opts.Diagnostic,
-	})
+	go runGithubPolicyRefresh(policyCtx, opts, policyCache)
 
 	streamCtx, stopStream := context.WithCancel(ctx)
 	defer stopStream()
 	streamErr := make(chan error, 1)
 	go func() {
-		streamErr <- managedstream.Run(streamCtx, managedstream.Options{
-			DBPath:            dbPath,
-			StatePath:         opts.StreamStatePath,
-			CloudURL:          loadedConfig.Config.CloudURL,
-			OrganizationID:    loadedConfig.Config.OrganizationID,
-			InstallationID:    installationState.InstallationID,
-			InstallToken:      installToken,
-			DeviceLabel:       loadedConfig.Config.Device.Label,
-			DeploymentVersion: managedconfig.DeploymentVersion,
-			Interval:          opts.StreamInterval,
-			HTTPClient:        opts.StreamHTTPClient,
-			Diagnostic:        opts.Diagnostic,
-		})
+		streamErr <- runManagedStream(streamCtx, opts, dbPath, installationState.InstallationID)
 	}()
 
 	// Cowork observation runs alongside Claude Code in the same daemon, replaying
 	// in-VM Cowork tool events into the same localruntime socket as agent "cowork".
 	// Enabled via managed.json (cowork_enabled) or the env var override.
-	if loadedConfig.Config.CoworkEnabled || coworkobserve.Enabled() {
+	if runtimeConfig.CoworkEnabled || coworkobserve.Enabled() {
 		go coworkobserve.Run(ctx, coworkobserve.Options{
 			SocketPath: socketPath,
 			StatePath:  filepath.Join(filepath.Dir(dbPath), "cowork-spool-offsets.json"),
@@ -162,6 +136,37 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 	}
 }
 
+type managedRuntimeConfig struct {
+	CloudURL       string
+	OrganizationID string
+	InstallToken   string
+	DeviceLabel    string
+	Mode           string
+	CoworkEnabled  bool
+}
+
+func loadManagedRuntimeConfig(ctx context.Context) (managedRuntimeConfig, error) {
+	loadedConfig, err := managedconfig.Load()
+	if err != nil {
+		if errors.Is(err, managedconfig.ErrNotManaged) {
+			return managedRuntimeConfig{}, err
+		}
+		return managedRuntimeConfig{}, fmt.Errorf("load managed config: %w", err)
+	}
+	installToken, err := managedconfig.ResolveInstallToken(ctx, loadedConfig.Config.Credentials.InstallTokenRef)
+	if err != nil {
+		return managedRuntimeConfig{}, fmt.Errorf("resolve install token: %w", err)
+	}
+	return managedRuntimeConfig{
+		CloudURL:       loadedConfig.Config.CloudURL,
+		OrganizationID: loadedConfig.Config.OrganizationID,
+		InstallToken:   installToken,
+		DeviceLabel:    loadedConfig.Config.Device.Label,
+		Mode:           loadedConfig.Config.Mode,
+		CoworkEnabled:  loadedConfig.Config.CoworkEnabled,
+	}, nil
+}
+
 func idleTimeoutOrDefault(idleTimeout time.Duration) time.Duration {
 	if idleTimeout == 0 {
 		return DefaultIdleTimeout()
@@ -176,6 +181,90 @@ func cleanupStaleSessions(ctx context.Context, dbPath string, idleTimeout time.D
 	}
 	defer store.Close()
 	return store.CloseStaleDaemonObservedSessions(ctx, time.Now().UTC().Add(-idleTimeout))
+}
+
+func runGithubPolicyRefresh(ctx context.Context, opts DaemonOptions, cache *githubpolicy.Cache) {
+	interval := opts.GithubPolicyInterval
+	if interval == 0 {
+		interval = githubpolicy.DefaultIntervalFromEnv()
+	}
+	refreshGithubPolicy(ctx, opts, cache)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			refreshGithubPolicy(ctx, opts, cache)
+		}
+	}
+}
+
+func refreshGithubPolicy(ctx context.Context, opts DaemonOptions, cache *githubpolicy.Cache) {
+	runtimeConfig, err := loadManagedRuntimeConfig(ctx)
+	if err != nil {
+		cache.MarkFetchFailed(err)
+		opts.Diagnostic.Printf("github policy config reload: %v\n", err)
+		return
+	}
+	snapshot, err := githubpolicy.FetchSnapshot(ctx, opts.GithubPolicyClient, runtimeConfig.CloudURL, runtimeConfig.InstallToken)
+	if err != nil {
+		cache.MarkFetchFailed(err)
+		opts.Diagnostic.Printf("github policy refresh: %v\n", err)
+		return
+	}
+	if err := cache.Apply(snapshot, time.Now().UTC()); err != nil {
+		opts.Diagnostic.Printf("github policy persist: %v\n", err)
+	}
+}
+
+func runManagedStream(ctx context.Context, opts DaemonOptions, dbPath, installationID string) error {
+	interval := opts.StreamInterval
+	if interval == 0 {
+		interval = managedstream.DefaultIntervalFromEnv()
+	}
+	flushManagedStream(ctx, opts, dbPath, installationID)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			flushManagedStream(ctx, opts, dbPath, installationID)
+		}
+	}
+}
+
+func flushManagedStream(ctx context.Context, opts DaemonOptions, dbPath, installationID string) {
+	streamOpts, err := managedStreamOptions(ctx, opts, dbPath, installationID)
+	if err != nil {
+		opts.Diagnostic.Printf("managed stream config reload: %v\n", err)
+		return
+	}
+	if err := managedstream.Flush(ctx, streamOpts); err != nil {
+		opts.Diagnostic.Printf("managed stream flush: %v\n", err)
+	}
+}
+
+func managedStreamOptions(ctx context.Context, opts DaemonOptions, dbPath, installationID string) (managedstream.Options, error) {
+	runtimeConfig, err := loadManagedRuntimeConfig(ctx)
+	if err != nil {
+		return managedstream.Options{}, err
+	}
+	return managedstream.Options{
+		DBPath:            dbPath,
+		StatePath:         opts.StreamStatePath,
+		CloudURL:          runtimeConfig.CloudURL,
+		OrganizationID:    runtimeConfig.OrganizationID,
+		InstallationID:    installationID,
+		InstallToken:      runtimeConfig.InstallToken,
+		DeviceLabel:       runtimeConfig.DeviceLabel,
+		DeploymentVersion: managedconfig.DeploymentVersion,
+		HTTPClient:        opts.StreamHTTPClient,
+		Diagnostic:        opts.Diagnostic,
+	}, nil
 }
 
 func cleanupInterval(idleTimeout time.Duration) time.Duration {

--- a/internal/managedobserve/daemon_test.go
+++ b/internal/managedobserve/daemon_test.go
@@ -192,6 +192,97 @@ func TestDaemonStreamsLedgerBatches(t *testing.T) {
 	}
 }
 
+func TestDaemonRefreshesGithubPolicyInstallToken(t *testing.T) {
+	policyTokens := make(chan string, 8)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/policy/github/snapshot":
+			token := r.Header.Get("Authorization")
+			select {
+			case policyTokens <- token:
+			default:
+			}
+			if token != "Bearer refreshed-install-token" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"schemaVersion":  "github-policy-snapshot-v1",
+				"organizationId": "org_123",
+				"providerKey":    "github",
+				"mode":           "observe",
+				"epoch":          1,
+				"hash":           "hash-1",
+				"rules":          []any{},
+				"generatedAt":    "2026-06-15T00:00:00.000Z",
+			})
+		case "/api/v1/authorization-ledger/batches":
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	dir := t.TempDir()
+	socketDir, err := os.MkdirTemp("/tmp", "kontext-managedobserve-policy-refresh-test-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp() error = %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	socketPath := filepath.Join(socketDir, "kontext.sock")
+	dbPath := filepath.Join(dir, "guard.db")
+	writeTestManagedConfigWithCloudURL(t, filepath.Join(dir, "managed.json"), server.URL)
+	t.Setenv("KONTEXT_INSTALL_TOKEN", "stale-install-token")
+	writeTestInstallation(t, filepath.Join(dir, "installation.json"))
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- RunDaemon(ctx, DaemonOptions{
+			SocketPath:           socketPath,
+			DBPath:               dbPath,
+			IdleTimeout:          time.Hour,
+			StreamInterval:       time.Hour,
+			StreamHTTPClient:     server.Client(),
+			GithubPolicyInterval: 20 * time.Millisecond,
+			GithubPolicyClient:   server.Client(),
+		})
+	}()
+	stopped := false
+	stop := func() {
+		if stopped {
+			return
+		}
+		stopped = true
+		cancel()
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Fatalf("RunDaemon() error = %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("RunDaemon did not stop")
+		}
+	}
+	t.Cleanup(stop)
+	waitForSocket(t, socketPath, errCh)
+	t.Setenv("KONTEXT_INSTALL_TOKEN", "refreshed-install-token")
+
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case token := <-policyTokens:
+			if token == "Bearer refreshed-install-token" {
+				stop()
+				return
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for refreshed policy token")
+		}
+	}
+}
+
 func TestCleanupIntervalNeverReturnsZero(t *testing.T) {
 	if got := cleanupInterval(time.Nanosecond); got != time.Nanosecond {
 		t.Fatalf("cleanupInterval(1ns) = %s, want 1ns", got)

--- a/internal/managedstream/stream.go
+++ b/internal/managedstream/stream.go
@@ -193,7 +193,7 @@ func Flush(ctx context.Context, opts Options) error {
 			var hostedErr *hostedIngestError
 			if errors.As(err, &hostedErr) && shouldRetryWithSmallerBatch(hostedErr.StatusCode) {
 				if limit == 1 {
-					return err
+					return advancePastMinimumBatch(statePath, batch, fmt.Sprintf("hosted status %d", hostedErr.StatusCode), err)
 				}
 				nextLimit := reducedBatchLimit(limit)
 				opts.Diagnostic.Printf(
@@ -282,9 +282,7 @@ func reducedBatchLimit(limit int) int {
 }
 
 func shouldRetryWithSmallerBatch(statusCode int) bool {
-	return statusCode == http.StatusBadRequest ||
-		statusCode == http.StatusRequestEntityTooLarge ||
-		statusCode == http.StatusUnprocessableEntity
+	return statusCode == http.StatusRequestEntityTooLarge
 }
 
 func payloadLimitViolation(payload Payload, bodyBytes int) string {

--- a/internal/managedstream/stream_test.go
+++ b/internal/managedstream/stream_test.go
@@ -240,6 +240,42 @@ func TestFlushRetriesWithSmallerBatchWhenHostedBackendRejectsSize(t *testing.T) 
 	}
 }
 
+func TestFlushDoesNotRetrySmallerBatchForHostedValidation(t *testing.T) {
+	store, dbPath := testStore(t)
+	for i := 0; i < 4; i++ {
+		saveTestDecision(t, store, fmt.Sprintf("session-%03d", i), fmt.Sprintf("toolu_%03d", i))
+	}
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"message":"organization_id does not match installation"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	statePath := filepath.Join(t.TempDir(), "stream-state.json")
+	err := Flush(context.Background(), Options{
+		DBPath:         dbPath,
+		StatePath:      statePath,
+		CloudURL:       server.URL,
+		OrganizationID: "org_wrong",
+		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
+		InstallToken:   "test-install-token",
+		BatchLimit:     4,
+		HTTPClient:     server.Client(),
+	})
+	if err == nil {
+		t.Fatal("Flush() error = nil, want hosted validation failure")
+	}
+	if requests != 1 {
+		t.Fatalf("request count = %d, want 1 terminal attempt", requests)
+	}
+	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+		t.Fatalf("state file error = %v, want not exist", err)
+	}
+}
+
 func TestFlushReportsHostedValidationBody(t *testing.T) {
 	store, dbPath := testStore(t)
 	saveTestDecision(t, store, "session-1", "toolu_1")
@@ -336,6 +372,42 @@ func TestFlushDoesNotAdvanceCursorPastHostedRejectedMinimumBatch(t *testing.T) {
 	}
 	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
 		t.Fatalf("state file error = %v, want not exist", err)
+	}
+}
+
+func TestFlushAdvancesCursorPastHostedTooLargeMinimumBatch(t *testing.T) {
+	store, dbPath := testStore(t)
+	saveTestDecision(t, store, "session-1", "toolu_1")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusRequestEntityTooLarge)
+		_, _ = w.Write([]byte(`{"message":"payload too large"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	statePath := filepath.Join(t.TempDir(), "stream-state.json")
+	err := Flush(context.Background(), Options{
+		DBPath:         dbPath,
+		StatePath:      statePath,
+		CloudURL:       server.URL,
+		OrganizationID: "org_123",
+		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
+		InstallToken:   "test-install-token",
+		BatchLimit:     1,
+		HTTPClient:     server.Client(),
+	})
+	if err == nil {
+		t.Fatal("Flush() error = nil, want hosted size failure diagnostic")
+	}
+	if !strings.Contains(err.Error(), "advanced cursor past rejected minimum batch") {
+		t.Fatalf("Flush() error = %q, want hosted size skip diagnostic", err.Error())
+	}
+	state, err := LoadState(statePath)
+	if err != nil {
+		t.Fatalf("LoadState() error = %v", err)
+	}
+	if state.UpdatedAfter == "" || state.ActionID == "" {
+		t.Fatalf("state = %+v, want cursor advanced", state)
 	}
 }
 


### PR DESCRIPTION
## Where We Are

PR #295 was closed because it fixed ledger token rotation but left GitHub policy refresh on the startup install token. It also kept shrinking batches for generic hosted 400/422 validation errors, which can retry the same invalid payload shape instead of stopping.

## Where We Want To Go

A running managed daemon should use a rotated install token for both policy refresh and ledger streaming. Hosted validation errors should fail once without advancing the cursor. Real 413 payload-size responses should still shrink batches, and a single rejected record should not be resent forever.

## How do we get there

Reload managed config and the install token before each policy refresh and stream flush. Limit hosted shrink retries to 413, and advance past a one-record 413 after recording the diagnostic error.

Verified with:

- go test ./internal/managedobserve ./internal/managedstream
- go test ./...
- go vet ./...
- go test -race ./internal/managedobserve ./internal/managedstream

