### PR TITLE
fix(daemon): ack non-blocking hooks before the ledger write

### DIFF
--- a/internal/localruntime/service.go
+++ b/internal/localruntime/service.go
@@ -172,9 +172,13 @@ func (s *Service) handleConn(ctx context.Context, conn net.Conn) {
 
 	if s.asyncIngest && shouldAsyncIngest(&req) {
 		s.wg.Add(1)
+		// Detach from the accept-loop context: shutdown cancels it, and a
+		// pending telemetry write must drain rather than abort — Shutdown
+		// already bounds the drain with its own context via wg.Wait.
+		ingestCtx := context.WithoutCancel(ctx)
 		go func() {
 			defer s.wg.Done()
-			s.ingestEvent(ctx, &req)
+			s.ingestEvent(ingestCtx, &req)
 		}()
 	}
 }

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -127,7 +127,13 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 		Mode:               mode,
 		Diagnostic:         opts.Diagnostic,
 		SkipInitialSession: true,
-		DisableAsyncIngest: true,
+		// Async ingest: non-blocking hooks (PostToolUse, session lifecycle)
+		// are acked immediately and written in the background. Synchronous
+		// writes queue on the store's single SQLite connection, and under a
+		// concurrent subagent burst that queueing blew the hook connection
+		// deadline — Claude Code timed the hook out and the event was lost
+		// (ENG-474). Decision-gating hooks (PreToolUse, UserPromptSubmit)
+		// stay synchronous, and Shutdown drains pending writes.
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
## Why

Stacked on #361. ENG-474 (root cause 4): the managed-observe daemon ingested every hook synchronously — the SQLite write had to finish before the hook got its response. Under a 40-subagent burst, writes queue on the store's single serialized connection, the 10s hook connection deadline blows, Claude Code times the hook out, and the event (usually the PostToolUse outcome) is lost.

## What

- Enable the existing (already tested) async ingest path for the daemon: non-blocking hooks (PostToolUse, session lifecycle) are acked immediately and written in the background. Decision-gating hooks (PreToolUse, UserPromptSubmit — `CanBlock()`) stay fully synchronous.
- Fix a drain bug this exposed: async writes ran on the accept-loop context, which shutdown cancels — a pending write was aborted mid-drain. They now run on `context.WithoutCancel`; `Shutdown` already waits on the WaitGroup (bounded by its own context), so pending writes complete. `TestDaemonSessionEndClosesHookSessionID` covers this end-to-end.

Linear: [ENG-474](https://linear.app/cobrowser/issue/ENG-474)

🤖 Generated with [Claude Code](https://claude.com/claude-code)