### PR TITLE
[AUTOMATION] fix: optimize guard policy category checks

### DIFF
--- a/internal/guard/policy/profiles.go
+++ b/internal/guard/policy/profiles.go
@@ -1,35 +1,14 @@
 package policy
 
-func enabledCategories(profile Profile) map[RuleCategory]bool {
-	categories := map[RuleCategory]bool{
-		CategoryDirectInfraAPIWithCredentials: true,
-		CategoryDestructivePersistentResource: true,
-	}
-	switch profile {
-	case ProfileRelaxed:
-		return categories
-	case ProfileBalanced:
-		categories[CategoryProductionMutation] = true
-		categories[CategoryCredentialAccess] = true
-		categories[CategorySourceControlWrite] = true
-	case ProfileStrict:
-		categories[CategoryProductionMutation] = true
-		categories[CategoryCredentialAccess] = true
-		categories[CategorySourceControlWrite] = true
-		categories[CategoryUnknownHighRiskCommand] = true
-		categories[CategoryManagedTool] = true
-		categories[CategoryProviderAPICall] = true
-	default:
-		categories[CategoryProductionMutation] = true
-		categories[CategoryCredentialAccess] = true
-		categories[CategorySourceControlWrite] = true
-		categories[CategoryUnknownHighRiskCommand] = true
-		categories[CategoryManagedTool] = true
-		categories[CategoryProviderAPICall] = true
-	}
-	return categories
-}
-
 func categoryEnabled(profile Profile, category RuleCategory) bool {
-	return enabledCategories(profile)[category]
+	switch category {
+	case CategoryDirectInfraAPIWithCredentials, CategoryDestructivePersistentResource:
+		return true
+	case CategoryProductionMutation, CategoryCredentialAccess, CategorySourceControlWrite:
+		return profile != ProfileRelaxed
+	case CategoryUnknownHighRiskCommand, CategoryManagedTool, CategoryProviderAPICall:
+		return profile == ProfileStrict || (profile != ProfileRelaxed && profile != ProfileBalanced)
+	default:
+		return false
+	}
 }

--- a/internal/guard/policy/profiles_test.go
+++ b/internal/guard/policy/profiles_test.go
@@ -1,0 +1,81 @@
+package policy
+
+import "testing"
+
+func TestCategoryEnabledByProfile(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile Profile
+		want    map[RuleCategory]bool
+	}{
+		{
+			name:    "relaxed keeps only always-on categories",
+			profile: ProfileRelaxed,
+			want: map[RuleCategory]bool{
+				CategoryDirectInfraAPIWithCredentials: true,
+				CategoryDestructivePersistentResource: true,
+			},
+		},
+		{
+			name:    "balanced enables shared guarded categories",
+			profile: ProfileBalanced,
+			want: map[RuleCategory]bool{
+				CategoryDirectInfraAPIWithCredentials: true,
+				CategoryDestructivePersistentResource: true,
+				CategoryProductionMutation:            true,
+				CategoryCredentialAccess:              true,
+				CategorySourceControlWrite:            true,
+			},
+		},
+		{
+			name:    "strict enables every built-in category",
+			profile: ProfileStrict,
+			want: map[RuleCategory]bool{
+				CategoryDirectInfraAPIWithCredentials: true,
+				CategoryDestructivePersistentResource: true,
+				CategoryProductionMutation:            true,
+				CategoryCredentialAccess:              true,
+				CategorySourceControlWrite:            true,
+				CategoryUnknownHighRiskCommand:        true,
+				CategoryManagedTool:                   true,
+				CategoryProviderAPICall:               true,
+			},
+		},
+		{
+			name:    "unknown profile falls back to strict behavior",
+			profile: Profile("paranoid"),
+			want: map[RuleCategory]bool{
+				CategoryDirectInfraAPIWithCredentials: true,
+				CategoryDestructivePersistentResource: true,
+				CategoryProductionMutation:            true,
+				CategoryCredentialAccess:              true,
+				CategorySourceControlWrite:            true,
+				CategoryUnknownHighRiskCommand:        true,
+				CategoryManagedTool:                   true,
+				CategoryProviderAPICall:               true,
+			},
+		},
+	}
+
+	categories := []RuleCategory{
+		CategoryDirectInfraAPIWithCredentials,
+		CategoryDestructivePersistentResource,
+		CategoryProductionMutation,
+		CategoryCredentialAccess,
+		CategorySourceControlWrite,
+		CategoryUnknownHighRiskCommand,
+		CategoryManagedTool,
+		CategoryProviderAPICall,
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, category := range categories {
+				got := categoryEnabled(tt.profile, category)
+				if got != tt.want[category] {
+					t.Fatalf("categoryEnabled(%q, %q) = %t, want %t", tt.profile, category, got, tt.want[category])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Summary
This optimizes guard policy evaluation by removing per-rule profile map allocations.

Before this, `internal/guard/policy/profiles.go` rebuilt the same category map for every rule in `Engine.Evaluate`, which added repeated allocation work on every policy decision.

Why
This gives kontext-cli a cheaper runtime path for guard policy evaluation:

risk event
-> categoryEnabled
-> rule match result

This PR does not broaden behavior beyond the optimization scope.

What changed
Optimized guard policy category checks
Removed per-call profile map construction
Preserved profile/category behavior, including the strict fallback for unknown profiles
Updated tests for profile category coverage

Verification
go test ./internal/guard/policy
go test ./...
go vet ./...
git diff --check