### PR TITLE
fix(managedstream): drain the full export backlog in one flush

### DIFF
--- a/internal/managedstream/stream.go
+++ b/internal/managedstream/stream.go
@@ -147,8 +147,10 @@ func Flush(ctx context.Context, opts Options) error {
 	}
 
 	limit := batchLimit(opts.BatchLimit)
-	now := time.Now().UTC()
 	for {
+		// Stamped per page: a full drain can run for minutes, and sent_at /
+		// heartbeat marks should reflect when each batch actually shipped.
+		now := time.Now().UTC()
 		batch, err := store.LedgerBatch(ctx, sqlite.LedgerExportOptions{
 			UpdatedAfter:   state.UpdatedAfter,
 			UpdatedAfterID: state.ActionID,
@@ -207,12 +209,23 @@ func Flush(ctx context.Context, opts Options) error {
 			opts.OnFlushSuccess()
 		}
 
-		if batch.Cursor != nil {
-			state.LastHeartbeatAttemptAt = now.Format(time.RFC3339Nano)
-			state.LastHeartbeatAt = now.Format(time.RFC3339Nano)
-			return saveCursor(statePath, batch, state)
+		if batch.Cursor == nil {
+			return nil
 		}
-		return nil
+		state.LastHeartbeatAttemptAt = now.Format(time.RFC3339Nano)
+		state.LastHeartbeatAt = now.Format(time.RFC3339Nano)
+		updatedAfter := batch.Cursor.UpdatedAt.UTC()
+		state.UpdatedAfter = &updatedAfter
+		state.ActionID = batch.Cursor.ActionID
+		if err := SaveState(statePath, state); err != nil {
+			return err
+		}
+		// Keep draining: one call empties the queue instead of shipping a
+		// single batch per tick. A 40-subagent burst generates events ~20x
+		// faster than one capped batch per 10s interval can ship them, which
+		// left the hosted dashboard reading a partial session for ~45 minutes
+		// (ENG-474). The cursor is persisted per batch, so an interrupted
+		// drain resumes where it stopped.
 	}
 }
 

--- a/internal/managedstream/stream_test.go
+++ b/internal/managedstream/stream_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -215,6 +216,58 @@ func TestFlushCapsBatchLimitBeforePosting(t *testing.T) {
 	}
 }
 
+func TestFlushDrainsBacklogInOneCall(t *testing.T) {
+	store, dbPath := testStore(t)
+	// 5 decisions -> 10 action rows; with a batch limit of 4 the backlog
+	// needs 3 posts. One Flush call must ship all of them, not one per tick.
+	for i := 0; i < 5; i++ {
+		saveTestDecision(t, store, fmt.Sprintf("session-%03d", i), fmt.Sprintf("toolu_%03d", i))
+	}
+
+	var mu sync.Mutex
+	var posts int
+	shipped := map[string]bool{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload Payload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("decode payload: %v", err)
+		}
+		mu.Lock()
+		posts++
+		for _, action := range payload.Actions {
+			if id, ok := action["id"].(string); ok {
+				shipped[id] = true
+			}
+		}
+		mu.Unlock()
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(server.Close)
+
+	if err := Flush(context.Background(), Options{
+		DBPath:         dbPath,
+		StatePath:      filepath.Join(t.TempDir(), "stream-state.json"),
+		CloudURL:       server.URL,
+		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
+		InstallToken:   "test-install-token",
+		BatchLimit:     4,
+		HTTPClient:     server.Client(),
+	}); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// Batches may overlap (receipt-chain continuity pulls referenced actions
+	// into a page), so assert distinct coverage rather than summed counts.
+	if len(shipped) != 10 {
+		t.Fatalf("shipped %d distinct actions in one Flush, want the whole backlog (10)", len(shipped))
+	}
+	if posts != 3 {
+		t.Fatalf("posts = %d, want 3 cursor pages of at most 4 actions", posts)
+	}
+}
+
 func TestFlushRetriesWithSmallerBatchWhenHostedBackendRejectsSize(t *testing.T) {
 	store, dbPath := testStore(t)
 	for i := 0; i < 4; i++ {
@@ -250,11 +303,22 @@ func TestFlushRetriesWithSmallerBatchWhenHostedBackendRejectsSize(t *testing.T) 
 		t.Fatalf("Flush() error = %v", err)
 	}
 
-	if len(actionCounts) != 2 {
-		t.Fatalf("request count = %d, want 2", len(actionCounts))
+	// The first post is rejected (413) and retried at half size; the same
+	// call then drains the remaining backlog at the reduced size.
+	if len(actionCounts) != 5 {
+		t.Fatalf("request count = %d, want 5 (1 rejected + 4 reduced batches)", len(actionCounts))
 	}
 	if actionCounts[0] <= actionCounts[1] {
 		t.Fatalf("action counts = %v, want retry with a smaller batch", actionCounts)
+	}
+	accepted := 0
+	for _, count := range actionCounts[1:] {
+		accepted += count
+	}
+	// Pages can overlap via receipt-chain continuity, so require at least
+	// full coverage of the 8-action backlog.
+	if accepted < 8 {
+		t.Fatalf("accepted %d actions, want at least the whole backlog (8)", accepted)
 	}
 	state, err := LoadState(statePath)
 	if err != nil {


### PR DESCRIPTION
## Why

ENG-474 (root cause 2): `Flush` returned after the first successful batch, so export throughput was one capped batch per 10s daemon tick — ~25 actions/10s once payload halving set in. A 40-subagent burst generated events ~20x faster; the hosted dashboard read a partial session for ~45 minutes (verified in prod logs: backlog from 12:02–12:10 UTC drained until 12:50).

## What

Keep posting cursor pages until the queue is empty. The cursor is persisted per batch, so an interrupted drain (ctx cancel, network error) resumes where it stopped. Payload-halving and 413 retry behavior are unchanged — a reduced limit now carries across the whole drain instead of being rediscovered per tick.

Tests: new `TestFlushDrainsBacklogInOneCall` (3 pages, full distinct coverage in one call); `TestFlushRetriesWithSmallerBatchWhenHostedBackendRejectsSize` updated for drain semantics.

Linear: [ENG-474](https://linear.app/cobrowser/issue/ENG-474)

🤖 Generated with [Claude Code](https://claude.com/claude-code)