### PR TITLE
fix(setup): show progress while installing launch agent

### DIFF
--- a/internal/setup/launchagent.go
+++ b/internal/setup/launchagent.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/kontext-security/kontext-cli/internal/managedobserve"
 )
@@ -17,6 +18,8 @@ import (
 // kickstart (managedobserve.Lifecycle) works identically for both install
 // kinds. The refusal gate in Run keeps the two from coexisting on one Mac.
 const LaunchAgentLabel = managedobserve.DefaultLaunchdLabel
+
+const launchctlCommandTimeout = 15 * time.Second
 
 func launchAgentPath() (string, error) {
 	home, err := os.UserHomeDir()
@@ -107,13 +110,13 @@ func installLaunchAgent(ctx context.Context, binary string) (plistPath, logPath 
 	// self-serve plist setup owns before bootstrapping the replacement. This
 	// keeps a machine linked to an older workspace from keeping the old job
 	// loaded while setup writes the new config.
-	if out, err := execCommand(ctx, "", "launchctl", "bootout", domainTarget, plistPath); err != nil {
-		if _, printErr := execCommand(ctx, "", "launchctl", "print", serviceTarget); printErr == nil {
+	if out, err := runLaunchctl(ctx, "bootout", domainTarget, plistPath); err != nil {
+		if _, printErr := runLaunchctl(ctx, "print", serviceTarget); printErr == nil {
 			return "", "", fmt.Errorf("launchctl bootout failed before reload: %w (%s)", err, strings.TrimSpace(out))
 		}
 	}
 
-	if out, err := execCommand(ctx, "", "launchctl", "bootstrap", domainTarget, plistPath); err != nil {
+	if out, err := runLaunchctl(ctx, "bootstrap", domainTarget, plistPath); err != nil {
 		detail := strings.TrimSpace(out)
 		if strings.Contains(detail, "Input/output error") {
 			return "", "", fmt.Errorf("launchctl bootstrap failed (%s) — this usually means no GUI login session; run `kontext setup` from a logged-in desktop session, not SSH", detail)
@@ -122,10 +125,21 @@ func installLaunchAgent(ctx context.Context, binary string) (plistPath, logPath 
 	}
 	// -k restarts a running agent: a re-run with a rotated token must not
 	// leave the old process flushing with the old credential.
-	if out, err := execCommand(ctx, "", "launchctl", "kickstart", "-k", serviceTarget); err != nil {
+	if out, err := runLaunchctl(ctx, "kickstart", "-k", serviceTarget); err != nil {
 		return "", "", fmt.Errorf("launchctl kickstart failed: %w (%s)", err, strings.TrimSpace(out))
 	}
 	return plistPath, logPath, nil
+}
+
+func runLaunchctl(ctx context.Context, args ...string) (string, error) {
+	launchCtx, cancel := context.WithTimeout(ctx, launchctlCommandTimeout)
+	defer cancel()
+
+	out, err := execCommand(launchCtx, "", "launchctl", args...)
+	if launchCtx.Err() != nil {
+		return out, launchCtx.Err()
+	}
+	return out, err
 }
 
 // removeLaunchAgent reverses installLaunchAgent; both steps tolerate
@@ -146,11 +160,11 @@ func removeLaunchAgent(ctx context.Context) (string, error) {
 	} else if err != nil {
 		return "", err
 	}
-	if out, err := execCommand(ctx, "", "launchctl", "bootout", domainTarget, plistPath); err != nil {
+	if out, err := runLaunchctl(ctx, "bootout", domainTarget, plistPath); err != nil {
 		if plistExists {
 			return "", fmt.Errorf("launchctl bootout failed: %w (%s)", err, strings.TrimSpace(out))
 		}
-		if _, printErr := execCommand(ctx, "", "launchctl", "print", serviceTarget); printErr == nil {
+		if _, printErr := runLaunchctl(ctx, "print", serviceTarget); printErr == nil {
 			return "", fmt.Errorf("launchctl bootout failed and %s is still loaded: %w (%s)", LaunchAgentLabel, err, strings.TrimSpace(out))
 		}
 	}

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -175,7 +175,12 @@ func Run(ctx context.Context, opts Options) error {
 	}
 	fmt.Fprintln(opts.Stdout, "  ✓ Claude Code hooks installed")
 
-	plistPath, logPath, err := installLaunchAgent(ctx, binary)
+	var plistPath, logPath string
+	err = runWithStatus(opts.Stdout, "Installing background agent", func() error {
+		var err error
+		plistPath, logPath, err = installLaunchAgent(ctx, binary)
+		return err
+	})
 	if err != nil {
 		return err
 	}
@@ -405,14 +410,18 @@ func installUserHooks(binary string) ([]string, error) {
 }
 
 func waitForDaemon(out io.Writer) error {
+	return runWithStatus(out, "Waiting for background agent", probeDaemon)
+}
+
+func runWithStatus(out io.Writer, label string, fn func() error) error {
 	if !isTerminalWriter(out) {
-		fmt.Fprintln(out, "  • Waiting for background agent...")
-		return probeDaemon()
+		fmt.Fprintf(out, "  • %s...\n", label)
+		return fn()
 	}
 
 	done := make(chan error, 1)
 	go func() {
-		done <- probeDaemon()
+		done <- fn()
 	}()
 
 	frames := []string{"◐", "◓", "◑", "◒"}
@@ -421,7 +430,7 @@ func waitForDaemon(out io.Writer) error {
 
 	frame := 0
 	for {
-		fmt.Fprintf(out, "\r  %s Waiting for background agent...", frames[frame%len(frames)])
+		fmt.Fprintf(out, "\r  %s %s...", frames[frame%len(frames)], label)
 		frame++
 		select {
 		case err := <-done:

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -216,6 +216,7 @@ func TestRunFullFlow(t *testing.T) {
 		"Kontext setup",
 		"Workspace\n  ✓ Acme (org_test)",
 		"Mac\n  ✓ Config written",
+		"  • Installing background agent...",
 		"  • Waiting for background agent...",
 		"  ✓ Background agent running",
 		"Next\n  Return to the Kontext dashboard.",
@@ -477,6 +478,34 @@ func TestInstallLaunchAgentBootsOutOwnedPlistBeforeBootstrap(t *testing.T) {
 	}
 	if launchctl[1][0] != "bootstrap" {
 		t.Fatalf("second launchctl call = %v, want bootstrap", launchctl[1])
+	}
+}
+
+func TestInstallLaunchAgentBoundsLaunchctlCalls(t *testing.T) {
+	h := newHarness(t)
+	checked := 0
+	overrideVar(t, &execCommand, func(ctx context.Context, stdin, name string, args ...string) (string, error) {
+		h.calls = append(h.calls, execCall{stdin: stdin, name: name, args: args})
+		if name != "launchctl" {
+			return "", nil
+		}
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatalf("launchctl %v ran without a deadline", args)
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 || remaining > launchctlCommandTimeout {
+			t.Fatalf("launchctl deadline remaining = %s, want within %s", remaining, launchctlCommandTimeout)
+		}
+		checked++
+		return "", nil
+	})
+
+	if _, _, err := installLaunchAgent(context.Background(), "/opt/homebrew/bin/kontext"); err != nil {
+		t.Fatal(err)
+	}
+	if checked != 3 {
+		t.Fatalf("bounded launchctl calls = %d, want 3", checked)
 	}
 }
 


### PR DESCRIPTION
## Where We Are
`kontext setup` could pause after "Claude Code hooks installed" while launchctl installed or restarted the background agent. The user only saw cursor activity during that wait.

## Where We Want To Go
Setup should show explicit progress while the background agent is being installed, and launchctl waits should be bounded.

## How do we get there
Wrap LaunchAgent installation in the same status renderer used for daemon startup. Run launchctl lifecycle calls with a 15 second timeout so setup cannot hang there indefinitely.
