### PR TITLE
feat: add codex agent adapter

### DIFF
--- a/cmd/kontext/main.go
+++ b/cmd/kontext/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/update"
 
 	_ "github.com/kontext-security/kontext-cli/internal/agent/claude"
+	_ "github.com/kontext-security/kontext-cli/internal/agent/codex"
 	_ "github.com/kontext-security/kontext-cli/internal/agent/cowork"
 )
 
@@ -445,7 +446,7 @@ func expectedHookEventFromArgs(args []string) (hook.HookName, error) {
 	if len(args) > 1 {
 		return "", fmt.Errorf("expected at most one hook event alias")
 	}
-	event, ok := claudemanaged.ParseEventAlias(args[0])
+	event, ok := hook.ParseEventAlias(args[0])
 	if !ok {
 		return "", fmt.Errorf("unknown hook event alias %q", args[0])
 	}
@@ -514,7 +515,7 @@ func evaluateViaSidecarForMode(socketPath string, event hook.Event, mode string)
 }
 
 func sidecarFailureResult(event hook.Event, reason, mode string) hook.Result {
-	if event.HookName != hook.HookPreToolUse {
+	if !event.HookName.CanBlock() {
 		return hook.Result{Decision: hook.DecisionAllow, Reason: reason}
 	}
 	if hookMode := normalizedHookMode(mode); hookMode != "" {

--- a/cmd/kontext/main_test.go
+++ b/cmd/kontext/main_test.go
@@ -272,6 +272,14 @@ func TestExpectedHookEventFromArgs(t *testing.T) {
 		t.Fatalf("event = %q, want PreToolUse", event)
 	}
 
+	event, err = expectedHookEventFromArgs([]string{"user-prompt-submit"})
+	if err != nil {
+		t.Fatalf("expectedHookEventFromArgs(user-prompt-submit) error = %v", err)
+	}
+	if event != hook.HookUserPromptSubmit {
+		t.Fatalf("event = %q, want UserPromptSubmit", event)
+	}
+
 	_, err = expectedHookEventFromArgs([]string{"pretooluse"})
 	if err == nil {
 		t.Fatal("expectedHookEventFromArgs() error = nil, want non-nil")
@@ -569,6 +577,24 @@ func TestEvaluateHookWithSidecarFailsClosedWhenEnforceSocketMissing(t *testing.T
 		Agent:    "claude",
 		HookName: hook.HookPreToolUse,
 		ToolName: "Bash",
+	})
+	if err != nil {
+		t.Fatalf("evaluateHookWithSidecar() error = %v", err)
+	}
+	if result.Decision != hook.DecisionDeny {
+		t.Fatalf("decision = %q, want DENY", result.Decision)
+	}
+	if result.Reason != "sidecar socket missing" {
+		t.Fatalf("reason = %q, want missing socket", result.Reason)
+	}
+}
+
+func TestEvaluateHookWithSidecarFailsClosedForBlockingPromptWhenEnforceSocketMissing(t *testing.T) {
+	t.Setenv("KONTEXT_ACCESS_MODE", "enforce")
+
+	result, err := evaluateHookWithSidecar("", hook.Event{
+		Agent:    "codex",
+		HookName: hook.HookUserPromptSubmit,
 	})
 	if err != nil {
 		t.Fatalf("evaluateHookWithSidecar() error = %v", err)

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -1,0 +1,24 @@
+// Package codex registers the Codex agent adapter.
+package codex
+
+import (
+	"github.com/kontext-security/kontext-cli/internal/agent"
+	"github.com/kontext-security/kontext-cli/internal/hook"
+	"github.com/kontext-security/kontext-cli/internal/hookruntime"
+)
+
+func init() {
+	agent.Register(&Codex{})
+}
+
+type Codex struct{}
+
+func (c *Codex) Name() string { return "codex" }
+
+func (c *Codex) DecodeHookInput(input []byte) (hook.Event, error) {
+	return hookruntime.DecodeCodexEvent(input, c.Name())
+}
+
+func (c *Codex) EncodeHookResult(event hook.Event, result hook.Result) ([]byte, error) {
+	return hookruntime.EncodeCodexResult(event.HookName.String(), result)
+}

--- a/internal/agent/codex/codex_test.go
+++ b/internal/agent/codex/codex_test.go
@@ -1,0 +1,42 @@
+package codex
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/agent"
+	"github.com/kontext-security/kontext-cli/internal/hook"
+)
+
+func TestCodexRegistersAgent(t *testing.T) {
+	t.Parallel()
+
+	a, ok := agent.Get("codex")
+	if !ok {
+		t.Fatal("codex agent was not registered")
+	}
+	if a.Name() != "codex" {
+		t.Fatalf("Name() = %q, want codex", a.Name())
+	}
+}
+
+func TestCodexAdapterDecodesAndEncodes(t *testing.T) {
+	t.Parallel()
+
+	c := &Codex{}
+	event, err := c.DecodeHookInput([]byte(`{"session_id":"s1","hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"pwd"}}`))
+	if err != nil {
+		t.Fatalf("DecodeHookInput() error = %v", err)
+	}
+	if event.SessionID != "codex-s1" || event.Agent != "codex" || event.HookName != hook.HookPreToolUse {
+		t.Fatalf("event = %+v, want codex PreToolUse", event)
+	}
+
+	out, err := c.EncodeHookResult(event, hook.Result{Decision: hook.DecisionAllow, Reason: "allowed"})
+	if err != nil {
+		t.Fatalf("EncodeHookResult() error = %v", err)
+	}
+	if strings.Contains(string(out), "suppressOutput") {
+		t.Fatalf("EncodeHookResult() = %s, want no suppressOutput", out)
+	}
+}

--- a/internal/guard/hookruntime/runtime_test.go
+++ b/internal/guard/hookruntime/runtime_test.go
@@ -61,6 +61,21 @@ func TestRunNonBlockingHookCannotBlock(t *testing.T) {
 	}
 }
 
+func TestRunUserPromptSubmitCanBlock(t *testing.T) {
+	t.Parallel()
+
+	adapter := &stubAdapter{
+		event: hook.Event{HookName: hook.HookUserPromptSubmit},
+	}
+	err := Run(context.Background(), adapter, stubProcessor{result: hook.Result{Decision: hook.DecisionDeny, Reason: "blocked"}}, ModeEnforce, bytes.NewReader(nil), io.Discard, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if adapter.result.Decision != hook.DecisionDeny {
+		t.Fatalf("decision = %s, want deny", adapter.result.Decision)
+	}
+}
+
 func TestRunObserveModeFormatsNonBlockingHookReason(t *testing.T) {
 	t.Parallel()
 

--- a/internal/hook/domain.go
+++ b/internal/hook/domain.go
@@ -11,6 +11,7 @@ const (
 	HookPostToolUseFailed HookName = "PostToolUseFailure"
 	HookSessionEnd        HookName = "SessionEnd"
 	HookUserPromptSubmit  HookName = "UserPromptSubmit"
+	HookStop              HookName = "Stop"
 )
 
 func (h HookName) String() string {
@@ -19,7 +20,7 @@ func (h HookName) String() string {
 
 func (h HookName) IsKnown() bool {
 	switch h {
-	case HookSessionStart, HookPreToolUse, HookPostToolUse, HookPostToolUseFailed, HookSessionEnd, HookUserPromptSubmit:
+	case HookSessionStart, HookPreToolUse, HookPostToolUse, HookPostToolUseFailed, HookSessionEnd, HookUserPromptSubmit, HookStop:
 		return true
 	default:
 		return false
@@ -27,7 +28,41 @@ func (h HookName) IsKnown() bool {
 }
 
 func (h HookName) CanBlock() bool {
-	return h == HookPreToolUse
+	return h == HookPreToolUse || h == HookUserPromptSubmit
+}
+
+type EventAlias struct {
+	Name  HookName
+	Alias string
+}
+
+var eventAliases = []EventAlias{
+	{Name: HookSessionStart, Alias: "session-start"},
+	{Name: HookPreToolUse, Alias: "pre-tool-use"},
+	{Name: HookPostToolUse, Alias: "post-tool-use"},
+	{Name: HookPostToolUseFailed, Alias: "post-tool-use-failure"},
+	{Name: HookSessionEnd, Alias: "session-end"},
+	{Name: HookUserPromptSubmit, Alias: "user-prompt-submit"},
+	{Name: HookStop, Alias: "stop"},
+}
+
+func ParseEventAlias(value string) (HookName, bool) {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	for _, event := range eventAliases {
+		if normalized == event.Alias {
+			return event.Name, true
+		}
+	}
+	return "", false
+}
+
+func AliasForEvent(name HookName) (string, bool) {
+	for _, event := range eventAliases {
+		if event.Name == name {
+			return event.Alias, true
+		}
+	}
+	return "", false
 }
 
 type Decision string

--- a/internal/hook/domain_test.go
+++ b/internal/hook/domain_test.go
@@ -72,10 +72,70 @@ func TestHookNameCanBlock(t *testing.T) {
 	if !HookPreToolUse.CanBlock() {
 		t.Fatalf("HookPreToolUse.CanBlock() = false, want true")
 	}
+	if !HookUserPromptSubmit.CanBlock() {
+		t.Fatalf("HookUserPromptSubmit.CanBlock() = false, want true")
+	}
 	if HookPostToolUse.CanBlock() {
 		t.Fatalf("HookPostToolUse.CanBlock() = true, want false")
 	}
-	if HookUserPromptSubmit.CanBlock() {
-		t.Fatalf("HookUserPromptSubmit.CanBlock() = true, want false")
+	if HookPostToolUseFailed.CanBlock() {
+		t.Fatalf("HookPostToolUseFailed.CanBlock() = true, want false")
+	}
+	if HookSessionEnd.CanBlock() {
+		t.Fatalf("HookSessionEnd.CanBlock() = true, want false")
+	}
+	if HookStop.CanBlock() {
+		t.Fatalf("HookStop.CanBlock() = true, want false")
+	}
+}
+
+func TestParseEventAlias(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		alias string
+		want  HookName
+	}{
+		{alias: "session-start", want: HookSessionStart},
+		{alias: "pre-tool-use", want: HookPreToolUse},
+		{alias: "post-tool-use", want: HookPostToolUse},
+		{alias: "post-tool-use-failure", want: HookPostToolUseFailed},
+		{alias: "session-end", want: HookSessionEnd},
+		{alias: "user-prompt-submit", want: HookUserPromptSubmit},
+		{alias: "stop", want: HookStop},
+		{alias: " Pre-Tool-Use ", want: HookPreToolUse},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.alias, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := ParseEventAlias(tt.alias)
+			if !ok {
+				t.Fatalf("ParseEventAlias(%q) ok = false", tt.alias)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseEventAlias(%q) = %q, want %q", tt.alias, got, tt.want)
+			}
+		})
+	}
+
+	if _, ok := ParseEventAlias("pretooluse"); ok {
+		t.Fatal("ParseEventAlias(pretooluse) ok = true, want false")
+	}
+}
+
+func TestAliasForEvent(t *testing.T) {
+	t.Parallel()
+
+	got, ok := AliasForEvent(HookUserPromptSubmit)
+	if !ok {
+		t.Fatal("AliasForEvent(HookUserPromptSubmit) ok = false")
+	}
+	if got != "user-prompt-submit" {
+		t.Fatalf("AliasForEvent(HookUserPromptSubmit) = %q, want user-prompt-submit", got)
+	}
+	if _, ok := AliasForEvent(HookName("Unknown")); ok {
+		t.Fatal("AliasForEvent(Unknown) ok = true, want false")
 	}
 }

--- a/internal/hookruntime/codex.go
+++ b/internal/hookruntime/codex.go
@@ -1,0 +1,219 @@
+package hookruntime
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/kontext-security/kontext-cli/internal/hook"
+)
+
+const codexSessionPrefix = "codex-"
+
+type codexHookInput struct {
+	SessionID      string          `json:"session_id"`
+	HookEventName  string          `json:"hook_event_name"`
+	ToolName       string          `json:"tool_name"`
+	ToolInput      json.RawMessage `json:"tool_input"`
+	ToolResponse   json.RawMessage `json:"tool_response"`
+	ToolUseID      string          `json:"tool_use_id"`
+	CWD            string          `json:"cwd"`
+	PermissionMode *string         `json:"permission_mode"`
+	Prompt         *string         `json:"prompt"`
+	Source         *string         `json:"source"`
+}
+
+type codexHookOutput struct {
+	Continue           *bool                    `json:"continue,omitempty"`
+	StopReason         string                   `json:"stopReason,omitempty"`
+	SystemMessage      string                   `json:"systemMessage,omitempty"`
+	Decision           string                   `json:"decision,omitempty"`
+	Reason             string                   `json:"reason,omitempty"`
+	HookSpecificOutput *codexHookSpecificOutput `json:"hookSpecificOutput,omitempty"`
+}
+
+type codexHookSpecificOutput struct {
+	HookEventName            string         `json:"hookEventName"`
+	PermissionDecision       string         `json:"permissionDecision,omitempty"`
+	PermissionDecisionReason string         `json:"permissionDecisionReason,omitempty"`
+	AdditionalContext        string         `json:"additionalContext,omitempty"`
+	UpdatedInput             map[string]any `json:"updatedInput,omitempty"`
+}
+
+func DecodeCodexEvent(input []byte, agentName string) (hook.Event, error) {
+	var h codexHookInput
+	if err := json.Unmarshal(input, &h); err != nil {
+		return hook.Event{}, fmt.Errorf("codex: decode hook input: %w", err)
+	}
+	if h.HookEventName == "" {
+		return hook.Event{}, fmt.Errorf("codex: hook event name missing")
+	}
+	hookName := hook.HookName(h.HookEventName)
+	if !codexSupportedHook(hookName) {
+		return hook.Event{}, fmt.Errorf("codex: unsupported hook event %q", h.HookEventName)
+	}
+
+	toolInput, err := normalizeCodexToolInput(h)
+	if err != nil {
+		return hook.Event{}, err
+	}
+	return hook.Event{
+		SessionID:      codexSessionID(h.SessionID),
+		Agent:          agentName,
+		HookName:       hookName,
+		ToolName:       h.ToolName,
+		ToolInput:      toolInput,
+		ToolResponse:   normalizeToolResponse(h.ToolResponse),
+		ToolUseID:      h.ToolUseID,
+		CWD:            h.CWD,
+		PermissionMode: stringPtrValue(h.PermissionMode),
+	}, nil
+}
+
+func EncodeCodexResult(hookEventName string, result hook.Result) ([]byte, error) {
+	hookName := hook.HookName(hookEventName)
+	if !codexSupportedHook(hookName) {
+		return nil, fmt.Errorf("codex: unsupported hook event %q", hookEventName)
+	}
+
+	reason := codexMeaningfulReason(result)
+	if hookName == hook.HookPreToolUse {
+		return encodeCodexPreToolUseResult(hookEventName, result, reason)
+	}
+	return encodeCodexNonPreToolUseResult(hookEventName, result, reason)
+}
+
+func encodeCodexPreToolUseResult(hookEventName string, result hook.Result, reason string) ([]byte, error) {
+	if result.Decision != hook.DecisionAllow {
+		return json.Marshal(codexHookOutput{
+			HookSpecificOutput: &codexHookSpecificOutput{
+				HookEventName:            hookEventName,
+				PermissionDecision:       string(hook.DecisionDeny),
+				PermissionDecisionReason: result.ClaudeReason(),
+			},
+		})
+	}
+
+	if result.UpdatedInput == nil && reason == "" {
+		return json.Marshal(codexHookOutput{})
+	}
+	out := codexHookOutput{
+		HookSpecificOutput: &codexHookSpecificOutput{
+			HookEventName:     hookEventName,
+			AdditionalContext: reason,
+			UpdatedInput:      result.UpdatedInput,
+		},
+	}
+	if result.UpdatedInput != nil {
+		out.HookSpecificOutput.PermissionDecision = string(hook.DecisionAllow)
+	}
+	return json.Marshal(out)
+}
+
+func encodeCodexNonPreToolUseResult(hookEventName string, result hook.Result, reason string) ([]byte, error) {
+	if result.Decision == hook.DecisionDeny {
+		switch hook.HookName(hookEventName) {
+		case hook.HookPostToolUse, hook.HookUserPromptSubmit:
+			return json.Marshal(codexHookOutput{
+				Decision: "block",
+				Reason:   result.ClaudeReason(),
+			})
+		case hook.HookSessionStart:
+			cont := false
+			return json.Marshal(codexHookOutput{
+				Continue:   &cont,
+				StopReason: result.ClaudeReason(),
+			})
+		case hook.HookStop:
+			return json.Marshal(codexHookOutput{})
+		}
+	}
+
+	if hook.HookName(hookEventName) == hook.HookStop {
+		return json.Marshal(codexHookOutput{})
+	}
+	if reason == "" {
+		return json.Marshal(codexHookOutput{})
+	}
+	return json.Marshal(codexHookOutput{
+		HookSpecificOutput: &codexHookSpecificOutput{
+			HookEventName:     hookEventName,
+			AdditionalContext: reason,
+		},
+	})
+}
+
+func codexSupportedHook(hookName hook.HookName) bool {
+	switch hookName {
+	case hook.HookSessionStart,
+		hook.HookPreToolUse,
+		hook.HookPostToolUse,
+		hook.HookUserPromptSubmit,
+		hook.HookStop:
+		return true
+	default:
+		return false
+	}
+}
+
+func codexSessionID(sessionID string) string {
+	if sessionID == "" || strings.HasPrefix(sessionID, codexSessionPrefix) {
+		return sessionID
+	}
+	return codexSessionPrefix + sessionID
+}
+
+func normalizeCodexToolInput(h codexHookInput) (map[string]any, error) {
+	toolInput, err := normalizeCodexJSONMap(h.ToolInput)
+	if err != nil {
+		return nil, err
+	}
+	if h.HookEventName == hook.HookUserPromptSubmit.String() && h.Prompt != nil {
+		if toolInput == nil {
+			toolInput = map[string]any{}
+		}
+		toolInput["prompt"] = *h.Prompt
+	}
+	if h.HookEventName == hook.HookSessionStart.String() && h.Source != nil {
+		if toolInput == nil {
+			toolInput = map[string]any{}
+		}
+		toolInput["source"] = *h.Source
+	}
+	return toolInput, nil
+}
+
+func normalizeCodexJSONMap(raw json.RawMessage) (map[string]any, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || string(trimmed) == "null" {
+		return nil, nil
+	}
+	var obj map[string]any
+	if err := decodeUseNumber(trimmed, &obj); err == nil {
+		return obj, nil
+	}
+	var value any
+	if err := decodeUseNumber(trimmed, &value); err != nil {
+		return nil, fmt.Errorf("codex: decode JSON value: %w", err)
+	}
+	return map[string]any{"value": value}, nil
+}
+
+func codexMeaningfulReason(result hook.Result) string {
+	reason := strings.TrimSpace(result.Reason)
+	switch {
+	case reason == "":
+		return ""
+	case strings.EqualFold(reason, "allowed"):
+		return ""
+	case strings.EqualFold(reason, "telemetry allowed"):
+		return ""
+	case strings.EqualFold(reason, "async telemetry event recorded"):
+		return ""
+	case strings.HasPrefix(reason, "Kontext observe mode: would allow;"):
+		return ""
+	default:
+		return reason
+	}
+}

--- a/internal/hookruntime/codex_test.go
+++ b/internal/hookruntime/codex_test.go
@@ -1,0 +1,300 @@
+package hookruntime
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/hook"
+)
+
+func TestDecodeCodexEventPreToolUse(t *testing.T) {
+	t.Parallel()
+
+	event, err := DecodeCodexEvent([]byte(`{
+		"session_id":"abc123",
+		"hook_event_name":"PreToolUse",
+		"tool_name":"Bash",
+		"tool_use_id":"call_123",
+		"tool_input":{"command":"npm test","id":9007199254740993},
+		"cwd":"/tmp/project",
+		"permission_mode":"default"
+	}`), "codex")
+	if err != nil {
+		t.Fatalf("DecodeCodexEvent() error = %v", err)
+	}
+	if event.SessionID != "codex-abc123" {
+		t.Fatalf("SessionID = %q, want prefixed id", event.SessionID)
+	}
+	if event.Agent != "codex" ||
+		event.HookName != hook.HookPreToolUse ||
+		event.ToolName != "Bash" ||
+		event.ToolUseID != "call_123" ||
+		event.CWD != "/tmp/project" ||
+		event.PermissionMode != "default" {
+		t.Fatalf("event = %+v, want decoded metadata", event)
+	}
+	if event.ToolInput["command"] != "npm test" {
+		t.Fatalf("ToolInput[command] = %v, want npm test", event.ToolInput["command"])
+	}
+	if num, ok := event.ToolInput["id"].(json.Number); !ok || num.String() != "9007199254740993" {
+		t.Fatalf("ToolInput[id] = %v (%T), want json.Number", event.ToolInput["id"], event.ToolInput["id"])
+	}
+}
+
+func TestDecodeCodexEventPreservesExistingSessionPrefix(t *testing.T) {
+	t.Parallel()
+
+	event, err := DecodeCodexEvent([]byte(`{"session_id":"codex-abc123","hook_event_name":"SessionStart","source":"startup"}`), "codex")
+	if err != nil {
+		t.Fatalf("DecodeCodexEvent() error = %v", err)
+	}
+	if event.SessionID != "codex-abc123" {
+		t.Fatalf("SessionID = %q, want unchanged prefixed id", event.SessionID)
+	}
+}
+
+func TestDecodeCodexEventSessionStartPreservesSource(t *testing.T) {
+	t.Parallel()
+
+	event, err := DecodeCodexEvent([]byte(`{
+		"session_id":"s1",
+		"hook_event_name":"SessionStart",
+		"source":"resume",
+		"tool_input":{"reason":"startup"}
+	}`), "codex")
+	if err != nil {
+		t.Fatalf("DecodeCodexEvent() error = %v", err)
+	}
+	if event.HookName != hook.HookSessionStart {
+		t.Fatalf("HookName = %q, want SessionStart", event.HookName)
+	}
+	if event.ToolInput["source"] != "resume" {
+		t.Fatalf("ToolInput[source] = %v, want resume", event.ToolInput["source"])
+	}
+	if event.ToolInput["reason"] != "startup" {
+		t.Fatalf("ToolInput[reason] = %v, want startup", event.ToolInput["reason"])
+	}
+}
+
+func TestDecodeCodexEventUserPromptSubmitPreservesPrompt(t *testing.T) {
+	t.Parallel()
+
+	event, err := DecodeCodexEvent([]byte(`{
+		"session_id":"s1",
+		"hook_event_name":"UserPromptSubmit",
+		"prompt":"ship it",
+		"tool_input":{"model":"gpt-5-codex"}
+	}`), "codex")
+	if err != nil {
+		t.Fatalf("DecodeCodexEvent() error = %v", err)
+	}
+	if event.HookName != hook.HookUserPromptSubmit {
+		t.Fatalf("HookName = %q, want UserPromptSubmit", event.HookName)
+	}
+	if event.ToolInput["prompt"] != "ship it" {
+		t.Fatalf("ToolInput[prompt] = %v, want prompt", event.ToolInput["prompt"])
+	}
+	if event.ToolInput["model"] != "gpt-5-codex" {
+		t.Fatalf("ToolInput[model] = %v, want gpt-5-codex", event.ToolInput["model"])
+	}
+}
+
+func TestDecodeCodexEventTopLevelPromptTakesPrecedence(t *testing.T) {
+	t.Parallel()
+
+	event, err := DecodeCodexEvent([]byte(`{
+		"session_id":"s1",
+		"hook_event_name":"UserPromptSubmit",
+		"prompt":"top-level prompt",
+		"tool_input":{"prompt":"nested prompt"}
+	}`), "codex")
+	if err != nil {
+		t.Fatalf("DecodeCodexEvent() error = %v", err)
+	}
+	if event.ToolInput["prompt"] != "top-level prompt" {
+		t.Fatalf("ToolInput[prompt] = %v, want top-level prompt", event.ToolInput["prompt"])
+	}
+}
+
+func TestDecodeCodexEventStop(t *testing.T) {
+	t.Parallel()
+
+	event, err := DecodeCodexEvent([]byte(`{
+		"session_id":"s1",
+		"hook_event_name":"Stop",
+		"last_assistant_message":"done"
+	}`), "codex")
+	if err != nil {
+		t.Fatalf("DecodeCodexEvent() error = %v", err)
+	}
+	if event.HookName != hook.HookStop {
+		t.Fatalf("HookName = %q, want Stop", event.HookName)
+	}
+}
+
+func TestDecodeCodexEventRejectsClaudeOnlyLifecycleHooks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "post tool use failure",
+			input: `{"session_id":"s1","hook_event_name":"PostToolUseFailure","tool_name":"Bash"}`,
+		},
+		{
+			name:  "session end",
+			input: `{"session_id":"s1","hook_event_name":"SessionEnd","tool_input":{"reason":"exit"}}`,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := DecodeCodexEvent([]byte(tt.input), "codex")
+			if err == nil {
+				t.Fatal("DecodeCodexEvent() error = nil, want unsupported event error")
+			}
+			if !strings.Contains(err.Error(), "unsupported hook event") {
+				t.Fatalf("DecodeCodexEvent() error = %v, want unsupported hook event", err)
+			}
+		})
+	}
+}
+
+func TestDecodeCodexEventPostToolUsePreservesArrayResponse(t *testing.T) {
+	t.Parallel()
+
+	event, err := DecodeCodexEvent([]byte(`{
+		"session_id":"s1",
+		"hook_event_name":"PostToolUse",
+		"tool_name":"mcp__fs__read",
+		"tool_response":[{"id":9007199254740993}]
+	}`), "codex")
+	if err != nil {
+		t.Fatalf("DecodeCodexEvent() error = %v", err)
+	}
+	content, ok := event.ToolResponse["content"].([]any)
+	if !ok || len(content) != 1 {
+		t.Fatalf("ToolResponse[content] = %v (%T), want one item", event.ToolResponse["content"], event.ToolResponse["content"])
+	}
+	id := content[0].(map[string]any)["id"]
+	if num, ok := id.(json.Number); !ok || num.String() != "9007199254740993" {
+		t.Fatalf("response id = %v (%T), want json.Number", id, id)
+	}
+}
+
+func TestDecodeCodexEventRejectsUnsupportedPermissionRequest(t *testing.T) {
+	t.Parallel()
+
+	_, err := DecodeCodexEvent([]byte(`{"hook_event_name":"PermissionRequest"}`), "codex")
+	if err == nil {
+		t.Fatal("DecodeCodexEvent() error = nil, want unsupported event error")
+	}
+	if !strings.Contains(err.Error(), "unsupported hook event") {
+		t.Fatalf("DecodeCodexEvent() error = %v, want unsupported hook event", err)
+	}
+}
+
+func TestEncodeCodexPreToolUseDenyOmitsSuppressOutput(t *testing.T) {
+	t.Parallel()
+
+	out, err := EncodeCodexResult("PreToolUse", hook.Result{
+		Decision: hook.DecisionDeny,
+		Reason:   "Blocked by policy",
+	})
+	if err != nil {
+		t.Fatalf("EncodeCodexResult() error = %v", err)
+	}
+	text := string(out)
+	if !strings.Contains(text, `"permissionDecision":"deny"`) || !strings.Contains(text, "Blocked by policy") {
+		t.Fatalf("EncodeCodexResult() = %s, want deny decision and reason", text)
+	}
+	if strings.Contains(text, "suppressOutput") {
+		t.Fatalf("EncodeCodexResult() = %s, want no suppressOutput", text)
+	}
+}
+
+func TestEncodeCodexPreToolUseAllowUpdatedInputOmitsSuppressOutput(t *testing.T) {
+	t.Parallel()
+
+	out, err := EncodeCodexResult("PreToolUse", hook.Result{
+		Decision:     hook.DecisionAllow,
+		Reason:       "allowed",
+		UpdatedInput: map[string]any{"command": "echo rewritten"},
+	})
+	if err != nil {
+		t.Fatalf("EncodeCodexResult() error = %v", err)
+	}
+	text := string(out)
+	if !strings.Contains(text, `"permissionDecision":"allow"`) || !strings.Contains(text, `"updatedInput"`) {
+		t.Fatalf("EncodeCodexResult() = %s, want allow decision and updatedInput", text)
+	}
+	if strings.Contains(text, "suppressOutput") {
+		t.Fatalf("EncodeCodexResult() = %s, want no suppressOutput", text)
+	}
+}
+
+func TestEncodeCodexAllowNoOpOmitsSuppressOutput(t *testing.T) {
+	t.Parallel()
+
+	out, err := EncodeCodexResult("PostToolUse", hook.Result{
+		Decision: hook.DecisionAllow,
+		Reason:   "async telemetry event recorded",
+	})
+	if err != nil {
+		t.Fatalf("EncodeCodexResult() error = %v", err)
+	}
+	if got := string(out); got != "{}" {
+		t.Fatalf("EncodeCodexResult() = %s, want empty object", got)
+	}
+	if strings.Contains(string(out), "suppressOutput") {
+		t.Fatalf("EncodeCodexResult() = %s, want no suppressOutput", out)
+	}
+}
+
+func TestEncodeCodexUserPromptSubmitDenyBlocks(t *testing.T) {
+	t.Parallel()
+
+	out, err := EncodeCodexResult("UserPromptSubmit", hook.Result{
+		Decision: hook.DecisionDeny,
+		Reason:   "Ask for confirmation first",
+	})
+	if err != nil {
+		t.Fatalf("EncodeCodexResult() error = %v", err)
+	}
+	text := string(out)
+	if !strings.Contains(text, `"decision":"block"`) || !strings.Contains(text, "Ask for confirmation first") {
+		t.Fatalf("EncodeCodexResult() = %s, want block decision", text)
+	}
+	if strings.Contains(text, "suppressOutput") {
+		t.Fatalf("EncodeCodexResult() = %s, want no suppressOutput", text)
+	}
+}
+
+func TestEncodeCodexStopNoOps(t *testing.T) {
+	t.Parallel()
+
+	out, err := EncodeCodexResult("Stop", hook.Result{
+		Decision: hook.DecisionDeny,
+		Reason:   "Run another pass",
+	})
+	if err != nil {
+		t.Fatalf("EncodeCodexResult() error = %v", err)
+	}
+	if got := string(out); got != "{}" {
+		t.Fatalf("EncodeCodexResult() = %s, want empty object", got)
+	}
+}
+
+func TestEncodeCodexRejectsUnsupportedEvent(t *testing.T) {
+	t.Parallel()
+
+	_, err := EncodeCodexResult("PermissionRequest", hook.Result{Decision: hook.DecisionAllow})
+	if err == nil {
+		t.Fatal("EncodeCodexResult() error = nil, want unsupported event error")
+	}
+}

