### PR TITLE
fix(githubpolicy): most-specific-wins eval + endpoint subject (ENG-450)

### DIFF
--- a/internal/githubpolicy/client.go
+++ b/internal/githubpolicy/client.go
@@ -68,7 +68,7 @@ func validateSnapshot(snapshot Snapshot) error {
 	}
 	for _, rule := range snapshot.Rules {
 		switch rule.Layer {
-		case LayerOrg, LayerUser, LayerAgent:
+		case LayerOrg, LayerUser, LayerAgent, LayerEndpoint:
 		default:
 			return fmt.Errorf("github policy rule %s has unknown layer %q", rule.ID, rule.Layer)
 		}

--- a/internal/githubpolicy/client_test.go
+++ b/internal/githubpolicy/client_test.go
@@ -1,0 +1,42 @@
+package githubpolicy
+
+import (
+	"strings"
+	"testing"
+)
+
+func snapshotForValidation(rules ...Rule) Snapshot {
+	return Snapshot{
+		SchemaVersion:  SchemaVersion,
+		OrganizationID: "org_test",
+		ProviderKey:    "github",
+		Mode:           ModeObserve,
+		Epoch:          1,
+		Hash:           "hash-1",
+		Rules:          rules,
+	}
+}
+
+func TestValidateSnapshotAcceptsEndpointLayer(t *testing.T) {
+	// Regression: endpoint-layer rules must pass validation, otherwise a fetch
+	// that includes them fails and the daemon silently keeps a stale snapshot.
+	snapshot := snapshotForValidation(
+		Rule{ID: "r-org", Layer: LayerOrg, SubjectID: "org_test", Effect: EffectDeny},
+		Rule{ID: "r-endpoint", Layer: LayerEndpoint, SubjectID: "ins_device1", ResourceID: ptr("acme/api"), Effect: EffectAllow},
+		Rule{ID: "r-user", Layer: LayerUser, SubjectID: "user-1", Effect: EffectAllow},
+		Rule{ID: "r-agent", Layer: LayerAgent, SubjectID: "app-1", Effect: EffectAllow},
+	)
+	if err := validateSnapshot(snapshot); err != nil {
+		t.Fatalf("validateSnapshot() = %v, want nil for all known layers", err)
+	}
+}
+
+func TestValidateSnapshotRejectsUnknownLayer(t *testing.T) {
+	snapshot := snapshotForValidation(
+		Rule{ID: "r-bad", Layer: "device", SubjectID: "x", Effect: EffectAllow},
+	)
+	err := validateSnapshot(snapshot)
+	if err == nil || !strings.Contains(err.Error(), "unknown layer") {
+		t.Fatalf("validateSnapshot() = %v, want unknown-layer error", err)
+	}
+}

--- a/internal/githubpolicy/evaluate.go
+++ b/internal/githubpolicy/evaluate.go
@@ -2,7 +2,6 @@ package githubpolicy
 
 import (
 	"fmt"
-	"strings"
 )
 
 // Reason codes shared with the cloud evaluator.
@@ -15,13 +14,16 @@ const (
 // ApplicationID are the Kontext user and application subjects; the managed
 // endpoint's trusted identity is the service account + installation, so both
 // are typically empty (unresolved) and user/agent-layer rules then never
-// match their subject.
+// match their subject. EndpointID is the installation ("ins_…") identity of
+// this managed endpoint — it is always known locally, so endpoint-layer rules
+// are the way to scope policy to a specific device on the managed path.
 type Request struct {
 	Action        string
 	Resource      string
 	BranchOrRef   string
 	UserID        string
 	ApplicationID string
+	EndpointID    string
 }
 
 // MatchedRule records one rule that matched the request, and whether it was
@@ -55,15 +57,17 @@ type Evaluation struct {
 	SubjectsResolved bool
 }
 
-// Evaluate mirrors the cloud evaluator exactly:
+// Evaluate mirrors the cloud evaluator exactly. It is most-specific-wins:
 //
 //  1. A rule matches when its layer subject matches and each non-null
 //     dimension equals the request value exactly (null = wildcard, no globs).
-//  2. Any matching deny ⇒ deny, regardless of specificity.
-//  3. Otherwise allow only if every layer consents. The org layer is strict:
-//     it needs a matching allow. The user and agent layers abstain (consent)
-//     while the snapshot has zero rules in that layer; once a layer has any
-//     rule it is active and silence vetoes again.
+//  2. Among the matching rules the most specific one decides, by this order:
+//     (a) more pinned dimensions (action/resource/branch) beats fewer; then
+//     (b) a user- or agent-layer rule beats an org-layer rule; then
+//     (c) on an exact tie of (a) and (b), deny beats allow.
+//     A broad org deny is therefore overridden by a more specific user/agent
+//     allow, which is in turn overridden by an even more specific deny.
+//  3. If no rule matches the request, it is denied (default deny).
 //
 // The boolean result is false when the snapshot carries no rules at all (no
 // active policy authored yet) — there is nothing to dry-run.
@@ -82,15 +86,14 @@ func Evaluate(snapshot Snapshot, status Status, request Request) (Evaluation, bo
 	}
 
 	layerSubjects := map[string]string{
-		LayerOrg:   snapshot.OrganizationID,
-		LayerUser:  request.UserID,
-		LayerAgent: request.ApplicationID,
+		LayerOrg:      snapshot.OrganizationID,
+		LayerUser:     request.UserID,
+		LayerAgent:    request.ApplicationID,
+		LayerEndpoint: request.EndpointID,
 	}
 
 	var matched []MatchedRule
-	var decidingDeny *Rule
-	allowLayers := map[string]bool{}
-	var firstOrgAllow *Rule
+	var winner *Rule
 	for i := range snapshot.Rules {
 		rule := &snapshot.Rules[i]
 		subject := layerSubjects[rule.Layer]
@@ -98,58 +101,32 @@ func Evaluate(snapshot Snapshot, status Status, request Request) (Evaluation, bo
 			continue
 		}
 		matched = append(matched, MatchedRule{ID: rule.ID, Layer: rule.Layer, Effect: rule.Effect})
-		if rule.Effect == EffectDeny {
-			if decidingDeny == nil {
-				decidingDeny = rule
-			}
-			continue
-		}
-		allowLayers[rule.Layer] = true
-		if rule.Layer == LayerOrg && firstOrgAllow == nil {
-			firstOrgAllow = rule
+		if winner == nil || rulePrecedes(rule, winner) {
+			winner = rule
 		}
 	}
 
-	if decidingDeny != nil {
-		markDecided(matched, decidingDeny.ID)
-		evaluation.Result = EffectDeny
-		evaluation.ReasonCode = ReasonCodeDeny
-		evaluation.Reason = fmt.Sprintf("denied by %s-layer deny rule on %s", decidingDeny.Layer, ruleScopeSummary(*decidingDeny))
-		evaluation.MatchedRules = matched
-		evaluation.DecidingRuleID = decidingDeny.ID
-		return evaluation, true
-	}
-
-	// User and agent layers consent by abstention while they hold no rules at
-	// all; the org layer is the mandatory ceiling and stays strict.
-	for _, layer := range []string{LayerUser, LayerAgent} {
-		if !snapshotHasLayerRules(snapshot, layer) {
-			allowLayers[layer] = true
-		}
-	}
-
-	var vetoLayers []string
-	for _, layer := range []string{LayerOrg, LayerUser, LayerAgent} {
-		if !allowLayers[layer] {
-			vetoLayers = append(vetoLayers, layer)
-		}
-	}
-	if len(vetoLayers) > 0 {
-		evaluation.Result = EffectDeny
-		evaluation.ReasonCode = ReasonCodeDeny
-		evaluation.Reason = fmt.Sprintf("no matching allow rule in active layer(s): %s", strings.Join(vetoLayers, ", "))
-		evaluation.MatchedRules = matched
-		return evaluation, true
-	}
-
-	if firstOrgAllow != nil {
-		markDecided(matched, firstOrgAllow.ID)
-		evaluation.DecidingRuleID = firstOrgAllow.ID
-	}
-	evaluation.Result = EffectAllow
-	evaluation.ReasonCode = ReasonCodeAllow
-	evaluation.Reason = "allowed by policy: every layer consents"
 	evaluation.MatchedRules = matched
+
+	if winner == nil {
+		// Rules exist but none match this request: default deny.
+		evaluation.Result = EffectDeny
+		evaluation.ReasonCode = ReasonCodeDeny
+		evaluation.Reason = "no matching policy rule (default deny)"
+		return evaluation, true
+	}
+
+	markDecided(matched, winner.ID)
+	evaluation.DecidingRuleID = winner.ID
+	if effectIsAllow(winner.Effect) {
+		evaluation.Result = EffectAllow
+		evaluation.ReasonCode = ReasonCodeAllow
+		evaluation.Reason = fmt.Sprintf("allowed by most-specific %s-layer allow rule on %s", winner.Layer, ruleScopeSummary(*winner))
+	} else {
+		evaluation.Result = EffectDeny
+		evaluation.ReasonCode = ReasonCodeDeny
+		evaluation.Reason = fmt.Sprintf("denied by most-specific %s-layer deny rule on %s", winner.Layer, ruleScopeSummary(*winner))
+	}
 	return evaluation, true
 }
 
@@ -166,13 +143,49 @@ func ruleMatchesRequest(rule *Rule, request Request) bool {
 	return true
 }
 
-func snapshotHasLayerRules(snapshot Snapshot, layer string) bool {
-	for i := range snapshot.Rules {
-		if snapshot.Rules[i].Layer == layer {
-			return true
-		}
+// rulePrecedes reports whether candidate should win over the current best under
+// most-specific-wins: more pinned dimensions, then user/agent over org, then
+// deny over allow on an exact tie. Returning false on a full tie keeps the
+// earlier rule, so evaluation is deterministic in snapshot order.
+func rulePrecedes(candidate, best *Rule) bool {
+	if dc, db := ruleDimensions(candidate), ruleDimensions(best); dc != db {
+		return dc > db
 	}
-	return false
+	if lc, lb := layerRank(candidate.Layer), layerRank(best.Layer); lc != lb {
+		return lc > lb
+	}
+	// Same specificity: a deny outranks an allow.
+	return !effectIsAllow(candidate.Effect) && effectIsAllow(best.Effect)
+}
+
+// ruleDimensions counts the pinned (non-wildcard) dimensions of a rule.
+func ruleDimensions(rule *Rule) int {
+	count := 0
+	if rule.ActionName != nil {
+		count++
+	}
+	if rule.ResourceID != nil {
+		count++
+	}
+	if rule.BranchOrRef != nil {
+		count++
+	}
+	return count
+}
+
+// layerRank orders subjects from least to most specific. A rule bound to a
+// specific user, application, or endpoint is more specific than an org-wide
+// rule; those specific-principal layers rank equally, so a conflict between
+// them falls through to deny-wins.
+func layerRank(layer string) int {
+	if layer == LayerOrg {
+		return 0
+	}
+	return 1
+}
+
+func effectIsAllow(effect string) bool {
+	return effect == EffectAllow
 }
 
 func markDecided(matched []MatchedRule, ruleID string) {

--- a/internal/githubpolicy/evaluate_test.go
+++ b/internal/githubpolicy/evaluate_test.go
@@ -52,7 +52,22 @@ func TestEvaluateOrgAllowAloneAllowsOrgWide(t *testing.T) {
 	}
 }
 
-func TestEvaluateDenyBeatsAllowRegardlessOfSpecificity(t *testing.T) {
+func TestEvaluateNoMatchingRuleDefaultsToDeny(t *testing.T) {
+	// Rules exist but none cover this repo: default deny.
+	snapshot := snapshotWithRules(Rule{
+		ID: "rule-other", Layer: LayerOrg, SubjectID: testOrgID,
+		ResourceID: ptr("acme/api"), Effect: EffectAllow,
+	})
+	evaluation, ok := Evaluate(snapshot, Status{}, Request{Action: "github.pr.write", Resource: "acme/web"})
+	if !ok || evaluation.Result != EffectDeny || evaluation.ReasonCode != ReasonCodeDeny {
+		t.Fatalf("Evaluate() = %+v, want default deny for unmatched request", evaluation)
+	}
+	if evaluation.DecidingRuleID != "" {
+		t.Fatalf("DecidingRuleID = %q, want empty when no rule matched", evaluation.DecidingRuleID)
+	}
+}
+
+func TestEvaluateMoreSpecificDenyBeatsBroaderAllow(t *testing.T) {
 	snapshot := snapshotWithRules(
 		Rule{
 			ID: "rule-deny", Layer: LayerOrg, SubjectID: testOrgID,
@@ -78,74 +93,225 @@ func TestEvaluateDenyBeatsAllowRegardlessOfSpecificity(t *testing.T) {
 		t.Fatalf("MatchedRules = %+v, want rule-deny marked decided", denied.MatchedRules)
 	}
 
-	// The deny is scoped: everything off-target still allows.
+	// The deny is scoped: everything off-target still allows via the broad allow.
 	allowed, ok := Evaluate(snapshot, Status{}, Request{Action: "github.pr.write", Resource: "acme/web"})
 	if !ok || allowed.Result != EffectAllow {
 		t.Fatalf("off-target request = %+v, want allow", allowed)
 	}
 }
 
-func TestEvaluateOrgLayerIsStrict(t *testing.T) {
-	// A user-layer rule alone activates nothing for the org layer: zero org
-	// rules deny everything.
+func TestEvaluateMoreSpecificAllowBeatsBroaderDeny(t *testing.T) {
+	// A broad org deny is overridden by a more specific user allow: the user is
+	// carved out of an otherwise org-wide block.
 	snapshot := snapshotWithRules(
-		Rule{ID: "rule-user", Layer: LayerUser, SubjectID: "user-1", Effect: EffectAllow},
+		Rule{ID: "rule-org-deny", Layer: LayerOrg, SubjectID: testOrgID, ResourceID: ptr("acme/api"), Effect: EffectDeny},
+		Rule{ID: "rule-user-allow", Layer: LayerUser, SubjectID: "user-1", ResourceID: ptr("acme/api"), Effect: EffectAllow},
 	)
-	evaluation, ok := Evaluate(snapshot, Status{}, Request{Action: "github.repo.read", UserID: "user-1"})
-	if !ok || evaluation.Result != EffectDeny {
-		t.Fatalf("Evaluate() = %+v, want deny from strict org layer", evaluation)
+
+	allowed, ok := Evaluate(snapshot, Status{}, Request{Action: "github.pr.write", Resource: "acme/api", UserID: "user-1"})
+	if !ok || allowed.Result != EffectAllow {
+		t.Fatalf("carved-out user = %+v, want allow", allowed)
+	}
+	if allowed.DecidingRuleID != "rule-user-allow" {
+		t.Fatalf("DecidingRuleID = %q, want rule-user-allow", allowed.DecidingRuleID)
+	}
+
+	// Everyone else still hits the org deny.
+	denied, ok := Evaluate(snapshot, Status{}, Request{Action: "github.pr.write", Resource: "acme/api", UserID: "user-2"})
+	if !ok || denied.Result != EffectDeny {
+		t.Fatalf("other user = %+v, want deny", denied)
 	}
 }
 
-func TestEvaluateUserLayerAbstainsUntilItHasRulesThenSilenceVetoes(t *testing.T) {
-	// No user rules: layer abstains, org allow carries the decision.
-	abstaining := snapshotWithRules(orgAllowAll("rule-org"))
-	evaluation, ok := Evaluate(abstaining, Status{}, Request{Action: "github.pr.write", UserID: "user-1"})
-	if !ok || evaluation.Result != EffectAllow {
-		t.Fatalf("abstaining user layer = %+v, want allow", evaluation)
+func TestEvaluateCarveOutScenario(t *testing.T) {
+	// The reported scenario:
+	//   1. org deny  — any action on acme/api
+	//   2. user allow — user-1 on acme/api (exception to the org block)
+	//   3. user deny  — user-1, github.issue.read on acme/api (exception to the
+	//      exception)
+	snapshot := snapshotWithRules(
+		Rule{ID: "r1-org-deny", Layer: LayerOrg, SubjectID: testOrgID, ResourceID: ptr("acme/api"), Effect: EffectDeny},
+		Rule{ID: "r2-user-allow", Layer: LayerUser, SubjectID: "user-1", ResourceID: ptr("acme/api"), Effect: EffectAllow},
+		Rule{ID: "r3-user-deny", Layer: LayerUser, SubjectID: "user-1", ResourceID: ptr("acme/api"), ActionName: ptr("github.issue.read"), Effect: EffectDeny},
+	)
+
+	cases := []struct {
+		name    string
+		request Request
+		want    string
+		ruleID  string
+	}{
+		{"user-1 allowed for a normal action", Request{Action: "github.pr.write", Resource: "acme/api", UserID: "user-1"}, EffectAllow, "r2-user-allow"},
+		{"user-1 denied for the carved-out action", Request{Action: "github.issue.read", Resource: "acme/api", UserID: "user-1"}, EffectDeny, "r3-user-deny"},
+		{"another user denied org-wide", Request{Action: "github.pr.write", Resource: "acme/api", UserID: "user-2"}, EffectDeny, "r1-org-deny"},
+		{"another user also denied for issue.read", Request{Action: "github.issue.read", Resource: "acme/api", UserID: "user-2"}, EffectDeny, "r1-org-deny"},
+	}
+	for _, testCase := range cases {
+		evaluation, ok := Evaluate(snapshot, Status{}, testCase.request)
+		if !ok || evaluation.Result != testCase.want {
+			t.Fatalf("%s: Evaluate(%+v) = %+v, want %s", testCase.name, testCase.request, evaluation, testCase.want)
+		}
+		if evaluation.DecidingRuleID != testCase.ruleID {
+			t.Fatalf("%s: DecidingRuleID = %q, want %q", testCase.name, evaluation.DecidingRuleID, testCase.ruleID)
+		}
+	}
+}
+
+func TestEvaluateUserAllowGrantsThatUserWithoutAnOrgRule(t *testing.T) {
+	// Org is no longer a mandatory ceiling: a user allow alone grants that user,
+	// while an unrelated user falls through to default deny.
+	snapshot := snapshotWithRules(
+		Rule{ID: "rule-user", Layer: LayerUser, SubjectID: "user-1", Effect: EffectAllow},
+	)
+
+	allowed, ok := Evaluate(snapshot, Status{}, Request{Action: "github.repo.read", UserID: "user-1"})
+	if !ok || allowed.Result != EffectAllow {
+		t.Fatalf("covered user = %+v, want allow", allowed)
 	}
 
-	// One user rule for someone else: the layer is active, silence vetoes.
-	active := snapshotWithRules(
+	denied, ok := Evaluate(snapshot, Status{}, Request{Action: "github.repo.read", UserID: "user-2"})
+	if !ok || denied.Result != EffectDeny {
+		t.Fatalf("uncovered user = %+v, want default deny", denied)
+	}
+}
+
+func TestEvaluateUnrelatedSubjectRuleDoesNotRestrictOthers(t *testing.T) {
+	// A rule bound to user-2 is irrelevant to user-1; the broad org allow still
+	// governs user-1. (Under the old layered-AND model this denied user-1.)
+	snapshot := snapshotWithRules(
 		orgAllowAll("rule-org"),
 		Rule{ID: "rule-user", Layer: LayerUser, SubjectID: "user-2", Effect: EffectAllow},
 	)
-	evaluation, ok = Evaluate(active, Status{}, Request{Action: "github.pr.write", UserID: "user-1"})
-	if !ok || evaluation.Result != EffectDeny {
-		t.Fatalf("active user layer without matching allow = %+v, want deny", evaluation)
+
+	for _, userID := range []string{"user-1", "user-2"} {
+		evaluation, ok := Evaluate(snapshot, Status{}, Request{Action: "github.pr.write", UserID: userID})
+		if !ok || evaluation.Result != EffectAllow {
+			t.Fatalf("user %q = %+v, want allow", userID, evaluation)
+		}
+	}
+}
+
+func TestEvaluateUserDenyCarvesAnExceptionOutOfOrgAllow(t *testing.T) {
+	snapshot := snapshotWithRules(
+		orgAllowAll("rule-org"),
+		Rule{ID: "rule-user-deny", Layer: LayerUser, SubjectID: "user-1", Effect: EffectDeny},
+	)
+
+	denied, ok := Evaluate(snapshot, Status{}, Request{Action: "github.pr.write", UserID: "user-1"})
+	if !ok || denied.Result != EffectDeny || denied.DecidingRuleID != "rule-user-deny" {
+		t.Fatalf("user-1 = %+v, want deny by rule-user-deny", denied)
 	}
 
-	// The covered user is allowed.
-	evaluation, ok = Evaluate(active, Status{}, Request{Action: "github.pr.write", UserID: "user-2"})
-	if !ok || evaluation.Result != EffectAllow {
-		t.Fatalf("active user layer with matching allow = %+v, want allow", evaluation)
+	allowed, ok := Evaluate(snapshot, Status{}, Request{Action: "github.pr.write", UserID: "user-2"})
+	if !ok || allowed.Result != EffectAllow {
+		t.Fatalf("user-2 = %+v, want allow", allowed)
 	}
 }
 
 func TestEvaluateAgentLayerMirrorsUserLayer(t *testing.T) {
+	// Agent-layer rules behave like user-layer rules: a rule for app-1 carves an
+	// exception for app-1 only; app-2 follows the broad org allow.
 	snapshot := snapshotWithRules(
 		orgAllowAll("rule-org"),
-		Rule{ID: "rule-agent", Layer: LayerAgent, SubjectID: "app-1", Effect: EffectAllow},
+		Rule{ID: "rule-agent-deny", Layer: LayerAgent, SubjectID: "app-1", Effect: EffectDeny},
 	)
-	evaluation, ok := Evaluate(snapshot, Status{}, Request{Action: "github.pr.write", ApplicationID: "app-2"})
-	if !ok || evaluation.Result != EffectDeny {
-		t.Fatalf("agent layer veto = %+v, want deny", evaluation)
+
+	denied, ok := Evaluate(snapshot, Status{}, Request{Action: "github.pr.write", ApplicationID: "app-1"})
+	if !ok || denied.Result != EffectDeny {
+		t.Fatalf("app-1 = %+v, want deny", denied)
+	}
+
+	allowed, ok := Evaluate(snapshot, Status{}, Request{Action: "github.pr.write", ApplicationID: "app-2"})
+	if !ok || allowed.Result != EffectAllow {
+		t.Fatalf("app-2 = %+v, want allow", allowed)
 	}
 }
 
 func TestEvaluateUnresolvedSubjectsCannotMatchUserOrAgentRules(t *testing.T) {
-	snapshot := snapshotWithRules(
+	// The managed endpoint resolves no Kontext user/app: user and agent rules
+	// cannot match their subject, so org rules govern and the evaluation is
+	// flagged as unresolved.
+	allowSnapshot := snapshotWithRules(
 		orgAllowAll("rule-org"),
 		Rule{ID: "rule-user", Layer: LayerUser, SubjectID: "user-1", Effect: EffectAllow},
 	)
-	// The managed endpoint resolves no Kontext user: the user layer is active
-	// and silence vetoes, flagged as unresolved subject on the evaluation.
-	evaluation, ok := Evaluate(snapshot, Status{}, Request{Action: "github.pr.write"})
-	if !ok || evaluation.Result != EffectDeny {
-		t.Fatalf("unresolved user subject = %+v, want deny", evaluation)
+	evaluation, ok := Evaluate(allowSnapshot, Status{}, Request{Action: "github.pr.write"})
+	if !ok || evaluation.Result != EffectAllow {
+		t.Fatalf("unresolved subject with org allow = %+v, want allow from org rule", evaluation)
 	}
 	if evaluation.SubjectsResolved {
 		t.Fatal("SubjectsResolved = true, want false for unresolved identity")
+	}
+
+	// A user allow cannot unlock anything when the subject is unresolved: the
+	// org deny still governs.
+	denySnapshot := snapshotWithRules(
+		Rule{ID: "rule-org-deny", Layer: LayerOrg, SubjectID: testOrgID, Effect: EffectDeny},
+		Rule{ID: "rule-user-allow", Layer: LayerUser, SubjectID: "user-1", Effect: EffectAllow},
+	)
+	denied, ok := Evaluate(denySnapshot, Status{}, Request{Action: "github.pr.write"})
+	if !ok || denied.Result != EffectDeny {
+		t.Fatalf("unresolved subject with org deny = %+v, want deny", denied)
+	}
+}
+
+func TestEvaluateEndpointLayerMatchesInstallationId(t *testing.T) {
+	// The managed endpoint resolves no user/app, but it always knows its own
+	// installation id, so endpoint-layer rules are matchable locally.
+	snapshot := snapshotWithRules(
+		Rule{ID: "rule-org-deny", Layer: LayerOrg, SubjectID: testOrgID, ResourceID: ptr("acme/api"), Effect: EffectDeny},
+		Rule{ID: "rule-endpoint-allow", Layer: LayerEndpoint, SubjectID: "ins_device1", ResourceID: ptr("acme/api"), Effect: EffectAllow},
+	)
+
+	// This endpoint is carved out of the org-wide deny.
+	allowed, ok := Evaluate(snapshot, Status{}, Request{Action: "github.pr.write", Resource: "acme/api", EndpointID: "ins_device1"})
+	if !ok || allowed.Result != EffectAllow || allowed.DecidingRuleID != "rule-endpoint-allow" {
+		t.Fatalf("matching endpoint = %+v, want allow by rule-endpoint-allow", allowed)
+	}
+
+	// A different endpoint still hits the org deny.
+	denied, ok := Evaluate(snapshot, Status{}, Request{Action: "github.pr.write", Resource: "acme/api", EndpointID: "ins_device2"})
+	if !ok || denied.Result != EffectDeny {
+		t.Fatalf("other endpoint = %+v, want deny", denied)
+	}
+
+	// An unresolved endpoint (empty id) cannot match the endpoint rule either.
+	unresolved, ok := Evaluate(snapshot, Status{}, Request{Action: "github.pr.write", Resource: "acme/api"})
+	if !ok || unresolved.Result != EffectDeny {
+		t.Fatalf("empty endpoint = %+v, want deny", unresolved)
+	}
+}
+
+func TestEvaluateEndpointCarveOutScenario(t *testing.T) {
+	// The reported carve-out, expressed with an endpoint subject (the trusted
+	// identity on the managed path):
+	//   1. org deny — any action on acme/api
+	//   2. endpoint allow — ins_device1 on acme/api
+	//   3. endpoint deny — ins_device1, github.issue.read on acme/api
+	snapshot := snapshotWithRules(
+		Rule{ID: "r1-org-deny", Layer: LayerOrg, SubjectID: testOrgID, ResourceID: ptr("acme/api"), Effect: EffectDeny},
+		Rule{ID: "r2-endpoint-allow", Layer: LayerEndpoint, SubjectID: "ins_device1", ResourceID: ptr("acme/api"), Effect: EffectAllow},
+		Rule{ID: "r3-endpoint-deny", Layer: LayerEndpoint, SubjectID: "ins_device1", ResourceID: ptr("acme/api"), ActionName: ptr("github.issue.read"), Effect: EffectDeny},
+	)
+
+	cases := []struct {
+		name    string
+		request Request
+		want    string
+		ruleID  string
+	}{
+		{"endpoint allowed for a normal action", Request{Action: "github.pr.write", Resource: "acme/api", EndpointID: "ins_device1"}, EffectAllow, "r2-endpoint-allow"},
+		{"endpoint denied for the carved-out action", Request{Action: "github.issue.read", Resource: "acme/api", EndpointID: "ins_device1"}, EffectDeny, "r3-endpoint-deny"},
+		{"other endpoint denied org-wide", Request{Action: "github.pr.write", Resource: "acme/api", EndpointID: "ins_device2"}, EffectDeny, "r1-org-deny"},
+	}
+	for _, testCase := range cases {
+		evaluation, ok := Evaluate(snapshot, Status{}, testCase.request)
+		if !ok || evaluation.Result != testCase.want {
+			t.Fatalf("%s: Evaluate(%+v) = %+v, want %s", testCase.name, testCase.request, evaluation, testCase.want)
+		}
+		if evaluation.DecidingRuleID != testCase.ruleID {
+			t.Fatalf("%s: DecidingRuleID = %q, want %q", testCase.name, evaluation.DecidingRuleID, testCase.ruleID)
+		}
 	}
 }
 

--- a/internal/githubpolicy/snapshot.go
+++ b/internal/githubpolicy/snapshot.go
@@ -35,6 +35,11 @@ const (
 	LayerOrg   = "org"
 	LayerUser  = "user"
 	LayerAgent = "agent"
+	// LayerEndpoint binds a rule to a managed endpoint's installation
+	// ("ins_…") id. Unlike user/agent, this subject is always resolvable on
+	// the managed endpoint, so it is how device-scoped policy is enforced
+	// locally.
+	LayerEndpoint = "endpoint"
 )
 
 // Rule effects.
@@ -51,8 +56,8 @@ const (
 type Rule struct {
 	ID    string `json:"id"`
 	Layer string `json:"layer"`
-	// SubjectID is the org id, kontext user id, or application id depending
-	// on Layer.
+	// SubjectID is the org id, kontext user id, application id, or endpoint
+	// installation id depending on Layer.
 	SubjectID string `json:"subjectId"`
 	// ResourceID is a repository slug "owner/repo", or nil for any repository.
 	ResourceID *string `json:"resourceId"`
@@ -62,9 +67,9 @@ type Rule struct {
 	// BranchOrRef is a branch or ref constraint, or nil for any branch.
 	BranchOrRef *string `json:"branchOrRef"`
 	Effect      string  `json:"effect"`
-	// Specificity is higher for more pinned rules. Ordering/diagnostic hint
-	// only — evaluation is NOT most-specific-wins; any matching deny beats
-	// any matching allow.
+	// Specificity is a diagnostic hint the cloud computes for display/sorting.
+	// The evaluator does not read it: it derives precedence from the rule's
+	// own dimensions and layer (see Evaluate — most-specific-wins).
 	Specificity int `json:"specificity"`
 }
 

--- a/internal/guard/app/server/policy.go
+++ b/internal/guard/app/server/policy.go
@@ -24,6 +24,9 @@ type RiskPolicyProvider struct {
 	policyEngine guardpolicy.Engine
 	policyConfig PolicyConfigProvider
 	githubPolicy githubpolicy.SnapshotProvider
+	// endpointID is this managed endpoint's installation ("ins_…") id, used as
+	// the endpoint-layer subject when evaluating synced GitHub policy.
+	endpointID string
 }
 
 type RiskPolicyProviderOptions struct {
@@ -32,6 +35,7 @@ type RiskPolicyProviderOptions struct {
 	PolicyConfig         guardpolicy.Config
 	PolicyConfigProvider PolicyConfigProvider
 	GithubPolicy         githubpolicy.SnapshotProvider
+	EndpointID           string
 }
 
 type staticPolicyConfigProvider struct {
@@ -62,6 +66,7 @@ func NewRiskPolicyProviderWithOptions(opts RiskPolicyProviderOptions) RiskPolicy
 		policyEngine: opts.PolicyEngine,
 		policyConfig: configProvider,
 		githubPolicy: opts.GithubPolicy,
+		endpointID:   opts.EndpointID,
 	}
 }
 
@@ -99,7 +104,10 @@ func (p RiskPolicyProvider) DecideHook(ctx context.Context, event risk.HookEvent
 // trusted identity is the service account + installation — Claude hook
 // payloads are not trusted human identity — so requests carry no Kontext
 // user/application subject and user/agent-layer rules cannot match their
-// subject (the evaluation flags this via SubjectsResolved).
+// subject (the evaluation flags this via SubjectsResolved). The endpoint's
+// own installation id IS known and trusted, so it is supplied as the
+// endpoint-layer subject; endpoint-scoped rules are how device policy is
+// enforced on this path.
 //
 // The boolean result reports whether the snapshot explicitly directs
 // enforcement; anything else is observe and never influences the decision.
@@ -123,6 +131,7 @@ func (p RiskPolicyProvider) evaluateGithubPolicy(event risk.HookEvent) ([]github
 			Action:      action.Action,
 			Resource:    action.Resource,
 			BranchOrRef: action.BranchOrRef,
+			EndpointID:  p.endpointID,
 		})
 		if ok {
 			evaluations = append(evaluations, evaluation)

--- a/internal/guard/app/server/server.go
+++ b/internal/guard/app/server/server.go
@@ -51,6 +51,7 @@ type Options struct {
 	PolicyConfig         policy.Config
 	PolicyConfigProvider PolicyConfigProvider
 	GithubPolicy         githubpolicy.SnapshotProvider
+	EndpointID           string
 	CurrentSessionID     string
 	Mode                 string
 }
@@ -93,6 +94,7 @@ func NewServerWithOptions(store *sqlite.Store, opts Options) (*Server, error) {
 		Judge:                opts.Judge,
 		PolicyConfigProvider: configProvider,
 		GithubPolicy:         opts.GithubPolicy,
+		EndpointID:           opts.EndpointID,
 	}), policyStore, opts)
 }
 

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -115,6 +115,7 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 		DBPath:             dbPath,
 		SocketPath:         socketPath,
 		GithubPolicy:       policyCache,
+		EndpointID:         installationState.InstallationID,
 		Mode:               mode,
 		Diagnostic:         opts.Diagnostic,
 		SkipInitialSession: true,

--- a/internal/runtimehost/host.go
+++ b/internal/runtimehost/host.go
@@ -39,6 +39,7 @@ type Options struct {
 	JudgeManagedDefault       bool
 	JudgeDownloadProgress     judge.DownloadProgressHandler
 	GithubPolicy              githubpolicy.SnapshotProvider
+	EndpointID                string
 	Mode                      guardhookruntime.Mode
 	Diagnostic                diagnostic.Logger
 	Out                       io.Writer
@@ -114,6 +115,7 @@ func Start(ctx context.Context, opts Options) (*Host, error) {
 	localServer, closeStore, err := server.OpenDefaultServerWithOptions(dbPath, server.Options{
 		Judge:            localJudge,
 		GithubPolicy:     opts.GithubPolicy,
+		EndpointID:       opts.EndpointID,
 		CurrentSessionID: serverSessionID,
 		Mode:             string(mode),
 	})


### PR DESCRIPTION
Part of [ENG-450](https://linear.app/cobrowser/issue/ENG-450/fix-github-access-policy-qa-gaps-from-observe-mode-testing) — fixing GitHub access-policy QA gaps found during observe-mode testing. Pairs with the cloud PR in `kontext-security/kontext`.

## 1. Most-specific-wins evaluation
The local engine used flat deny-overrides + layered-AND: a broad org `DENY` short-circuited to deny before a more-specific user/endpoint `ALLOW` could be weighed (so a "block the repo, allow my endpoint" carve-out never worked). `Evaluate` now ranks matching rules by:
1. pinned dimensions (action/resource/branch) — more beats fewer
2. specific subject (user/agent/endpoint) over org
3. deny over allow on an exact tie

No matching rule ⇒ default deny. Mirrors the cloud reference evaluator.

## 2. Endpoint subject
The managed endpoint has no resolved user/application identity, so user/agent-layer rules can never match locally. The daemon **does** always know its own installation id (`ins_…`), which is stable across pkg updates and uninstall. That id is now stamped as the endpoint-layer subject (`Request.EndpointID`), threaded `daemon → runtimehost → guard server → policy provider`. Endpoint-scoped rules are how device policy is matched on the managed path.

## Tests
- `go test ./...` green; gofmt/vet clean
- New/updated `evaluate_test.go` coverage including the carve-out scenario expressed with endpoint rules

## Note
The synced GitHub policy is still **observe-only** (mode hardcoded cloud-side), so these decisions are recorded as dry-runs and don't block yet — enforce is a separate, deliberate step.