### PR TITLE
[AUTOMATION] fix(clawpatch): harden guard socket directory

### DIFF
--- a/internal/localruntime/socket.go
+++ b/internal/localruntime/socket.go
@@ -1,9 +1,11 @@
 package localruntime
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 )
 
 func DefaultSocketPath() string {
@@ -14,5 +16,31 @@ func DefaultSocketPath() string {
 }
 
 func EnsureSocketDir(socketPath string) error {
-	return os.MkdirAll(filepath.Dir(socketPath), 0o700)
+	dir := filepath.Clean(filepath.Dir(socketPath))
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s is a symlink", dir)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", dir)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return errors.New("socket directory ownership is unavailable")
+	}
+	if int(stat.Uid) != os.Getuid() {
+		return fmt.Errorf("socket directory %s is owned by uid %d, want %d", dir, stat.Uid, os.Getuid())
+	}
+	if info.Mode().Perm() != 0o700 {
+		if err := os.Chmod(dir, 0o700); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/localruntime/socket_test.go
+++ b/internal/localruntime/socket_test.go
@@ -1,0 +1,47 @@
+package localruntime
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestEnsureSocketDirTightensPermissiveDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix socket directory permissions are not portable to windows")
+	}
+	dir := filepath.Join(t.TempDir(), "socket-dir")
+	if err := os.Mkdir(dir, 0o777); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+	if err := os.Chmod(dir, 0o777); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+
+	if err := EnsureSocketDir(filepath.Join(dir, "kontext.sock")); err != nil {
+		t.Fatalf("EnsureSocketDir() error = %v", err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Fatalf("socket dir mode = %#o, want 0700", got)
+	}
+}
+
+func TestEnsureSocketDirRejectsSymlinkParent(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "target")
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+	link := filepath.Join(t.TempDir(), "socket-link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	if err := EnsureSocketDir(filepath.Join(link, "kontext.sock")); err == nil {
+		t.Fatal("EnsureSocketDir() error = nil, want failure for symlink parent")
+	}
+}


### PR DESCRIPTION
## Where We Are

The guard daemon creates its local Unix socket under a predictable `/tmp/kontext-guard-<uid>` directory. If that directory already exists with loose permissions, the daemon keeps using it unchanged.

## Where We Want To Go

The guard daemon should only listen from a same-user, non-symlink socket directory with `0700` permissions.

## How do we get there

Make `internal/localruntime.EnsureSocketDir` match the managed-observe hardening path: reject symlinks and non-directories, require same-user ownership, and force `0700` before listening. Added focused tests for permissive directories and symlink parents. Verified with `go test ./...`, `go vet ./...`, `npm exec --yes --package pnpm@10.0.0 -- pnpm install --frozen-lockfile`, `npm exec --yes --package pnpm@10.0.0 -- pnpm --dir web/guard-dashboard typecheck`, and `git diff --check`.
