### PR TITLE
fix(setup): bound launch agent install safely

### DIFF
--- a/internal/setup/launchagent.go
+++ b/internal/setup/launchagent.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/kontext-security/kontext-cli/internal/managedobserve"
 )
@@ -17,6 +18,8 @@ import (
 // kickstart (managedobserve.Lifecycle) works identically for both install
 // kinds. The refusal gate in Run keeps the two from coexisting on one Mac.
 const LaunchAgentLabel = managedobserve.DefaultLaunchdLabel
+
+const launchctlCommandTimeout = 15 * time.Second
 
 func launchAgentPath() (string, error) {
 	home, err := os.UserHomeDir()
@@ -107,13 +110,17 @@ func installLaunchAgent(ctx context.Context, binary string) (plistPath, logPath 
 	// self-serve plist setup owns before bootstrapping the replacement. This
 	// keeps a machine linked to an older workspace from keeping the old job
 	// loaded while setup writes the new config.
-	if out, err := execCommand(ctx, "", "launchctl", "bootout", domainTarget, plistPath); err != nil {
-		if _, printErr := execCommand(ctx, "", "launchctl", "print", serviceTarget); printErr == nil {
+	if out, err := runLaunchctl(ctx, "bootout", domainTarget, plistPath); err != nil {
+		loaded, printErr := launchAgentLoaded(ctx, serviceTarget, true)
+		if printErr != nil {
+			return "", "", fmt.Errorf("launchctl bootout failed before reload and service state is unknown: %w (%s)", err, strings.TrimSpace(out))
+		}
+		if loaded {
 			return "", "", fmt.Errorf("launchctl bootout failed before reload: %w (%s)", err, strings.TrimSpace(out))
 		}
 	}
 
-	if out, err := execCommand(ctx, "", "launchctl", "bootstrap", domainTarget, plistPath); err != nil {
+	if out, err := runLaunchctl(ctx, "bootstrap", domainTarget, plistPath); err != nil {
 		detail := strings.TrimSpace(out)
 		if strings.Contains(detail, "Input/output error") {
 			return "", "", fmt.Errorf("launchctl bootstrap failed (%s) — this usually means no GUI login session; run `kontext setup` from a logged-in desktop session, not SSH", detail)
@@ -122,10 +129,50 @@ func installLaunchAgent(ctx context.Context, binary string) (plistPath, logPath 
 	}
 	// -k restarts a running agent: a re-run with a rotated token must not
 	// leave the old process flushing with the old credential.
-	if out, err := execCommand(ctx, "", "launchctl", "kickstart", "-k", serviceTarget); err != nil {
+	if out, err := runLaunchctl(ctx, "kickstart", "-k", serviceTarget); err != nil {
 		return "", "", fmt.Errorf("launchctl kickstart failed: %w (%s)", err, strings.TrimSpace(out))
 	}
 	return plistPath, logPath, nil
+}
+
+func runLaunchctl(ctx context.Context, args ...string) (string, error) {
+	launchCtx, cancel := context.WithTimeout(ctx, launchctlCommandTimeout)
+	defer cancel()
+
+	out, err := execCommand(launchCtx, "", "launchctl", args...)
+	if launchCtx.Err() != nil {
+		return out, launchCtx.Err()
+	}
+	return out, err
+}
+
+func launchAgentLoaded(ctx context.Context, serviceTarget string, bounded bool) (bool, error) {
+	var (
+		out string
+		err error
+	)
+	if bounded {
+		out, err = runLaunchctl(ctx, "print", serviceTarget)
+	} else {
+		out, err = execCommand(ctx, "", "launchctl", "print", serviceTarget)
+	}
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false, fmt.Errorf("launchctl print failed: %w (%s)", err, strings.TrimSpace(out))
+	}
+	if launchctlPrintMeansAbsent(out) {
+		return false, nil
+	}
+	return false, fmt.Errorf("launchctl print failed: %w (%s)", err, strings.TrimSpace(out))
+}
+
+func launchctlPrintMeansAbsent(output string) bool {
+	normalized := strings.ToLower(output)
+	return strings.Contains(normalized, "could not find service") ||
+		strings.Contains(normalized, "service is not loaded") ||
+		strings.Contains(normalized, "no such service")
 }
 
 // removeLaunchAgent reverses installLaunchAgent; both steps tolerate
@@ -150,7 +197,11 @@ func removeLaunchAgent(ctx context.Context) (string, error) {
 		if plistExists {
 			return "", fmt.Errorf("launchctl bootout failed: %w (%s)", err, strings.TrimSpace(out))
 		}
-		if _, printErr := execCommand(ctx, "", "launchctl", "print", serviceTarget); printErr == nil {
+		loaded, printErr := launchAgentLoaded(ctx, serviceTarget, false)
+		if printErr != nil {
+			return "", fmt.Errorf("launchctl bootout failed and %s state is unknown: %w", LaunchAgentLabel, printErr)
+		}
+		if loaded {
 			return "", fmt.Errorf("launchctl bootout failed and %s is still loaded: %w (%s)", LaunchAgentLabel, err, strings.TrimSpace(out))
 		}
 	}

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -175,7 +175,12 @@ func Run(ctx context.Context, opts Options) error {
 	}
 	fmt.Fprintln(opts.Stdout, "  ✓ Claude Code hooks installed")
 
-	plistPath, logPath, err := installLaunchAgent(ctx, binary)
+	var plistPath, logPath string
+	err = runWithStatus(opts.Stdout, "Installing background agent", func() error {
+		var err error
+		plistPath, logPath, err = installLaunchAgent(ctx, binary)
+		return err
+	})
 	if err != nil {
 		return err
 	}
@@ -405,14 +410,18 @@ func installUserHooks(binary string) ([]string, error) {
 }
 
 func waitForDaemon(out io.Writer) error {
+	return runWithStatus(out, "Waiting for background agent", probeDaemon)
+}
+
+func runWithStatus(out io.Writer, label string, fn func() error) error {
 	if !isTerminalWriter(out) {
-		fmt.Fprintln(out, "  • Waiting for background agent...")
-		return probeDaemon()
+		fmt.Fprintf(out, "  • %s...\n", label)
+		return fn()
 	}
 
 	done := make(chan error, 1)
 	go func() {
-		done <- probeDaemon()
+		done <- fn()
 	}()
 
 	frames := []string{"◐", "◓", "◑", "◒"}
@@ -421,7 +430,7 @@ func waitForDaemon(out io.Writer) error {
 
 	frame := 0
 	for {
-		fmt.Fprintf(out, "\r  %s Waiting for background agent...", frames[frame%len(frames)])
+		fmt.Fprintf(out, "\r  %s %s...", frames[frame%len(frames)], label)
 		frame++
 		select {
 		case err := <-done:

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -216,6 +216,7 @@ func TestRunFullFlow(t *testing.T) {
 		"Kontext setup",
 		"Workspace\n  ✓ Acme (org_test)",
 		"Mac\n  ✓ Config written",
+		"  • Installing background agent...",
 		"  • Waiting for background agent...",
 		"  ✓ Background agent running",
 		"Next\n  Return to the Kontext dashboard.",
@@ -480,6 +481,59 @@ func TestInstallLaunchAgentBootsOutOwnedPlistBeforeBootstrap(t *testing.T) {
 	}
 }
 
+func TestInstallLaunchAgentIgnoresBootoutWhenServiceIsAbsent(t *testing.T) {
+	h := newHarness(t)
+	overrideVar(t, &execCommand, func(_ context.Context, stdin, name string, args ...string) (string, error) {
+		h.calls = append(h.calls, execCall{stdin: stdin, name: name, args: args})
+		if name != "launchctl" {
+			return "", nil
+		}
+		switch args[0] {
+		case "bootout":
+			return "No such process", errors.New("exit status 113")
+		case "print":
+			return "Could not find service", errors.New("exit status 113")
+		default:
+			return "", nil
+		}
+	})
+
+	if _, _, err := installLaunchAgent(context.Background(), "/opt/homebrew/bin/kontext"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestInstallLaunchAgentBoundsMutatingLaunchctlCalls(t *testing.T) {
+	h := newHarness(t)
+	checked := 0
+	overrideVar(t, &execCommand, func(ctx context.Context, stdin, name string, args ...string) (string, error) {
+		h.calls = append(h.calls, execCall{stdin: stdin, name: name, args: args})
+		if name != "launchctl" {
+			return "", nil
+		}
+		switch args[0] {
+		case "bootout", "bootstrap", "kickstart":
+			deadline, ok := ctx.Deadline()
+			if !ok {
+				t.Fatalf("launchctl %v ran without a deadline", args)
+			}
+			remaining := time.Until(deadline)
+			if remaining <= 0 || remaining > launchctlCommandTimeout {
+				t.Fatalf("launchctl deadline remaining = %s, want within %s", remaining, launchctlCommandTimeout)
+			}
+			checked++
+		}
+		return "", nil
+	})
+
+	if _, _, err := installLaunchAgent(context.Background(), "/opt/homebrew/bin/kontext"); err != nil {
+		t.Fatal(err)
+	}
+	if checked != 3 {
+		t.Fatalf("bounded launchctl calls = %d, want 3", checked)
+	}
+}
+
 func TestInstallLaunchAgentSurfacesBootstrapFailure(t *testing.T) {
 	h := newHarness(t)
 	overrideVar(t, &execCommand, func(_ context.Context, stdin, name string, args ...string) (string, error) {
@@ -493,6 +547,54 @@ func TestInstallLaunchAgentSurfacesBootstrapFailure(t *testing.T) {
 	_, _, err := installLaunchAgent(context.Background(), "/opt/homebrew/bin/kontext")
 	if err == nil || !strings.Contains(err.Error(), "launchctl bootstrap failed") {
 		t.Fatalf("installLaunchAgent() error = %v, want bootstrap failure", err)
+	}
+}
+
+func TestRemoveLaunchAgentDoesNotTreatUnknownServiceStateAsAbsent(t *testing.T) {
+	h := newHarness(t)
+	overrideVar(t, &execCommand, func(ctx context.Context, stdin, name string, args ...string) (string, error) {
+		h.calls = append(h.calls, execCall{stdin: stdin, name: name, args: args})
+		if name != "launchctl" {
+			return "", nil
+		}
+		switch args[0] {
+		case "bootout":
+			return "No such process", errors.New("exit status 113")
+		case "print":
+			if _, ok := ctx.Deadline(); ok {
+				t.Fatal("uninstall service-state check must not use the install timeout")
+			}
+			return "timed out", context.DeadlineExceeded
+		default:
+			return "", nil
+		}
+	})
+
+	_, err := removeLaunchAgent(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "state is unknown") {
+		t.Fatalf("removeLaunchAgent() error = %v, want unknown-state failure", err)
+	}
+}
+
+func TestRemoveLaunchAgentAcceptsKnownAbsentServiceState(t *testing.T) {
+	h := newHarness(t)
+	overrideVar(t, &execCommand, func(_ context.Context, stdin, name string, args ...string) (string, error) {
+		h.calls = append(h.calls, execCall{stdin: stdin, name: name, args: args})
+		if name != "launchctl" {
+			return "", nil
+		}
+		switch args[0] {
+		case "bootout":
+			return "No such process", errors.New("exit status 113")
+		case "print":
+			return "Could not find service", errors.New("exit status 113")
+		default:
+			return "", nil
+		}
+	})
+
+	if _, err := removeLaunchAgent(context.Background()); err != nil {
+		t.Fatalf("removeLaunchAgent() error = %v, want known absent service accepted", err)
 	}
 }
 


### PR DESCRIPTION
## Where We Are

`kontext setup` can look stuck while launchd installs or restarts the background agent. The previous fix bounded all launchctl checks, but that made uninstall unsafe when service state was unknown.

## Where We Want To Go

Setup should show clear progress and avoid unbounded install waits. Uninstall must fail closed if it cannot prove the daemon is unloaded.

## How do we get there

This wraps LaunchAgent install in the existing status renderer and bounds install-time `bootout`, `bootstrap`, and `kickstart` calls to 15 seconds. Service-state checks now treat cancellation or timeout as unknown state. Uninstall uses an unbounded state check and errors if the state is unknown instead of treating the daemon as absent.

Validated with `go test ./...`, including tests for install progress output, bounded install launchctl calls, and uninstall refusing unknown launchd state.
