### PR TITLE
feat(managedobserve): add daemon homebrew updater

### DIFF
--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -35,6 +35,7 @@ type DaemonOptions struct {
 	// FallbackDeploymentVersion is reported to the ledger when no MDM
 	// deployment-version marker exists (self-serve brew installs).
 	FallbackDeploymentVersion string
+	HomebrewUpdater           func(context.Context, managedconfig.LoadedConfig, diagnostic.Logger) <-chan struct{}
 }
 
 func RunDaemon(ctx context.Context, opts DaemonOptions) error {
@@ -137,6 +138,12 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 		streamErr <- runManagedStream(streamCtx, opts, dbPath, installationState.InstallationID)
 	}()
 
+	startUpdater := opts.HomebrewUpdater
+	if startUpdater == nil {
+		startUpdater = startHomebrewUpdater
+	}
+	upgraded := startUpdater(ctx, loadedConfig, opts.Diagnostic)
+
 	// Cowork observation runs alongside Claude Code in the same daemon, replaying
 	// in-VM Cowork tool events into the same localruntime socket as agent "cowork".
 	// Enabled via managed.json (cowork_enabled) or the env var override.
@@ -160,6 +167,11 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 		select {
 		case <-ctx.Done():
 			return nil
+		case _, ok := <-upgraded:
+			if ok {
+				return nil
+			}
+			upgraded = nil
 		case err := <-streamErr:
 			if err != nil {
 				opts.Diagnostic.Printf("managed stream exited: %v\n", err)

--- a/internal/managedobserve/daemon_test.go
+++ b/internal/managedobserve/daemon_test.go
@@ -12,9 +12,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
 	"github.com/kontext-security/kontext-cli/internal/hook"
 	"github.com/kontext-security/kontext-cli/internal/localruntime"
+	"github.com/kontext-security/kontext-cli/internal/managedconfig"
 )
 
 func TestDaemonPreservesHookSessionIDs(t *testing.T) {
@@ -453,6 +455,59 @@ func TestDaemonRefreshesGithubPolicyInstallToken(t *testing.T) {
 		case <-deadline:
 			t.Fatal("timed out waiting for refreshed policy token")
 		}
+	}
+}
+
+func TestRunDaemonExitsCleanlyAfterHomebrewUpgradeSignal(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	dir := t.TempDir()
+	socketDir, err := os.MkdirTemp("/tmp", "kontext-managedobserve-updater-test-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp() error = %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	socketPath := filepath.Join(socketDir, "kontext.sock")
+	dbPath := filepath.Join(dir, "guard.db")
+	writeTestManagedConfigWithCloudURL(t, filepath.Join(dir, "managed.json"), server.URL)
+	writeTestInstallation(t, filepath.Join(dir, "installation.json"))
+
+	upgraded := make(chan struct{}, 1)
+	started := make(chan struct{}, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- RunDaemon(ctx, DaemonOptions{
+			SocketPath:       socketPath,
+			DBPath:           dbPath,
+			IdleTimeout:      time.Hour,
+			StreamInterval:   time.Hour,
+			StreamHTTPClient: server.Client(),
+			HomebrewUpdater: func(context.Context, managedconfig.LoadedConfig, diagnostic.Logger) <-chan struct{} {
+				started <- struct{}{}
+				return upgraded
+			},
+		})
+	}()
+	waitForSocket(t, socketPath, errCh)
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("updater did not start")
+	}
+
+	upgraded <- struct{}{}
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("RunDaemon() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunDaemon did not exit after upgrade signal")
 	}
 }
 

