### PR TITLE
[AUTOMATION] feat: clean up guard decision types

### DIFF
--- a/internal/guard/app/server/runtime.go
+++ b/internal/guard/app/server/runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/kontext-security/kontext-cli/internal/guard/decision"
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
 	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
 	"github.com/kontext-security/kontext-cli/internal/hook"
@@ -137,7 +138,7 @@ func riskDecisionFromHookResult(result hook.Result) risk.RiskDecision {
 		return decision
 	}
 	return risk.RiskDecision{
-		Decision:   risk.Decision(result.Decision),
+		Decision:   decision.Decision(result.Decision),
 		Reason:     result.Reason,
 		ReasonCode: result.ReasonCode,
 		EventID:    result.EventID,

--- a/internal/guard/app/server/server.go
+++ b/internal/guard/app/server/server.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/kontext-security/kontext-cli/internal/githubpolicy"
+	"github.com/kontext-security/kontext-cli/internal/guard/decision"
 	"github.com/kontext-security/kontext-cli/internal/guard/judge"
 	"github.com/kontext-security/kontext-cli/internal/guard/policy"
 	"github.com/kontext-security/kontext-cli/internal/guard/policyconfig"
@@ -40,10 +41,10 @@ type Server struct {
 }
 
 type ProcessResponse struct {
-	Decision   risk.Decision `json:"decision"`
-	Reason     string        `json:"reason"`
-	ReasonCode string        `json:"reason_code"`
-	EventID    string        `json:"event_id"`
+	Decision   decision.Decision `json:"decision"`
+	Reason     string            `json:"reason"`
+	ReasonCode string            `json:"reason_code"`
+	EventID    string            `json:"event_id"`
 }
 
 type Options struct {

--- a/internal/guard/judge/fixtures.go
+++ b/internal/guard/judge/fixtures.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"strings"
+
+	"github.com/kontext-security/kontext-cli/internal/guard/decision"
 )
 
 type Fixture struct {
@@ -26,11 +28,11 @@ type FixtureHookEvent struct {
 }
 
 type FixtureExpected struct {
-	ShouldCallJudge bool      `json:"should_call_judge"`
-	Decision        Decision  `json:"decision"`
-	RiskLevel       RiskLevel `json:"risk_level"`
-	Categories      []string  `json:"categories"`
-	ReasonContains  []string  `json:"reason_contains"`
+	ShouldCallJudge bool              `json:"should_call_judge"`
+	Decision        decision.Decision `json:"decision"`
+	RiskLevel       RiskLevel         `json:"risk_level"`
+	Categories      []string          `json:"categories"`
+	ReasonContains  []string          `json:"reason_contains"`
 }
 
 type FixtureNormalizedEvent struct {

--- a/internal/guard/judge/types.go
+++ b/internal/guard/judge/types.go
@@ -14,8 +14,6 @@ const (
 	DecisionDeny  = decision.Deny
 )
 
-type Decision = decision.Decision
-
 type RiskLevel string
 
 const (
@@ -37,10 +35,10 @@ type ToolInput struct {
 }
 
 type Output struct {
-	Decision   Decision  `json:"decision"`
-	RiskLevel  RiskLevel `json:"risk_level"`
-	Categories []string  `json:"categories"`
-	Reason     string    `json:"reason"`
+	Decision   decision.Decision `json:"decision"`
+	RiskLevel  RiskLevel         `json:"risk_level"`
+	Categories []string          `json:"categories"`
+	Reason     string            `json:"reason"`
 }
 
 type Metadata struct {

--- a/internal/guard/policy/engine_test.go
+++ b/internal/guard/policy/engine_test.go
@@ -3,6 +3,7 @@ package policy
 import (
 	"testing"
 
+	"github.com/kontext-security/kontext-cli/internal/guard/decision"
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
 )
 
@@ -11,7 +12,7 @@ func TestEngineEvaluateProfileBehavior(t *testing.T) {
 		name     string
 		event    risk.RiskEvent
 		profile  Profile
-		decision Decision
+		decision decision.Decision
 		category RuleCategory
 		reason   string
 	}{

--- a/internal/guard/policy/types.go
+++ b/internal/guard/policy/types.go
@@ -14,8 +14,6 @@ const (
 	DecisionDeny  = decision.Deny
 )
 
-type Decision = decision.Decision
-
 type Stage string
 
 const (
@@ -96,19 +94,19 @@ func (c Config) Validate() error {
 }
 
 type Result struct {
-	Decision       Decision     `json:"decision"`
-	Stage          Stage        `json:"stage"`
-	Matched        bool         `json:"matched"`
-	RuleID         string       `json:"rule_id,omitempty"`
-	Category       RuleCategory `json:"category,omitempty"`
-	Profile        Profile      `json:"profile"`
-	PolicyVersion  string       `json:"policy_version"`
-	PolicyHash     string       `json:"policy_hash"`
-	RulePack       string       `json:"rule_pack"`
-	ReasonCode     string       `json:"reason_code"`
-	Reason         string       `json:"reason"`
-	NonBypassable  bool         `json:"non_bypassable"`
-	MatchedSignals []string     `json:"matched_signals,omitempty"`
+	Decision       decision.Decision `json:"decision"`
+	Stage          Stage             `json:"stage"`
+	Matched        bool              `json:"matched"`
+	RuleID         string            `json:"rule_id,omitempty"`
+	Category       RuleCategory      `json:"category,omitempty"`
+	Profile        Profile           `json:"profile"`
+	PolicyVersion  string            `json:"policy_version"`
+	PolicyHash     string            `json:"policy_hash"`
+	RulePack       string            `json:"rule_pack"`
+	ReasonCode     string            `json:"reason_code"`
+	Reason         string            `json:"reason"`
+	NonBypassable  bool              `json:"non_bypassable"`
+	MatchedSignals []string          `json:"matched_signals,omitempty"`
 }
 
 func PolicyHash(cfg Config, rulePack string) string {

--- a/internal/guard/risk/types.go
+++ b/internal/guard/risk/types.go
@@ -36,8 +36,6 @@ const (
 	DecisionDeny  = decision.Deny
 )
 
-type Decision = decision.Decision
-
 type AuthorizationDecision string
 
 const (
@@ -56,53 +54,53 @@ const (
 )
 
 type RiskEvent struct {
-	Type               EventType `json:"type"`
-	Provider           string    `json:"provider,omitempty"`
-	ProviderCategory   string    `json:"provider_category,omitempty"`
-	Operation          string    `json:"operation,omitempty"`
-	OperationClass     string    `json:"operation_class,omitempty"`
-	ResourceClass      string    `json:"resource_class,omitempty"`
-	Environment        string    `json:"environment,omitempty"`
-	CredentialObserved bool      `json:"credential_observed"`
-	CredentialSource   string    `json:"credential_source,omitempty"`
-	DirectAPICall      bool      `json:"direct_api_call"`
-	ExplicitUserIntent bool      `json:"explicit_user_intent"`
-	PathClass          string    `json:"path_class,omitempty"`
-	CommandSummary     string    `json:"command_summary,omitempty"`
-	RequestSummary     string    `json:"request_summary,omitempty"`
-	Decision           Decision  `json:"decision,omitempty"`
-	ReasonCode         string    `json:"reason_code,omitempty"`
-	ModelVersion       string    `json:"model_version,omitempty"`
-	GuardID            string    `json:"guard_id,omitempty"`
-	RiskScore          *float64  `json:"risk_score,omitempty"`
-	Confidence         float64   `json:"confidence,omitempty"`
-	Signals            []string  `json:"signals,omitempty"`
-	DecisionStage      string    `json:"decision_stage,omitempty"`
-	PolicyVersion      string    `json:"policy_version,omitempty"`
-	PolicyHash         string    `json:"policy_hash,omitempty"`
-	PolicyProfile      string    `json:"policy_profile,omitempty"`
-	PolicyRulePack     string    `json:"policy_rule_pack,omitempty"`
-	PolicyRuleID       string    `json:"policy_rule_id,omitempty"`
-	PolicyRuleCategory string    `json:"policy_rule_category,omitempty"`
-	PolicySignals      []string  `json:"policy_signals,omitempty"`
-	JudgeRuntime       string    `json:"judge_runtime,omitempty"`
-	JudgeModel         string    `json:"judge_model,omitempty"`
-	JudgeDurationMs    *int64    `json:"judge_duration_ms,omitempty"`
-	JudgeFailureKind   string    `json:"judge_failure_kind,omitempty"`
-	JudgeRiskLevel     string    `json:"judge_risk_level,omitempty"`
-	JudgeCategories    []string  `json:"judge_categories,omitempty"`
+	Type               EventType         `json:"type"`
+	Provider           string            `json:"provider,omitempty"`
+	ProviderCategory   string            `json:"provider_category,omitempty"`
+	Operation          string            `json:"operation,omitempty"`
+	OperationClass     string            `json:"operation_class,omitempty"`
+	ResourceClass      string            `json:"resource_class,omitempty"`
+	Environment        string            `json:"environment,omitempty"`
+	CredentialObserved bool              `json:"credential_observed"`
+	CredentialSource   string            `json:"credential_source,omitempty"`
+	DirectAPICall      bool              `json:"direct_api_call"`
+	ExplicitUserIntent bool              `json:"explicit_user_intent"`
+	PathClass          string            `json:"path_class,omitempty"`
+	CommandSummary     string            `json:"command_summary,omitempty"`
+	RequestSummary     string            `json:"request_summary,omitempty"`
+	Decision           decision.Decision `json:"decision,omitempty"`
+	ReasonCode         string            `json:"reason_code,omitempty"`
+	ModelVersion       string            `json:"model_version,omitempty"`
+	GuardID            string            `json:"guard_id,omitempty"`
+	RiskScore          *float64          `json:"risk_score,omitempty"`
+	Confidence         float64           `json:"confidence,omitempty"`
+	Signals            []string          `json:"signals,omitempty"`
+	DecisionStage      string            `json:"decision_stage,omitempty"`
+	PolicyVersion      string            `json:"policy_version,omitempty"`
+	PolicyHash         string            `json:"policy_hash,omitempty"`
+	PolicyProfile      string            `json:"policy_profile,omitempty"`
+	PolicyRulePack     string            `json:"policy_rule_pack,omitempty"`
+	PolicyRuleID       string            `json:"policy_rule_id,omitempty"`
+	PolicyRuleCategory string            `json:"policy_rule_category,omitempty"`
+	PolicySignals      []string          `json:"policy_signals,omitempty"`
+	JudgeRuntime       string            `json:"judge_runtime,omitempty"`
+	JudgeModel         string            `json:"judge_model,omitempty"`
+	JudgeDurationMs    *int64            `json:"judge_duration_ms,omitempty"`
+	JudgeFailureKind   string            `json:"judge_failure_kind,omitempty"`
+	JudgeRiskLevel     string            `json:"judge_risk_level,omitempty"`
+	JudgeCategories    []string          `json:"judge_categories,omitempty"`
 }
 
 type RiskDecision struct {
-	Decision     Decision  `json:"decision"`
-	Reason       string    `json:"reason"`
-	ReasonCode   string    `json:"reason_code"`
-	EventID      string    `json:"event_id,omitempty"`
-	RiskScore    *float64  `json:"risk_score,omitempty"`
-	Threshold    *float64  `json:"threshold,omitempty"`
-	ModelVersion string    `json:"model_version,omitempty"`
-	GuardID      string    `json:"guard_id,omitempty"`
-	RiskEvent    RiskEvent `json:"risk_event"`
+	Decision     decision.Decision `json:"decision"`
+	Reason       string            `json:"reason"`
+	ReasonCode   string            `json:"reason_code"`
+	EventID      string            `json:"event_id,omitempty"`
+	RiskScore    *float64          `json:"risk_score,omitempty"`
+	Threshold    *float64          `json:"threshold,omitempty"`
+	ModelVersion string            `json:"model_version,omitempty"`
+	GuardID      string            `json:"guard_id,omitempty"`
+	RiskEvent    RiskEvent         `json:"risk_event"`
 	// GithubPolicy carries the synced-policy dry-run evaluations for this
 	// event; each one is recorded as a separate request.decided ledger row.
 	GithubPolicy []githubpolicy.Evaluation `json:"github_policy,omitempty"`

--- a/internal/guard/store/sqlite/store.go
+++ b/internal/guard/store/sqlite/store.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	_ "modernc.org/sqlite"
 
+	"github.com/kontext-security/kontext-cli/internal/guard/decision"
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
 )
 
@@ -25,19 +26,19 @@ type Store struct {
 }
 
 type DecisionRecord struct {
-	ID            string         `json:"id"`
-	SessionID     string         `json:"session_id"`
-	ToolUseID     string         `json:"tool_use_id,omitempty"`
-	HookEventName string         `json:"hook_event_name"`
-	ToolName      string         `json:"tool_name,omitempty"`
-	Decision      risk.Decision  `json:"decision"`
-	ReasonCode    string         `json:"reason_code"`
-	Reason        string         `json:"reason"`
-	RiskScore     *float64       `json:"risk_score,omitempty"`
-	Threshold     *float64       `json:"threshold,omitempty"`
-	ModelVersion  string         `json:"model_version,omitempty"`
-	RiskEvent     risk.RiskEvent `json:"risk_event"`
-	CreatedAt     time.Time      `json:"created_at"`
+	ID            string            `json:"id"`
+	SessionID     string            `json:"session_id"`
+	ToolUseID     string            `json:"tool_use_id,omitempty"`
+	HookEventName string            `json:"hook_event_name"`
+	ToolName      string            `json:"tool_name,omitempty"`
+	Decision      decision.Decision `json:"decision"`
+	ReasonCode    string            `json:"reason_code"`
+	Reason        string            `json:"reason"`
+	RiskScore     *float64          `json:"risk_score,omitempty"`
+	Threshold     *float64          `json:"threshold,omitempty"`
+	ModelVersion  string            `json:"model_version,omitempty"`
+	RiskEvent     risk.RiskEvent    `json:"risk_event"`
+	CreatedAt     time.Time         `json:"created_at"`
 }
 
 type Summary struct {
@@ -1178,7 +1179,7 @@ func canonicalEventType(hookEventName string) string {
 	}
 }
 
-func canonicalDecisionResult(decision risk.Decision) string {
+func canonicalDecisionResult(decision decision.Decision) string {
 	switch strings.ToLower(strings.TrimSpace(string(decision))) {
 	case "allow":
 		return "allow"
@@ -1210,7 +1211,7 @@ func actionStatus(canonicalEvent, decisionResult string) string {
 	}
 }
 
-func adapterDecision(decision risk.Decision) string {
+func adapterDecision(decision decision.Decision) string {
 	normalized := strings.ToLower(strings.TrimSpace(string(decision)))
 	switch normalized {
 	case "allow", "deny":

--- a/internal/guard/store/sqlite/store_test.go
+++ b/internal/guard/store/sqlite/store_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kontext-security/kontext-cli/internal/guard/decision"
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
 )
 
@@ -716,7 +717,7 @@ func TestUnsupportedCanonicalDecisionFailsClosedInLedger(t *testing.T) {
 		HookEventName: "PreToolUse",
 		ToolName:      "Bash",
 	}, risk.RiskDecision{
-		Decision:   risk.Decision("step_up"),
+		Decision:   decision.Decision("step_up"),
 		Reason:     "approval required",
 		ReasonCode: "approval_required",
 		RiskEvent:  risk.RiskEvent{Type: risk.EventNormalToolCall},
@@ -742,7 +743,7 @@ where id = ?
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(events) != 1 || events[0].Decision != risk.Decision("deny") {
+	if len(events) != 1 || events[0].Decision != decision.Decision("deny") {
 		t.Fatalf("events = %+v, want step-up fail-closed as deny", events)
 	}
 


### PR DESCRIPTION
Summary
This cleans up guard decision types by using internal/guard/decision.Decision as the one shared decision type.

Before this, judge, risk, and policy each re-declared the same Decision type alias in separate packages, which made the same domain type look package-owned and easier to let drift.

Now internal/guard/decision.Decision is the canonical path:

judge/risk/policy/store/server
-> internal/guard/decision.Decision
-> shared guard decision values

Why
This gives kontext-cli a cleaner maintenance path for guard decision handling:

judge output
-> risk and policy models
-> sqlite records and server responses
-> one canonical decision type

This PR does not broaden behavior beyond the cleanup scope.

What changed
Removed duplicate guard Decision type aliases
Consolidated shared structs onto internal/guard/decision.Decision
Updated tests for the canonical decision type in guard packages

Verification
go test ./internal/guard/judge ./internal/guard/risk ./internal/guard/policy ./internal/guard/store/sqlite ./internal/guard/app/server
go test ./...
go vet ./...
git diff --check
