### PR TITLE
fix(setup): clean org-managed setup UX

### DIFF
--- a/cmd/kontext/setup.go
+++ b/cmd/kontext/setup.go
@@ -10,8 +10,10 @@ func setupCmd() *cobra.Command {
 	var token, cloudURL string
 	var uninstall bool
 	cmd := &cobra.Command{
-		Use:   "setup",
-		Short: "Connect this Mac to your Kontext organization",
+		Use:           "setup",
+		Short:         "Connect this Mac to your Kontext organization",
+		SilenceUsage:  true,
+		SilenceErrors: true,
 		Long: `Connect this Mac to your Kontext organization (self-serve managed observe).
 
 Setup asks for the install token created in the Kontext dashboard, stores it

--- a/cmd/kontext/setup_test.go
+++ b/cmd/kontext/setup_test.go
@@ -42,3 +42,13 @@ func TestSetupCmdRegistered(t *testing.T) {
 		t.Fatalf("Use = %q", cmd.Use)
 	}
 }
+
+func TestSetupCmdSilencesUsageForRuntimeErrors(t *testing.T) {
+	cmd := setupCmd()
+	if !cmd.SilenceUsage {
+		t.Fatal("setup runtime errors should not print command usage")
+	}
+	if !cmd.SilenceErrors {
+		t.Fatal("setup runtime errors should be printed once by main")
+	}
+}

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -6,6 +6,7 @@
 package setup
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -18,6 +19,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -68,6 +70,9 @@ var (
 	isTerminal = func(fd int) bool {
 		return term.IsTerminal(fd)
 	}
+	readLine = func(r io.Reader) (string, error) {
+		return bufio.NewReader(r).ReadString('\n')
+	}
 	executablePath = os.Executable
 	geteuid        = os.Geteuid
 	resolveToken   = managedconfig.ResolveInstallToken
@@ -79,6 +84,7 @@ var (
 		return conn.Close()
 	}
 	systemConfigPath    = managedconfig.DefaultPath
+	orgInstallTokenPath = "/Library/Application Support/Kontext/install-token"
 	managedSettingsPath = claudemanaged.ManagedSettingsDropInPath
 	managedSettingsFile = claudemanaged.ManagedSettingsPath
 	goos                = runtime.GOOS
@@ -113,14 +119,18 @@ func Run(ctx context.Context, opts Options) error {
 	if err != nil {
 		return err
 	}
-	if err := refuseManagedEnvironments(settingsData); err != nil {
+	fmt.Fprintln(opts.Stdout, "Kontext setup")
+
+	ok, err := prepareManagedEnvironment(ctx, opts, settingsData)
+	if err != nil {
 		return err
+	}
+	if !ok {
+		return nil
 	}
 	if err := preflightLegacyUserHooks(); err != nil {
 		return err
 	}
-
-	fmt.Fprintln(opts.Stdout, "Kontext setup")
 
 	cloudURL := strings.TrimSpace(opts.CloudURL)
 	if cloudURL == "" {
@@ -218,24 +228,113 @@ func Run(ctx context.Context, opts Options) error {
 	return nil
 }
 
-// refuseManagedEnvironments keeps self-serve setup away from machines that
-// are (or claim to be) organization-managed: a system config under /Library
-// always outranks anything setup could write, so proceeding would only
-// produce artifacts the daemon ignores.
-func refuseManagedEnvironments(settingsData []byte) error {
+// prepareManagedEnvironment keeps self-serve setup away from machines that
+// are silently organization-managed. In an interactive terminal, setup can
+// remove the local enterprise state and continue; in non-interactive contexts,
+// it refuses with copy-pasteable cleanup steps.
+func prepareManagedEnvironment(ctx context.Context, opts Options, settingsData []byte) (bool, error) {
 	// ANY env override means config resolution is explicitly env-driven —
 	// even one pointing at the user path. Setup must not write state whose
 	// activation depends on an environment variable it doesn't control.
 	if strings.TrimSpace(os.Getenv(managedconfig.EnvPath)) != "" {
-		return fmt.Errorf("%s is set; unset it before running setup", managedconfig.EnvPath)
+		return false, fmt.Errorf("%s is set; unset it before running setup", managedconfig.EnvPath)
 	}
 	if _, err := os.Lstat(systemConfigPath); err == nil {
-		return fmt.Errorf("this Mac is organization-managed\n\nSystem config\n  %s\n\nSelf-serve setup cannot continue because system config wins over user config.\nNothing changed.", systemConfigPath)
+		confirmed, err := confirmRemoveOrganizationManagedInstall(ctx, opts)
+		if err != nil {
+			return false, err
+		}
+		if !confirmed {
+			return false, nil
+		}
 	} else if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("cannot determine whether this Mac is organization-managed: %w", err)
+		return false, fmt.Errorf("cannot determine whether this Mac is organization-managed: %w", err)
 	}
 	if err := refuseUnknownManagedSettingsOwner(settingsData); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func confirmRemoveOrganizationManagedInstall(ctx context.Context, opts Options) (bool, error) {
+	if !isTerminal(int(os.Stdin.Fd())) {
+		return false, errors.New(organizationManagedMessage("Self-serve setup cannot continue because system config wins over user config."))
+	}
+
+	fmt.Fprintln(opts.Stdout, "\nMac")
+	fmt.Fprintln(opts.Stdout, "  ! Organization-managed install detected")
+	fmt.Fprintf(opts.Stdout, "  • System config: %s\n", systemConfigPath)
+	fmt.Fprint(opts.Stdout, "  ? Remove organization-managed install and continue? [y/N] ")
+
+	answer, err := readLine(os.Stdin)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return false, fmt.Errorf("read confirmation: %w", err)
+	}
+	switch strings.ToLower(strings.TrimSpace(answer)) {
+	case "y", "yes":
+		if err := removeOrganizationManagedInstall(ctx); err != nil {
+			return false, err
+		}
+		fmt.Fprintln(opts.Stdout, "  ✓ Organization-managed files removed")
+		fmt.Fprintln(opts.Stdout, "  ✓ Organization-managed background agent stopped")
+		return true, nil
+	default:
+		fmt.Fprintln(opts.Stdout, "  • Nothing changed.")
+		fmt.Fprintln(opts.Stdout, "\nNext")
+		fmt.Fprintln(opts.Stdout, "  Remove the MDM profile or enterprise package that installed Kontext.")
+		fmt.Fprintln(opts.Stdout, "  For local testing, remove the enterprise files and run setup again.")
+		return false, nil
+	}
+}
+
+func removeOrganizationManagedInstall(ctx context.Context) error {
+	removeRootSettings, err := ownedRootManagedSettingsExists()
+	if err != nil {
 		return err
+	}
+	paths := []string{systemConfigPath, orgInstallTokenPath}
+	if removeRootSettings {
+		paths = append(paths, managedSettingsFile)
+	}
+	if err := removeOrganizationManagedFiles(ctx, paths...); err != nil {
+		return err
+	}
+
+	serviceTarget := "gui/" + strconv.Itoa(os.Getuid()) + "/" + LaunchAgentLabel
+	out, err := execCommand(ctx, "", "launchctl", "bootout", serviceTarget)
+	if err != nil && !launchctlPrintMeansAbsent(out) {
+		return fmt.Errorf("stop organization-managed background agent: launchctl bootout failed: %w (%s)", err, strings.TrimSpace(out))
+	}
+	return nil
+}
+
+func ownedRootManagedSettingsExists() (bool, error) {
+	data, err := os.ReadFile(managedSettingsFile)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("cannot determine Claude root managed settings ownership: %w", err)
+	}
+	if !claudemanaged.IsManagedSettingsDropIn(data) {
+		return false, fmt.Errorf("Claude Code root managed settings already exist\n\nManaged settings\n  %s\n\nSelf-serve setup cannot continue because root managed settings may contain organization or foreign hooks.\nNothing changed.", managedSettingsFile)
+	}
+	return true, nil
+}
+
+func removeOrganizationManagedFiles(ctx context.Context, paths ...string) error {
+	if geteuid() == 0 {
+		for _, path := range paths {
+			if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("remove organization-managed file %s: %w", path, err)
+			}
+		}
+		return nil
+	}
+
+	args := append([]string{"rm", "-f"}, paths...)
+	if err := runPrivilegedCommand(ctx, "sudo", args...); err != nil {
+		return fmt.Errorf("remove organization-managed files: %w", err)
 	}
 	return nil
 }
@@ -260,6 +359,24 @@ func refuseUnknownManagedSettingsOwner(_ []byte) error {
 		return fmt.Errorf("Claude Code managed hooks already exist\n\nManaged hooks\n  %s\n\nSelf-serve setup cannot continue because hook ownership is unknown.\nNothing changed.", managedSettingsPath)
 	}
 	return nil
+}
+
+func organizationManagedMessage(reason string) string {
+	return fmt.Sprintf(`Organization-managed install detected
+
+Mac
+  ! %s
+  • System config: %s
+  • Nothing changed.
+
+Remove the organization-managed install first:
+  1. Remove the MDM profile or enterprise package that installed Kontext.
+  2. For local testing, clean the enterprise files:
+     sudo rm -f "/Library/Application Support/Kontext/managed.json"
+     sudo rm -f "/Library/Application Support/Kontext/install-token"
+     sudo rm -f "/Library/Application Support/ClaudeCode/managed-settings.json"
+     launchctl bootout gui/$(id -u)/%s 2>/dev/null || true
+  3. Run self-serve setup again.`, reason, systemConfigPath, LaunchAgentLabel)
 }
 
 // acquireToken never mutates the input: a token containing whitespace fails

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -44,6 +45,7 @@ func newHarness(t *testing.T) *harness {
 
 	overrideVar(t, &goos, "darwin")
 	overrideVar(t, &systemConfigPath, filepath.Join(h.home, "no-system", "managed.json"))
+	overrideVar(t, &orgInstallTokenPath, filepath.Join(h.home, "no-system", "install-token"))
 	overrideVar(t, &managedSettingsPath, filepath.Join(h.home, "Library", "Application Support", "ClaudeCode", "managed-settings.d", "20-kontext.json"))
 	overrideVar(t, &managedSettingsFile, filepath.Join(h.home, "Library", "Application Support", "ClaudeCode", "managed-settings.json"))
 	overrideVar(t, &geteuid, func() int { return 0 })
@@ -319,12 +321,161 @@ func TestRunRefusesMDMManagedMac(t *testing.T) {
 		t.Fatalf("Run() error = %v, want MDM refusal", err)
 	}
 	for _, want := range []string{
-		"System config\n  " + system,
+		"Organization-managed install detected",
+		"System config: " + system,
 		"system config wins over user config",
+		"Remove the organization-managed install first",
+		`sudo rm -f "/Library/Application Support/Kontext/managed.json"`,
 		"Nothing changed.",
 	} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("Run() error = %v, missing %q", err, want)
+		}
+	}
+}
+
+func TestRunStopsWhenOrganizationManagedRemovalDeclined(t *testing.T) {
+	h := newHarness(t)
+	allowLoopback(t)
+	if err := os.MkdirAll(filepath.Dir(systemConfigPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(systemConfigPath, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	overrideVar(t, &isTerminal, func(int) bool { return true })
+	overrideVar(t, &readLine, func(io.Reader) (string, error) { return "no\n", nil })
+	server := pingServer(t, "tok")
+
+	if err := Run(context.Background(), h.options("tok", server)); err != nil {
+		t.Fatalf("Run() error = %v, want clean stop", err)
+	}
+
+	if _, err := os.Stat(systemConfigPath); err != nil {
+		t.Fatalf("system config changed after declined removal: %v", err)
+	}
+	if _, err := os.Stat(managedconfig.UserPath()); !os.IsNotExist(err) {
+		t.Fatal("managed.json written despite declined removal")
+	}
+	if len(h.keychain) != 0 {
+		t.Fatal("keychain written despite declined removal")
+	}
+	for _, call := range h.calls {
+		if call.name == "launchctl" {
+			t.Fatalf("launchctl called despite declined removal: %v", call.args)
+		}
+	}
+	stdout := h.out.String()
+	for _, want := range []string{
+		"Kontext setup",
+		"Organization-managed install detected",
+		"Remove organization-managed install and continue? [y/N]",
+		"Nothing changed.",
+		"Remove the MDM profile or enterprise package",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestRunRemovesOrganizationManagedInstallAndContinues(t *testing.T) {
+	h := newHarness(t)
+	allowLoopback(t)
+	ownedRootSettings, err := managedSettingsData("/opt/homebrew/bin/kontext")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{systemConfigPath, orgInstallTokenPath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("{}"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Dir(managedSettingsFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(managedSettingsFile, ownedRootSettings, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	overrideVar(t, &isTerminal, func(int) bool { return true })
+	overrideVar(t, &readLine, func(io.Reader) (string, error) { return "yes\n", nil })
+	server := pingServer(t, "tok")
+
+	if err := Run(context.Background(), h.options("tok", server)); err != nil {
+		t.Fatalf("Run() error = %v\nstdout:\n%s\nstderr:\n%s", err, h.out.String(), h.errOut.String())
+	}
+
+	for _, path := range []string{systemConfigPath, orgInstallTokenPath} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("%s still exists after org removal: %v", path, err)
+		}
+	}
+	if _, err := os.Stat(managedSettingsFile); !os.IsNotExist(err) {
+		t.Fatalf("root managed settings still exist after org removal: %v", err)
+	}
+	if h.keychain[KeychainItemName] != "tok" {
+		t.Fatalf("keychain = %q", h.keychain[KeychainItemName])
+	}
+	if _, err := managedconfig.LoadFile(managedconfig.UserPath()); err != nil {
+		t.Fatalf("user managed config missing after continued setup: %v", err)
+	}
+
+	var stoppedOrgAgent bool
+	for _, call := range h.calls {
+		if call.name == "launchctl" && len(call.args) == 2 && call.args[0] == "bootout" && strings.HasSuffix(call.args[1], "/"+LaunchAgentLabel) {
+			stoppedOrgAgent = true
+		}
+	}
+	if !stoppedOrgAgent {
+		t.Fatalf("launchctl calls = %v, want org agent bootout by service label", h.calls)
+	}
+	stdout := h.out.String()
+	for _, want := range []string{
+		"Remove organization-managed install and continue? [y/N]",
+		"Organization-managed files removed",
+		"Organization-managed background agent stopped",
+		"Workspace\n  ✓ Acme (org_test)",
+		"Next\n  Return to the Kontext dashboard.",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestRunDoesNotRemoveForeignRootManagedSettings(t *testing.T) {
+	h := newHarness(t)
+	allowLoopback(t)
+	for _, path := range []string{systemConfigPath, orgInstallTokenPath, managedSettingsFile} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("foreign settings"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	overrideVar(t, &isTerminal, func(int) bool { return true })
+	overrideVar(t, &readLine, func(io.Reader) (string, error) { return "yes\n", nil })
+	server := pingServer(t, "tok")
+
+	err := Run(context.Background(), h.options("tok", server))
+	if err == nil || !strings.Contains(err.Error(), "root managed settings may contain organization or foreign hooks") {
+		t.Fatalf("Run() error = %v, want root settings ownership refusal", err)
+	}
+	for _, path := range []string{systemConfigPath, orgInstallTokenPath, managedSettingsFile} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("%s removed before ownership was proven: %v", path, err)
+		}
+	}
+	if len(h.keychain) != 0 {
+		t.Fatal("keychain written despite root settings ownership refusal")
+	}
+	for _, call := range h.calls {
+		if call.name == "launchctl" {
+			t.Fatalf("launchctl called despite root settings ownership refusal: %v", call.args)
 		}
 	}
 }
@@ -643,6 +794,13 @@ func TestUninstallKeepsManagedHooksWhenOrganizationManaged(t *testing.T) {
 	if err := os.WriteFile(managedSettingsPath, []byte("{}"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	plist := filepath.Join(h.home, "Library", "LaunchAgents", LaunchAgentLabel+".plist")
+	if err := os.MkdirAll(filepath.Dir(plist), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(plist, []byte("plist"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := Uninstall(context.Background(), h.options("", pingServer(t, "unused"))); err != nil {
 		t.Fatalf("Uninstall() error = %v", err)
@@ -651,11 +809,36 @@ func TestUninstallKeepsManagedHooksWhenOrganizationManaged(t *testing.T) {
 	if _, err := os.Stat(managedSettingsPath); err != nil {
 		t.Fatalf("managed settings removed with organization config present: %v", err)
 	}
-	if !strings.Contains(h.errOut.String(), "organization-managed") {
-		t.Fatalf("stderr missing organization-managed warning:\n%s", h.errOut.String())
+	for _, want := range []string{
+		"Organization-managed install detected",
+		"Self-serve uninstall cannot remove organization-managed state",
+		"Remove the organization-managed install first",
+		`sudo rm -f "/Library/Application Support/Kontext/managed.json"`,
+	} {
+		if !strings.Contains(h.errOut.String(), want) {
+			t.Fatalf("stderr missing %q:\n%s", want, h.errOut.String())
+		}
 	}
 	if !strings.Contains(h.out.String(), "Kept Claude Code managed hooks") {
 		t.Fatalf("stdout missing kept managed hooks message:\n%s", h.out.String())
+	}
+	if !strings.Contains(h.out.String(), "Self-serve background agent removed") {
+		t.Fatalf("stdout missing self-serve agent removal:\n%s", h.out.String())
+	}
+	if _, err := os.Stat(plist); !os.IsNotExist(err) {
+		t.Fatalf("self-serve LaunchAgent plist still exists after uninstall: %v", err)
+	}
+	var bootedOutPlist bool
+	for _, call := range h.calls {
+		if call.name == "launchctl" && len(call.args) == 3 && call.args[0] == "bootout" && call.args[2] == plist {
+			bootedOutPlist = true
+		}
+		if call.name == "launchctl" && len(call.args) == 2 && strings.HasSuffix(call.args[1], "/"+LaunchAgentLabel) {
+			t.Fatalf("organization-managed uninstall booted out by label: %v", call.args)
+		}
+	}
+	if !bootedOutPlist {
+		t.Fatalf("launchctl calls = %v, want bootout by self-serve plist path", h.calls)
 	}
 }
 

--- a/internal/setup/uninstall.go
+++ b/internal/setup/uninstall.go
@@ -32,26 +32,41 @@ func Uninstall(ctx context.Context, opts Options) error {
 		return err
 	}
 	if organizationManaged {
-		fmt.Fprintln(opts.Stderr, "warning: an organization-managed (MDM) Kontext install remains active on this Mac and is not affected by this command")
+		fmt.Fprintln(opts.Stderr, organizationManagedMessage("Self-serve uninstall cannot remove organization-managed state."))
 	}
 
-	plistPath, err := removeLaunchAgent(ctx)
-	if err != nil {
-		return err
-	}
-	fmt.Fprintf(opts.Stdout, "✓ Background agent removed (%s)\n", plistPath)
+	fmt.Fprintln(opts.Stdout, "Kontext uninstall")
+	fmt.Fprintln(opts.Stdout, "\nMac")
 
 	if organizationManaged {
-		fmt.Fprintf(opts.Stdout, "· Kept Claude Code managed hooks because an organization-managed install is active (%s)\n", managedSettingsPath)
+		removed, path, err := removeSelfServeLaunchAgentIfPresent(ctx)
+		if err != nil {
+			return err
+		}
+		if removed {
+			fmt.Fprintf(opts.Stdout, "  ✓ Self-serve background agent removed (%s)\n", path)
+		} else {
+			fmt.Fprintf(opts.Stdout, "  • No self-serve background agent to remove (%s)\n", path)
+		}
+	} else {
+		plistPath, err := removeLaunchAgent(ctx)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(opts.Stdout, "  ✓ Background agent removed (%s)\n", plistPath)
+	}
+
+	if organizationManaged {
+		fmt.Fprintf(opts.Stdout, "  • Kept Claude Code managed hooks because an organization-managed install is active (%s)\n", managedSettingsPath)
 	} else {
 		removed, err := removeManagedSettings(ctx)
 		if err != nil {
 			return err
 		}
 		if removed {
-			fmt.Fprintf(opts.Stdout, "✓ Claude Code managed hooks removed (%s)\n", managedSettingsPath)
+			fmt.Fprintf(opts.Stdout, "  ✓ Claude Code managed hooks removed (%s)\n", managedSettingsPath)
 		} else {
-			fmt.Fprintf(opts.Stdout, "· Kept Claude Code managed hooks because ownership is unknown (%s)\n", managedSettingsPath)
+			fmt.Fprintf(opts.Stdout, "  • Kept Claude Code managed hooks because ownership is unknown (%s)\n", managedSettingsPath)
 		}
 	}
 
@@ -62,7 +77,7 @@ func Uninstall(ctx context.Context, opts Options) error {
 	if _, err := os.Lstat(settingsPath); errors.Is(err, os.ErrNotExist) {
 		// A removal must never CREATE settings: on a machine without Claude
 		// settings (or after the user deleted them) there is nothing to do.
-		fmt.Fprintln(opts.Stdout, "· No Claude Code settings file — no hooks to remove")
+		fmt.Fprintln(opts.Stdout, "  • No Claude Code settings file; no hooks to remove")
 	} else if err != nil {
 		return err
 	} else {
@@ -79,29 +94,44 @@ func Uninstall(ctx context.Context, opts Options) error {
 		if err := claudemanaged.WriteUserSettings(settingsPath, settings); err != nil {
 			return err
 		}
-		fmt.Fprintln(opts.Stdout, "✓ Claude Code hooks removed from ~/.claude/settings.json")
+		fmt.Fprintln(opts.Stdout, "  ✓ Claude Code hooks removed from ~/.claude/settings.json")
 	}
 
 	if err := deleteKeychainTokens(ctx); err != nil {
 		return err
 	}
-	fmt.Fprintf(opts.Stdout, "✓ Install token removed from your keychain (%s)\n", KeychainItemName)
+	fmt.Fprintf(opts.Stdout, "  ✓ Install token removed from your keychain (%s)\n", KeychainItemName)
 
 	if path := managedconfig.UserPath(); path != "" {
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 			return err
 		}
-		fmt.Fprintf(opts.Stdout, "✓ Managed config removed (%s)\n", path)
+		fmt.Fprintf(opts.Stdout, "  ✓ Managed config removed (%s)\n", path)
 	}
 
+	fmt.Fprintln(opts.Stdout, "\nKept")
 	if identity := installation.UserPath(); identity != "" {
 		if _, err := os.Lstat(identity); err == nil {
-			fmt.Fprintf(opts.Stdout, "· Kept installation identity %s (re-running setup reuses the same endpoint)\n", identity)
+			fmt.Fprintf(opts.Stdout, "  • Installation identity (%s)\n", identity)
 		}
 	}
-	fmt.Fprintln(opts.Stdout, "· Kept local observe data and logs under ~/Library/Application Support/Kontext and ~/Library/Logs/Kontext")
-	fmt.Fprintln(opts.Stdout, "· The kontext binary is managed by Homebrew (`brew uninstall kontext` to remove)")
+	fmt.Fprintln(opts.Stdout, "  • Local observe data and logs under ~/Library/Application Support/Kontext and ~/Library/Logs/Kontext")
+	fmt.Fprintln(opts.Stdout, "  • Homebrew-owned kontext binary (`brew uninstall kontext`)")
 	return nil
+}
+
+func removeSelfServeLaunchAgentIfPresent(ctx context.Context) (bool, string, error) {
+	plistPath, err := launchAgentPath()
+	if err != nil {
+		return false, "", err
+	}
+	if _, err := os.Lstat(plistPath); errors.Is(err, os.ErrNotExist) {
+		return false, plistPath, nil
+	} else if err != nil {
+		return false, plistPath, err
+	}
+	path, err := removeLaunchAgent(ctx)
+	return err == nil, path, err
 }
 
 // removeManagedSettings removes the drop-in only when it is ours by content


### PR DESCRIPTION
## Where We Are

`kontext setup` gave a noisy failure when an organization-managed install was present. It printed usage, repeated the error, and left the user without a clean path to switch this Mac to self-serve.

## Where We Want To Go

Setup should make the choice obvious. If local organization-managed state exists, the user can remove it and continue, or decline and stop without writes. Non-interactive setup should fail once with clear cleanup steps.

## How do we get there

- Prompt interactive setup before writing self-serve state when `/Library/Application Support/Kontext/managed.json` exists.
- On yes, remove the local organization-managed config, install token, root Claude managed settings, stop the org-managed LaunchAgent, then continue setup.
- On no, stop cleanly and print the next action.
- Silence Cobra usage/errors for runtime setup failures and align uninstall output with setup status logs.
- Verified with `go test ./internal/setup ./cmd/kontext`, `git diff --check`, and `go test ./...`.

