### PR TITLE
feat(githubpolicy): bump snapshot schema to v2 (ENG-450 review)

### DIFF
--- a/internal/githubpolicy/snapshot.go
+++ b/internal/githubpolicy/snapshot.go
@@ -15,8 +15,10 @@
 // kontext cloud repository.
 package githubpolicy
 
-// SchemaVersion identifies the snapshot wire format.
-const SchemaVersion = "github-policy-snapshot-v1"
+// SchemaVersion identifies the snapshot wire format. v2 added the endpoint
+// layer and most-specific-wins evaluation; a snapshot at any other version is
+// rejected (fail closed) rather than misread under the wrong semantics.
+const SchemaVersion = "github-policy-snapshot-v2"
 
 // Enforcement directive for the local engine.
 //


### PR DESCRIPTION
Follow-up to [#307](https://github.com/kontext-security/kontext-cli/pull/307) (merged) and the paired cloud PR [kontext#588](https://github.com/kontext-security/kontext/pull/588).

#307 changed what the snapshot payload *means* — added the `endpoint` layer and switched evaluation to most-specific-wins — but kept `schemaVersion` at `v1`. A reviewer flagged that a v1-only endpoint would then silently accept the payload and either drop endpoint rules or apply the old deny-overrides semantics.

This bumps `SchemaVersion` to `github-policy-snapshot-v2`. The version check (`client.go` / `cache.go`) now rejects any non-v2 snapshot, so an out-of-date endpoint **fails closed** (keeps its last state) on a version mismatch instead of misreading the payload. New endpoints understand v2.

Must land together with the cloud bump in kontext#588 (which emits v2). Observe-only today, so the only effect of skew is an old endpoint not recording dry-runs until updated.