--- a/internal/managedobserve/updater.go
+++ b/internal/managedobserve/updater.go
@@ -1,0 +1,196 @@
+package managedobserve
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/diagnostic"
+	"github.com/kontext-security/kontext-cli/internal/managedconfig"
+)
+
+const (
+	envNoUpdateCheck            = "KONTEXT_NO_UPDATE_CHECK"
+	envDaemonUpdateInterval     = "KONTEXT_DAEMON_UPDATE_INTERVAL"
+	homebrewFormula             = "kontext-security/tap/kontext"
+	defaultDaemonUpdateInterval = 24 * time.Hour
+	brewListTimeout             = 15 * time.Second
+	brewUpdateTimeout           = 2 * time.Minute
+	brewUpgradeTimeout          = 5 * time.Minute
+)
+
+type commandRunner func(ctx context.Context, path string, args ...string) (string, error)
+
+var (
+	runtimeGOOS                    = runtime.GOOS
+	executablePath                 = os.Executable
+	evalSymlinksPath               = filepath.EvalSymlinks
+	statPath                       = os.Stat
+	runCommand       commandRunner = runCommandOutput
+)
+
+func startHomebrewUpdater(ctx context.Context, loadedConfig managedconfig.LoadedConfig, log diagnostic.Logger) <-chan struct{} {
+	upgraded := make(chan struct{}, 1)
+	cfg, ok := homebrewUpdaterConfig(ctx, loadedConfig, log)
+	if !ok {
+		close(upgraded)
+		return upgraded
+	}
+	go runHomebrewUpdater(ctx, cfg, log, upgraded)
+	return upgraded
+}
+
+type homebrewUpdaterConfigValue struct {
+	brewPath string
+	interval time.Duration
+}
+
+func homebrewUpdaterConfig(ctx context.Context, loadedConfig managedconfig.LoadedConfig, log diagnostic.Logger) (homebrewUpdaterConfigValue, bool) {
+	if runtimeGOOS != "darwin" {
+		return homebrewUpdaterConfigValue{}, false
+	}
+	if loadedConfig.Scope != managedconfig.ScopeUser {
+		return homebrewUpdaterConfigValue{}, false
+	}
+	if strings.TrimSpace(os.Getenv(envNoUpdateCheck)) != "" {
+		return homebrewUpdaterConfigValue{}, false
+	}
+	brewPath, ok := currentExecutableBrewPath()
+	if !ok {
+		logHomebrewUpdater(log, "daemon updater eligibility: brew not found\n")
+		return homebrewUpdaterConfigValue{}, false
+	}
+	if _, err := brewInstalledVersion(ctx, brewPath); err != nil {
+		logHomebrewUpdater(log, "daemon updater eligibility: brew list failed: %v\n", err)
+		return homebrewUpdaterConfigValue{}, false
+	}
+	return homebrewUpdaterConfigValue{
+		brewPath: brewPath,
+		interval: daemonUpdateInterval(),
+	}, true
+}
+
+func runHomebrewUpdater(ctx context.Context, cfg homebrewUpdaterConfigValue, log diagnostic.Logger, upgraded chan<- struct{}) {
+	ticker := time.NewTicker(cfg.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			changed, err := checkHomebrewUpgrade(ctx, cfg.brewPath)
+			if err != nil {
+				logHomebrewUpdater(log, "daemon updater: %v\n", err)
+				continue
+			}
+			if changed {
+				logHomebrewUpdater(log, "daemon updater: upgraded %s; exiting for launchd restart\n", homebrewFormula)
+				select {
+				case upgraded <- struct{}{}:
+				default:
+				}
+				return
+			}
+		}
+	}
+}
+
+func checkHomebrewUpgrade(ctx context.Context, brewPath string) (bool, error) {
+	before, err := brewInstalledVersion(ctx, brewPath)
+	if err != nil {
+		return false, fmt.Errorf("version before upgrade: %w", err)
+	}
+	if _, err := runBrewWithTimeout(ctx, brewUpdateTimeout, brewPath, "update-if-needed"); err != nil {
+		return false, fmt.Errorf("brew update-if-needed: %w", err)
+	}
+	if _, err := runBrewWithTimeout(ctx, brewUpgradeTimeout, brewPath, "upgrade", "--formula", "--no-ask", homebrewFormula); err != nil {
+		return false, fmt.Errorf("brew upgrade: %w", err)
+	}
+	after, err := brewInstalledVersion(ctx, brewPath)
+	if err != nil {
+		return false, fmt.Errorf("version after upgrade: %w", err)
+	}
+	return after != "" && before != after, nil
+}
+
+func brewInstalledVersion(ctx context.Context, brewPath string) (string, error) {
+	output, err := runBrewWithTimeout(ctx, brewListTimeout, brewPath, "list", "--versions", homebrewFormula)
+	if err != nil {
+		return "", err
+	}
+	fields := strings.Fields(output)
+	if len(fields) < 2 {
+		return "", fmt.Errorf("unexpected brew list output %q", strings.TrimSpace(output))
+	}
+	return fields[len(fields)-1], nil
+}
+
+func runBrewWithTimeout(parent context.Context, timeout time.Duration, brewPath string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(parent, timeout)
+	defer cancel()
+	output, err := runCommand(ctx, brewPath, args...)
+	if ctx.Err() != nil {
+		return output, ctx.Err()
+	}
+	return output, err
+}
+
+func currentExecutableBrewPath() (string, bool) {
+	exe, err := executablePath()
+	if err != nil {
+		return "", false
+	}
+	resolved, err := evalSymlinksPath(exe)
+	if err != nil {
+		return "", false
+	}
+	for _, path := range []string{"/opt/homebrew/bin/brew", "/usr/local/bin/brew"} {
+		prefix := strings.TrimSuffix(path, "/bin/brew")
+		if !strings.HasPrefix(resolved, prefix+"/Cellar/kontext/") {
+			continue
+		}
+		info, err := statPath(path)
+		if err == nil && !info.IsDir() {
+			return path, true
+		}
+	}
+	return "", false
+}
+
+func daemonUpdateInterval() time.Duration {
+	raw := strings.TrimSpace(os.Getenv(envDaemonUpdateInterval))
+	if raw == "" {
+		return defaultDaemonUpdateInterval
+	}
+	interval, err := time.ParseDuration(raw)
+	if err != nil || interval <= 0 {
+		return defaultDaemonUpdateInterval
+	}
+	return interval
+}
+
+func runCommandOutput(ctx context.Context, path string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, path, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return string(output), ctx.Err()
+		}
+		return string(output), fmt.Errorf("%w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return string(output), nil
+}
+
+func logHomebrewUpdater(log diagnostic.Logger, format string, args ...any) {
+	if log.Enabled() {
+		log.Printf(format, args...)
+		return
+	}
+	fmt.Fprint(os.Stderr, diagnostic.Redact(fmt.Sprintf(format, args...)))
+}

