### PR TITLE
feat(managedconfig): remove client organization id

### DIFF
--- a/cmd/kontext/main_test.go
+++ b/cmd/kontext/main_test.go
@@ -208,7 +208,6 @@ func writeManagedConfigForCmdTest(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "managed.json")
 	if err := os.WriteFile(path, []byte(`{
   "version": "managed-install-v1",
-  "organization_id": "org_123",
   "cloud_url": "https://app.kontext.dev",
   "mode": "observe",
   "agent": "claude",

--- a/internal/managedconfig/config.go
+++ b/internal/managedconfig/config.go
@@ -86,18 +86,28 @@ func ResolvePath() (string, Scope) {
 }
 
 type Config struct {
-	Version        string      `json:"version"`
-	OrganizationID string      `json:"organization_id"`
-	CloudURL       string      `json:"cloud_url"`
-	Mode           string      `json:"mode"`
-	Agent          string      `json:"agent"`
-	Credentials    Credentials `json:"credentials"`
-	Device         Device      `json:"device,omitempty"`
+	Version     string      `json:"version"`
+	CloudURL    string      `json:"cloud_url"`
+	Mode        string      `json:"mode"`
+	Agent       string      `json:"agent"`
+	Credentials Credentials `json:"credentials"`
+	Device      Device      `json:"device,omitempty"`
 	// CoworkEnabled turns on Claude Cowork observation/enforcement in the
 	// managed-observe daemon (the posture follows Mode). A managed.json field
 	// so MDM-deployed installs control it through config rather than launchd
 	// environment plumbing.
 	CoworkEnabled bool `json:"cowork_enabled,omitempty"`
+}
+
+type configFile struct {
+	Version              string          `json:"version"`
+	LegacyOrganizationID json.RawMessage `json:"organization_id,omitempty"`
+	CloudURL             string          `json:"cloud_url"`
+	Mode                 string          `json:"mode"`
+	Agent                string          `json:"agent"`
+	Credentials          Credentials     `json:"credentials"`
+	Device               Device          `json:"device,omitempty"`
+	CoworkEnabled        bool            `json:"cowork_enabled,omitempty"`
 }
 
 type Credentials struct {
@@ -170,14 +180,22 @@ func Parse(data []byte) (Config, error) {
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.DisallowUnknownFields()
 
-	var cfg Config
-	if err := decoder.Decode(&cfg); err != nil {
+	var file configFile
+	if err := decoder.Decode(&file); err != nil {
 		return Config{}, err
 	}
 	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
 		return Config{}, errors.New("unexpected trailing JSON value")
 	}
-	return normalizeAndValidate(cfg)
+	return normalizeAndValidate(Config{
+		Version:       file.Version,
+		CloudURL:      file.CloudURL,
+		Mode:          file.Mode,
+		Agent:         file.Agent,
+		Credentials:   file.Credentials,
+		Device:        file.Device,
+		CoworkEnabled: file.CoworkEnabled,
+	})
 }
 
 func ParseTokenRef(value string) (TokenRef, error) {
@@ -240,7 +258,6 @@ func ResolveInstallToken(ctx context.Context, ref TokenRef) (string, error) {
 
 func normalizeAndValidate(cfg Config) (Config, error) {
 	cfg.Version = strings.TrimSpace(cfg.Version)
-	cfg.OrganizationID = strings.TrimSpace(cfg.OrganizationID)
 	cfg.CloudURL = strings.TrimSpace(cfg.CloudURL)
 	cfg.Mode = strings.TrimSpace(cfg.Mode)
 	cfg.Agent = strings.TrimSpace(cfg.Agent)
@@ -250,9 +267,6 @@ func normalizeAndValidate(cfg Config) (Config, error) {
 
 	if cfg.Version != Version {
 		return Config{}, fmt.Errorf("version must be %q", Version)
-	}
-	if cfg.OrganizationID == "" {
-		return Config{}, errors.New("organization_id is required")
 	}
 	if err := validateCloudURL(cfg.CloudURL); err != nil {
 		return Config{}, err

--- a/internal/managedconfig/config_test.go
+++ b/internal/managedconfig/config_test.go
@@ -19,7 +19,6 @@ func TestLoadFileMissingReturnsErrNotManaged(t *testing.T) {
 func TestParseValidConfigNormalizesStrings(t *testing.T) {
 	cfg, err := Parse([]byte(`{
   "version": " managed-install-v1 ",
-  "organization_id": " org_123 ",
   "cloud_url": " https://api.kontext.dev ",
   "mode": " observe ",
   "agent": " claude ",
@@ -33,7 +32,7 @@ func TestParseValidConfigNormalizesStrings(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse() error = %v", err)
 	}
-	if cfg.Version != Version || cfg.OrganizationID != "org_123" || cfg.CloudURL != "https://api.kontext.dev" {
+	if cfg.Version != Version || cfg.CloudURL != "https://api.kontext.dev" {
 		t.Fatalf("config not normalized: %+v", cfg)
 	}
 	if got := cfg.Credentials.InstallTokenRef; got.Source != "keychain" || got.Name != "kontext-managed-install-token" {
@@ -41,6 +40,14 @@ func TestParseValidConfigNormalizesStrings(t *testing.T) {
 	}
 	if cfg.Device.Label != "Engineering Mac" {
 		t.Fatalf("device label = %q", cfg.Device.Label)
+	}
+}
+
+func TestParseIgnoresLegacyOrganizationID(t *testing.T) {
+	input := strings.Replace(validConfigJSON(), `"cloud_url":`, `"organization_id": "org_123",
+  "cloud_url":`, 1)
+	if _, err := Parse([]byte(input)); err != nil {
+		t.Fatalf("Parse() error = %v", err)
 	}
 }
 
@@ -79,7 +86,6 @@ func TestParseModeObserveAndEnforce(t *testing.T) {
 func TestParseRejectsUnknownFields(t *testing.T) {
 	_, err := Parse([]byte(`{
   "version": "managed-install-v1",
-  "organization_id": "org_123",
   "cloud_url": "https://api.kontext.dev",
   "mode": "observe",
   "agent": "claude",
@@ -101,7 +107,6 @@ func TestParseRejectsTrailingJSON(t *testing.T) {
 func TestParseRequiresFields(t *testing.T) {
 	tests := map[string]string{
 		"version":           `"version": ""`,
-		"organization_id":   `"organization_id": ""`,
 		"cloud_url":         `"cloud_url": ""`,
 		"mode":              `"mode": ""`,
 		"agent":             `"agent": ""`,
@@ -266,7 +271,6 @@ func TestLoadFileReturnsChecksumAndPath(t *testing.T) {
 func validConfigJSON() string {
 	return `{
   "version": "managed-install-v1",
-  "organization_id": "org_123",
   "cloud_url": "https://api.kontext.dev",
   "mode": "observe",
   "agent": "claude",
@@ -285,11 +289,10 @@ func replacementFor(field string) string {
 		return `"install_token_ref": "env:KONTEXT_INSTALL_TOKEN"`
 	default:
 		return `"` + field + `": "` + map[string]string{
-			"version":         "managed-install-v1",
-			"organization_id": "org_123",
-			"cloud_url":       "https://api.kontext.dev",
-			"mode":            "observe",
-			"agent":           "claude",
+			"version":   "managed-install-v1",
+			"cloud_url": "https://api.kontext.dev",
+			"mode":      "observe",
+			"agent":     "claude",
 		}[field] + `"`
 	}
 }

--- a/internal/managedconfig/resolve_path_test.go
+++ b/internal/managedconfig/resolve_path_test.go
@@ -105,9 +105,6 @@ func TestLoadResolvesUserScopeConfig(t *testing.T) {
 	if loaded.Scope != ScopeUser {
 		t.Fatalf("Load() scope = %q, want %q", loaded.Scope, ScopeUser)
 	}
-	if loaded.Config.OrganizationID != "org_123" {
-		t.Fatalf("Load() org = %q", loaded.Config.OrganizationID)
-	}
 }
 
 func TestLoadInvalidSystemConfigDoesNotFallThroughToUser(t *testing.T) {

--- a/internal/managedobserve/daemon_test.go
+++ b/internal/managedobserve/daemon_test.go
@@ -614,7 +614,6 @@ func writeTestManagedConfigWithCloudURL(t *testing.T, path, cloudURL string) {
 	t.Setenv("KONTEXT_INSTALL_TOKEN", "test-install-token")
 	if err := os.WriteFile(path, []byte(`{
   "version": "managed-install-v1",
-  "organization_id": "org_123",
   "cloud_url": "`+cloudURL+`",
   "mode": "observe",
   "agent": "claude",

--- a/internal/managedobserve/doctor.go
+++ b/internal/managedobserve/doctor.go
@@ -32,7 +32,6 @@ func PrintStatus(out io.Writer) {
 	}
 
 	fmt.Fprintf(out, "  config: %s (%s)\n", loaded.Path, describeScope(loaded.Scope))
-	fmt.Fprintf(out, "  organization: %s\n", loaded.Config.OrganizationID)
 
 	identityPath := installationPathForScope(loaded.Scope)
 	if state, err := installation.LoadFile(identityPath); err == nil {

--- a/internal/managedobserve/doctor_test.go
+++ b/internal/managedobserve/doctor_test.go
@@ -33,4 +33,7 @@ func TestPrintStatusReportsInstallationLoadError(t *testing.T) {
 	if strings.Contains(output, "installation: not created yet") {
 		t.Fatalf("PrintStatus() output = %q, must not hide invalid state as missing", output)
 	}
+	if strings.Contains(output, "\n  organization:") {
+		t.Fatalf("PrintStatus() output = %q, must not print local organization", output)
+	}
 }

--- a/internal/managedobserve/lifecycle_test.go
+++ b/internal/managedobserve/lifecycle_test.go
@@ -196,7 +196,6 @@ func TestActiveRequiresValidManagedConfig(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "managed.json")
 	if err := os.WriteFile(path, []byte(`{
   "version": "managed-install-v1",
-  "organization_id": "org_123",
   "cloud_url": "https://app.kontext.dev",
   "mode": "observe",
   "agent": "claude",

--- a/internal/managedobserve/scope_test.go
+++ b/internal/managedobserve/scope_test.go
@@ -66,7 +66,6 @@ func TestRunDaemonParksOnScopeMismatch(t *testing.T) {
 	config := filepath.Join(dir, "managed.json")
 	if err := os.WriteFile(config, []byte(`{
   "version": "managed-install-v1",
-  "organization_id": "org_x",
   "cloud_url": "https://api.kontext.dev",
   "mode": "observe",
   "agent": "claude",

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -145,7 +145,7 @@ func Run(ctx context.Context, opts Options) error {
 
 	fmt.Fprintln(opts.Stdout, "\nMac")
 
-	configPath, err := writeUserManagedConfig(cloudURL, ping.OrganizationID, deviceLabel(ctx))
+	configPath, err := writeUserManagedConfig(cloudURL, deviceLabel(ctx))
 	if err != nil {
 		return err
 	}
@@ -301,18 +301,17 @@ func deviceLabel(ctx context.Context) string {
 	return host
 }
 
-func writeUserManagedConfig(cloudURL, organizationID, label string) (string, error) {
+func writeUserManagedConfig(cloudURL, label string) (string, error) {
 	path := managedconfig.UserPath()
 	if path == "" {
 		return "", errors.New("cannot resolve your home directory")
 	}
 
 	cfg := managedconfig.Config{
-		Version:        managedconfig.Version,
-		OrganizationID: organizationID,
-		CloudURL:       cloudURL,
-		Mode:           managedconfig.Mode,
-		Agent:          managedconfig.Agent,
+		Version:  managedconfig.Version,
+		CloudURL: cloudURL,
+		Mode:     managedconfig.Mode,
+		Agent:    managedconfig.Agent,
 		Credentials: managedconfig.Credentials{
 			InstallTokenRef: managedconfig.TokenRef{Source: "keychain", Name: KeychainItemName},
 		},

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -166,14 +166,18 @@ func TestRunFullFlow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadFile(user path) after setup: %v", err)
 	}
-	if loaded.Config.OrganizationID != "org_test" {
-		t.Fatalf("org = %q", loaded.Config.OrganizationID)
-	}
 	if loaded.Config.Credentials.InstallTokenRef.String() != "keychain:"+KeychainItemName {
 		t.Fatalf("token ref = %q", loaded.Config.Credentials.InstallTokenRef)
 	}
 	if loaded.Config.Device.Label != "Test MacBook" {
 		t.Fatalf("device label = %q", loaded.Config.Device.Label)
+	}
+	data, err := os.ReadFile(managedconfig.UserPath())
+	if err != nil {
+		t.Fatalf("ReadFile(user managed config) error = %v", err)
+	}
+	if strings.Contains(string(data), "organization_id") {
+		t.Fatalf("managed config contains organization_id:\n%s", data)
 	}
 
 	// Installation identity created at the user path.


### PR DESCRIPTION
## Where We Are

Managed config still stores `organization_id`, even though hosted tenancy now comes from the install token. That leaves stale client-side tenancy data in `managed.json` and in doctor output.

## Where We Want To Go

Managed config should only hold client-owned settings: cloud URL, mode, agent, token reference, device label, and daemon options. Setup can still show the workspace returned by `/authorization-ledger/ping`, but it should not persist that org ID locally.

## How do we get there

Remove `OrganizationID` from `managedconfig.Config`, stop requiring it during validation, and keep a decode-only legacy key so existing files with `organization_id` do not fail as unknown JSON. Update setup to write configs without the field and update doctor to stop printing a local organization line. Focused tests passed for `./internal/managedconfig`, `./internal/setup`, `./internal/managedobserve`, and `./cmd/kontext`. Full `go test ./...` and `go vet ./...` also pass.

