### PR TITLE
feat(managedstream): add daemon heartbeats

### DIFF
--- a/internal/managedobserve/daemon_test.go
+++ b/internal/managedobserve/daemon_test.go
@@ -167,28 +167,35 @@ func TestDaemonStreamsLedgerBatches(t *testing.T) {
 		t.Fatalf("Process() error = %v", err)
 	}
 
-	select {
-	case body := <-requests:
-		if body.OrganizationID != "" {
-			t.Fatalf("organization_id sent = %q, want omitted (token binds the org)", body.OrganizationID)
-		}
-		if body.InstallationID != "ins_0123456789abcdefghijklmnopqrstuv" {
-			t.Fatalf("installation_id = %q", body.InstallationID)
-		}
-		if body.Device == nil || body.Device.Label != "test-mac" {
-			t.Fatalf("device = %+v, want label from managed config", body.Device)
-		}
-		found := false
-		for _, action := range body.Actions {
-			if action.SessionID == "claude-stream-session" {
-				found = true
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case body := <-requests:
+			if len(body.Actions) == 0 {
+				continue
 			}
+			if body.OrganizationID != "" {
+				t.Fatalf("organization_id sent = %q, want omitted (token binds the org)", body.OrganizationID)
+			}
+			if body.InstallationID != "ins_0123456789abcdefghijklmnopqrstuv" {
+				t.Fatalf("installation_id = %q", body.InstallationID)
+			}
+			if body.Device == nil || body.Device.Label != "test-mac" {
+				t.Fatalf("device = %+v, want label from managed config", body.Device)
+			}
+			found := false
+			for _, action := range body.Actions {
+				if action.SessionID == "claude-stream-session" {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("authorization_actions = %+v, want claude stream session action", body.Actions)
+			}
+			return
+		case <-deadline:
+			t.Fatal("timed out waiting for hosted ledger batch")
 		}
-		if !found {
-			t.Fatalf("authorization_actions = %+v, want claude stream session action", body.Actions)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for hosted ledger batch")
 	}
 }
 

--- a/internal/managedstream/authfailure_test.go
+++ b/internal/managedstream/authfailure_test.go
@@ -28,11 +28,17 @@ func TestFlushDoesNotFireOnFlushSuccessWithoutPosting(t *testing.T) {
 	// about the token — it must not clear a "token rejected" breadcrumb on an
 	// idle machine whose token is still revoked.
 	_, dbPath := testStore(t)
+	statePath := filepath.Join(filepath.Dir(dbPath), "state.json")
+	if err := SaveState(statePath, State{
+		LastHeartbeatAttemptAt: time.Now().UTC().Format(time.RFC3339Nano),
+	}); err != nil {
+		t.Fatalf("SaveState() error = %v", err)
+	}
 
 	fired := false
 	err := Flush(context.Background(), Options{
 		DBPath:         dbPath,
-		StatePath:      filepath.Join(filepath.Dir(dbPath), "state.json"),
+		StatePath:      statePath,
 		CloudURL:       "https://unreachable.invalid",
 		InstallationID: "ins_test",
 		InstallToken:   "any",

--- a/internal/managedstream/stream.go
+++ b/internal/managedstream/stream.go
@@ -25,9 +25,10 @@ const (
 	SchemaVersion   = "authorization-ledger-v1"
 	DefaultEndpoint = "/api/v1/authorization-ledger/batches"
 
-	DefaultBatchLimit = 100
-	MaxPayloadBytes   = 192 * 1024
-	DefaultInterval   = 10 * time.Second
+	DefaultBatchLimit        = 100
+	MaxPayloadBytes          = 192 * 1024
+	DefaultInterval          = 10 * time.Second
+	DefaultHeartbeatInterval = 60 * time.Second
 
 	maxPayloadSessions = 100
 	maxPayloadActions  = 1000
@@ -50,6 +51,7 @@ type Options struct {
 	DeviceLabel       string
 	DeploymentVersion func() string
 	Interval          time.Duration
+	HeartbeatInterval time.Duration
 	BatchLimit        int
 	HTTPClient        *http.Client
 	Diagnostic        diagnostic.Logger
@@ -96,13 +98,17 @@ type Device struct {
 }
 
 type State struct {
-	UpdatedAfter *time.Time
-	ActionID     string
+	UpdatedAfter           *time.Time
+	ActionID               string
+	LastHeartbeatAttemptAt string
+	LastHeartbeatAt        string
 }
 
 type persistedState struct {
-	UpdatedAfter string `json:"updated_after,omitempty"`
-	ActionID     string `json:"action_id,omitempty"`
+	UpdatedAfter           string `json:"updated_after,omitempty"`
+	ActionID               string `json:"action_id,omitempty"`
+	LastHeartbeatAttemptAt string `json:"last_heartbeat_attempt_at,omitempty"`
+	LastHeartbeatAt        string `json:"last_heartbeat_at,omitempty"`
 }
 
 func Run(ctx context.Context, opts Options) error {
@@ -175,6 +181,7 @@ func Flush(ctx context.Context, opts Options) error {
 	}
 
 	limit := batchLimit(opts.BatchLimit)
+	now := time.Now().UTC()
 	for {
 		batch, err := store.LedgerBatch(ctx, sqlite.LedgerExportOptions{
 			UpdatedAfter:   state.UpdatedAfter,
@@ -185,29 +192,10 @@ func Flush(ctx context.Context, opts Options) error {
 			return err
 		}
 		if len(batch.Actions) == 0 {
-			return nil
+			return postHeartbeatIfDue(ctx, opts, statePath, state, now)
 		}
 
-		payload := Payload{
-			SchemaVersion:      SchemaVersion,
-			InstallationID:     opts.InstallationID,
-			BatchID:            "batch_" + uuid.NewString(),
-			SentAt:             time.Now().UTC().Format(time.RFC3339Nano),
-			Sessions:           batch.Sessions,
-			Actions:            batch.Actions,
-			Receipts:           batch.Receipts,
-			ReceiptChainAnchor: batch.ReceiptChainAnchor,
-		}
-		// Resolve the deployment version per flush so an in-place package upgrade
-		// is reflected without restarting the daemon.
-		label := strings.TrimSpace(opts.DeviceLabel)
-		deploymentVersion := ""
-		if opts.DeploymentVersion != nil {
-			deploymentVersion = strings.TrimSpace(opts.DeploymentVersion())
-		}
-		if label != "" || deploymentVersion != "" {
-			payload.Device = &Device{Label: label, DeploymentVersion: deploymentVersion}
-		}
+		payload := newPayload(opts, batch.Sessions, batch.Actions, batch.Receipts, batch.ReceiptChainAnchor, now)
 
 		body, err := json.Marshal(payload)
 		if err != nil {
@@ -215,7 +203,7 @@ func Flush(ctx context.Context, opts Options) error {
 		}
 		if reason := payloadLimitViolation(payload, len(body)); reason != "" {
 			if limit == 1 {
-				return advancePastMinimumBatch(statePath, batch, reason, nil)
+				return advancePastMinimumBatch(statePath, batch, state, reason, nil)
 			}
 			nextLimit := reducedBatchLimit(limit)
 			opts.Diagnostic.Printf(
@@ -254,10 +242,76 @@ func Flush(ctx context.Context, opts Options) error {
 		}
 
 		if batch.Cursor != nil {
-			return saveCursor(statePath, batch)
+			state.LastHeartbeatAttemptAt = now.Format(time.RFC3339Nano)
+			state.LastHeartbeatAt = now.Format(time.RFC3339Nano)
+			return saveCursor(statePath, batch, state)
 		}
 		return nil
 	}
+}
+
+func postHeartbeatIfDue(ctx context.Context, opts Options, statePath string, state State, now time.Time) error {
+	if !heartbeatDue(state.LastHeartbeatAttemptAt, heartbeatInterval(opts.HeartbeatInterval), now) {
+		return nil
+	}
+
+	state.LastHeartbeatAttemptAt = now.Format(time.RFC3339Nano)
+	if err := SaveState(statePath, state); err != nil {
+		return err
+	}
+
+	payload := newPayload(opts, nil, nil, nil, nil, now)
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	if err := post(ctx, opts, body); err != nil {
+		return err
+	}
+
+	if opts.OnFlushSuccess != nil {
+		opts.OnFlushSuccess()
+	}
+	state.LastHeartbeatAt = now.Format(time.RFC3339Nano)
+	return SaveState(statePath, state)
+}
+
+func newPayload(
+	opts Options,
+	sessions []sqlite.LedgerRecord,
+	actions []sqlite.LedgerRecord,
+	receipts []sqlite.LedgerRecord,
+	receiptChainAnchor *sqlite.LedgerReceiptChainAnchor,
+	now time.Time,
+) Payload {
+	payload := Payload{
+		SchemaVersion:      SchemaVersion,
+		InstallationID:     opts.InstallationID,
+		BatchID:            "batch_" + uuid.NewString(),
+		SentAt:             now.Format(time.RFC3339Nano),
+		Sessions:           nonNilRecords(sessions),
+		Actions:            nonNilRecords(actions),
+		Receipts:           nonNilRecords(receipts),
+		ReceiptChainAnchor: receiptChainAnchor,
+	}
+	// Resolve the deployment version per flush so an in-place package upgrade
+	// is reflected without restarting the daemon.
+	label := strings.TrimSpace(opts.DeviceLabel)
+	deploymentVersion := ""
+	if opts.DeploymentVersion != nil {
+		deploymentVersion = strings.TrimSpace(opts.DeploymentVersion())
+	}
+	if label != "" || deploymentVersion != "" {
+		payload.Device = &Device{Label: label, DeploymentVersion: deploymentVersion}
+	}
+	return payload
+}
+
+func nonNilRecords(records []sqlite.LedgerRecord) []sqlite.LedgerRecord {
+	if records != nil {
+		return records
+	}
+	return []sqlite.LedgerRecord{}
 }
 
 func post(ctx context.Context, opts Options, body []byte) error {
@@ -327,9 +381,7 @@ func reducedBatchLimit(limit int) int {
 }
 
 func shouldRetryWithSmallerBatch(statusCode int) bool {
-	return statusCode == http.StatusBadRequest ||
-		statusCode == http.StatusRequestEntityTooLarge ||
-		statusCode == http.StatusUnprocessableEntity
+	return statusCode == http.StatusRequestEntityTooLarge
 }
 
 func payloadLimitViolation(payload Payload, bodyBytes int) string {
@@ -347,14 +399,14 @@ func payloadLimitViolation(payload Payload, bodyBytes int) string {
 	}
 }
 
-func advancePastMinimumBatch(statePath string, batch sqlite.LedgerBatch, reason string, cause error) error {
+func advancePastMinimumBatch(statePath string, batch sqlite.LedgerBatch, state State, reason string, cause error) error {
 	if batch.Cursor == nil {
 		if cause != nil {
 			return cause
 		}
 		return fmt.Errorf("managed stream minimum batch rejected: %s", reason)
 	}
-	if err := saveCursor(statePath, batch); err != nil {
+	if err := saveCursor(statePath, batch, state); err != nil {
 		return err
 	}
 	if cause != nil {
@@ -363,12 +415,11 @@ func advancePastMinimumBatch(statePath string, batch sqlite.LedgerBatch, reason 
 	return fmt.Errorf("managed stream advanced cursor past oversized minimum batch: %s", reason)
 }
 
-func saveCursor(statePath string, batch sqlite.LedgerBatch) error {
+func saveCursor(statePath string, batch sqlite.LedgerBatch, state State) error {
 	updatedAfter := batch.Cursor.UpdatedAt.UTC()
-	return SaveState(statePath, State{
-		UpdatedAfter: &updatedAfter,
-		ActionID:     batch.Cursor.ActionID,
-	})
+	state.UpdatedAfter = &updatedAfter
+	state.ActionID = batch.Cursor.ActionID
+	return SaveState(statePath, state)
 }
 
 func parseStateUpdatedAfter(value string) (time.Time, error) {
@@ -444,6 +495,24 @@ func DefaultIntervalFromEnv() time.Duration {
 	return DefaultInterval
 }
 
+func heartbeatInterval(value time.Duration) time.Duration {
+	if value > 0 {
+		return value
+	}
+	return DefaultHeartbeatInterval
+}
+
+func heartbeatDue(lastAttemptAt string, interval time.Duration, now time.Time) bool {
+	if strings.TrimSpace(lastAttemptAt) == "" {
+		return true
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(lastAttemptAt))
+	if err != nil {
+		return true
+	}
+	return !parsed.Add(interval).After(now)
+}
+
 func LoadState(path string) (State, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -465,6 +534,8 @@ func LoadState(path string) (State, error) {
 		state.UpdatedAfter = &parsed
 	}
 	state.ActionID = strings.TrimSpace(persisted.ActionID)
+	state.LastHeartbeatAttemptAt = strings.TrimSpace(persisted.LastHeartbeatAttemptAt)
+	state.LastHeartbeatAt = strings.TrimSpace(persisted.LastHeartbeatAt)
 	return state, nil
 }
 
@@ -472,7 +543,11 @@ func SaveState(path string, state State) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}
-	persisted := persistedState{ActionID: strings.TrimSpace(state.ActionID)}
+	persisted := persistedState{
+		ActionID:               strings.TrimSpace(state.ActionID),
+		LastHeartbeatAttemptAt: strings.TrimSpace(state.LastHeartbeatAttemptAt),
+		LastHeartbeatAt:        strings.TrimSpace(state.LastHeartbeatAt),
+	}
 	if state.UpdatedAfter != nil {
 		persisted.UpdatedAfter = state.UpdatedAfter.UTC().Format(time.RFC3339Nano)
 	}

--- a/internal/managedstream/stream_test.go
+++ b/internal/managedstream/stream_test.go
@@ -63,6 +63,9 @@ func TestFlushPostsLedgerBatchWithInstallationIdentity(t *testing.T) {
 	if state.UpdatedAfter == nil {
 		t.Fatal("updated_after was not persisted")
 	}
+	if state.LastHeartbeatAttemptAt == "" || state.LastHeartbeatAt == "" {
+		t.Fatalf("heartbeat state = %+v, want ledger success to count as heartbeat", state)
+	}
 }
 
 func TestFlushOmitsBlankDeviceLabel(t *testing.T) {
@@ -367,6 +370,50 @@ func TestFlushAdvancesCursorPastOversizedMinimumBatch(t *testing.T) {
 	}
 }
 
+func TestFlushPreservesHeartbeatStatePastOversizedMinimumBatch(t *testing.T) {
+	store, dbPath := testStore(t)
+	saveLargeTestDecision(t, store, "session-1", "toolu_1")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(server.Close)
+
+	statePath := filepath.Join(t.TempDir(), "stream-state.json")
+	lastAttempt := time.Now().Add(-30 * time.Second).UTC().Format(time.RFC3339Nano)
+	lastSuccess := time.Now().Add(-90 * time.Second).UTC().Format(time.RFC3339Nano)
+	if err := SaveState(statePath, State{
+		LastHeartbeatAttemptAt: lastAttempt,
+		LastHeartbeatAt:        lastSuccess,
+	}); err != nil {
+		t.Fatalf("SaveState() error = %v", err)
+	}
+
+	err := Flush(context.Background(), Options{
+		DBPath:         dbPath,
+		StatePath:      statePath,
+		CloudURL:       server.URL,
+		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
+		InstallToken:   "test-install-token",
+		BatchLimit:     1,
+		HTTPClient:     server.Client(),
+	})
+	if err == nil {
+		t.Fatal("Flush() error = nil, want oversized minimum batch diagnostic")
+	}
+
+	state, err := LoadState(statePath)
+	if err != nil {
+		t.Fatalf("LoadState() error = %v", err)
+	}
+	if state.UpdatedAfter == nil || state.ActionID == "" {
+		t.Fatalf("state = %+v, want cursor advanced", state)
+	}
+	if state.LastHeartbeatAttemptAt != lastAttempt || state.LastHeartbeatAt != lastSuccess {
+		t.Fatalf("heartbeat state = %+v, want attempt %q success %q", state, lastAttempt, lastSuccess)
+	}
+}
+
 func TestFlushDefaultsStatePathBesideLedgerDB(t *testing.T) {
 	t.Setenv(envStatePath, "")
 	store, dbPath := testStore(t)
@@ -403,7 +450,10 @@ func TestFlushUsesUpdatedAfterCursor(t *testing.T) {
 
 	statePath := filepath.Join(t.TempDir(), "stream-state.json")
 	updatedAfter := time.Now().Add(time.Hour).UTC()
-	if err := SaveState(statePath, State{UpdatedAfter: &updatedAfter}); err != nil {
+	if err := SaveState(statePath, State{
+		UpdatedAfter:           &updatedAfter,
+		LastHeartbeatAttemptAt: time.Now().UTC().Format(time.RFC3339Nano),
+	}); err != nil {
 		t.Fatalf("SaveState() error = %v", err)
 	}
 
@@ -426,6 +476,131 @@ func TestFlushUsesUpdatedAfterCursor(t *testing.T) {
 	}
 	if called {
 		t.Fatal("server was called despite cursor being newer than action")
+	}
+}
+
+func TestFlushPostsHeartbeatWhenNoActionsArePending(t *testing.T) {
+	_, dbPath := testStore(t)
+
+	var got Payload
+	server := capturePayloadServer(t, &got)
+	t.Cleanup(server.Close)
+
+	onFlushSuccessCalled := false
+	statePath := filepath.Join(t.TempDir(), "stream-state.json")
+	if err := Flush(context.Background(), Options{
+		DBPath:            dbPath,
+		StatePath:         statePath,
+		CloudURL:          server.URL,
+		InstallationID:    "ins_0123456789abcdefghijklmnopqrstuv",
+		InstallToken:      "test-install-token",
+		DeviceLabel:       "michel-macbook",
+		HeartbeatInterval: time.Minute,
+		HTTPClient:        server.Client(),
+		OnFlushSuccess:    func() { onFlushSuccessCalled = true },
+	}); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+
+	if got.SchemaVersion != SchemaVersion {
+		t.Fatalf("schema_version = %q, want %q", got.SchemaVersion, SchemaVersion)
+	}
+	if got.InstallationID != "ins_0123456789abcdefghijklmnopqrstuv" {
+		t.Fatalf("installation_id = %q", got.InstallationID)
+	}
+	if got.Device == nil || got.Device.Label != "michel-macbook" {
+		t.Fatalf("device = %+v", got.Device)
+	}
+	if len(got.Sessions) != 0 || len(got.Actions) != 0 || len(got.Receipts) != 0 {
+		t.Fatalf("heartbeat counts = sessions %d actions %d receipts %d, want all zero", len(got.Sessions), len(got.Actions), len(got.Receipts))
+	}
+	if !onFlushSuccessCalled {
+		t.Fatal("OnFlushSuccess was not called for accepted heartbeat")
+	}
+
+	state, err := LoadState(statePath)
+	if err != nil {
+		t.Fatalf("LoadState() error = %v", err)
+	}
+	if state.UpdatedAfter != nil || state.ActionID != "" {
+		t.Fatalf("state = %+v, want heartbeat not to advance ledger cursor", state)
+	}
+	if state.LastHeartbeatAttemptAt == "" || state.LastHeartbeatAt == "" {
+		t.Fatalf("heartbeat state = %+v, want attempt and success persisted", state)
+	}
+}
+
+func TestFlushSkipsHeartbeatBeforeInterval(t *testing.T) {
+	_, dbPath := testStore(t)
+	statePath := filepath.Join(t.TempDir(), "stream-state.json")
+	if err := SaveState(statePath, State{
+		LastHeartbeatAttemptAt: time.Now().UTC().Format(time.RFC3339Nano),
+	}); err != nil {
+		t.Fatalf("SaveState() error = %v", err)
+	}
+
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(server.Close)
+
+	if err := Flush(context.Background(), Options{
+		DBPath:            dbPath,
+		StatePath:         statePath,
+		CloudURL:          server.URL,
+		InstallationID:    "ins_0123456789abcdefghijklmnopqrstuv",
+		InstallToken:      "test-install-token",
+		HeartbeatInterval: time.Minute,
+		HTTPClient:        server.Client(),
+	}); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if called {
+		t.Fatal("server was called before heartbeat interval elapsed")
+	}
+}
+
+func TestFlushPersistsHeartbeatAttemptWhenHostedBackendFails(t *testing.T) {
+	_, dbPath := testStore(t)
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	statePath := filepath.Join(t.TempDir(), "stream-state.json")
+	opts := Options{
+		DBPath:            dbPath,
+		StatePath:         statePath,
+		CloudURL:          server.URL,
+		InstallationID:    "ins_0123456789abcdefghijklmnopqrstuv",
+		InstallToken:      "test-install-token",
+		HeartbeatInterval: time.Minute,
+		HTTPClient:        server.Client(),
+	}
+	if err := Flush(context.Background(), opts); err == nil {
+		t.Fatal("Flush() error = nil, want hosted failure")
+	}
+	state, err := LoadState(statePath)
+	if err != nil {
+		t.Fatalf("LoadState() error = %v", err)
+	}
+	if state.LastHeartbeatAttemptAt == "" {
+		t.Fatalf("state = %+v, want failed attempt persisted", state)
+	}
+	if state.LastHeartbeatAt != "" {
+		t.Fatalf("state = %+v, want no successful heartbeat", state)
+	}
+
+	if err := Flush(context.Background(), opts); err != nil {
+		t.Fatalf("second Flush() error = %v, want throttled no-op", err)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d, want failed heartbeat throttled", requests)
 	}
 }
 


### PR DESCRIPTION
## Where We Are

Managed-observe only streamed ledger batches when hook activity existed. An idle but healthy daemon had no hosted signal, and failed idle uploads could retry every stream tick.

## Where We Want To Go

Idle managed daemons should check in through the existing ledger endpoint without changing the hosted payload contract. A normal ledger upload should also count as a heartbeat.

## How do we get there

This adds a 60-second heartbeat interval to managedstream, persists heartbeat attempt/success timestamps in stream state, and posts an empty ledger batch when no actions are pending. Failed heartbeats persist the attempt timestamp before upload so blocked egress does not retry every 10 seconds. The existing `organization_id` payload field stays unchanged. Verified with `go test ./...`, `go vet ./...`, and `git diff --check`.