--- a/internal/managedobserve/updater_test.go
+++ b/internal/managedobserve/updater_test.go
@@ -1,0 +1,358 @@
+package managedobserve
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/diagnostic"
+	"github.com/kontext-security/kontext-cli/internal/managedconfig"
+)
+
+func TestHomebrewUpdaterEligibility(t *testing.T) {
+	tests := []struct {
+		name         string
+		goos         string
+		scope        managedconfig.Scope
+		exe          string
+		optBrew      bool
+		intelBrew    bool
+		listErr      error
+		noUpdate     string
+		want         bool
+		wantBrewPath string
+	}{
+		{
+			name:         "user scope brew install enables updater",
+			goos:         "darwin",
+			scope:        managedconfig.ScopeUser,
+			exe:          "/opt/homebrew/Cellar/kontext/1.2.3/bin/kontext",
+			optBrew:      true,
+			want:         true,
+			wantBrewPath: "/opt/homebrew/bin/brew",
+		},
+		{
+			name:         "intel brew install uses matching brew path",
+			goos:         "darwin",
+			scope:        managedconfig.ScopeUser,
+			exe:          "/usr/local/Cellar/kontext/1.2.3/bin/kontext",
+			optBrew:      true,
+			intelBrew:    true,
+			want:         true,
+			wantBrewPath: "/usr/local/bin/brew",
+		},
+		{
+			name:      "system scope skips updater",
+			goos:      "darwin",
+			scope:     managedconfig.ScopeSystem,
+			exe:       "/opt/homebrew/Cellar/kontext/1.2.3/bin/kontext",
+			optBrew:   true,
+			intelBrew: true,
+			want:      false,
+		},
+		{
+			name:    "non darwin skips updater",
+			goos:    "linux",
+			scope:   managedconfig.ScopeUser,
+			exe:     "/opt/homebrew/Cellar/kontext/1.2.3/bin/kontext",
+			optBrew: true,
+			want:    false,
+		},
+		{
+			name:  "missing brew skips updater",
+			goos:  "darwin",
+			scope: managedconfig.ScopeUser,
+			exe:   "/opt/homebrew/Cellar/kontext/1.2.3/bin/kontext",
+			want:  false,
+		},
+		{
+			name:         "failed brew list skips updater",
+			goos:         "darwin",
+			scope:        managedconfig.ScopeUser,
+			exe:          "/opt/homebrew/Cellar/kontext/1.2.3/bin/kontext",
+			optBrew:      true,
+			listErr:      errors.New("formula missing"),
+			want:         false,
+			wantBrewPath: "/opt/homebrew/bin/brew",
+		},
+		{
+			name:     "no update check env skips updater",
+			goos:     "darwin",
+			scope:    managedconfig.ScopeUser,
+			exe:      "/opt/homebrew/Cellar/kontext/1.2.3/bin/kontext",
+			optBrew:  true,
+			noUpdate: "1",
+			want:     false,
+		},
+		{
+			name:      "non brew executable skips updater",
+			goos:      "darwin",
+			scope:     managedconfig.ScopeUser,
+			exe:       "/usr/local/bin/kontext",
+			optBrew:   true,
+			intelBrew: true,
+			want:      false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resetUpdaterSeams(t)
+			runtimeGOOS = tc.goos
+			executablePath = func() (string, error) { return "/tmp/kontext", nil }
+			evalSymlinksPath = func(string) (string, error) { return tc.exe, nil }
+			statPath = func(path string) (os.FileInfo, error) {
+				if tc.optBrew && path == "/opt/homebrew/bin/brew" {
+					return fakeFileInfo{name: "brew"}, nil
+				}
+				if tc.intelBrew && path == "/usr/local/bin/brew" {
+					return fakeFileInfo{name: "brew"}, nil
+				}
+				return nil, os.ErrNotExist
+			}
+			var gotBrewPath string
+			runCommand = func(_ context.Context, path string, args ...string) (string, error) {
+				if reflect.DeepEqual(args, []string{"list", "--versions", homebrewFormula}) {
+					gotBrewPath = path
+					if tc.listErr != nil {
+						return "", tc.listErr
+					}
+					return "kontext-security/tap/kontext 1.2.3\n", nil
+				}
+				t.Fatalf("unexpected command args = %v", args)
+				return "", nil
+			}
+			if tc.noUpdate != "" {
+				t.Setenv(envNoUpdateCheck, tc.noUpdate)
+			}
+
+			_, got := homebrewUpdaterConfig(context.Background(), managedconfig.LoadedConfig{Scope: tc.scope}, diagnostic.Logger{})
+			if got != tc.want {
+				t.Fatalf("homebrewUpdaterConfig() ok = %v, want %v", got, tc.want)
+			}
+			if gotBrewPath != tc.wantBrewPath {
+				t.Fatalf("brew path = %q, want %q", gotBrewPath, tc.wantBrewPath)
+			}
+		})
+	}
+}
+
+func TestCheckHomebrewUpgradeNoVersionChange(t *testing.T) {
+	resetUpdaterSeams(t)
+	var calls [][]string
+	runCommand = func(_ context.Context, _ string, args ...string) (string, error) {
+		calls = append(calls, append([]string(nil), args...))
+		if args[0] == "list" {
+			return "kontext-security/tap/kontext 1.2.3\n", nil
+		}
+		return "", nil
+	}
+
+	changed, err := checkHomebrewUpgrade(context.Background(), "/opt/homebrew/bin/brew")
+	if err != nil {
+		t.Fatalf("checkHomebrewUpgrade() error = %v", err)
+	}
+	if changed {
+		t.Fatal("checkHomebrewUpgrade() changed = true, want false")
+	}
+	want := [][]string{
+		{"list", "--versions", homebrewFormula},
+		{"update-if-needed"},
+		{"upgrade", "--formula", "--no-ask", homebrewFormula},
+		{"list", "--versions", homebrewFormula},
+	}
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("commands = %#v, want %#v", calls, want)
+	}
+}
+
+func TestHomebrewUpdaterEligibilityHonorsCanceledContext(t *testing.T) {
+	resetUpdaterSeams(t)
+	runtimeGOOS = "darwin"
+	executablePath = func() (string, error) { return "/tmp/kontext", nil }
+	evalSymlinksPath = func(string) (string, error) {
+		return "/opt/homebrew/Cellar/kontext/1.2.3/bin/kontext", nil
+	}
+	statPath = func(path string) (os.FileInfo, error) {
+		if path == "/opt/homebrew/bin/brew" {
+			return fakeFileInfo{name: "brew"}, nil
+		}
+		return nil, os.ErrNotExist
+	}
+	sawCanceledContext := false
+	runCommand = func(ctx context.Context, _ string, args ...string) (string, error) {
+		if !reflect.DeepEqual(args, []string{"list", "--versions", homebrewFormula}) {
+			t.Fatalf("unexpected command args = %v", args)
+		}
+		if errors.Is(ctx.Err(), context.Canceled) {
+			sawCanceledContext = true
+		}
+		return "", ctx.Err()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, ok := homebrewUpdaterConfig(ctx, managedconfig.LoadedConfig{Scope: managedconfig.ScopeUser}, diagnostic.Logger{})
+	if ok {
+		t.Fatal("homebrewUpdaterConfig() ok = true, want false after cancellation")
+	}
+	if !sawCanceledContext {
+		t.Fatal("brew list did not receive canceled daemon context")
+	}
+}
+
+func TestCheckHomebrewUpgradeVersionChange(t *testing.T) {
+	resetUpdaterSeams(t)
+	listCalls := 0
+	runCommand = func(_ context.Context, _ string, args ...string) (string, error) {
+		if args[0] != "list" {
+			return "", nil
+		}
+		listCalls++
+		if listCalls == 1 {
+			return "kontext-security/tap/kontext 1.2.3\n", nil
+		}
+		return "kontext-security/tap/kontext 1.2.4\n", nil
+	}
+
+	changed, err := checkHomebrewUpgrade(context.Background(), "/opt/homebrew/bin/brew")
+	if err != nil {
+		t.Fatalf("checkHomebrewUpgrade() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("checkHomebrewUpgrade() changed = false, want true")
+	}
+}
+
+func TestRunHomebrewUpdaterLogsUpdateFailureAndKeepsRunning(t *testing.T) {
+	resetUpdaterSeams(t)
+	logs := make(chan string, 8)
+	runCommand = func(_ context.Context, _ string, args ...string) (string, error) {
+		if args[0] == "update-if-needed" {
+			return "", errors.New("network down")
+		}
+		return "kontext-security/tap/kontext 1.2.3\n", nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	upgraded := make(chan struct{}, 1)
+	go runHomebrewUpdater(ctx, homebrewUpdaterConfigValue{
+		brewPath: "/opt/homebrew/bin/brew",
+		interval: time.Millisecond,
+	}, diagnostic.New(channelWriter{ch: logs}, true), upgraded)
+
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case line := <-logs:
+			if !strings.Contains(line, "brew update-if-needed") {
+				continue
+			}
+			select {
+			case <-upgraded:
+				t.Fatal("updater signaled upgrade after update failure")
+			default:
+			}
+			return
+		case <-deadline:
+			t.Fatal("timed out waiting for updater failure log")
+		}
+	}
+}
+
+func TestCheckHomebrewUpgradeUpgradeFailure(t *testing.T) {
+	resetUpdaterSeams(t)
+	runCommand = func(_ context.Context, _ string, args ...string) (string, error) {
+		if args[0] == "upgrade" {
+			return "", errors.New("pinned formula")
+		}
+		return "kontext-security/tap/kontext 1.2.3\n", nil
+	}
+
+	changed, err := checkHomebrewUpgrade(context.Background(), "/opt/homebrew/bin/brew")
+	if err == nil || !strings.Contains(err.Error(), "brew upgrade") {
+		t.Fatalf("checkHomebrewUpgrade() error = %v, want brew upgrade error", err)
+	}
+	if changed {
+		t.Fatal("checkHomebrewUpgrade() changed = true, want false")
+	}
+}
+
+func TestCheckHomebrewUpgradeTimeout(t *testing.T) {
+	resetUpdaterSeams(t)
+	runCommand = func(ctx context.Context, _ string, args ...string) (string, error) {
+		if args[0] == "list" {
+			return "kontext-security/tap/kontext 1.2.3\n", nil
+		}
+		<-ctx.Done()
+		return "", ctx.Err()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	changed, err := checkHomebrewUpgrade(ctx, "/opt/homebrew/bin/brew")
+	if err == nil || !strings.Contains(err.Error(), "brew update-if-needed") {
+		t.Fatalf("checkHomebrewUpgrade() error = %v, want update timeout error", err)
+	}
+	if changed {
+		t.Fatal("checkHomebrewUpgrade() changed = true, want false")
+	}
+}
+
+func TestDaemonUpdateIntervalFromEnv(t *testing.T) {
+	t.Setenv(envDaemonUpdateInterval, "25ms")
+	if got := daemonUpdateInterval(); got != 25*time.Millisecond {
+		t.Fatalf("daemonUpdateInterval() = %s, want 25ms", got)
+	}
+
+	t.Setenv(envDaemonUpdateInterval, "not-a-duration")
+	if got := daemonUpdateInterval(); got != defaultDaemonUpdateInterval {
+		t.Fatalf("daemonUpdateInterval(invalid) = %s, want %s", got, defaultDaemonUpdateInterval)
+	}
+}
+
+func resetUpdaterSeams(t *testing.T) {
+	t.Helper()
+	runtimeGOOS = runtime.GOOS
+	executablePath = os.Executable
+	evalSymlinksPath = filepath.EvalSymlinks
+	statPath = os.Stat
+	runCommand = runCommandOutput
+	t.Cleanup(func() {
+		runtimeGOOS = runtime.GOOS
+		executablePath = os.Executable
+		evalSymlinksPath = filepath.EvalSymlinks
+		statPath = os.Stat
+		runCommand = runCommandOutput
+	})
+}
+
+type fakeFileInfo struct {
+	name string
+}
+
+func (f fakeFileInfo) Name() string       { return f.name }
+func (f fakeFileInfo) Size() int64        { return 0 }
+func (f fakeFileInfo) Mode() os.FileMode  { return 0o755 }
+func (f fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (f fakeFileInfo) IsDir() bool        { return false }
+func (f fakeFileInfo) Sys() any           { return nil }
+
+type channelWriter struct {
+	ch chan<- string
+}
+
+func (w channelWriter) Write(p []byte) (int, error) {
+	select {
+	case w.ch <- string(p):
+	default:
+	}
+	return len(p), nil
+}


### PR DESCRIPTION
## Where We Are

Self-serve Homebrew installs can stay stale after `kontext setup` because the managed-observe daemon keeps running the old binary until something else restarts it.

## Where We Want To Go

User-scope Brew installs should update themselves from the daemon without prompts. MDM/system installs, non-Brew installs, hooks, and disabled update checks must not run this path.

## How do we get there

Add a daemon-only Homebrew updater in `internal/managedobserve`. It checks only `kontext-security/tap/kontext`, uses fixed Brew paths, applies bounded command timeouts, and signals `RunDaemon` to exit only when the installed version changes so launchd restarts through the new binary. Verified with `go test ./internal/managedobserve ./internal/update ./internal/setup` and `go test ./...`.