--- a/internal/localruntime/conversions.go
+++ b/internal/localruntime/conversions.go
@@ -144,7 +144,7 @@ func rawMap(data json.RawMessage) (map[string]any, error) {
 
 func normalizeHookName(value string) (hook.HookName, bool) {
 	switch hookName := hook.HookName(strings.TrimSpace(value)); hookName {
-	case hook.HookSessionStart, hook.HookPreToolUse, hook.HookPostToolUse, hook.HookPostToolUseFailed, hook.HookSessionEnd, hook.HookUserPromptSubmit:
+	case hook.HookSessionStart, hook.HookPreToolUse, hook.HookPostToolUse, hook.HookPostToolUseFailed, hook.HookSessionEnd, hook.HookUserPromptSubmit, hook.HookStop:
 		return hookName, true
 	default:
 		return "", false

--- a/internal/localruntime/service.go
+++ b/internal/localruntime/service.go
@@ -170,7 +170,7 @@ func (s *Service) handleConn(ctx context.Context, conn net.Conn) {
 		return
 	}
 
-	if s.asyncIngest && req.HookEvent != hook.HookPreToolUse.String() {
+	if s.asyncIngest && shouldAsyncIngest(&req) {
 		s.wg.Add(1)
 		go func() {
 			defer s.wg.Done()
@@ -190,6 +190,14 @@ func (s *Service) ingestEvent(ctx context.Context, req *EvaluateRequest) {
 		return
 	}
 	s.closeSessionEnd(ctx, event)
+}
+
+func shouldAsyncIngest(req *EvaluateRequest) bool {
+	if req == nil {
+		return false
+	}
+	hookName, ok := normalizeHookName(req.HookEvent)
+	return ok && !hookName.CanBlock()
 }
 
 func (s *Service) process(ctx context.Context, req *EvaluateRequest) EvaluateResult {

--- a/internal/localruntime/service_test.go
+++ b/internal/localruntime/service_test.go
@@ -74,6 +74,42 @@ func TestServiceCanAckTelemetryBeforeAsyncIngest(t *testing.T) {
 	}
 }
 
+func TestServiceDoesNotAsyncIngestBlockingPromptSubmit(t *testing.T) {
+	t.Parallel()
+
+	runtime := &stubRuntime{
+		evaluateResult: hook.Result{
+			Decision: hook.DecisionDeny,
+			Reason:   "blocked by runtime",
+		},
+	}
+	service := newTestService(t, runtime, true)
+	client := NewClient(service.SocketPath())
+
+	result, err := client.Process(context.Background(), hook.Event{
+		SessionID: "agent-session",
+		HookName:  hook.HookUserPromptSubmit,
+	})
+	if err != nil {
+		t.Fatalf("Process() error = %v", err)
+	}
+	if result.Decision != hook.DecisionDeny || result.Reason != "blocked by runtime" {
+		t.Fatalf("Process() = %+v, want runtime deny result", result)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := service.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+	if got := runtime.evaluateCalls.Load(); got != 1 {
+		t.Fatalf("EvaluateHook calls = %d, want 1", got)
+	}
+	if got := runtime.ingestCalls.Load(); got != 0 {
+		t.Fatalf("IngestEvent calls = %d, want 0", got)
+	}
+}
+
 func TestServiceShutdownDrainsAsyncIngest(t *testing.T) {
 	t.Parallel()
 

--- a/internal/managedobserve/lifecycle.go
+++ b/internal/managedobserve/lifecycle.go
@@ -139,7 +139,7 @@ func observeResult(event hook.Event, result hook.Result) hook.Result {
 	if result.Decision == "" {
 		result.Decision = hook.DecisionAllow
 	}
-	if event.HookName == hook.HookPreToolUse {
+	if event.HookName.CanBlock() {
 		decision := result.Decision
 		if result.Reason == "" {
 			result.Reason = "no reason provided"

--- a/internal/managedobserve/lifecycle_test.go
+++ b/internal/managedobserve/lifecycle_test.go
@@ -187,6 +187,20 @@ func TestLifecycleHealthySocketDoesNotKickstart(t *testing.T) {
 	}
 }
 
+func TestObserveResultFormatsBlockingPromptSubmit(t *testing.T) {
+	result := observeResult(hook.Event{HookName: hook.HookUserPromptSubmit}, hook.Result{
+		Decision: hook.DecisionDeny,
+		Reason:   "prompt policy",
+	})
+
+	if result.Decision != hook.DecisionAllow || result.Mode != string(guardhookruntime.ModeObserve) {
+		t.Fatalf("result = %+v, want observe allow", result)
+	}
+	if result.Reason != "Kontext observe mode: would deny; prompt policy" {
+		t.Fatalf("reason = %q, want observe deny reason", result.Reason)
+	}
+}
+
 func TestActiveRequiresValidManagedConfig(t *testing.T) {
 	t.Setenv("KONTEXT_MANAGED_CONFIG", filepath.Join(t.TempDir(), "missing.json"))
 	if Active() {

--- a/internal/runtimecore/core_test.go
+++ b/internal/runtimecore/core_test.go
@@ -27,6 +27,10 @@ func TestIngestEventRejectsBlockingHooks(t *testing.T) {
 	if err == nil {
 		t.Fatal("IngestEvent() error = nil, want blocking hook rejection")
 	}
+	_, err = core.IngestEvent(context.Background(), hook.Event{HookName: hook.HookUserPromptSubmit})
+	if err == nil {
+		t.Fatal("IngestEvent(UserPromptSubmit) error = nil, want blocking hook rejection")
+	}
 }
 
 func TestProcessHookRoutesByBlockingCapability(t *testing.T) {
@@ -42,15 +46,19 @@ func TestProcessHookRoutesByBlockingCapability(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	prompt, err := core.ProcessHook(context.Background(), hook.Event{HookName: hook.HookUserPromptSubmit})
+	if err != nil {
+		t.Fatal(err)
+	}
 	ingest, err := core.ProcessHook(context.Background(), hook.Event{HookName: hook.HookPostToolUse})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if runtime.evaluateCalls != 1 || runtime.ingestCalls != 1 {
+	if runtime.evaluateCalls != 2 || runtime.ingestCalls != 1 {
 		t.Fatalf("calls evaluate=%d ingest=%d", runtime.evaluateCalls, runtime.ingestCalls)
 	}
-	if evaluate.Decision != hook.DecisionDeny || ingest.Reason != "recorded" {
-		t.Fatalf("evaluate=%+v ingest=%+v", evaluate, ingest)
+	if evaluate.Decision != hook.DecisionDeny || prompt.Decision != hook.DecisionDeny || ingest.Reason != "recorded" {
+		t.Fatalf("evaluate=%+v prompt=%+v ingest=%+v", evaluate, prompt, ingest)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Register Codex as a first-class agent adapter.
- Add Codex hook decoding/encoding for session, tool, prompt, and turn-stop events.

## Review notes
- `UserPromptSubmit` is intentionally treated as a blocking event in the shared hook domain. In enforce mode, runtime/socket failures fail closed for `UserPromptSubmit`, matching Codex's ability to block prompts. Claude Guard user hooks still only install `PreToolUse`/`PostToolUse`, so this does not add a Claude user-hook install path.
- Codex `Stop` is treated as turn-scoped telemetry, not as a session-finalization event. Codex does not emit Claude's `SessionEnd`.

## Verification
- `go test ./...`