### PR TITLE
feat: support codex permission requests

### DIFF
--- a/internal/codexmanaged/hooks.go
+++ b/internal/codexmanaged/hooks.go
@@ -20,6 +20,7 @@ const (
 var SupportedEvents = []hook.EventAlias{
 	{Name: hook.HookSessionStart, Alias: "session-start"},
 	{Name: hook.HookPreToolUse, Alias: "pre-tool-use"},
+	{Name: hook.HookPermissionRequest, Alias: "permission-request"},
 	{Name: hook.HookPostToolUse, Alias: "post-tool-use"},
 	{Name: hook.HookPostToolUseFailed, Alias: "post-tool-use-failure"},
 	{Name: hook.HookSessionEnd, Alias: "session-end"},

--- a/internal/codexmanaged/hooks_test.go
+++ b/internal/codexmanaged/hooks_test.go
@@ -201,6 +201,7 @@ func TestIsManagedHookCommand(t *testing.T) {
 		{"'/usr/local/bin/kontext' hook --agent 'codex' 'pre-tool-use'", true},
 		{"'/Users/o'\\''brien/bin/kontext' hook --agent 'codex' 'pre-tool-use'", true},
 		{"'/Applications/Kontext CLI/kontext' hook --agent 'codex' 'session-start'", true},
+		{"'/opt/homebrew/bin/kontext' hook --agent codex permission-request", true},
 		{"'/Applications/Kontext CLI/kontext' hook --agent 'codex' 'post-tool-use-failure'", true},
 		{"'/Applications/Kontext CLI/kontext' hook --agent 'codex' 'session-end'", true},
 		{"'/opt/homebrew/bin/kontext' hook --agent codex user-prompt-submit", true},

--- a/internal/guard/risk/decision.go
+++ b/internal/guard/risk/decision.go
@@ -5,7 +5,7 @@ const PolicyVersionLaunchV0 = "guard-launch-v0"
 func DecideRisk(event HookEvent) (RiskDecision, error) {
 	riskEvent := NormalizeHookEvent(event)
 	riskEvent.PolicyVersion = PolicyVersionLaunchV0
-	if event.HookEventName != "PreToolUse" {
+	if !evaluatesRiskPolicy(event.HookEventName) {
 		riskEvent.Decision = DecisionAllow
 		riskEvent.ReasonCode = "async_telemetry"
 		riskEvent.DecisionStage = "async_telemetry"
@@ -39,6 +39,15 @@ func DecideRisk(event HookEvent) (RiskDecision, error) {
 		}
 	}
 	return decision, nil
+}
+
+func evaluatesRiskPolicy(hookEventName string) bool {
+	switch hookEventName {
+	case "PreToolUse", "PermissionRequest":
+		return true
+	default:
+		return false
+	}
 }
 
 func DeterministicDecision(event RiskEvent) RiskDecision {

--- a/internal/guard/risk/risk_test.go
+++ b/internal/guard/risk/risk_test.go
@@ -197,6 +197,19 @@ func TestDeterministicDecisionBlocksDestructiveCommand(t *testing.T) {
 	}
 }
 
+func TestDeterministicDecisionBlocksPermissionRequest(t *testing.T) {
+	decision, err := DecideRisk(HookEvent{HookEventName: "PermissionRequest", ToolName: "Bash", ToolInput: map[string]any{"command": "drop database"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Decision != DecisionDeny {
+		t.Fatalf("decision = %s", decision.Decision)
+	}
+	if decision.ReasonCode != "destructive_operation_without_intent" {
+		t.Fatalf("reason code = %s", decision.ReasonCode)
+	}
+}
+
 func TestDeterministicDecisionAllowsNormalToolCalls(t *testing.T) {
 	decision, err := DecideRisk(HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{"file_path": "README.md"}})
 	if err != nil {

--- a/internal/hook/domain.go
+++ b/internal/hook/domain.go
@@ -7,6 +7,7 @@ type HookName string
 const (
 	HookSessionStart      HookName = "SessionStart"
 	HookPreToolUse        HookName = "PreToolUse"
+	HookPermissionRequest HookName = "PermissionRequest"
 	HookPostToolUse       HookName = "PostToolUse"
 	HookPostToolUseFailed HookName = "PostToolUseFailure"
 	HookSessionEnd        HookName = "SessionEnd"
@@ -19,7 +20,7 @@ func (h HookName) String() string {
 
 func (h HookName) IsKnown() bool {
 	switch h {
-	case HookSessionStart, HookPreToolUse, HookPostToolUse, HookPostToolUseFailed, HookSessionEnd, HookUserPromptSubmit:
+	case HookSessionStart, HookPreToolUse, HookPermissionRequest, HookPostToolUse, HookPostToolUseFailed, HookSessionEnd, HookUserPromptSubmit:
 		return true
 	default:
 		return false
@@ -27,7 +28,7 @@ func (h HookName) IsKnown() bool {
 }
 
 func (h HookName) CanBlock() bool {
-	return h == HookPreToolUse || h == HookUserPromptSubmit
+	return h == HookPreToolUse || h == HookPermissionRequest || h == HookUserPromptSubmit
 }
 
 type EventAlias struct {
@@ -38,6 +39,7 @@ type EventAlias struct {
 var eventAliases = []EventAlias{
 	{Name: HookSessionStart, Alias: "session-start"},
 	{Name: HookPreToolUse, Alias: "pre-tool-use"},
+	{Name: HookPermissionRequest, Alias: "permission-request"},
 	{Name: HookPostToolUse, Alias: "post-tool-use"},
 	{Name: HookPostToolUseFailed, Alias: "post-tool-use-failure"},
 	{Name: HookSessionEnd, Alias: "session-end"},

--- a/internal/hook/domain_test.go
+++ b/internal/hook/domain_test.go
@@ -75,6 +75,9 @@ func TestHookNameCanBlock(t *testing.T) {
 	if !HookUserPromptSubmit.CanBlock() {
 		t.Fatalf("HookUserPromptSubmit.CanBlock() = false, want true")
 	}
+	if !HookPermissionRequest.CanBlock() {
+		t.Fatalf("HookPermissionRequest.CanBlock() = false, want true")
+	}
 	if HookPostToolUse.CanBlock() {
 		t.Fatalf("HookPostToolUse.CanBlock() = true, want false")
 	}
@@ -95,6 +98,7 @@ func TestParseEventAlias(t *testing.T) {
 	}{
 		{alias: "session-start", want: HookSessionStart},
 		{alias: "pre-tool-use", want: HookPreToolUse},
+		{alias: "permission-request", want: HookPermissionRequest},
 		{alias: "post-tool-use", want: HookPostToolUse},
 		{alias: "post-tool-use-failure", want: HookPostToolUseFailed},
 		{alias: "session-end", want: HookSessionEnd},
@@ -124,7 +128,14 @@ func TestParseEventAlias(t *testing.T) {
 func TestAliasForEvent(t *testing.T) {
 	t.Parallel()
 
-	got, ok := AliasForEvent(HookUserPromptSubmit)
+	got, ok := AliasForEvent(HookPermissionRequest)
+	if !ok {
+		t.Fatal("AliasForEvent(HookPermissionRequest) ok = false")
+	}
+	if got != "permission-request" {
+		t.Fatalf("AliasForEvent(HookPermissionRequest) = %q, want permission-request", got)
+	}
+	got, ok = AliasForEvent(HookUserPromptSubmit)
 	if !ok {
 		t.Fatal("AliasForEvent(HookUserPromptSubmit) ok = false")
 	}

--- a/internal/hookruntime/codex.go
+++ b/internal/hookruntime/codex.go
@@ -37,8 +37,14 @@ type codexHookSpecificOutput struct {
 	HookEventName            string         `json:"hookEventName"`
 	PermissionDecision       string         `json:"permissionDecision,omitempty"`
 	PermissionDecisionReason string         `json:"permissionDecisionReason,omitempty"`
+	Decision                 *codexDecision `json:"decision,omitempty"`
 	AdditionalContext        string         `json:"additionalContext,omitempty"`
 	UpdatedInput             map[string]any `json:"updatedInput,omitempty"`
+}
+
+type codexDecision struct {
+	Behavior string `json:"behavior"`
+	Message  string `json:"message,omitempty"`
 }
 
 func DecodeCodexEvent(input []byte, agentName string) (hook.Event, error) {
@@ -81,6 +87,9 @@ func EncodeCodexResult(hookEventName string, result hook.Result) ([]byte, error)
 	if hookName == hook.HookPreToolUse {
 		return encodeCodexPreToolUseResult(hookEventName, result, reason)
 	}
+	if hookName == hook.HookPermissionRequest {
+		return encodeCodexPermissionRequestResult(hookEventName, result)
+	}
 	return encodeCodexNonPreToolUseResult(hookEventName, result, reason)
 }
 
@@ -109,6 +118,48 @@ func encodeCodexPreToolUseResult(hookEventName string, result hook.Result, reaso
 		out.HookSpecificOutput.PermissionDecision = string(hook.DecisionAllow)
 	}
 	return json.Marshal(out)
+}
+
+func encodeCodexPermissionRequestResult(hookEventName string, result hook.Result) ([]byte, error) {
+	if codexShouldDeclinePermissionRequest(result) {
+		return json.Marshal(codexHookOutput{})
+	}
+	if result.Decision != hook.DecisionAllow {
+		return json.Marshal(codexHookOutput{
+			HookSpecificOutput: &codexHookSpecificOutput{
+				HookEventName: hookEventName,
+				Decision: &codexDecision{
+					Behavior: string(hook.DecisionDeny),
+					Message:  result.ClaudeReason(),
+				},
+			},
+		})
+	}
+	if !codexCanAllowPermissionRequest(result) {
+		return json.Marshal(codexHookOutput{})
+	}
+	return json.Marshal(codexHookOutput{
+		HookSpecificOutput: &codexHookSpecificOutput{
+			HookEventName: hookEventName,
+			Decision: &codexDecision{
+				Behavior: string(hook.DecisionAllow),
+			},
+		},
+	})
+}
+
+func codexShouldDeclinePermissionRequest(result hook.Result) bool {
+	if strings.EqualFold(strings.TrimSpace(result.Mode), "observe") {
+		return true
+	}
+	reason := strings.TrimSpace(result.Reason)
+	return strings.HasPrefix(reason, "Kontext observe mode: would deny;") ||
+		strings.HasPrefix(reason, "Kontext observe mode: would allow;")
+}
+
+func codexCanAllowPermissionRequest(result hook.Result) bool {
+	mode := strings.TrimSpace(result.Mode)
+	return mode == "" || strings.EqualFold(mode, "local") || strings.EqualFold(mode, "enforce")
 }
 
 func encodeCodexNonPreToolUseResult(hookEventName string, result hook.Result, reason string) ([]byte, error) {
@@ -143,6 +194,7 @@ func codexSupportedHook(hookName hook.HookName) bool {
 	switch hookName {
 	case hook.HookSessionStart,
 		hook.HookPreToolUse,
+		hook.HookPermissionRequest,
 		hook.HookPostToolUse,
 		hook.HookPostToolUseFailed,
 		hook.HookSessionEnd,

--- a/internal/hookruntime/codex_test.go
+++ b/internal/hookruntime/codex_test.go
@@ -174,15 +174,118 @@ func TestDecodeCodexEventPostToolUsePreservesArrayResponse(t *testing.T) {
 	}
 }
 
-func TestDecodeCodexEventRejectsUnsupportedPermissionRequest(t *testing.T) {
+func TestDecodeCodexEventPermissionRequest(t *testing.T) {
 	t.Parallel()
 
-	_, err := DecodeCodexEvent([]byte(`{"hook_event_name":"PermissionRequest"}`), "codex")
+	event, err := DecodeCodexEvent([]byte(`{
+		"session_id":"s1",
+		"hook_event_name":"PermissionRequest",
+		"tool_name":"Bash",
+		"tool_input":{"command":"sudo make install"}
+	}`), "codex")
+	if err != nil {
+		t.Fatalf("DecodeCodexEvent() error = %v", err)
+	}
+	if event.HookName != hook.HookPermissionRequest || !event.HookName.CanBlock() {
+		t.Fatalf("HookName = %q, want blocking PermissionRequest", event.HookName)
+	}
+	if event.ToolInput["command"] != "sudo make install" {
+		t.Fatalf("ToolInput[command] = %v, want command", event.ToolInput["command"])
+	}
+}
+
+func TestDecodeCodexEventRejectsUnsupportedEvent(t *testing.T) {
+	t.Parallel()
+
+	_, err := DecodeCodexEvent([]byte(`{"hook_event_name":"UnsupportedHook"}`), "codex")
 	if err == nil {
 		t.Fatal("DecodeCodexEvent() error = nil, want unsupported event error")
 	}
 	if !strings.Contains(err.Error(), "unsupported hook event") {
 		t.Fatalf("DecodeCodexEvent() error = %v, want unsupported hook event", err)
+	}
+}
+
+func TestEncodeCodexPermissionRequestDeny(t *testing.T) {
+	t.Parallel()
+
+	out, err := EncodeCodexResult("PermissionRequest", hook.Result{
+		Decision: hook.DecisionDeny,
+		Reason:   "Blocked by policy",
+	})
+	if err != nil {
+		t.Fatalf("EncodeCodexResult() error = %v", err)
+	}
+	var got codexHookOutput
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if got.HookSpecificOutput == nil || got.HookSpecificOutput.Decision == nil {
+		t.Fatalf("EncodeCodexResult() = %s, want hookSpecificOutput.decision", out)
+	}
+	if got.HookSpecificOutput.Decision.Behavior != "deny" {
+		t.Fatalf("behavior = %q, want deny", got.HookSpecificOutput.Decision.Behavior)
+	}
+	if got.HookSpecificOutput.Decision.Message != "Blocked by policy" {
+		t.Fatalf("message = %q, want reason", got.HookSpecificOutput.Decision.Message)
+	}
+}
+
+func TestEncodeCodexPermissionRequestAllow(t *testing.T) {
+	t.Parallel()
+
+	for _, mode := range []string{"", "local", "enforce"} {
+		mode := mode
+		t.Run("mode="+mode, func(t *testing.T) {
+			t.Parallel()
+
+			out, err := EncodeCodexResult("PermissionRequest", hook.Result{
+				Decision: hook.DecisionAllow,
+				Mode:     mode,
+				Reason:   "allowed",
+			})
+			if err != nil {
+				t.Fatalf("EncodeCodexResult() error = %v", err)
+			}
+			var got codexHookOutput
+			if err := json.Unmarshal(out, &got); err != nil {
+				t.Fatalf("Unmarshal() error = %v", err)
+			}
+			if got.HookSpecificOutput == nil || got.HookSpecificOutput.Decision == nil {
+				t.Fatalf("EncodeCodexResult() = %s, want hookSpecificOutput.decision", out)
+			}
+			if got.HookSpecificOutput.Decision.Behavior != "allow" {
+				t.Fatalf("behavior = %q, want allow", got.HookSpecificOutput.Decision.Behavior)
+			}
+			if got.HookSpecificOutput.Decision.Message != "" {
+				t.Fatalf("message = %q, want empty allow message", got.HookSpecificOutput.Decision.Message)
+			}
+		})
+	}
+}
+
+func TestEncodeCodexPermissionRequestDeclinesObserveDecisions(t *testing.T) {
+	t.Parallel()
+
+	tests := []hook.Result{
+		{Decision: hook.DecisionAllow, Mode: "observe", Reason: "Kontext observe mode: would deny; blocked"},
+		{Decision: hook.DecisionAllow, Mode: "observe", Reason: "Kontext observe mode: would allow; allowed"},
+		{Decision: hook.DecisionAllow, Reason: "Kontext observe mode: would deny; blocked"},
+		{Decision: hook.DecisionAllow, Mode: "no_policy", Reason: "backend observed a block"},
+	}
+	for _, result := range tests {
+		result := result
+		t.Run(result.Reason+" "+result.Mode, func(t *testing.T) {
+			t.Parallel()
+
+			out, err := EncodeCodexResult("PermissionRequest", result)
+			if err != nil {
+				t.Fatalf("EncodeCodexResult() error = %v", err)
+			}
+			if got := string(out); got != "{}" {
+				t.Fatalf("EncodeCodexResult() = %s, want empty object", got)
+			}
+		})
 	}
 }
 
@@ -265,7 +368,7 @@ func TestEncodeCodexUserPromptSubmitDenyBlocks(t *testing.T) {
 func TestEncodeCodexRejectsUnsupportedEvent(t *testing.T) {
 	t.Parallel()
 
-	_, err := EncodeCodexResult("PermissionRequest", hook.Result{Decision: hook.DecisionAllow})
+	_, err := EncodeCodexResult("UnsupportedHook", hook.Result{Decision: hook.DecisionAllow})
 	if err == nil {
 		t.Fatal("EncodeCodexResult() error = nil, want unsupported event error")
 	}

--- a/internal/localruntime/conversions.go
+++ b/internal/localruntime/conversions.go
@@ -144,7 +144,7 @@ func rawMap(data json.RawMessage) (map[string]any, error) {
 
 func normalizeHookName(value string) (hook.HookName, bool) {
 	switch hookName := hook.HookName(strings.TrimSpace(value)); hookName {
-	case hook.HookSessionStart, hook.HookPreToolUse, hook.HookPostToolUse, hook.HookPostToolUseFailed, hook.HookSessionEnd, hook.HookUserPromptSubmit:
+	case hook.HookSessionStart, hook.HookPreToolUse, hook.HookPermissionRequest, hook.HookPostToolUse, hook.HookPostToolUseFailed, hook.HookSessionEnd, hook.HookUserPromptSubmit:
 		return hookName, true
 	default:
 		return "", false

--- a/internal/localruntime/conversions_test.go
+++ b/internal/localruntime/conversions_test.go
@@ -48,6 +48,26 @@ func TestEvaluateRequestFromEventPreservesHookFields(t *testing.T) {
 	}
 }
 
+func TestEvaluateRequestFromEventPreservesPermissionRequest(t *testing.T) {
+	t.Parallel()
+
+	req, err := EvaluateRequestFromEvent(hook.Event{
+		HookName:  hook.HookPermissionRequest,
+		ToolName:  "Bash",
+		ToolInput: map[string]any{"command": "sudo make install"},
+	})
+	if err != nil {
+		t.Fatalf("EvaluateRequestFromEvent() error = %v", err)
+	}
+
+	if req.HookEvent != "PermissionRequest" || req.ToolName != "Bash" {
+		t.Fatalf("request = %+v, want PermissionRequest Bash event", req)
+	}
+	if !json.Valid(req.ToolInput) {
+		t.Fatalf("ToolInput = %s, want valid JSON", req.ToolInput)
+	}
+}
+
 func TestEventFromEvaluateRequestPreservesHookFields(t *testing.T) {
 	t.Parallel()
 
@@ -85,6 +105,26 @@ func TestEventFromEvaluateRequestPreservesHookFields(t *testing.T) {
 		event.IsInterrupt == nil ||
 		*event.IsInterrupt {
 		t.Fatalf("event = %+v, want request fields preserved", event)
+	}
+}
+
+func TestEventFromEvaluateRequestAcceptsPermissionRequest(t *testing.T) {
+	t.Parallel()
+
+	event, err := EventFromEvaluateRequest("session-123", "codex", &EvaluateRequest{
+		HookEvent: "PermissionRequest",
+		ToolName:  "Bash",
+		ToolInput: json.RawMessage(`{"command":"sudo make install"}`),
+	})
+	if err != nil {
+		t.Fatalf("EventFromEvaluateRequest() error = %v", err)
+	}
+
+	if event.HookName != hook.HookPermissionRequest || !event.HookName.CanBlock() {
+		t.Fatalf("event.HookName = %q, want blocking PermissionRequest", event.HookName)
+	}
+	if event.ToolInput["command"] != "sudo make install" {
+		t.Fatalf("ToolInput[command] = %v, want command preserved", event.ToolInput["command"])
 	}
 }
 

--- a/internal/localruntime/service.go
+++ b/internal/localruntime/service.go
@@ -170,7 +170,7 @@ func (s *Service) handleConn(ctx context.Context, conn net.Conn) {
 		return
 	}
 
-	if s.asyncIngest && shouldAsyncIngest(&req) {
+	if s.shouldAsyncIngest(&req) {
 		s.wg.Add(1)
 		go func() {
 			defer s.wg.Done()
@@ -192,14 +192,6 @@ func (s *Service) ingestEvent(ctx context.Context, req *EvaluateRequest) {
 	s.closeSessionEnd(ctx, event)
 }
 
-func shouldAsyncIngest(req *EvaluateRequest) bool {
-	if req == nil {
-		return false
-	}
-	hookName, ok := normalizeHookName(req.HookEvent)
-	return ok && !hookName.CanBlock()
-}
-
 func (s *Service) process(ctx context.Context, req *EvaluateRequest) EvaluateResult {
 	event, err := EventFromEvaluateRequest(s.sessionID, s.agentName, req)
 	if err != nil {
@@ -219,6 +211,14 @@ func (s *Service) process(ctx context.Context, req *EvaluateRequest) EvaluateRes
 	}
 	s.closeSessionEnd(ctx, event)
 	return s.result(event, result)
+}
+
+func (s *Service) shouldAsyncIngest(req *EvaluateRequest) bool {
+	if !s.asyncIngest || req == nil {
+		return false
+	}
+	hookName, ok := normalizeHookName(req.HookEvent)
+	return ok && !hookName.CanBlock()
 }
 
 func (s *Service) result(event hook.Event, result hook.Result) EvaluateResult {

--- a/internal/localruntime/service_test.go
+++ b/internal/localruntime/service_test.go
@@ -42,6 +42,42 @@ func TestServiceEvaluatesBlockingHook(t *testing.T) {
 	}
 }
 
+func TestServiceEvaluatesPermissionRequestSynchronously(t *testing.T) {
+	t.Parallel()
+
+	runtime := &stubRuntime{
+		evaluateResult: hook.Result{
+			Decision: hook.DecisionDeny,
+			Reason:   "blocked by runtime",
+		},
+	}
+	service := newTestService(t, runtime, true)
+	client := NewClient(service.SocketPath())
+
+	result, err := client.Process(context.Background(), hook.Event{
+		HookName: hook.HookPermissionRequest,
+		ToolName: "Bash",
+		ToolInput: map[string]any{
+			"command": "sudo make install",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Process() error = %v", err)
+	}
+	if result.Decision != hook.DecisionDeny || result.Reason != "blocked by runtime" {
+		t.Fatalf("Process() = %+v, want runtime deny result", result)
+	}
+	if got := runtime.evaluateCalls.Load(); got != 1 {
+		t.Fatalf("EvaluateHook calls = %d, want 1", got)
+	}
+	if err := service.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+	if got := runtime.ingestCalls.Load(); got != 0 {
+		t.Fatalf("IngestEvent calls = %d, want 0", got)
+	}
+}
+
 func TestServiceCanAckTelemetryBeforeAsyncIngest(t *testing.T) {
 	t.Parallel()
 
@@ -256,6 +292,23 @@ func TestServiceFailsClosedWhenBlockingHookPayloadCannotDecode(t *testing.T) {
 	service := newTestService(t, &stubRuntime{}, false)
 	result := service.process(context.Background(), &EvaluateRequest{
 		HookEvent: "PreToolUse",
+		ToolInput: []byte(`{`),
+	})
+
+	if result.Allowed {
+		t.Fatal("result.Allowed = true, want false")
+	}
+	if result.Decision != string(hook.DecisionDeny) {
+		t.Fatalf("result.Decision = %q, want deny", result.Decision)
+	}
+}
+
+func TestServiceFailsClosedWhenPermissionRequestPayloadCannotDecode(t *testing.T) {
+	t.Parallel()
+
+	service := newTestService(t, &stubRuntime{}, true)
+	result := service.process(context.Background(), &EvaluateRequest{
+		HookEvent: "PermissionRequest",
 		ToolInput: []byte(`{`),
 	})
 


### PR DESCRIPTION
## Summary
- Add Codex `PermissionRequest` as a blocking hook event.
- Route approval requests through local runtime/risk policy and install the hook.
- Decline observe-mode permission decisions so Codex keeps its normal approval flow.

## Verification
- `go test ./...`