### PR TITLE
fix(setup): tolerate loaded agent after kickstart timeout

### DIFF
--- a/internal/setup/launchagent.go
+++ b/internal/setup/launchagent.go
@@ -130,6 +130,12 @@ func installLaunchAgent(ctx context.Context, binary string) (plistPath, logPath 
 	// -k restarts a running agent: a re-run with a rotated token must not
 	// leave the old process flushing with the old credential.
 	if out, err := runLaunchctl(ctx, "kickstart", "-k", serviceTarget); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			loaded, printErr := launchAgentLoaded(ctx, serviceTarget, true)
+			if printErr == nil && loaded {
+				return plistPath, logPath, nil
+			}
+		}
 		return "", "", fmt.Errorf("launchctl kickstart failed: %w (%s)", err, strings.TrimSpace(out))
 	}
 	return plistPath, logPath, nil

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -550,6 +550,98 @@ func TestInstallLaunchAgentSurfacesBootstrapFailure(t *testing.T) {
 	}
 }
 
+func TestInstallLaunchAgentAcceptsKickstartTimeoutWhenServiceIsLoaded(t *testing.T) {
+	h := newHarness(t)
+	overrideVar(t, &execCommand, func(ctx context.Context, stdin, name string, args ...string) (string, error) {
+		h.calls = append(h.calls, execCall{stdin: stdin, name: name, args: args})
+		if name != "launchctl" {
+			return "", nil
+		}
+		switch args[0] {
+		case "kickstart":
+			return "", context.DeadlineExceeded
+		case "print":
+			if _, ok := ctx.Deadline(); !ok {
+				t.Fatal("install service-state check must use the install timeout")
+			}
+			return "", nil
+		default:
+			return "", nil
+		}
+	})
+
+	if _, _, err := installLaunchAgent(context.Background(), "/opt/homebrew/bin/kontext"); err != nil {
+		t.Fatalf("installLaunchAgent() error = %v, want nil", err)
+	}
+
+	var sawKickstart, sawPrint bool
+	for _, call := range h.calls {
+		if call.name != "launchctl" {
+			continue
+		}
+		if call.args[0] == "kickstart" {
+			sawKickstart = true
+		}
+		if sawKickstart && call.args[0] == "print" {
+			sawPrint = true
+		}
+	}
+	if !sawPrint {
+		t.Fatalf("launchctl calls = %v, want print after failed kickstart", h.calls)
+	}
+}
+
+func TestInstallLaunchAgentSurfacesKickstartFailureWhenServiceIsNotLoaded(t *testing.T) {
+	h := newHarness(t)
+	overrideVar(t, &execCommand, func(_ context.Context, stdin, name string, args ...string) (string, error) {
+		h.calls = append(h.calls, execCall{stdin: stdin, name: name, args: args})
+		if name != "launchctl" {
+			return "", nil
+		}
+		switch args[0] {
+		case "kickstart":
+			return "", context.DeadlineExceeded
+		case "print":
+			return "Could not find service", errors.New("exit status 113")
+		default:
+			return "", nil
+		}
+	})
+
+	_, _, err := installLaunchAgent(context.Background(), "/opt/homebrew/bin/kontext")
+	if err == nil || !strings.Contains(err.Error(), "launchctl kickstart failed") {
+		t.Fatalf("installLaunchAgent() error = %v, want kickstart failure", err)
+	}
+}
+
+func TestInstallLaunchAgentSurfacesNonTimeoutKickstartFailureWhenServiceIsLoaded(t *testing.T) {
+	h := newHarness(t)
+	overrideVar(t, &execCommand, func(_ context.Context, stdin, name string, args ...string) (string, error) {
+		h.calls = append(h.calls, execCall{stdin: stdin, name: name, args: args})
+		if name != "launchctl" {
+			return "", nil
+		}
+		switch args[0] {
+		case "kickstart":
+			return "operation not permitted", errors.New("exit status 1")
+		case "print":
+			return "", nil
+		default:
+			return "", nil
+		}
+	})
+
+	_, _, err := installLaunchAgent(context.Background(), "/opt/homebrew/bin/kontext")
+	if err == nil || !strings.Contains(err.Error(), "launchctl kickstart failed") {
+		t.Fatalf("installLaunchAgent() error = %v, want kickstart failure", err)
+	}
+	for _, call := range h.calls {
+		if call.name == "launchctl" && call.args[0] == "print" {
+			t.Fatalf("launchctl calls = %v, non-timeout kickstart failure should not probe loaded state", h.calls)
+		}
+	}
+}
+
 func TestRemoveLaunchAgentDoesNotTreatUnknownServiceStateAsAbsent(t *testing.T) {
 	h := newHarness(t)
 	overrideVar(t, &execCommand, func(ctx context.Context, stdin, name string, args ...string) (string, error) {


### PR DESCRIPTION
## Where We Are

`kontext setup` can finish the new org install, then report failure if `launchctl kickstart` times out after launchd has already loaded the self-serve managed-observe job.

## Where We Want To Go

Setup should only fail the restart step when launchd cannot see the service. A slow `kickstart` should not make a valid install look broken.

## How do we get there

After a failed `launchctl kickstart -k`, setup now checks `launchctl print` for the service. If the service is loaded, setup continues to the existing daemon socket wait. If launchd cannot find the service, setup still returns the original kickstart error.

Validated with `go test ./internal/setup` and `go test ./...`.
