### PR TITLE
fix(managedstream): hold the persisted export cursor back by a safety lag

### DIFF
--- a/internal/guard/store/sqlite/store.go
+++ b/internal/guard/store/sqlite/store.go
@@ -781,6 +781,15 @@ func (s *Store) insertAction(ctx context.Context, tx *sql.Tx, actionID, sessionI
 }
 
 func (s *Store) insertActionRecord(ctx context.Context, tx *sql.Tx, action map[string]any, receiptType string, now time.Time) error {
+	// The cursor key orders the hosted export. Stamp it at write time: the
+	// event timestamps in the record are captured before this write queues on
+	// the store's single serialized connection, and under load a stale stamp
+	// can land behind an already-persisted export cursor. Re-stamping here
+	// shrinks that stamp-to-commit gap to the instant before COMMIT, well
+	// inside the exporter's cursorSafetyLag. This intentionally overwrites any
+	// updated_at_cursor_key the caller set in actionValues; `now` is still the
+	// business timestamp used for the receipt appended below.
+	action["updated_at_cursor_key"] = ledgerTimestampCursorKeyFromTime(time.Now().UTC())
 	columns := []string{
 		"id", "session_id", "tool_use_id", "canonical_event_type", "adapter_event_name", "correlation_key",
 		"tool_name", "provider", "operation", "operation_class", "resource_class", "resource_id", "parameters_redacted_json", "parameters_hash",

--- a/internal/managedstream/stream.go
+++ b/internal/managedstream/stream.go
@@ -30,6 +30,15 @@ const (
 	DefaultInterval          = 10 * time.Second
 	DefaultHeartbeatInterval = 60 * time.Second
 
+	// cursorSafetyLag holds the persisted export cursor this far behind the
+	// newest exported row. Rows are stamped with a timestamp captured before
+	// their write queues on the store's single serialized connection, so
+	// under concurrent hook load a row can COMMIT after a flush has already
+	// advanced the cursor past its stamp — a strict cursor would then skip it
+	// forever. Re-reading the lag window re-sends recent rows instead; the
+	// hosted upsert is idempotent per action id, so duplicates are harmless.
+	cursorSafetyLag = 30 * time.Second
+
 	maxPayloadSessions = 100
 	maxPayloadActions  = 1000
 	maxPayloadReceipts = 2000
@@ -147,13 +156,18 @@ func Flush(ctx context.Context, opts Options) error {
 	}
 
 	limit := batchLimit(opts.BatchLimit)
+	// Pagination within this call uses the true batch cursor so the drain
+	// makes forward progress; only the PERSISTED cursor is held back by
+	// cursorSafetyLag (see clampCursor).
+	pageUpdatedAfter := state.UpdatedAfter
+	pageActionID := state.ActionID
 	for {
 		// Stamped per page: a full drain can run for minutes, and sent_at /
 		// heartbeat marks should reflect when each batch actually shipped.
 		now := time.Now().UTC()
 		batch, err := store.LedgerBatch(ctx, sqlite.LedgerExportOptions{
-			UpdatedAfter:   state.UpdatedAfter,
-			UpdatedAfterID: state.ActionID,
+			UpdatedAfter:   pageUpdatedAfter,
+			UpdatedAfterID: pageActionID,
 			Limit:          limit,
 		})
 		if err != nil {
@@ -214,12 +228,21 @@ func Flush(ctx context.Context, opts Options) error {
 		}
 		state.LastHeartbeatAttemptAt = now.Format(time.RFC3339Nano)
 		state.LastHeartbeatAt = now.Format(time.RFC3339Nano)
-		updatedAfter := batch.Cursor.UpdatedAt.UTC()
-		state.UpdatedAfter = &updatedAfter
-		state.ActionID = batch.Cursor.ActionID
+		cursorAt := batch.Cursor.UpdatedAt.UTC()
+		safeAt, safeID := clampCursor(cursorAt, batch.Cursor.ActionID, now)
+		// Never regress the persisted cursor: advancePastMinimumBatch may have
+		// deliberately advanced it past a poison row, and clamping back behind
+		// that row would re-fetch it (and re-fail) until it ages out of the
+		// lag window.
+		if cursorAdvances(state, safeAt, safeID) {
+			state.UpdatedAfter = &safeAt
+			state.ActionID = safeID
+		}
 		if err := SaveState(statePath, state); err != nil {
 			return err
 		}
+		pageUpdatedAfter = &cursorAt
+		pageActionID = batch.Cursor.ActionID
 		// Keep draining: one call empties the queue instead of shipping a
 		// single batch per tick. A 40-subagent burst generates events ~20x
 		// faster than one capped batch per 10s interval can ship them, which
@@ -395,11 +418,40 @@ func advancePastMinimumBatch(statePath string, batch sqlite.LedgerBatch, state S
 	return fmt.Errorf("managed stream advanced cursor past oversized minimum batch: %s", reason)
 }
 
+// saveCursor persists the TRUE cursor, without the safety lag. It is only
+// used to advance past a poison minimum batch — clamping there could pin the
+// cursor before the rejected row and re-fetch it forever.
 func saveCursor(statePath string, batch sqlite.LedgerBatch, state State) error {
 	updatedAfter := batch.Cursor.UpdatedAt.UTC()
 	state.UpdatedAfter = &updatedAfter
 	state.ActionID = batch.Cursor.ActionID
 	return SaveState(statePath, state)
+}
+
+// clampCursor holds the persisted cursor back to now-cursorSafetyLag so rows
+// whose writes commit after the flush read (but with an earlier timestamp
+// stamp) are re-scanned on the next flush instead of being skipped forever.
+// A clamped cursor does not correspond to a stored row, so the id tiebreak
+// is cleared.
+func clampCursor(cursorAt time.Time, actionID string, now time.Time) (time.Time, string) {
+	maxSafe := now.Add(-cursorSafetyLag)
+	if cursorAt.After(maxSafe) {
+		return maxSafe, ""
+	}
+	return cursorAt, actionID
+}
+
+// cursorAdvances reports whether (at, id) sorts strictly after the cursor
+// already persisted in state, matching the (updated_at_cursor_key, id)
+// export ordering.
+func cursorAdvances(state State, at time.Time, id string) bool {
+	if state.UpdatedAfter == nil {
+		return true
+	}
+	if at.After(*state.UpdatedAfter) {
+		return true
+	}
+	return at.Equal(*state.UpdatedAfter) && id > state.ActionID
 }
 
 func parseStateUpdatedAfter(value string) (time.Time, error) {

--- a/internal/managedstream/stream_test.go
+++ b/internal/managedstream/stream_test.go
@@ -2,6 +2,7 @@ package managedstream
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -265,6 +266,94 @@ func TestFlushDrainsBacklogInOneCall(t *testing.T) {
 	}
 	if posts != 3 {
 		t.Fatalf("posts = %d, want 3 cursor pages of at most 4 actions", posts)
+	}
+}
+
+func TestFlushReexportsRowsThatCommitAfterCursorAdvance(t *testing.T) {
+	store, dbPath := testStore(t)
+	saveTestDecision(t, store, "session-1", "toolu_1")
+
+	var mu sync.Mutex
+	shippedToolUseIDs := map[string]bool{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload Payload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("decode payload: %v", err)
+		}
+		mu.Lock()
+		for _, action := range payload.Actions {
+			if id, ok := action["tool_use_id"].(string); ok {
+				shippedToolUseIDs[id] = true
+			}
+		}
+		mu.Unlock()
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(server.Close)
+
+	statePath := filepath.Join(t.TempDir(), "stream-state.json")
+	flush := func() {
+		t.Helper()
+		if err := Flush(context.Background(), Options{
+			DBPath:         dbPath,
+			StatePath:      statePath,
+			CloudURL:       server.URL,
+			InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
+			InstallToken:   "test-install-token",
+			HTTPClient:     server.Client(),
+		}); err != nil {
+			t.Fatalf("Flush() error = %v", err)
+		}
+	}
+
+	flush()
+
+	// Simulate the concurrency race: a hook write captures its timestamp
+	// before the flush above reads the queue, but only COMMITs afterwards.
+	// Its cursor key then sorts BEFORE the cursor the flush persisted.
+	saveTestDecision(t, store, "session-1", "toolu_late")
+	backdated := time.Now().UTC().Add(-5 * time.Second).Format("2006-01-02T15:04:05.000000000Z07:00")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if _, err := db.Exec(
+		`update authorization_actions set updated_at_cursor_key = ? where tool_use_id = 'toolu_late'`,
+		backdated,
+	); err != nil {
+		t.Fatalf("backdate cursor key: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	flush()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !shippedToolUseIDs["toolu_late"] {
+		t.Fatal("late-committed row was never exported: strict cursor skipped it")
+	}
+}
+
+func TestCursorAdvancesIsMonotonic(t *testing.T) {
+	base := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	persisted := State{UpdatedAfter: &base, ActionID: "act_b"}
+
+	if cursorAdvances(persisted, base.Add(-time.Second), "act_z") {
+		t.Fatal("cursor must not regress behind the persisted timestamp (poison-row skip would be undone)")
+	}
+	if cursorAdvances(persisted, base, "act_a") {
+		t.Fatal("cursor must not regress behind the persisted id tiebreak")
+	}
+	if !cursorAdvances(persisted, base, "act_c") {
+		t.Fatal("same timestamp with a later id must advance")
+	}
+	if !cursorAdvances(persisted, base.Add(time.Second), "") {
+		t.Fatal("later timestamp must advance")
+	}
+	if !cursorAdvances(State{}, base, "act_a") {
+		t.Fatal("empty state must always advance")
 	}
 }
 


### PR DESCRIPTION
## Why

Stacked on #360. ENG-474 (root cause 3): ledger rows are stamped with a timestamp captured **before** their write queues on the store's single serialized SQLite connection. Under concurrent hook load a row can COMMIT after a flush has advanced the strict export cursor past its stamp — the strict `>` cursor then never returns it: the event silently never reaches hosted.

## What

Persist the cursor clamped to `now - 30s` (`cursorSafetyLag`): the next flush re-scans the recent window, so late-committing rows are picked up. Re-sent rows are harmless — hosted ingest upserts per action id. In-call pagination still uses the true batch cursor, so the drain from #360 makes forward progress. `advancePastMinimumBatch` intentionally keeps the unclamped cursor (clamping would re-fetch the poison row forever).

Tests: new `TestFlushReexportsRowsThatCommitAfterCursorAdvance` — backdates a row's cursor key behind the persisted cursor (the exact race) and asserts the next flush exports it. Fails on the strict-cursor behavior.

Future hardening (out of scope): paginate on a monotonic insert sequence instead of timestamps.

Linear: [ENG-474](https://linear.app/cobrowser/issue/ENG-474)

🤖 Generated with [Claude Code](https://claude.com/claude-code)