### PR TITLE
feat: hubspot provider policy — classifier, sync, dry-run + Cowork bash coverage

### DIFF
--- a/internal/githubpolicy/classifier.go
+++ b/internal/githubpolicy/classifier.go
@@ -73,7 +73,11 @@ func ClassifyProviderActionsWithCWD(toolName string, toolInput map[string]any, c
 	}
 	loadGitContext := memoizedGitContext(gitContext)
 	switch strings.ToLower(toolName) {
-	case "bash", "shell":
+	// "mcp__workspace__bash" is Claude Cowork's shell: commands run in its
+	// sandbox VM through an MCP tool instead of the native Bash tool, with
+	// the command string in the same input field. Unwrapping it here is what
+	// makes GitHub activity inside Cowork sessions classifiable at all.
+	case "bash", "shell", "mcp__workspace__bash":
 		command := commandFromToolInput(toolInput)
 		if command == "" {
 			return nil

--- a/internal/githubpolicy/classifier_test.go
+++ b/internal/githubpolicy/classifier_test.go
@@ -366,3 +366,24 @@ func TestClassifyGitDashCUsesTargetContext(t *testing.T) {
 		t.Fatalf("git -C push = %+v, want %+v", got, want)
 	}
 }
+
+func TestClassifyCoworkWorkspaceBash(t *testing.T) {
+	// Claude Cowork runs shell commands through the mcp__workspace__bash MCP
+	// tool instead of a native Bash tool. The command string must classify
+	// exactly like a native bash invocation, or GitHub activity inside Cowork
+	// sessions is invisible to policy.
+	actions := ClassifyProviderActionsWithCWD(
+		"mcp__workspace__bash",
+		map[string]any{"command": "git push https://github.com/acme/api.git main"},
+		"",
+		func(string) GitContext { return GitContext{} },
+	)
+	want := []ProviderAction{{Action: "github.repo.write", Resource: "acme/api", BranchOrRef: "main"}}
+	if !reflect.DeepEqual(actions, want) {
+		t.Fatalf("ClassifyProviderActionsWithCWD(mcp__workspace__bash) = %+v, want %+v", actions, want)
+	}
+	// A non-shell workspace tool must not be treated as a command.
+	if actions := ClassifyProviderActionsWithCWD("mcp__workspace__read_file", map[string]any{"path": "x"}, "", nil); actions != nil {
+		t.Fatalf("workspace read_file classified: %+v", actions)
+	}
+}

--- a/internal/guard/app/server/githubpolicy_test.go
+++ b/internal/guard/app/server/githubpolicy_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kontext-security/kontext-cli/internal/githubpolicy"
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
+	"github.com/kontext-security/kontext-cli/internal/providerpolicy"
 )
 
 type staticGithubPolicy struct {
@@ -44,12 +45,12 @@ func githubPushEvent() risk.HookEvent {
 func TestDecideHookRecordsGithubDryRunWithoutBlocking(t *testing.T) {
 	denyResource := "acme/api"
 	provider := NewRiskPolicyProviderWithOptions(RiskPolicyProviderOptions{
-		GithubPolicy: staticGithubPolicy{
+		ProviderPolicies: []ProviderPolicyBinding{GithubPolicyBinding(staticGithubPolicy{
 			snapshot: githubTestSnapshot(githubpolicy.ModeObserve,
 				githubpolicy.Rule{ID: "rule-deny", Layer: githubpolicy.LayerOrg, SubjectID: "org_test", ResourceID: &denyResource, Effect: githubpolicy.EffectDeny},
 			),
 			loaded: true,
-		},
+		})},
 	})
 
 	decision, err := provider.DecideHook(context.Background(), githubPushEvent())
@@ -61,10 +62,10 @@ func TestDecideHookRecordsGithubDryRunWithoutBlocking(t *testing.T) {
 	if decision.Decision != risk.DecisionAllow {
 		t.Fatalf("Decision = %v, want allow in observe mode", decision.Decision)
 	}
-	if len(decision.GithubPolicy) != 1 {
-		t.Fatalf("GithubPolicy evaluations = %d, want 1", len(decision.GithubPolicy))
+	if len(githubEvaluations(decision)) != 1 {
+		t.Fatalf("GithubPolicy evaluations = %d, want 1", len(githubEvaluations(decision)))
 	}
-	evaluation := decision.GithubPolicy[0]
+	evaluation := githubEvaluations(decision)[0]
 	if evaluation.Result != githubpolicy.EffectDeny || evaluation.ReasonCode != githubpolicy.ReasonCodeDeny {
 		t.Fatalf("evaluation = %+v, want would-deny", evaluation)
 	}
@@ -76,12 +77,12 @@ func TestDecideHookRecordsGithubDryRunWithoutBlocking(t *testing.T) {
 func TestDecideHookEnforceModeDeniesBeforeJudge(t *testing.T) {
 	denyResource := "acme/api"
 	provider := NewRiskPolicyProviderWithOptions(RiskPolicyProviderOptions{
-		GithubPolicy: staticGithubPolicy{
+		ProviderPolicies: []ProviderPolicyBinding{GithubPolicyBinding(staticGithubPolicy{
 			snapshot: githubTestSnapshot(githubpolicy.ModeEnforce,
 				githubpolicy.Rule{ID: "rule-deny", Layer: githubpolicy.LayerOrg, SubjectID: "org_test", ResourceID: &denyResource, Effect: githubpolicy.EffectDeny},
 			),
 			loaded: true,
-		},
+		})},
 	})
 
 	decision, err := provider.DecideHook(context.Background(), githubPushEvent())
@@ -99,12 +100,12 @@ func TestDecideHookEnforceModeDeniesBeforeJudge(t *testing.T) {
 func TestDecideHookUnknownModeIsTreatedAsObserve(t *testing.T) {
 	denyResource := "acme/api"
 	provider := NewRiskPolicyProviderWithOptions(RiskPolicyProviderOptions{
-		GithubPolicy: staticGithubPolicy{
+		ProviderPolicies: []ProviderPolicyBinding{GithubPolicyBinding(staticGithubPolicy{
 			snapshot: githubTestSnapshot("enforce-later-maybe",
 				githubpolicy.Rule{ID: "rule-deny", Layer: githubpolicy.LayerOrg, SubjectID: "org_test", ResourceID: &denyResource, Effect: githubpolicy.EffectDeny},
 			),
 			loaded: true,
-		},
+		})},
 	})
 
 	decision, err := provider.DecideHook(context.Background(), githubPushEvent())
@@ -114,19 +115,19 @@ func TestDecideHookUnknownModeIsTreatedAsObserve(t *testing.T) {
 	if decision.Decision != risk.DecisionAllow {
 		t.Fatalf("Decision = %v, want allow: only an explicit enforce mode may block", decision.Decision)
 	}
-	if len(decision.GithubPolicy) != 1 {
-		t.Fatalf("evaluations = %d, want dry-run recorded regardless of mode", len(decision.GithubPolicy))
+	if len(githubEvaluations(decision)) != 1 {
+		t.Fatalf("evaluations = %d, want dry-run recorded regardless of mode", len(githubEvaluations(decision)))
 	}
 }
 
 func TestDecideHookNonGithubEventsCarryNoEvaluations(t *testing.T) {
 	provider := NewRiskPolicyProviderWithOptions(RiskPolicyProviderOptions{
-		GithubPolicy: staticGithubPolicy{
+		ProviderPolicies: []ProviderPolicyBinding{GithubPolicyBinding(staticGithubPolicy{
 			snapshot: githubTestSnapshot(githubpolicy.ModeObserve,
 				githubpolicy.Rule{ID: "rule-allow", Layer: githubpolicy.LayerOrg, SubjectID: "org_test", Effect: githubpolicy.EffectAllow},
 			),
 			loaded: true,
-		},
+		})},
 	})
 
 	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{
@@ -138,8 +139,8 @@ func TestDecideHookNonGithubEventsCarryNoEvaluations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DecideHook() error = %v", err)
 	}
-	if len(decision.GithubPolicy) != 0 {
-		t.Fatalf("evaluations = %+v, want none for non-GitHub activity", decision.GithubPolicy)
+	if len(githubEvaluations(decision)) != 0 {
+		t.Fatalf("evaluations = %+v, want none for non-GitHub activity", githubEvaluations(decision))
 	}
 }
 
@@ -149,7 +150,18 @@ func TestDecideHookWithoutSnapshotProviderIsUnchanged(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DecideHook() error = %v", err)
 	}
-	if decision.Decision != risk.DecisionAllow || len(decision.GithubPolicy) != 0 {
+	if decision.Decision != risk.DecisionAllow || len(githubEvaluations(decision)) != 0 {
 		t.Fatalf("decision = %+v, want plain allow with no evaluations", decision)
 	}
+}
+
+// githubEvaluations unwraps the github provider's evaluations from the
+// provider-keyed decision field, keeping these assertions readable.
+func githubEvaluations(decision risk.RiskDecision) []providerpolicy.Evaluation {
+	for _, group := range decision.ProviderPolicy {
+		if group.Provider == "github" {
+			return group.Evaluations
+		}
+	}
+	return nil
 }

--- a/internal/guard/app/server/hubspotpolicy_test.go
+++ b/internal/guard/app/server/hubspotpolicy_test.go
@@ -1,0 +1,133 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/guard/risk"
+	"github.com/kontext-security/kontext-cli/internal/hubspotpolicy"
+	"github.com/kontext-security/kontext-cli/internal/providerpolicy"
+)
+
+type staticSnapshotProvider struct {
+	snapshot providerpolicy.Snapshot
+	status   providerpolicy.Status
+	loaded   bool
+}
+
+func (p staticSnapshotProvider) CurrentSnapshot() (providerpolicy.Snapshot, providerpolicy.Status, bool) {
+	return p.snapshot, p.status, p.loaded
+}
+
+func hubspotTestSnapshot(mode string, rules ...providerpolicy.Rule) providerpolicy.Snapshot {
+	return providerpolicy.Snapshot{
+		SchemaVersion:  hubspotpolicy.SchemaVersionV1,
+		OrganizationID: "org_test",
+		ProviderKey:    "hubspot",
+		Mode:           mode,
+		Epoch:          2,
+		Hash:           "hash-2",
+		Rules:          rules,
+	}
+}
+
+// The exact tool-name shape Claude Cowork emits for the HubSpot connector,
+// observed live: the server segment is the connector-instance uuid.
+func hubspotWriteEvent() risk.HookEvent {
+	return risk.HookEvent{
+		SessionID:     "session-1",
+		HookEventName: "PreToolUse",
+		ToolName:      "mcp__5c56899e-3e6c-4803-85ca-ff1912393966__manage_crm_objects",
+		ToolInput: map[string]any{
+			"updateRequest": map[string]any{
+				"objects": []any{map[string]any{"objectType": "deals", "id": "813518832889"}},
+			},
+		},
+	}
+}
+
+func TestDecideHookRecordsHubspotDryRunWithoutBlocking(t *testing.T) {
+	denyResource := "deals"
+	denyAction := "hubspot.object.write"
+	provider := NewRiskPolicyProviderWithOptions(RiskPolicyProviderOptions{
+		ProviderPolicies: []ProviderPolicyBinding{HubspotPolicyBinding(staticSnapshotProvider{
+			snapshot: hubspotTestSnapshot(providerpolicy.ModeObserve,
+				providerpolicy.Rule{ID: "rule-deny-deals", Layer: providerpolicy.LayerOrg, SubjectID: "org_test", ResourceID: &denyResource, ActionName: &denyAction, Effect: providerpolicy.EffectDeny},
+			),
+			loaded: true,
+		})},
+	})
+
+	decision, err := provider.DecideHook(context.Background(), hubspotWriteEvent())
+	if err != nil {
+		t.Fatalf("DecideHook() error = %v", err)
+	}
+	// Observe mode: the policy would deny, but the runtime decision is
+	// untouched — nothing is ever blocked.
+	if decision.Decision != risk.DecisionAllow {
+		t.Fatalf("Decision = %v, want allow in observe mode", decision.Decision)
+	}
+	if len(decision.ProviderPolicy) != 1 || decision.ProviderPolicy[0].Provider != "hubspot" {
+		t.Fatalf("ProviderPolicy = %+v, want one hubspot group", decision.ProviderPolicy)
+	}
+	evaluations := decision.ProviderPolicy[0].Evaluations
+	if len(evaluations) != 1 {
+		t.Fatalf("evaluations = %d, want 1", len(evaluations))
+	}
+	evaluation := evaluations[0]
+	if evaluation.Result != providerpolicy.EffectDeny || evaluation.Request.Resource != "deals" {
+		t.Fatalf("evaluation = %+v, want would-deny on deals", evaluation)
+	}
+	if evaluation.Request.Action != "hubspot.object.write" {
+		t.Fatalf("action = %q", evaluation.Request.Action)
+	}
+}
+
+func TestDecideHookEvaluatesBothProvidersIndependently(t *testing.T) {
+	provider := NewRiskPolicyProviderWithOptions(RiskPolicyProviderOptions{
+		ProviderPolicies: []ProviderPolicyBinding{
+			GithubPolicyBinding(staticSnapshotProvider{
+				snapshot: providerpolicy.Snapshot{
+					SchemaVersion:  "github-policy-snapshot-v2",
+					OrganizationID: "org_test",
+					ProviderKey:    "github",
+					Mode:           providerpolicy.ModeObserve,
+					Epoch:          1,
+					Hash:           "hash-1",
+					Rules:          []providerpolicy.Rule{{ID: "r-gh", Layer: providerpolicy.LayerOrg, SubjectID: "org_test", Effect: providerpolicy.EffectAllow}},
+				},
+				loaded: true,
+			}),
+			HubspotPolicyBinding(staticSnapshotProvider{
+				snapshot: hubspotTestSnapshot(providerpolicy.ModeObserve,
+					providerpolicy.Rule{ID: "r-hs", Layer: providerpolicy.LayerOrg, SubjectID: "org_test", Effect: providerpolicy.EffectAllow},
+				),
+				loaded: true,
+			}),
+		},
+	})
+
+	// A HubSpot MCP call must produce hubspot evaluations only — the GitHub
+	// classifier does not fire on it, and vice versa.
+	decision, err := provider.DecideHook(context.Background(), hubspotWriteEvent())
+	if err != nil {
+		t.Fatalf("DecideHook() error = %v", err)
+	}
+	if len(decision.ProviderPolicy) != 1 || decision.ProviderPolicy[0].Provider != "hubspot" {
+		t.Fatalf("ProviderPolicy = %+v, want hubspot only", decision.ProviderPolicy)
+	}
+
+	githubEvent := risk.HookEvent{
+		SessionID:     "session-1",
+		HookEventName: "PreToolUse",
+		ToolName:      "Bash",
+		ToolInput:     map[string]any{"command": "git push https://github.com/acme/api.git main"},
+	}
+	decision, err = provider.DecideHook(context.Background(), githubEvent)
+	if err != nil {
+		t.Fatalf("DecideHook() error = %v", err)
+	}
+	if len(decision.ProviderPolicy) != 1 || decision.ProviderPolicy[0].Provider != "github" {
+		t.Fatalf("ProviderPolicy = %+v, want github only", decision.ProviderPolicy)
+	}
+}

--- a/internal/guard/app/server/hubspotpolicy_test.go
+++ b/internal/guard/app/server/hubspotpolicy_test.go
@@ -131,3 +131,56 @@ func TestDecideHookEvaluatesBothProvidersIndependently(t *testing.T) {
 		t.Fatalf("ProviderPolicy = %+v, want github only", decision.ProviderPolicy)
 	}
 }
+
+func TestDecideHookAnyEnforcingProviderDenyWins(t *testing.T) {
+	// Enforce-mode invariant: when two enforcing providers both evaluate one
+	// event, a deny from EITHER must deny the event — the first provider's
+	// allow must not shadow the second's deny. (Classifiers are disjoint
+	// today, so this guards the invariant for when they are not.)
+	denyAction := "hubspot.object.write"
+	provider := NewRiskPolicyProviderWithOptions(RiskPolicyProviderOptions{
+		ProviderPolicies: []ProviderPolicyBinding{
+			{
+				// A synthetic first provider whose classifier fires on the
+				// same event and whose enforcing snapshot allows everything.
+				Provider: "synthetic",
+				Snapshots: staticSnapshotProvider{
+					snapshot: providerpolicy.Snapshot{
+						SchemaVersion:  "synthetic-v1",
+						OrganizationID: "org_test",
+						ProviderKey:    "synthetic",
+						Mode:           providerpolicy.ModeEnforce,
+						Epoch:          1,
+						Hash:           "hash-s",
+						Rules:          []providerpolicy.Rule{{ID: "s-allow", Layer: providerpolicy.LayerOrg, SubjectID: "org_test", Effect: providerpolicy.EffectAllow}},
+					},
+					loaded: true,
+				},
+				Classify: func(risk.HookEvent) []providerpolicy.Request {
+					return []providerpolicy.Request{{Action: "synthetic.read"}}
+				},
+			},
+			HubspotPolicyBinding(staticSnapshotProvider{
+				snapshot: hubspotTestSnapshot(providerpolicy.ModeEnforce,
+					providerpolicy.Rule{ID: "hs-deny", Layer: providerpolicy.LayerOrg, SubjectID: "org_test", ActionName: &denyAction, Effect: providerpolicy.EffectDeny},
+					providerpolicy.Rule{ID: "hs-allow", Layer: providerpolicy.LayerOrg, SubjectID: "org_test", Effect: providerpolicy.EffectAllow},
+				),
+				loaded: true,
+			}),
+		},
+	})
+
+	decision, err := provider.DecideHook(context.Background(), hubspotWriteEvent())
+	if err != nil {
+		t.Fatalf("DecideHook() error = %v", err)
+	}
+	if decision.Decision != risk.DecisionDeny {
+		t.Fatalf("Decision = %v, want deny — the second enforcing provider's deny must win", decision.Decision)
+	}
+	if decision.RiskEvent.DecisionStage != "hubspot_policy_deny" {
+		t.Fatalf("DecisionStage = %q, want hubspot_policy_deny", decision.RiskEvent.DecisionStage)
+	}
+	if len(decision.ProviderPolicy) != 2 {
+		t.Fatalf("ProviderPolicy groups = %d, want both providers recorded", len(decision.ProviderPolicy))
+	}
+}

--- a/internal/guard/app/server/policy.go
+++ b/internal/guard/app/server/policy.go
@@ -9,7 +9,61 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/guard/judge"
 	guardpolicy "github.com/kontext-security/kontext-cli/internal/guard/policy"
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
+	"github.com/kontext-security/kontext-cli/internal/hubspotpolicy"
+	"github.com/kontext-security/kontext-cli/internal/providerpolicy"
 )
+
+// ProviderPolicyBinding wires one provider's synced policy into the decision
+// path: a snapshot source plus a classifier turning hook events into that
+// provider's canonical policy requests (subject fields are filled in by the
+// evaluator).
+type ProviderPolicyBinding struct {
+	Provider  string
+	Snapshots providerpolicy.SnapshotProvider
+	Classify  func(event risk.HookEvent) []providerpolicy.Request
+}
+
+// GithubPolicyBinding binds the GitHub classifier to a snapshot source.
+func GithubPolicyBinding(snapshots providerpolicy.SnapshotProvider) ProviderPolicyBinding {
+	return ProviderPolicyBinding{
+		Provider:  "github",
+		Snapshots: snapshots,
+		Classify: func(event risk.HookEvent) []providerpolicy.Request {
+			actions := githubpolicy.ClassifyProviderActionsWithCWD(event.ToolName, event.ToolInput, event.CWD, func(cwd string) githubpolicy.GitContext {
+				return githubpolicy.GitContextFromCWD(cwd)
+			})
+			requests := make([]providerpolicy.Request, 0, len(actions))
+			for _, action := range actions {
+				requests = append(requests, providerpolicy.Request{
+					Action:      action.Action,
+					Resource:    action.Resource,
+					BranchOrRef: action.BranchOrRef,
+				})
+			}
+			return requests
+		},
+	}
+}
+
+// HubspotPolicyBinding binds the HubSpot classifier to a snapshot source. The
+// Cowork connector registry is resolved lazily per event from the hook cwd.
+func HubspotPolicyBinding(snapshots providerpolicy.SnapshotProvider) ProviderPolicyBinding {
+	return ProviderPolicyBinding{
+		Provider:  "hubspot",
+		Snapshots: snapshots,
+		Classify: func(event risk.HookEvent) []providerpolicy.Request {
+			actions := hubspotpolicy.ClassifyProviderActions(event.ToolName, event.ToolInput, hubspotpolicy.ConnectorResolverForCWD(event.CWD))
+			requests := make([]providerpolicy.Request, 0, len(actions))
+			for _, action := range actions {
+				requests = append(requests, providerpolicy.Request{
+					Action:   action.Action,
+					Resource: action.Resource,
+				})
+			}
+			return requests
+		},
+	}
+}
 
 type PolicyProvider interface {
 	DecideHook(context.Context, risk.HookEvent) (risk.RiskDecision, error)
@@ -23,9 +77,10 @@ type RiskPolicyProvider struct {
 	judge        judge.Judge
 	policyEngine guardpolicy.Engine
 	policyConfig PolicyConfigProvider
-	githubPolicy githubpolicy.SnapshotProvider
+	// providerPolicies are the synced-policy bindings evaluated per event.
+	providerPolicies []ProviderPolicyBinding
 	// endpointID is this managed endpoint's installation ("ins_…") id, used as
-	// the endpoint-layer subject when evaluating synced GitHub policy.
+	// the endpoint-layer subject when evaluating synced provider policy.
 	endpointID string
 }
 
@@ -34,7 +89,7 @@ type RiskPolicyProviderOptions struct {
 	PolicyEngine         guardpolicy.Engine
 	PolicyConfig         guardpolicy.Config
 	PolicyConfigProvider PolicyConfigProvider
-	GithubPolicy         githubpolicy.SnapshotProvider
+	ProviderPolicies     []ProviderPolicyBinding
 	EndpointID           string
 }
 
@@ -62,11 +117,11 @@ func NewRiskPolicyProviderWithOptions(opts RiskPolicyProviderOptions) RiskPolicy
 		configProvider = staticPolicyConfigProvider{config: opts.PolicyConfig}
 	}
 	return RiskPolicyProvider{
-		judge:        opts.Judge,
-		policyEngine: opts.PolicyEngine,
-		policyConfig: configProvider,
-		githubPolicy: opts.GithubPolicy,
-		endpointID:   opts.EndpointID,
+		judge:            opts.Judge,
+		policyEngine:     opts.PolicyEngine,
+		policyConfig:     configProvider,
+		providerPolicies: opts.ProviderPolicies,
+		endpointID:       opts.EndpointID,
 	}
 }
 
@@ -77,83 +132,88 @@ func (p RiskPolicyProvider) DecideHook(ctx context.Context, event risk.HookEvent
 	riskEvent := risk.NormalizeHookEvent(event)
 	policyResult := p.policyEngine.Evaluate(riskEvent, p.activePolicyConfig(ctx))
 	applyPolicyMetadata(&riskEvent, policyResult)
-	// Local layering: deterministic guardrails > synced GitHub policy >
+	// Local layering: deterministic guardrails > synced provider policy >
 	// probabilistic signals. A guardrail deny stands regardless of what the
-	// synced policy would have said; the synced policy (when enforcing)
+	// synced policy would have said; a synced policy (when enforcing)
 	// pre-empts the judge.
-	githubEvaluations, githubEnforce := p.evaluateGithubPolicy(event)
+	providerEvaluations, enforcing := p.evaluateProviderPolicies(event)
 	if policyResult.Decision == guardpolicy.DecisionDeny {
-		return withGithubPolicy(deterministicDenyDecision(riskEvent, policyResult), githubEvaluations), nil
+		return withProviderPolicy(deterministicDenyDecision(riskEvent, policyResult), providerEvaluations), nil
 	}
-	if githubEnforce && len(githubEvaluations) > 0 {
-		return withGithubPolicy(githubPolicyDecision(riskEvent, githubEvaluations), githubEvaluations), nil
+	if enforcing != nil {
+		return withProviderPolicy(providerPolicyDecision(riskEvent, *enforcing), providerEvaluations), nil
 	}
 	if p.judge == nil {
-		return withGithubPolicy(deterministicAllowDecision(riskEvent, policyResult), githubEvaluations), nil
+		return withProviderPolicy(deterministicAllowDecision(riskEvent, policyResult), providerEvaluations), nil
 	}
 
 	result, err := p.judge.Decide(ctx, judgeInputFromRiskEvent(event, riskEvent))
 	if err != nil {
-		return withGithubPolicy(judgeFailOpenDecision(riskEvent, p.judge, err), githubEvaluations), nil
+		return withProviderPolicy(judgeFailOpenDecision(riskEvent, p.judge, err), providerEvaluations), nil
 	}
-	return withGithubPolicy(judgeDecision(riskEvent, result), githubEvaluations), nil
+	return withProviderPolicy(judgeDecision(riskEvent, result), providerEvaluations), nil
 }
 
-// evaluateGithubPolicy classifies the event into canonical GitHub actions and
-// evaluates each against the synced policy snapshot. The managed endpoint's
-// trusted identity is the service account + installation — Claude hook
-// payloads are not trusted human identity — so requests carry no Kontext
-// user/application subject and user/agent-layer rules cannot match their
-// subject (the evaluation flags this via SubjectsResolved). The endpoint's
-// own installation id IS known and trusted, so it is supplied as the
-// endpoint-layer subject; endpoint-scoped rules are how device policy is
-// enforced on this path.
+// evaluateProviderPolicies classifies the event through every bound
+// provider's classifier and evaluates the classified actions against that
+// provider's synced snapshot. The managed endpoint's trusted identity is the
+// service account + installation — Claude hook payloads are not trusted human
+// identity — so requests carry no Kontext user/application subject and
+// user/agent-layer rules cannot match their subject (the evaluation flags
+// this via SubjectsResolved). The endpoint's own installation id IS known and
+// trusted, so it is supplied as the endpoint-layer subject; endpoint-scoped
+// rules are how device policy is enforced on this path.
 //
-// The boolean result reports whether the snapshot explicitly directs
-// enforcement; anything else is observe and never influences the decision.
-func (p RiskPolicyProvider) evaluateGithubPolicy(event risk.HookEvent) ([]githubpolicy.Evaluation, bool) {
-	if p.githubPolicy == nil {
-		return nil, false
-	}
-	snapshot, status, ok := p.githubPolicy.CurrentSnapshot()
-	if !ok || len(snapshot.Rules) == 0 {
-		return nil, false
-	}
-	actions := githubpolicy.ClassifyProviderActionsWithCWD(event.ToolName, event.ToolInput, event.CWD, func(cwd string) githubpolicy.GitContext {
-		return githubpolicy.GitContextFromCWD(cwd)
-	})
-	if len(actions) == 0 {
-		return nil, false
-	}
-	evaluations := make([]githubpolicy.Evaluation, 0, len(actions))
-	for _, action := range actions {
-		evaluation, ok := githubpolicy.Evaluate(snapshot, status, githubpolicy.Request{
-			Action:      action.Action,
-			Resource:    action.Resource,
-			BranchOrRef: action.BranchOrRef,
-			EndpointID:  p.endpointID,
-		})
-		if ok {
-			evaluations = append(evaluations, evaluation)
+// The second result is the first provider whose snapshot explicitly directs
+// enforcement AND produced evaluations for this event; nil otherwise. In the
+// observer pilot every snapshot is observe-mode, so it is always nil.
+func (p RiskPolicyProvider) evaluateProviderPolicies(event risk.HookEvent) ([]risk.ProviderPolicyEvaluations, *risk.ProviderPolicyEvaluations) {
+	var all []risk.ProviderPolicyEvaluations
+	var enforcing *risk.ProviderPolicyEvaluations
+	for _, binding := range p.providerPolicies {
+		if binding.Snapshots == nil || binding.Classify == nil {
+			continue
+		}
+		snapshot, status, ok := binding.Snapshots.CurrentSnapshot()
+		if !ok || len(snapshot.Rules) == 0 {
+			continue
+		}
+		requests := binding.Classify(event)
+		if len(requests) == 0 {
+			continue
+		}
+		evaluations := make([]providerpolicy.Evaluation, 0, len(requests))
+		for _, request := range requests {
+			request.EndpointID = p.endpointID
+			if evaluation, ok := providerpolicy.Evaluate(snapshot, status, request); ok {
+				evaluations = append(evaluations, evaluation)
+			}
+		}
+		if len(evaluations) == 0 {
+			continue
+		}
+		all = append(all, risk.ProviderPolicyEvaluations{Provider: binding.Provider, Evaluations: evaluations})
+		if snapshot.Enforce() && enforcing == nil {
+			enforcing = &all[len(all)-1]
 		}
 	}
-	return evaluations, snapshot.Enforce()
+	return all, enforcing
 }
 
-func withGithubPolicy(decision risk.RiskDecision, evaluations []githubpolicy.Evaluation) risk.RiskDecision {
-	decision.GithubPolicy = evaluations
+func withProviderPolicy(decision risk.RiskDecision, evaluations []risk.ProviderPolicyEvaluations) risk.RiskDecision {
+	decision.ProviderPolicy = evaluations
 	return decision
 }
 
-// githubPolicyDecision is the enforce-mode path, reserved for after the
+// providerPolicyDecision is the enforce-mode path, reserved for after the
 // observer pilot: the synced policy outranks probabilistic signals, so its
 // verdict decides instead of the judge. Any denied action denies the event.
-func githubPolicyDecision(riskEvent risk.RiskEvent, evaluations []githubpolicy.Evaluation) risk.RiskDecision {
-	for _, evaluation := range evaluations {
-		if evaluation.Result == githubpolicy.EffectDeny {
+func providerPolicyDecision(riskEvent risk.RiskEvent, provider risk.ProviderPolicyEvaluations) risk.RiskDecision {
+	for _, evaluation := range provider.Evaluations {
+		if evaluation.Result == providerpolicy.EffectDeny {
 			riskEvent.Decision = risk.DecisionDeny
 			riskEvent.ReasonCode = evaluation.ReasonCode
-			riskEvent.DecisionStage = "github_policy_deny"
+			riskEvent.DecisionStage = provider.Provider + "_policy_deny"
 			return risk.RiskDecision{
 				Decision:   risk.DecisionDeny,
 				Reason:     evaluation.Reason,
@@ -163,10 +223,10 @@ func githubPolicyDecision(riskEvent risk.RiskEvent, evaluations []githubpolicy.E
 			}
 		}
 	}
-	allowed := evaluations[0]
+	allowed := provider.Evaluations[0]
 	riskEvent.Decision = risk.DecisionAllow
 	riskEvent.ReasonCode = allowed.ReasonCode
-	riskEvent.DecisionStage = "github_policy_allow"
+	riskEvent.DecisionStage = provider.Provider + "_policy_allow"
 	return risk.RiskDecision{
 		Decision:   risk.DecisionAllow,
 		Reason:     allowed.Reason,

--- a/internal/guard/app/server/policy.go
+++ b/internal/guard/app/server/policy.go
@@ -140,8 +140,8 @@ func (p RiskPolicyProvider) DecideHook(ctx context.Context, event risk.HookEvent
 	if policyResult.Decision == guardpolicy.DecisionDeny {
 		return withProviderPolicy(deterministicDenyDecision(riskEvent, policyResult), providerEvaluations), nil
 	}
-	if enforcing != nil {
-		return withProviderPolicy(providerPolicyDecision(riskEvent, *enforcing), providerEvaluations), nil
+	if len(enforcing) > 0 {
+		return withProviderPolicy(providerPolicyDecision(riskEvent, enforcing), providerEvaluations), nil
 	}
 	if p.judge == nil {
 		return withProviderPolicy(deterministicAllowDecision(riskEvent, policyResult), providerEvaluations), nil
@@ -165,11 +165,11 @@ func (p RiskPolicyProvider) DecideHook(ctx context.Context, event risk.HookEvent
 // rules are how device policy is enforced on this path.
 //
 // The second result is the first provider whose snapshot explicitly directs
-// enforcement AND produced evaluations for this event; nil otherwise. In the
-// observer pilot every snapshot is observe-mode, so it is always nil.
-func (p RiskPolicyProvider) evaluateProviderPolicies(event risk.HookEvent) ([]risk.ProviderPolicyEvaluations, *risk.ProviderPolicyEvaluations) {
+// enforcement AND produced evaluations for this event; empty otherwise. In
+// the observer pilot every snapshot is observe-mode, so it is always empty.
+func (p RiskPolicyProvider) evaluateProviderPolicies(event risk.HookEvent) ([]risk.ProviderPolicyEvaluations, []risk.ProviderPolicyEvaluations) {
 	var all []risk.ProviderPolicyEvaluations
-	var enforcing *risk.ProviderPolicyEvaluations
+	var enforcing []risk.ProviderPolicyEvaluations
 	for _, binding := range p.providerPolicies {
 		if binding.Snapshots == nil || binding.Classify == nil {
 			continue
@@ -194,12 +194,8 @@ func (p RiskPolicyProvider) evaluateProviderPolicies(event risk.HookEvent) ([]ri
 		}
 		group := risk.ProviderPolicyEvaluations{Provider: binding.Provider, Evaluations: evaluations}
 		all = append(all, group)
-		if snapshot.Enforce() && enforcing == nil {
-			// Point at a local copy, never into `all`'s backing array — a
-			// later append() may reallocate it and leave a slice-element
-			// pointer dangling at a stale array.
-			g := group
-			enforcing = &g
+		if snapshot.Enforce() {
+			enforcing = append(enforcing, group)
 		}
 	}
 	return all, enforcing
@@ -212,26 +208,31 @@ func withProviderPolicy(decision risk.RiskDecision, evaluations []risk.ProviderP
 
 // providerPolicyDecision is the enforce-mode path, reserved for after the
 // observer pilot: the synced policy outranks probabilistic signals, so its
-// verdict decides instead of the judge. Any denied action denies the event.
-func providerPolicyDecision(riskEvent risk.RiskEvent, provider risk.ProviderPolicyEvaluations) risk.RiskDecision {
-	for _, evaluation := range provider.Evaluations {
-		if evaluation.Result == providerpolicy.EffectDeny {
-			riskEvent.Decision = risk.DecisionDeny
-			riskEvent.ReasonCode = evaluation.ReasonCode
-			riskEvent.DecisionStage = provider.Provider + "_policy_deny"
-			return risk.RiskDecision{
-				Decision:   risk.DecisionDeny,
-				Reason:     evaluation.Reason,
-				ReasonCode: evaluation.ReasonCode,
-				GuardID:    evaluation.DecidingRuleID,
-				RiskEvent:  riskEvent,
+// verdict decides instead of the judge. ANY enforcing provider's denied
+// action denies the event — an event that classifies under two enforcing
+// providers must not slip through because the first one allowed it.
+func providerPolicyDecision(riskEvent risk.RiskEvent, enforcing []risk.ProviderPolicyEvaluations) risk.RiskDecision {
+	for _, provider := range enforcing {
+		for _, evaluation := range provider.Evaluations {
+			if evaluation.Result == providerpolicy.EffectDeny {
+				riskEvent.Decision = risk.DecisionDeny
+				riskEvent.ReasonCode = evaluation.ReasonCode
+				riskEvent.DecisionStage = provider.Provider + "_policy_deny"
+				return risk.RiskDecision{
+					Decision:   risk.DecisionDeny,
+					Reason:     evaluation.Reason,
+					ReasonCode: evaluation.ReasonCode,
+					GuardID:    evaluation.DecidingRuleID,
+					RiskEvent:  riskEvent,
+				}
 			}
 		}
 	}
-	allowed := provider.Evaluations[0]
+	first := enforcing[0]
+	allowed := first.Evaluations[0]
 	riskEvent.Decision = risk.DecisionAllow
 	riskEvent.ReasonCode = allowed.ReasonCode
-	riskEvent.DecisionStage = provider.Provider + "_policy_allow"
+	riskEvent.DecisionStage = first.Provider + "_policy_allow"
 	return risk.RiskDecision{
 		Decision:   risk.DecisionAllow,
 		Reason:     allowed.Reason,

--- a/internal/guard/app/server/policy.go
+++ b/internal/guard/app/server/policy.go
@@ -192,9 +192,14 @@ func (p RiskPolicyProvider) evaluateProviderPolicies(event risk.HookEvent) ([]ri
 		if len(evaluations) == 0 {
 			continue
 		}
-		all = append(all, risk.ProviderPolicyEvaluations{Provider: binding.Provider, Evaluations: evaluations})
+		group := risk.ProviderPolicyEvaluations{Provider: binding.Provider, Evaluations: evaluations}
+		all = append(all, group)
 		if snapshot.Enforce() && enforcing == nil {
-			enforcing = &all[len(all)-1]
+			// Point at a local copy, never into `all`'s backing array — a
+			// later append() may reallocate it and leave a slice-element
+			// pointer dangling at a stale array.
+			g := group
+			enforcing = &g
 		}
 	}
 	return all, enforcing

--- a/internal/guard/app/server/server.go
+++ b/internal/guard/app/server/server.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kontext-security/kontext-cli/internal/githubpolicy"
 	"github.com/kontext-security/kontext-cli/internal/guard/judge"
 	"github.com/kontext-security/kontext-cli/internal/guard/policy"
 	"github.com/kontext-security/kontext-cli/internal/guard/policyconfig"
@@ -51,7 +50,7 @@ type Options struct {
 	Judge                judge.Judge
 	PolicyConfig         policy.Config
 	PolicyConfigProvider PolicyConfigProvider
-	GithubPolicy         githubpolicy.SnapshotProvider
+	ProviderPolicies     []ProviderPolicyBinding
 	EndpointID           string
 	CurrentSessionID     string
 	Mode                 string
@@ -101,7 +100,7 @@ func NewServerWithOptions(store *sqlite.Store, opts Options) (*Server, error) {
 	return NewServerWithPolicyConfigAndOptions(store, NewRiskPolicyProviderWithOptions(RiskPolicyProviderOptions{
 		Judge:                opts.Judge,
 		PolicyConfigProvider: configProvider,
-		GithubPolicy:         opts.GithubPolicy,
+		ProviderPolicies:     opts.ProviderPolicies,
 		EndpointID:           opts.EndpointID,
 	}), policyStore, opts)
 }

--- a/internal/guard/risk/types.go
+++ b/internal/guard/risk/types.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/kontext-security/kontext-cli/internal/providerpolicy"
 	"github.com/kontext-security/kontext-cli/internal/guard/decision"
+	"github.com/kontext-security/kontext-cli/internal/providerpolicy"
 )
 
 type HookEvent struct {

--- a/internal/guard/risk/types.go
+++ b/internal/guard/risk/types.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/kontext-security/kontext-cli/internal/githubpolicy"
+	"github.com/kontext-security/kontext-cli/internal/providerpolicy"
 	"github.com/kontext-security/kontext-cli/internal/guard/decision"
 )
 
@@ -103,9 +103,17 @@ type RiskDecision struct {
 	ModelVersion string    `json:"model_version,omitempty"`
 	GuardID      string    `json:"guard_id,omitempty"`
 	RiskEvent    RiskEvent `json:"risk_event"`
-	// GithubPolicy carries the synced-policy dry-run evaluations for this
-	// event; each one is recorded as a separate request.decided ledger row.
-	GithubPolicy []githubpolicy.Evaluation `json:"github_policy,omitempty"`
+	// ProviderPolicy carries the synced-policy dry-run evaluations for this
+	// event, grouped per provider; each evaluation is recorded as a separate
+	// request.decided ledger row.
+	ProviderPolicy []ProviderPolicyEvaluations `json:"provider_policy,omitempty"`
+}
+
+// ProviderPolicyEvaluations groups one provider's synced-policy evaluations
+// for an event.
+type ProviderPolicyEvaluations struct {
+	Provider    string                      `json:"provider"`
+	Evaluations []providerpolicy.Evaluation `json:"evaluations"`
 }
 
 func MarshalInput(value map[string]any) string {

--- a/internal/guard/store/sqlite/dryrun.go
+++ b/internal/guard/store/sqlite/dryrun.go
@@ -9,29 +9,47 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/kontext-security/kontext-cli/internal/githubpolicy"
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
+	"github.com/kontext-security/kontext-cli/internal/providerpolicy"
 )
 
-// insertGithubDryRunActions records the synced GitHub policy's would-be
+// insertProviderDryRunActions records each synced provider policy's would-be
 // decisions. Each evaluated action gets its own request.decided row with
 // decision_category "dry_run", separate from the runtime's own decided row —
 // in observe mode nothing is ever blocked, the dry-run row only documents
 // what the policy would have done.
-func (s *Store) insertGithubDryRunActions(ctx context.Context, tx *sql.Tx, sessionID string, event risk.HookEvent, decision risk.RiskDecision, now time.Time) error {
-	for i, evaluation := range decision.GithubPolicy {
-		action, err := githubDryRunActionValues("act_"+uuid.NewString(), sessionID, event, decision, evaluation, now.Add(time.Duration(i)*time.Millisecond))
-		if err != nil {
-			return err
-		}
-		if err := s.insertActionRecord(ctx, tx, action, "decision", now); err != nil {
-			return err
+func (s *Store) insertProviderDryRunActions(ctx context.Context, tx *sql.Tx, sessionID string, event risk.HookEvent, decision risk.RiskDecision, now time.Time) error {
+	sequence := 0
+	for _, group := range decision.ProviderPolicy {
+		for _, evaluation := range group.Evaluations {
+			action, err := providerDryRunActionValues("act_"+uuid.NewString(), sessionID, group.Provider, event, decision, evaluation, now.Add(time.Duration(sequence)*time.Millisecond))
+			if err != nil {
+				return err
+			}
+			if err := s.insertActionRecord(ctx, tx, action, "decision", now); err != nil {
+				return err
+			}
+			sequence++
 		}
 	}
 	return nil
 }
 
-func githubDryRunActionValues(actionID, sessionID string, event risk.HookEvent, decision risk.RiskDecision, evaluation githubpolicy.Evaluation, now time.Time) (map[string]any, error) {
+// providerResourceClass names the normalized resource class each provider's
+// policy anchor belongs to (the taxonomy in
+// docs/guides/access-control-event-schema.md of the cloud repo).
+func providerResourceClass(provider string) string {
+	switch provider {
+	case "github":
+		return "repo"
+	case "hubspot":
+		return "object"
+	default:
+		return "unknown"
+	}
+}
+
+func providerDryRunActionValues(actionID, sessionID, provider string, event risk.HookEvent, decision risk.RiskDecision, evaluation providerpolicy.Evaluation, now time.Time) (map[string]any, error) {
 	riskEvent := decision.RiskEvent
 	parametersJSON, parametersHash := mustHashJSON(map[string]any{
 		"command_summary": riskEvent.CommandSummary,
@@ -47,18 +65,12 @@ func githubDryRunActionValues(actionID, sessionID string, event risk.HookEvent, 
 	}
 	identityJSON, identityHash := mustHashJSON(identityPayload)
 
-	githubContext := map[string]any{}
-	if owner, repo, ok := splitRepoSlug(evaluation.Request.Resource); ok {
-		githubContext["owner"] = owner
-		githubContext["repo"] = repo
-	}
-	if evaluation.Request.BranchOrRef != "" {
-		githubContext["branch_or_ref"] = evaluation.Request.BranchOrRef
-	}
 	contextPayload := map[string]any{
 		"cwd":             event.CWD,
 		"hook_event_name": event.HookEventName,
-		"github_policy": map[string]any{
+		// Keyed per provider ("github_policy", "hubspot_policy") so github
+		// rows stay byte-identical to the pre-hubspot producer.
+		provider + "_policy": map[string]any{
 			"schema_version":    evaluation.SchemaVersion,
 			"mode":              evaluation.Mode,
 			"epoch":             evaluation.Epoch,
@@ -68,14 +80,24 @@ func githubDryRunActionValues(actionID, sessionID string, event risk.HookEvent, 
 			"groups_resolved":   evaluation.GroupsResolved,
 		},
 	}
-	if len(githubContext) > 0 {
-		contextPayload["github"] = githubContext
+	if provider == "github" {
+		githubContext := map[string]any{}
+		if owner, repo, ok := splitRepoSlug(evaluation.Request.Resource); ok {
+			githubContext["owner"] = owner
+			githubContext["repo"] = repo
+		}
+		if evaluation.Request.BranchOrRef != "" {
+			githubContext["branch_or_ref"] = evaluation.Request.BranchOrRef
+		}
+		if len(githubContext) > 0 {
+			contextPayload["github"] = githubContext
+		}
 	}
 	contextJSON, contextHash := mustHashJSON(contextPayload)
 
 	matchedRules := evaluation.MatchedRules
 	if matchedRules == nil {
-		matchedRules = []githubpolicy.MatchedRule{}
+		matchedRules = []providerpolicy.MatchedRule{}
 	}
 	matchedRulesJSON := mustJSONText(matchedRules)
 
@@ -88,10 +110,10 @@ func githubDryRunActionValues(actionID, sessionID string, event risk.HookEvent, 
 		"adapter_event_name":       event.HookEventName,
 		"correlation_key":          correlationKey(event),
 		"tool_name":                event.ToolName,
-		"provider":                 "github",
+		"provider":                 provider,
 		"operation":                evaluation.Request.Action,
 		"operation_class":          operationClassFromAction(evaluation.Request.Action),
-		"resource_class":           "repo",
+		"resource_class":           providerResourceClass(provider),
 		"resource_id":              nullIfEmpty(evaluation.Request.Resource),
 		"parameters_redacted_json": parametersJSON,
 		"parameters_hash":          parametersHash,

--- a/internal/guard/store/sqlite/dryrun_test.go
+++ b/internal/guard/store/sqlite/dryrun_test.go
@@ -30,7 +30,7 @@ func TestSaveDecisionRecordsGithubDryRunRows(t *testing.T) {
 		Reason:     "observed",
 		ReasonCode: "deterministic_allow",
 		RiskEvent:  risk.RiskEvent{CommandSummary: "git push origin main"},
-		GithubPolicy: []githubpolicy.Evaluation{{
+		ProviderPolicy: []risk.ProviderPolicyEvaluations{{Provider: "github", Evaluations: []githubpolicy.Evaluation{{
 			Request:    githubpolicy.Request{Action: "github.repo.write", Resource: "acme/api", BranchOrRef: "main"},
 			Result:     "deny",
 			ReasonCode: githubpolicy.ReasonCodeDeny,
@@ -43,7 +43,7 @@ func TestSaveDecisionRecordsGithubDryRunRows(t *testing.T) {
 			Mode:           githubpolicy.ModeObserve,
 			Epoch:          5,
 			Hash:           "hash-5",
-		}},
+		}}}},
 	}
 	if _, err := store.SaveDecision(context.Background(), event, decision); err != nil {
 		t.Fatalf("SaveDecision() error = %v", err)
@@ -168,14 +168,14 @@ func TestDryRunRowsDoNotCountAsCriticalActions(t *testing.T) {
 	}
 	decision := risk.RiskDecision{
 		Decision: risk.DecisionAllow,
-		GithubPolicy: []githubpolicy.Evaluation{{
+		ProviderPolicy: []risk.ProviderPolicyEvaluations{{Provider: "github", Evaluations: []githubpolicy.Evaluation{{
 			Request:    githubpolicy.Request{Action: "github.repo.write", Resource: "acme/api"},
 			Result:     "deny",
 			ReasonCode: githubpolicy.ReasonCodeDeny,
 			Reason:     "would deny",
 			Epoch:      5,
 			Hash:       "hash-5",
-		}},
+		}}}},
 	}
 	if _, err := store.SaveDecision(context.Background(), event, decision); err != nil {
 		t.Fatalf("SaveDecision() error = %v", err)
@@ -234,5 +234,79 @@ func TestSaveDecisionWithoutGithubPolicyAddsNoExtraRows(t *testing.T) {
 	}
 	if len(batch.Actions) != 2 {
 		t.Fatalf("actions = %d, want proposed + decided only", len(batch.Actions))
+	}
+}
+
+func TestSaveDecisionRecordsHubspotDryRunRow(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatalf("OpenStore() error = %v", err)
+	}
+	defer store.Close()
+
+	event := risk.HookEvent{
+		SessionID:     "session-1",
+		Agent:         "cowork",
+		HookEventName: "PreToolUse",
+		ToolName:      "mcp__5c56899e-3e6c-4803-85ca-ff1912393966__manage_crm_objects",
+		ToolInput:     map[string]any{"updateRequest": map[string]any{"objects": []any{map[string]any{"objectType": "deals"}}}},
+		ToolUseID:     "toolu_hs",
+	}
+	decision := risk.RiskDecision{
+		Decision: risk.DecisionAllow,
+		ProviderPolicy: []risk.ProviderPolicyEvaluations{{Provider: "hubspot", Evaluations: []githubpolicy.Evaluation{{
+			Request:        githubpolicy.Request{Action: "hubspot.object.write", Resource: "deals"},
+			Result:         "deny",
+			ReasonCode:     githubpolicy.ReasonCodeDeny,
+			Reason:         "would deny",
+			DecidingRuleID: "rule-deny-deals",
+			Mode:           githubpolicy.ModeObserve,
+			Epoch:          2,
+			Hash:           "hash-2",
+			SchemaVersion:  "hubspot-policy-snapshot-v1",
+		}}}},
+	}
+	if _, err := store.SaveDecision(context.Background(), event, decision); err != nil {
+		t.Fatalf("SaveDecision() error = %v", err)
+	}
+
+	batch, err := store.LedgerBatch(context.Background(), LedgerExportOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("LedgerBatch() error = %v", err)
+	}
+	var dryRun LedgerRecord
+	for _, action := range batch.Actions {
+		if action["decision_category"] == "dry_run" {
+			dryRun = action
+		}
+	}
+	if dryRun == nil {
+		t.Fatal("no dry_run row found")
+	}
+
+	expectations := map[string]any{
+		"provider":        "hubspot",
+		"resource_class":  "object",
+		"resource_id":     "deals",
+		"operation":       "hubspot.object.write",
+		"operation_class": "write",
+		"decision_result": "deny",
+		"policy_id":       "rule-deny-deals",
+		"policy_hash":     "hash-2",
+	}
+	for key, want := range expectations {
+		if got := dryRun[key]; got != want {
+			t.Errorf("dry run %s = %v, want %v", key, got, want)
+		}
+	}
+
+	contextJSON, _ := dryRun["context_json"].(map[string]any)
+	policyContext, _ := contextJSON["hubspot_policy"].(map[string]any)
+	if policyContext["schema_version"] != "hubspot-policy-snapshot-v1" || policyContext["mode"] != "observe" {
+		t.Fatalf("context_json.hubspot_policy = %v", policyContext)
+	}
+	// The github repo-slug context block is github-only.
+	if _, present := contextJSON["github"]; present {
+		t.Fatalf("context_json.github present on a hubspot row: %v", contextJSON)
 	}
 }

--- a/internal/guard/store/sqlite/dryrun_test.go
+++ b/internal/guard/store/sqlite/dryrun_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kontext-security/kontext-cli/internal/githubpolicy"
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
+	"github.com/kontext-security/kontext-cli/internal/providerpolicy"
 )
 
 func TestSaveDecisionRecordsGithubDryRunRows(t *testing.T) {
@@ -30,17 +30,17 @@ func TestSaveDecisionRecordsGithubDryRunRows(t *testing.T) {
 		Reason:     "observed",
 		ReasonCode: "deterministic_allow",
 		RiskEvent:  risk.RiskEvent{CommandSummary: "git push origin main"},
-		ProviderPolicy: []risk.ProviderPolicyEvaluations{{Provider: "github", Evaluations: []githubpolicy.Evaluation{{
-			Request:    githubpolicy.Request{Action: "github.repo.write", Resource: "acme/api", BranchOrRef: "main"},
+		ProviderPolicy: []risk.ProviderPolicyEvaluations{{Provider: "github", Evaluations: []providerpolicy.Evaluation{{
+			Request:    providerpolicy.Request{Action: "github.repo.write", Resource: "acme/api", BranchOrRef: "main"},
 			Result:     "deny",
-			ReasonCode: githubpolicy.ReasonCodeDeny,
+			ReasonCode: providerpolicy.ReasonCodeDeny,
 			Reason:     "denied by org-layer deny rule on github.repo.write @ acme/api",
-			MatchedRules: []githubpolicy.MatchedRule{
+			MatchedRules: []providerpolicy.MatchedRule{
 				{ID: "rule-deny", Layer: "org", Effect: "deny", Decided: true},
 				{ID: "rule-allow", Layer: "org", Effect: "allow"},
 			},
 			DecidingRuleID: "rule-deny",
-			Mode:           githubpolicy.ModeObserve,
+			Mode:           providerpolicy.ModeObserve,
 			Epoch:          5,
 			Hash:           "hash-5",
 		}}}},
@@ -80,7 +80,7 @@ func TestSaveDecisionRecordsGithubDryRunRows(t *testing.T) {
 
 	expectations := map[string]any{
 		"decision_result": "deny",
-		"reason_code":     githubpolicy.ReasonCodeDeny,
+		"reason_code":     providerpolicy.ReasonCodeDeny,
 		"provider":        "github",
 		"resource_class":  "repo",
 		"resource_id":     "acme/api",
@@ -168,10 +168,10 @@ func TestDryRunRowsDoNotCountAsCriticalActions(t *testing.T) {
 	}
 	decision := risk.RiskDecision{
 		Decision: risk.DecisionAllow,
-		ProviderPolicy: []risk.ProviderPolicyEvaluations{{Provider: "github", Evaluations: []githubpolicy.Evaluation{{
-			Request:    githubpolicy.Request{Action: "github.repo.write", Resource: "acme/api"},
+		ProviderPolicy: []risk.ProviderPolicyEvaluations{{Provider: "github", Evaluations: []providerpolicy.Evaluation{{
+			Request:    providerpolicy.Request{Action: "github.repo.write", Resource: "acme/api"},
 			Result:     "deny",
-			ReasonCode: githubpolicy.ReasonCodeDeny,
+			ReasonCode: providerpolicy.ReasonCodeDeny,
 			Reason:     "would deny",
 			Epoch:      5,
 			Hash:       "hash-5",
@@ -254,13 +254,13 @@ func TestSaveDecisionRecordsHubspotDryRunRow(t *testing.T) {
 	}
 	decision := risk.RiskDecision{
 		Decision: risk.DecisionAllow,
-		ProviderPolicy: []risk.ProviderPolicyEvaluations{{Provider: "hubspot", Evaluations: []githubpolicy.Evaluation{{
-			Request:        githubpolicy.Request{Action: "hubspot.object.write", Resource: "deals"},
+		ProviderPolicy: []risk.ProviderPolicyEvaluations{{Provider: "hubspot", Evaluations: []providerpolicy.Evaluation{{
+			Request:        providerpolicy.Request{Action: "hubspot.object.write", Resource: "deals"},
 			Result:         "deny",
-			ReasonCode:     githubpolicy.ReasonCodeDeny,
+			ReasonCode:     providerpolicy.ReasonCodeDeny,
 			Reason:         "would deny",
 			DecidingRuleID: "rule-deny-deals",
-			Mode:           githubpolicy.ModeObserve,
+			Mode:           providerpolicy.ModeObserve,
 			Epoch:          2,
 			Hash:           "hash-2",
 			SchemaVersion:  "hubspot-policy-snapshot-v1",

--- a/internal/guard/store/sqlite/store.go
+++ b/internal/guard/store/sqlite/store.go
@@ -778,7 +778,7 @@ on conflict(id) do update set
 		if err := s.insertAction(ctx, tx, actionID, sessionID, event, decision, canonicalEventRequestDecided, "decision", captureMode, now.Add(time.Millisecond)); err != nil {
 			return DecisionRecord{}, err
 		}
-		if err := s.insertGithubDryRunActions(ctx, tx, sessionID, event, decision, now.Add(2*time.Millisecond)); err != nil {
+		if err := s.insertProviderDryRunActions(ctx, tx, sessionID, event, decision, now.Add(2*time.Millisecond)); err != nil {
 			return DecisionRecord{}, err
 		}
 	} else {

--- a/internal/hubspotpolicy/classifier.go
+++ b/internal/hubspotpolicy/classifier.go
@@ -1,0 +1,261 @@
+package hubspotpolicy
+
+import (
+	"strings"
+)
+
+// Canonical HubSpot action names emitted by the classifier, mirroring the
+// shared action catalog (packages/shared/src/hubspot/action-catalog.ts):
+//
+//	hubspot.object.read / hubspot.object.write — CRM data; the object type is
+//	  the resource anchor (Resource), normalized to canonical names.
+//	hubspot.api.read / hubspot.api.write — everything else the connector
+//	  exposes: account/user info, marketing analytics, landing pages,
+//	  connector utilities.
+const (
+	ActionObjectRead  = "hubspot.object.read"
+	ActionObjectWrite = "hubspot.object.write"
+	ActionAPIRead     = "hubspot.api.read"
+	ActionAPIWrite    = "hubspot.api.write"
+)
+
+// ProviderAction is one classified HubSpot action. Resource is the CRM
+// object type (e.g. "contacts") when the tool input names one, otherwise
+// empty ("any resource" for rule-matching purposes).
+type ProviderAction struct {
+	Action   string
+	Resource string
+}
+
+// ConnectorResolver resolves an MCP server segment (the middle part of an
+// "mcp__<server>__<tool>" tool name) against Cowork's per-session connector
+// registry. resolved=false means the registry could not answer (no config
+// file, unknown id) and the tool-name fallback decides; resolved=true with
+// isHubspot=false is a definitive counter-signal — the segment maps to a
+// different server — and suppresses classification even for HubSpot-looking
+// tool names.
+type ConnectorResolver func(serverSegment string) (isHubspot, resolved bool)
+
+// toolClassification says how one HubSpot connector tool maps to canonical
+// actions. Exactly one of the fields drives the mapping.
+type toolClassification struct {
+	action string
+	// objectTyped tools carry the CRM object type in their input; the
+	// classifier extracts and normalizes it into Resource.
+	objectTyped bool
+	// actionInput tools (manage_landing_page) are read or write depending on
+	// their "action" input value.
+	actionInput bool
+}
+
+// hubspotTools is the full tool surface of the remote HubSpot MCP server,
+// verified against live Cowork sessions and the connector's published input
+// schemas (ENG-466). Unknown tools from the connector fall back to
+// hubspot.api.read/write by name heuristics in classifyTool.
+var hubspotTools = map[string]toolClassification{
+	// CRM data reads — objectType is a mandatory input on the search/get
+	// tools and present on the property tools.
+	"search_crm_objects": {action: ActionObjectRead, objectTyped: true},
+	"get_crm_objects":    {action: ActionObjectRead, objectTyped: true},
+	"search_properties":  {action: ActionObjectRead, objectTyped: true},
+	"get_properties":     {action: ActionObjectRead, objectTyped: true},
+	// SQL over the whole CRM: a read, but across every object type, so no
+	// single resource anchor. Matches wildcard-resource rules only.
+	"query_crm_data": {action: ActionObjectRead},
+	// The connector's only CRM write tool (create/update; it has no delete).
+	"manage_crm_objects": {action: ActionObjectWrite, objectTyped: true},
+	// Account/marketing reads.
+	"get_user_details":              {action: ActionAPIRead},
+	"get_organization_details":      {action: ActionAPIRead},
+	"search_owners":                 {action: ActionAPIRead},
+	"get_campaign_analytics":        {action: ActionAPIRead},
+	"get_campaign_asset_metrics":    {action: ActionAPIRead},
+	"get_campaign_contacts_by_type": {action: ActionAPIRead},
+	"get_content_analytics_report":  {action: ActionAPIRead},
+	"render_landing_page_ui":        {action: ActionAPIRead},
+	"tool_guidance":                 {action: ActionAPIRead},
+	"submit_feedback":               {action: ActionAPIRead},
+	// Landing pages: one tool for both directions; the "action" input value
+	// decides read vs write.
+	"manage_landing_page": {action: ActionAPIWrite, actionInput: true},
+}
+
+// landingPageReadActions are the side-effect-free values of
+// manage_landing_page's "action" input, per the connector's input schema.
+// Unknown values classify as write (fail conservative).
+var landingPageReadActions = map[string]bool{
+	"MODULES":       true,
+	"MODULE_TYPES":  true,
+	"MODULE_DEF":    true,
+	"MODULE_STYLES": true,
+	"MODULE_GUIDE":  true,
+	"TEMPLATES":     true,
+	"REVIEW":        true,
+}
+
+// standardObjectTypeIDs maps HubSpot's numeric object-type ids to their
+// canonical names, so a rule pinned on "contacts" matches regardless of which
+// spelling the tool input carried. Unmapped ids (custom objects "2-…" and
+// rarer standard objects) pass through verbatim — a rule can pin the raw id
+// and the audit trail shows exactly what was touched.
+var standardObjectTypeIDs = map[string]string{
+	"0-1": "contacts",
+	"0-2": "companies",
+	"0-3": "deals",
+	"0-5": "tickets",
+	"0-7": "products",
+	"0-8": "line_items",
+}
+
+// ClassifyProviderActions classifies one hook event's tool call into
+// canonical HubSpot actions. Only MCP tool calls are classified: the HubSpot
+// surface reachable from Claude Cowork / Claude Code is the remote MCP
+// connector, so there is no shell or URL grammar here (raw api.hubapi.com
+// classification is a deliberate non-goal for v1).
+//
+// The connector is identified in two steps: resolver (Cowork's connector
+// registry, matching the server URL host) first, then a tool-name fallback —
+// HubSpot's tool names are distinctive enough that a name match alone is
+// safe, and the registry file is an undocumented Claude-internal format we
+// must not hard-depend on.
+func ClassifyProviderActions(toolName string, toolInput map[string]any, resolver ConnectorResolver) []ProviderAction {
+	serverSegment, tool, ok := splitMCPToolName(toolName)
+	if !ok {
+		return nil
+	}
+	classification, known := hubspotTools[tool]
+	if !known {
+		return nil
+	}
+	if !isHubspotServer(serverSegment, resolver) {
+		return nil
+	}
+
+	switch {
+	case classification.actionInput:
+		action := ActionAPIWrite
+		if value, _ := toolInput["action"].(string); landingPageReadActions[strings.ToUpper(strings.TrimSpace(value))] {
+			action = ActionAPIRead
+		}
+		return []ProviderAction{{Action: action}}
+	case classification.objectTyped:
+		types := objectTypesFromInput(tool, toolInput)
+		if len(types) == 0 {
+			return []ProviderAction{{Action: classification.action}}
+		}
+		actions := make([]ProviderAction, 0, len(types))
+		for _, objectType := range types {
+			actions = append(actions, ProviderAction{Action: classification.action, Resource: objectType})
+		}
+		return actions
+	default:
+		return []ProviderAction{{Action: classification.action}}
+	}
+}
+
+// splitMCPToolName splits "mcp__<server>__<tool>" into its server segment and
+// tool name. The server segment may itself contain "__"-free UUIDs (Cowork
+// connectors) or plain names (Claude Code .mcp.json entries).
+func splitMCPToolName(toolName string) (server, tool string, ok bool) {
+	const prefix = "mcp__"
+	if !strings.HasPrefix(toolName, prefix) {
+		return "", "", false
+	}
+	rest := toolName[len(prefix):]
+	// The tool name is everything after the LAST "__" so server segments
+	// containing "__" (none observed, but cheap to be safe) still split.
+	index := strings.LastIndex(rest, "__")
+	if index <= 0 || index+2 >= len(rest) {
+		return "", "", false
+	}
+	return rest[:index], rest[index+2:], true
+}
+
+// isHubspotServer decides whether the server segment is the HubSpot
+// connector. The registry (when it can answer) is authoritative in both
+// directions. Without an answer, a segment naming HubSpot directly
+// ("hubspot" from .mcp.json, "claude_ai_HubSpot" from a claude.ai connector)
+// matches, and an opaque connector-instance id (Cowork UUIDs) carries no
+// counter-signal, so the distinctive tool name decides. A named non-HubSpot
+// segment ("workspace", "linear") stays unclassified.
+func isHubspotServer(segment string, resolver ConnectorResolver) bool {
+	if resolver != nil {
+		if isHubspot, resolved := resolver(segment); resolved {
+			return isHubspot
+		}
+	}
+	return strings.Contains(strings.ToLower(segment), "hubspot") || looksLikeOpaqueID(segment)
+}
+
+// looksLikeOpaqueID reports whether the server segment is an opaque
+// connector-instance id (Cowork UUIDs) rather than a human-chosen name. Only
+// consulted when no registry is available: an opaque id carries no counter-
+// signal, so the distinctive tool name decides.
+func looksLikeOpaqueID(segment string) bool {
+	if len(segment) < 16 {
+		return false
+	}
+	for _, r := range segment {
+		switch {
+		case r >= '0' && r <= '9', r >= 'a' && r <= 'f', r == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// objectTypesFromInput extracts the CRM object type(s) a tool call touches.
+// Search/get/property tools carry a single top-level objectType;
+// manage_crm_objects nests them per object under createRequest/updateRequest,
+// and one call may touch several types — each becomes its own action.
+func objectTypesFromInput(tool string, input map[string]any) []string {
+	if tool != "manage_crm_objects" {
+		if objectType := normalizeObjectType(stringField(input, "objectType")); objectType != "" {
+			return []string{objectType}
+		}
+		return nil
+	}
+	seen := map[string]bool{}
+	var types []string
+	for _, requestKey := range []string{"createRequest", "updateRequest"} {
+		request, _ := input[requestKey].(map[string]any)
+		if request == nil {
+			continue
+		}
+		objects, _ := request["objects"].([]any)
+		for _, entry := range objects {
+			object, _ := entry.(map[string]any)
+			if object == nil {
+				continue
+			}
+			objectType := normalizeObjectType(stringField(object, "objectType"))
+			if objectType != "" && !seen[objectType] {
+				seen[objectType] = true
+				types = append(types, objectType)
+			}
+		}
+		// Some request shapes carry the object type at the request level.
+		if objectType := normalizeObjectType(stringField(request, "objectType")); objectType != "" && !seen[objectType] {
+			seen[objectType] = true
+			types = append(types, objectType)
+		}
+	}
+	return types
+}
+
+// normalizeObjectType maps HubSpot's numeric object-type ids to canonical
+// names and lower-cases name spellings, so policy rules match one canonical
+// form. Unmapped ids pass through verbatim.
+func normalizeObjectType(objectType string) string {
+	objectType = strings.ToLower(strings.TrimSpace(objectType))
+	if canonical, ok := standardObjectTypeIDs[objectType]; ok {
+		return canonical
+	}
+	return objectType
+}
+
+func stringField(input map[string]any, key string) string {
+	value, _ := input[key].(string)
+	return value
+}

--- a/internal/hubspotpolicy/classifier.go
+++ b/internal/hubspotpolicy/classifier.go
@@ -74,7 +74,10 @@ var hubspotTools = map[string]toolClassification{
 	"get_content_analytics_report":  {action: ActionAPIRead},
 	"render_landing_page_ui":        {action: ActionAPIRead},
 	"tool_guidance":                 {action: ActionAPIRead},
-	"submit_feedback":               {action: ActionAPIRead},
+	// submit_feedback sends data to HubSpot — an egress side effect, so it is
+	// a write for policy purposes (a deny on hubspot.api.write should catch
+	// it), even though it touches no CRM data.
+	"submit_feedback": {action: ActionAPIWrite},
 	// Landing pages: one tool for both directions; the "action" input value
 	// decides read vs write.
 	"manage_landing_page": {action: ActionAPIWrite, actionInput: true},

--- a/internal/hubspotpolicy/classifier_test.go
+++ b/internal/hubspotpolicy/classifier_test.go
@@ -1,0 +1,177 @@
+package hubspotpolicy
+
+import (
+	"reflect"
+	"testing"
+)
+
+// coworkUUIDTool builds a tool name the way Claude Cowork emits connector
+// tools: the server segment is the connector-instance uuid, observed live as
+// e.g. "mcp__5c56899e-3e6c-4803-85ca-ff1912393966__search_crm_objects".
+func coworkUUIDTool(tool string) string {
+	return "mcp__5c56899e-3e6c-4803-85ca-ff1912393966__" + tool
+}
+
+func resolveAlwaysHubspot(string) (bool, bool) { return true, true }
+func resolveNeverHubspot(string) (bool, bool)  { return false, true }
+func resolveNothing(string) (bool, bool)       { return false, false }
+
+func TestClassifyProviderActions(t *testing.T) {
+	tests := []struct {
+		name     string
+		toolName string
+		input    map[string]any
+		resolver ConnectorResolver
+		want     []ProviderAction
+	}{
+		{
+			name:     "search with objectType is an object read on that type",
+			toolName: coworkUUIDTool("search_crm_objects"),
+			input:    map[string]any{"objectType": "contacts", "query": "test"},
+			resolver: resolveAlwaysHubspot,
+			want:     []ProviderAction{{Action: ActionObjectRead, Resource: "contacts"}},
+		},
+		{
+			name:     "numeric object-type id normalizes to the canonical name",
+			toolName: coworkUUIDTool("get_crm_objects"),
+			input:    map[string]any{"objectType": "0-3"},
+			resolver: resolveAlwaysHubspot,
+			want:     []ProviderAction{{Action: ActionObjectRead, Resource: "deals"}},
+		},
+		{
+			name:     "unmapped object-type id passes through verbatim",
+			toolName: coworkUUIDTool("search_crm_objects"),
+			input:    map[string]any{"objectType": "2-12345"},
+			resolver: resolveAlwaysHubspot,
+			want:     []ProviderAction{{Action: ActionObjectRead, Resource: "2-12345"}},
+		},
+		{
+			name:     "manage_crm_objects emits one write per distinct object type",
+			toolName: coworkUUIDTool("manage_crm_objects"),
+			input: map[string]any{
+				"createRequest": map[string]any{
+					"objects": []any{
+						map[string]any{"objectType": "contacts"},
+						map[string]any{"objectType": "0-1"}, // same type, other spelling
+					},
+				},
+				"updateRequest": map[string]any{
+					"objects": []any{
+						map[string]any{"objectType": "Deals"},
+					},
+				},
+			},
+			resolver: resolveAlwaysHubspot,
+			want: []ProviderAction{
+				{Action: ActionObjectWrite, Resource: "contacts"},
+				{Action: ActionObjectWrite, Resource: "deals"},
+			},
+		},
+		{
+			name:     "manage_crm_objects without a parsable type is still a write",
+			toolName: coworkUUIDTool("manage_crm_objects"),
+			input:    map[string]any{"confirmationStatus": "confirmed"},
+			resolver: resolveAlwaysHubspot,
+			want:     []ProviderAction{{Action: ActionObjectWrite}},
+		},
+		{
+			name:     "query_crm_data is a read with no resource anchor",
+			toolName: coworkUUIDTool("query_crm_data"),
+			input:    map[string]any{"sql": "SELECT lifecyclestage, COUNT(*) FROM contacts GROUP BY 1"},
+			resolver: resolveAlwaysHubspot,
+			want:     []ProviderAction{{Action: ActionObjectRead}},
+		},
+		{
+			name:     "account-level tools are api reads",
+			toolName: coworkUUIDTool("get_user_details"),
+			input:    map[string]any{},
+			resolver: resolveAlwaysHubspot,
+			want:     []ProviderAction{{Action: ActionAPIRead}},
+		},
+		{
+			name:     "landing page read action classifies as api read",
+			toolName: coworkUUIDTool("manage_landing_page"),
+			input:    map[string]any{"action": "TEMPLATES"},
+			resolver: resolveAlwaysHubspot,
+			want:     []ProviderAction{{Action: ActionAPIRead}},
+		},
+		{
+			name:     "landing page write action classifies as api write",
+			toolName: coworkUUIDTool("manage_landing_page"),
+			input:    map[string]any{"action": "CREATE_FROM_TEMPLATE", "pageName": "Kontext Test Page"},
+			resolver: resolveAlwaysHubspot,
+			want:     []ProviderAction{{Action: ActionAPIWrite}},
+		},
+		{
+			name:     "unknown landing page action fails conservative to write",
+			toolName: coworkUUIDTool("manage_landing_page"),
+			input:    map[string]any{"action": "SOME_FUTURE_ACTION"},
+			resolver: resolveAlwaysHubspot,
+			want:     []ProviderAction{{Action: ActionAPIWrite}},
+		},
+		{
+			name:     "registry counter-signal suppresses a hubspot-named tool",
+			toolName: coworkUUIDTool("search_crm_objects"),
+			input:    map[string]any{"objectType": "contacts"},
+			resolver: resolveNeverHubspot,
+			want:     nil,
+		},
+		{
+			name:     "unresolved registry falls back to the distinctive tool name on an opaque id",
+			toolName: coworkUUIDTool("search_crm_objects"),
+			input:    map[string]any{"objectType": "contacts"},
+			resolver: resolveNothing,
+			want:     []ProviderAction{{Action: ActionObjectRead, Resource: "contacts"}},
+		},
+		{
+			name:     "claude code style hubspot server segment matches by name",
+			toolName: "mcp__claude_ai_HubSpot__search_crm_objects",
+			input:    map[string]any{"objectType": "companies"},
+			resolver: resolveNothing,
+			want:     []ProviderAction{{Action: ActionObjectRead, Resource: "companies"}},
+		},
+		{
+			name:     "named non-hubspot server stays unclassified without registry proof",
+			toolName: "mcp__workspace__search_crm_objects",
+			input:    map[string]any{"objectType": "contacts"},
+			resolver: resolveNothing,
+			want:     nil,
+		},
+		{
+			name:     "unknown tool on the hubspot connector stays unclassified",
+			toolName: coworkUUIDTool("delete_all_the_things"),
+			input:    map[string]any{},
+			resolver: resolveAlwaysHubspot,
+			want:     nil,
+		},
+		{
+			name:     "non-mcp tools are never hubspot",
+			toolName: "Bash",
+			input:    map[string]any{"command": "curl https://api.hubapi.com/crm/v3/objects/contacts"},
+			resolver: resolveAlwaysHubspot,
+			want:     nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := ClassifyProviderActions(test.toolName, test.input, test.resolver)
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("ClassifyProviderActions() = %+v, want %+v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestSplitMCPToolName(t *testing.T) {
+	server, tool, ok := splitMCPToolName("mcp__5c56899e-3e6c__manage_crm_objects")
+	if !ok || server != "5c56899e-3e6c" || tool != "manage_crm_objects" {
+		t.Fatalf("splitMCPToolName() = %q, %q, %v", server, tool, ok)
+	}
+	if _, _, ok := splitMCPToolName("Bash"); ok {
+		t.Fatal("splitMCPToolName(Bash) should not parse")
+	}
+	if _, _, ok := splitMCPToolName("mcp__onlyserver"); ok {
+		t.Fatal("splitMCPToolName without a tool part should not parse")
+	}
+}

--- a/internal/hubspotpolicy/classifier_test.go
+++ b/internal/hubspotpolicy/classifier_test.go
@@ -89,6 +89,13 @@ func TestClassifyProviderActions(t *testing.T) {
 			want:     []ProviderAction{{Action: ActionAPIRead}},
 		},
 		{
+			name:     "submit_feedback is an api write (egress side effect)",
+			toolName: coworkUUIDTool("submit_feedback"),
+			input:    map[string]any{"feedback": "great"},
+			resolver: resolveAlwaysHubspot,
+			want:     []ProviderAction{{Action: ActionAPIWrite}},
+		},
+		{
 			name:     "landing page read action classifies as api read",
 			toolName: coworkUUIDTool("manage_landing_page"),
 			input:    map[string]any{"action": "TEMPLATES"},

--- a/internal/hubspotpolicy/coworkconnectors.go
+++ b/internal/hubspotpolicy/coworkconnectors.go
@@ -1,0 +1,116 @@
+package hubspotpolicy
+
+import (
+	"encoding/json"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// HubspotMCPHost is the host of HubSpot's remote MCP server. Identification
+// keys on the URL host — where the connector's calls actually go — never on
+// its display name, which is free text.
+const HubspotMCPHost = "mcp.hubspot.com"
+
+// maxSessionConfigBytes caps how much of a Cowork session config the resolver
+// reads. Real configs (with full tool schemas) run a few hundred KB.
+const maxSessionConfigBytes = 8 << 20
+
+// coworkSessionConfig is the subset of Cowork's per-session config file
+// (local_<id>.json) the resolver needs: the connector registry mapping each
+// connector-instance uuid to its server URL.
+//
+// This is an undocumented Claude-internal format. The resolver is therefore
+// best-effort by design: any read/parse failure reports "unresolved" and the
+// classifier's tool-name fallback decides.
+type coworkSessionConfig struct {
+	RemoteMCPServersConfig []struct {
+		UUID string `json:"uuid"`
+		URL  string `json:"url"`
+	} `json:"remoteMcpServersConfig"`
+}
+
+// ConnectorResolverForCWD returns a ConnectorResolver backed by the Cowork
+// session config next to the hook event's working directory, memoized so the
+// file is read at most once per classification. A non-Cowork cwd (no session
+// config anywhere above it) yields a resolver that never resolves.
+//
+// Cowork session layout: hook cwd points at (or below)
+// …/local_<id>/outputs, and the session config is the sibling file
+// …/local_<id>.json.
+func ConnectorResolverForCWD(cwd string) ConnectorResolver {
+	loaded := false
+	var hosts map[string]string
+	return func(serverSegment string) (bool, bool) {
+		if !loaded {
+			loaded = true
+			hosts = connectorHostsForCWD(cwd)
+		}
+		host, ok := hosts[serverSegment]
+		if !ok {
+			return false, false
+		}
+		return host == HubspotMCPHost, true
+	}
+}
+
+// connectorHostsForCWD walks up from cwd looking for the Cowork session
+// config and returns connector uuid → server URL host. nil means "no
+// registry" (not a Cowork session, unreadable file, unparseable JSON).
+func connectorHostsForCWD(cwd string) map[string]string {
+	configPath := sessionConfigPath(cwd)
+	if configPath == "" {
+		return nil
+	}
+	info, err := os.Stat(configPath)
+	if err != nil || info.Size() > maxSessionConfigBytes {
+		return nil
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil
+	}
+	var config coworkSessionConfig
+	if err := json.Unmarshal(data, &config); err != nil {
+		return nil
+	}
+	hosts := make(map[string]string, len(config.RemoteMCPServersConfig))
+	for _, server := range config.RemoteMCPServersConfig {
+		if server.UUID == "" {
+			continue
+		}
+		parsed, err := url.Parse(server.URL)
+		if err != nil || parsed.Hostname() == "" {
+			continue
+		}
+		hosts[server.UUID] = parsed.Hostname()
+	}
+	return hosts
+}
+
+// sessionConfigPath finds the Cowork session config for a cwd by walking up a
+// few levels looking for a directory whose sibling file "<dirname>.json"
+// exists (…/local_<id>/outputs → …/local_<id>.json). The walk is bounded: a
+// hook cwd is at most a couple of levels below the session directory.
+func sessionConfigPath(cwd string) string {
+	dir := filepath.Clean(strings.TrimSpace(cwd))
+	if dir == "" || dir == "." {
+		return ""
+	}
+	for range [4]int{} {
+		base := filepath.Base(dir)
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		if strings.HasPrefix(base, "local_") {
+			candidate := filepath.Join(parent, base+".json")
+			if _, err := os.Stat(candidate); err == nil {
+				return candidate
+			}
+		}
+		dir = parent
+	}
+	return ""
+}

--- a/internal/hubspotpolicy/coworkconnectors_test.go
+++ b/internal/hubspotpolicy/coworkconnectors_test.go
@@ -1,0 +1,77 @@
+package hubspotpolicy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeCoworkSession lays out the observed Cowork session shape:
+// <dir>/local_<id>.json next to <dir>/local_<id>/outputs (the hook cwd).
+func writeCoworkSession(t *testing.T, config string) (cwd string) {
+	t.Helper()
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "local_0056ddd3-e8cd")
+	cwd = filepath.Join(sessionDir, "outputs")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "local_0056ddd3-e8cd.json"), []byte(config), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	return cwd
+}
+
+const sessionConfig = `{
+  "sessionId": "abc",
+  "remoteMcpServersConfig": [
+    {"uuid": "5c56899e-3e6c-4803-85ca-ff1912393966", "name": "HubSpot", "url": "https://mcp.hubspot.com/anthropic"},
+    {"uuid": "100744ce-4ed5-4792-86f4-d44cb3e57a24", "name": "Linear", "url": "https://mcp.linear.app/mcp"}
+  ]
+}`
+
+func TestConnectorResolverForCWDResolvesByURLHost(t *testing.T) {
+	cwd := writeCoworkSession(t, sessionConfig)
+	resolver := ConnectorResolverForCWD(cwd)
+
+	isHubspot, resolved := resolver("5c56899e-3e6c-4803-85ca-ff1912393966")
+	if !resolved || !isHubspot {
+		t.Fatalf("hubspot uuid = (%v, %v), want (true, true)", isHubspot, resolved)
+	}
+	// Another connector resolves definitively to NOT hubspot — the
+	// counter-signal that suppresses same-named tools on other servers.
+	isHubspot, resolved = resolver("100744ce-4ed5-4792-86f4-d44cb3e57a24")
+	if !resolved || isHubspot {
+		t.Fatalf("linear uuid = (%v, %v), want (false, true)", isHubspot, resolved)
+	}
+	// Unknown ids are unresolved, not counter-signals.
+	if _, resolved := resolver("deadbeef-0000"); resolved {
+		t.Fatal("unknown uuid should be unresolved")
+	}
+}
+
+func TestConnectorResolverForCWDHandlesDeeperCWDs(t *testing.T) {
+	cwd := writeCoworkSession(t, sessionConfig)
+	deeper := filepath.Join(cwd, "some", "subdir")
+	if err := os.MkdirAll(deeper, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if isHubspot, resolved := ConnectorResolverForCWD(deeper)("5c56899e-3e6c-4803-85ca-ff1912393966"); !resolved || !isHubspot {
+		t.Fatalf("deeper cwd = (%v, %v), want (true, true)", isHubspot, resolved)
+	}
+}
+
+func TestConnectorResolverForCWDNonCoworkAndMalformed(t *testing.T) {
+	// A plain project directory: no session config anywhere above.
+	if _, resolved := ConnectorResolverForCWD(t.TempDir())("5c56899e"); resolved {
+		t.Fatal("non-cowork cwd should never resolve")
+	}
+	// Malformed JSON is best-effort: unresolved, never an error.
+	cwd := writeCoworkSession(t, "{not json")
+	if _, resolved := ConnectorResolverForCWD(cwd)("5c56899e"); resolved {
+		t.Fatal("malformed session config should be unresolved")
+	}
+	if _, resolved := ConnectorResolverForCWD("")(""); resolved {
+		t.Fatal("empty cwd should be unresolved")
+	}
+}

--- a/internal/hubspotpolicy/policy.go
+++ b/internal/hubspotpolicy/policy.go
@@ -1,0 +1,36 @@
+// Package hubspotpolicy classifies HubSpot activity (the remote HubSpot MCP
+// connector used by Claude Cowork and Claude Code) into canonical provider
+// actions and binds the shared provider-policy sync machinery
+// (internal/providerpolicy) to the HubSpot snapshot contract.
+//
+// The contract mirrors packages/shared/src/hubspot/policy-snapshot.ts in the
+// kontext cloud repository. Like the GitHub pilot the directive is
+// observe-only: the engine records what it *would* allow or deny, but never
+// blocks.
+package hubspotpolicy
+
+import (
+	"github.com/kontext-security/kontext-cli/internal/providerpolicy"
+)
+
+// SchemaVersionV1 is the only HubSpot snapshot wire format. It ships the
+// group layer and endpoint directory from day one — there are no deployed
+// pre-v1 clients to negotiate with. Anything else is rejected (fail closed).
+const SchemaVersionV1 = "hubspot-policy-snapshot-v1"
+
+// SnapshotEndpoint is the cloud path serving the HubSpot policy snapshot.
+// Tenancy is resolved from the install token.
+const SnapshotEndpoint = "/api/v1/policy/hubspot/snapshot"
+
+// Config binds the shared sync machinery to the HubSpot snapshot contract.
+var Config = providerpolicy.Config{
+	ProviderKey:      "hubspot",
+	SnapshotEndpoint: SnapshotEndpoint,
+	RequestSchema:    SchemaVersionV1,
+	Schemas: []providerpolicy.SchemaSupport{
+		{Version: SchemaVersionV1, GroupLayer: true, Directory: true},
+	},
+	CacheFileName:    "hubspot-policy-snapshot.json",
+	CacheTempPattern: ".hubspot-policy-*.tmp",
+	RefreshEnvVar:    "KONTEXT_HUBSPOT_POLICY_REFRESH_INTERVAL",
+}

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -327,8 +327,14 @@ func refreshProviderPolicy(ctx context.Context, opts DaemonOptions, config provi
 	}
 	snapshot, err := providerpolicy.FetchSnapshot(ctx, opts.PolicyHTTPClient, loadedConfig.Config.CloudURL, installToken, installationID, config)
 	if errors.Is(err, providerpolicy.ErrNotConfigured) {
-		// The org has not activated this provider — no policy to sync and
-		// nothing to alarm on. The cache keeps whatever state it had.
+		// Contract: the cloud signals "provider deactivated / no rules" with an
+		// EMPTY snapshot (epoch 0, zero rules), never a 404. A 404 therefore
+		// means the route does not exist yet (older cloud during rollout —
+		// nothing was ever cached) or a transient infra blip — in which case
+		// wiping the persisted snapshot would drop valid policy until the next
+		// successful refresh (or forever, if the daemon restarts first). Keep
+		// whatever is cached, mark it stale, and skip the per-tick alarm log.
+		cache.MarkFetchFailed(err)
 		return
 	}
 	if err != nil {

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -12,25 +12,31 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/claudemanaged"
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 	"github.com/kontext-security/kontext-cli/internal/githubpolicy"
+	"github.com/kontext-security/kontext-cli/internal/guard/app/server"
 	guardhookruntime "github.com/kontext-security/kontext-cli/internal/guard/hookruntime"
 	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
+	"github.com/kontext-security/kontext-cli/internal/hubspotpolicy"
 	"github.com/kontext-security/kontext-cli/internal/installation"
 	"github.com/kontext-security/kontext-cli/internal/managedconfig"
 	"github.com/kontext-security/kontext-cli/internal/managedstream"
 	"github.com/kontext-security/kontext-cli/internal/payloadcapture"
+	"github.com/kontext-security/kontext-cli/internal/providerpolicy"
 	"github.com/kontext-security/kontext-cli/internal/runtimehost"
 )
 
 type DaemonOptions struct {
-	SocketPath            string
-	DBPath                string
-	IdleTimeout           time.Duration
-	StreamStatePath       string
-	StreamInterval        time.Duration
-	StreamHTTPClient      *http.Client
-	GithubPolicyCachePath string
-	GithubPolicyInterval  time.Duration
-	GithubPolicyClient    *http.Client
+	SocketPath             string
+	DBPath                 string
+	IdleTimeout            time.Duration
+	StreamStatePath        string
+	StreamInterval         time.Duration
+	StreamHTTPClient       *http.Client
+	GithubPolicyCachePath  string
+	HubspotPolicyCachePath string
+	// PolicyRefreshInterval and PolicyHTTPClient apply to every provider's
+	// snapshot refresh loop (test knobs; zero values use defaults).
+	PolicyRefreshInterval time.Duration
+	PolicyHTTPClient      *http.Client
 	Diagnostic            diagnostic.Logger
 	// FallbackDeploymentVersion is reported to the ledger when no MDM
 	// deployment-version marker exists (self-serve brew installs).
@@ -110,20 +116,17 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 		return fmt.Errorf("parse managed mode: %w", err)
 	}
 
-	policyCachePath := opts.GithubPolicyCachePath
-	if policyCachePath == "" {
-		policyCachePath = githubpolicy.DefaultCachePathForDB(dbPath)
-	}
-	policyCache := githubpolicy.NewCache(policyCachePath)
-	if err := policyCache.LoadPersisted(); err != nil {
-		opts.Diagnostic.Printf("github policy cache load: %v\n", err)
-	}
+	githubCache := newProviderPolicyCache(opts.GithubPolicyCachePath, dbPath, githubpolicy.Config, opts.Diagnostic)
+	hubspotCache := newProviderPolicyCache(opts.HubspotPolicyCachePath, dbPath, hubspotpolicy.Config, opts.Diagnostic)
 
 	host, err := runtimehost.Start(ctx, runtimehost.Options{
-		AgentName:          managedconfig.Agent,
-		DBPath:             dbPath,
-		SocketPath:         socketPath,
-		GithubPolicy:       policyCache,
+		AgentName:  managedconfig.Agent,
+		DBPath:     dbPath,
+		SocketPath: socketPath,
+		ProviderPolicies: []server.ProviderPolicyBinding{
+			server.GithubPolicyBinding(githubCache),
+			server.HubspotPolicyBinding(hubspotCache),
+		},
 		EndpointID:         installationState.InstallationID,
 		Mode:               mode,
 		Diagnostic:         opts.Diagnostic,
@@ -144,13 +147,16 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 	// Restore the capture mode from the persisted snapshot before the first
 	// fetch completes, so an offline restart keeps the org's last-known
 	// directive instead of silently reverting to the "summary" default.
-	if snapshot, _, ok := policyCache.CurrentSnapshot(); ok {
+	if snapshot, _, ok := githubCache.CurrentSnapshot(); ok {
 		host.SetPayloadCaptureMode(payloadcapture.NormalizeMode(snapshot.PayloadCaptureMode))
 	}
 
 	policyCtx, stopPolicyRefresh := context.WithCancel(ctx)
 	defer stopPolicyRefresh()
-	go runGithubPolicy(policyCtx, opts, policyCache, installationState.InstallationID, host.SetPayloadCaptureMode)
+	// Capture mode rides the github snapshot only (the org-level directive);
+	// other providers' refreshers pass nil and never touch the gate.
+	go runProviderPolicy(policyCtx, opts, githubpolicy.Config, githubCache, installationState.InstallationID, host.SetPayloadCaptureMode)
+	go runProviderPolicy(policyCtx, opts, hubspotpolicy.Config, hubspotCache, installationState.InstallationID, nil)
 
 	streamCtx, stopStream := context.WithCancel(ctx)
 	defer stopStream()
@@ -281,12 +287,25 @@ func loadManagedConfig(ctx context.Context) (managedconfig.LoadedConfig, string,
 	return loadedConfig, installToken, nil
 }
 
-func runGithubPolicy(ctx context.Context, opts DaemonOptions, cache *githubpolicy.Cache, installationID string, applyCaptureMode func(payloadcapture.Mode)) {
-	interval := opts.GithubPolicyInterval
-	if interval == 0 {
-		interval = githubpolicy.DefaultIntervalFromEnv()
+// newProviderPolicyCache builds and disk-primes one provider's snapshot
+// cache, defaulting the path next to the guard DB.
+func newProviderPolicyCache(path, dbPath string, config providerpolicy.Config, diag diagnostic.Logger) *providerpolicy.Cache {
+	if path == "" {
+		path = providerpolicy.DefaultCachePathForDB(dbPath, config)
 	}
-	refreshGithubPolicy(ctx, opts, cache, installationID, applyCaptureMode)
+	cache := providerpolicy.NewCache(path, config)
+	if err := cache.LoadPersisted(); err != nil {
+		diag.Printf("%s policy cache load: %v\n", config.ProviderKey, err)
+	}
+	return cache
+}
+
+func runProviderPolicy(ctx context.Context, opts DaemonOptions, config providerpolicy.Config, cache *providerpolicy.Cache, installationID string, applyCaptureMode func(payloadcapture.Mode)) {
+	interval := opts.PolicyRefreshInterval
+	if interval == 0 {
+		interval = providerpolicy.IntervalFromEnv(config)
+	}
+	refreshProviderPolicy(ctx, opts, config, cache, installationID, applyCaptureMode)
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
@@ -294,26 +313,31 @@ func runGithubPolicy(ctx context.Context, opts DaemonOptions, cache *githubpolic
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			refreshGithubPolicy(ctx, opts, cache, installationID, applyCaptureMode)
+			refreshProviderPolicy(ctx, opts, config, cache, installationID, applyCaptureMode)
 		}
 	}
 }
 
-func refreshGithubPolicy(ctx context.Context, opts DaemonOptions, cache *githubpolicy.Cache, installationID string, applyCaptureMode func(payloadcapture.Mode)) {
+func refreshProviderPolicy(ctx context.Context, opts DaemonOptions, config providerpolicy.Config, cache *providerpolicy.Cache, installationID string, applyCaptureMode func(payloadcapture.Mode)) {
 	loadedConfig, installToken, err := loadManagedConfig(ctx)
 	if err != nil {
 		cache.MarkFetchFailed(err)
-		opts.Diagnostic.Printf("github policy config reload: %v\n", err)
+		opts.Diagnostic.Printf("%s policy config reload: %v\n", config.ProviderKey, err)
 		return
 	}
-	snapshot, err := githubpolicy.FetchSnapshot(ctx, opts.GithubPolicyClient, loadedConfig.Config.CloudURL, installToken, installationID)
+	snapshot, err := providerpolicy.FetchSnapshot(ctx, opts.PolicyHTTPClient, loadedConfig.Config.CloudURL, installToken, installationID, config)
+	if errors.Is(err, providerpolicy.ErrNotConfigured) {
+		// The org has not activated this provider — no policy to sync and
+		// nothing to alarm on. The cache keeps whatever state it had.
+		return
+	}
 	if err != nil {
 		cache.MarkFetchFailed(err)
-		opts.Diagnostic.Printf("github policy refresh: %v\n", err)
+		opts.Diagnostic.Printf("%s policy refresh: %v\n", config.ProviderKey, err)
 		return
 	}
 	if err := cache.Apply(snapshot, time.Now().UTC()); err != nil {
-		opts.Diagnostic.Printf("github policy persist: %v\n", err)
+		opts.Diagnostic.Printf("%s policy persist: %v\n", config.ProviderKey, err)
 	}
 	// Applied from the freshly fetched snapshot, not re-read from the cache:
 	// payloadCaptureMode is excluded from the snapshot hash, so the fetched

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -300,12 +300,23 @@ func newProviderPolicyCache(path, dbPath string, config providerpolicy.Config, d
 	return cache
 }
 
+// notConfiguredBackoffTicks stretches the refresh interval while the cloud
+// answers 404 (route not deployed for this provider yet): every endpoint
+// polling every provider each minute doubles fleet-wide policy traffic per
+// added provider for orgs that never activate it. At the default 60s tick
+// this backs off to ~10 minutes; the one-time activation lag when a provider
+// route first ships is acceptable.
+const notConfiguredBackoffTicks = 10
+
 func runProviderPolicy(ctx context.Context, opts DaemonOptions, config providerpolicy.Config, cache *providerpolicy.Cache, installationID string, applyCaptureMode func(payloadcapture.Mode)) {
 	interval := opts.PolicyRefreshInterval
 	if interval == 0 {
 		interval = providerpolicy.IntervalFromEnv(config)
 	}
-	refreshProviderPolicy(ctx, opts, config, cache, installationID, applyCaptureMode)
+	skipTicks := 0
+	if refreshProviderPolicy(ctx, opts, config, cache, installationID, applyCaptureMode) {
+		skipTicks = notConfiguredBackoffTicks - 1
+	}
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
@@ -313,17 +324,25 @@ func runProviderPolicy(ctx context.Context, opts DaemonOptions, config providerp
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			refreshProviderPolicy(ctx, opts, config, cache, installationID, applyCaptureMode)
+			if skipTicks > 0 {
+				skipTicks--
+				continue
+			}
+			if refreshProviderPolicy(ctx, opts, config, cache, installationID, applyCaptureMode) {
+				skipTicks = notConfiguredBackoffTicks - 1
+			}
 		}
 	}
 }
 
-func refreshProviderPolicy(ctx context.Context, opts DaemonOptions, config providerpolicy.Config, cache *providerpolicy.Cache, installationID string, applyCaptureMode func(payloadcapture.Mode)) {
+// refreshProviderPolicy fetches and applies one snapshot; it reports whether
+// the cloud answered not-configured (the caller backs off polling then).
+func refreshProviderPolicy(ctx context.Context, opts DaemonOptions, config providerpolicy.Config, cache *providerpolicy.Cache, installationID string, applyCaptureMode func(payloadcapture.Mode)) bool {
 	loadedConfig, installToken, err := loadManagedConfig(ctx)
 	if err != nil {
 		cache.MarkFetchFailed(err)
 		opts.Diagnostic.Printf("%s policy config reload: %v\n", config.ProviderKey, err)
-		return
+		return false
 	}
 	snapshot, err := providerpolicy.FetchSnapshot(ctx, opts.PolicyHTTPClient, loadedConfig.Config.CloudURL, installToken, installationID, config)
 	if errors.Is(err, providerpolicy.ErrNotConfigured) {
@@ -335,12 +354,12 @@ func refreshProviderPolicy(ctx context.Context, opts DaemonOptions, config provi
 		// successful refresh (or forever, if the daemon restarts first). Keep
 		// whatever is cached, mark it stale, and skip the per-tick alarm log.
 		cache.MarkFetchFailed(err)
-		return
+		return true
 	}
 	if err != nil {
 		cache.MarkFetchFailed(err)
 		opts.Diagnostic.Printf("%s policy refresh: %v\n", config.ProviderKey, err)
-		return
+		return false
 	}
 	if err := cache.Apply(snapshot, time.Now().UTC()); err != nil {
 		opts.Diagnostic.Printf("%s policy persist: %v\n", config.ProviderKey, err)
@@ -351,6 +370,7 @@ func refreshProviderPolicy(ctx context.Context, opts DaemonOptions, config provi
 	if applyCaptureMode != nil {
 		applyCaptureMode(payloadcapture.NormalizeMode(snapshot.PayloadCaptureMode))
 	}
+	return false
 }
 
 func runManagedStream(ctx context.Context, opts DaemonOptions, dbPath, installationID string) error {

--- a/internal/managedobserve/daemon_test.go
+++ b/internal/managedobserve/daemon_test.go
@@ -393,6 +393,10 @@ func TestDaemonRefreshesGithubPolicyInstallToken(t *testing.T) {
 				"rules":          []any{},
 				"generatedAt":    "2026-06-15T00:00:00.000Z",
 			})
+		case "/api/v1/policy/hubspot/snapshot":
+			// Org without an activated HubSpot provider: the daemon must
+			// treat this as quietly-not-configured, not a fetch failure.
+			w.WriteHeader(http.StatusNotFound)
 		case "/api/v1/authorization-ledger/batches":
 			w.WriteHeader(http.StatusAccepted)
 		default:
@@ -422,8 +426,8 @@ func TestDaemonRefreshesGithubPolicyInstallToken(t *testing.T) {
 			IdleTimeout:          time.Hour,
 			StreamInterval:       time.Hour,
 			StreamHTTPClient:     server.Client(),
-			GithubPolicyInterval: 20 * time.Millisecond,
-			GithubPolicyClient:   server.Client(),
+			PolicyRefreshInterval: 20 * time.Millisecond,
+			PolicyHTTPClient:   server.Client(),
 		})
 	}()
 	stopped := false

--- a/internal/managedobserve/daemon_test.go
+++ b/internal/managedobserve/daemon_test.go
@@ -421,13 +421,13 @@ func TestDaemonRefreshesGithubPolicyInstallToken(t *testing.T) {
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- RunDaemon(ctx, DaemonOptions{
-			SocketPath:           socketPath,
-			DBPath:               dbPath,
-			IdleTimeout:          time.Hour,
-			StreamInterval:       time.Hour,
-			StreamHTTPClient:     server.Client(),
+			SocketPath:            socketPath,
+			DBPath:                dbPath,
+			IdleTimeout:           time.Hour,
+			StreamInterval:        time.Hour,
+			StreamHTTPClient:      server.Client(),
 			PolicyRefreshInterval: 20 * time.Millisecond,
-			PolicyHTTPClient:   server.Client(),
+			PolicyHTTPClient:      server.Client(),
 		})
 	}()
 	stopped := false

--- a/internal/managedobserve/daemon_test.go
+++ b/internal/managedobserve/daemon_test.go
@@ -394,8 +394,10 @@ func TestDaemonRefreshesGithubPolicyInstallToken(t *testing.T) {
 				"generatedAt":    "2026-06-15T00:00:00.000Z",
 			})
 		case "/api/v1/policy/hubspot/snapshot":
-			// Org without an activated HubSpot provider: the daemon must
-			// treat this as quietly-not-configured, not a fetch failure.
+			// A cloud without the hubspot snapshot route yet answers 404.
+			// Contract: deactivation is signaled by an EMPTY snapshot, never
+			// 404 — so the daemon treats this as quietly-not-configured
+			// (keep any cache, mark stale, back off polling), not a failure.
 			w.WriteHeader(http.StatusNotFound)
 		case "/api/v1/authorization-ledger/batches":
 			w.WriteHeader(http.StatusAccepted)

--- a/internal/providerpolicy/cache_test.go
+++ b/internal/providerpolicy/cache_test.go
@@ -1,0 +1,54 @@
+package providerpolicy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func clearTestConfig() Config {
+	return Config{
+		ProviderKey:      "testprov",
+		CacheFileName:    "testprov-policy-snapshot.json",
+		CacheTempPattern: ".testprov-policy-*.tmp",
+		Schemas:          []SchemaSupport{{Version: "testprov-policy-snapshot-v1"}},
+	}
+}
+
+func clearTestSnapshot() Snapshot {
+	return Snapshot{
+		SchemaVersion:  "testprov-policy-snapshot-v1",
+		OrganizationID: "org-1",
+		ProviderKey:    "testprov",
+		Mode:           ModeObserve,
+		Epoch:          3,
+		Hash:           "hash-3",
+		Rules:          []Rule{{ID: "r1", Layer: LayerOrg, SubjectID: "org-1", Effect: EffectAllow}},
+	}
+}
+
+func TestCacheKeepsSnapshotOnNotConfiguredFetch(t *testing.T) {
+	// Contract: a 404 from the cloud (route not deployed / infra blip) must
+	// NOT drop cached policy — deactivation is signaled by an EMPTY snapshot,
+	// never by 404. The cache keeps serving, marked stale, and the persisted
+	// mirror survives a daemon restart.
+	path := filepath.Join(t.TempDir(), "testprov-policy-snapshot.json")
+	cache := NewCache(path, clearTestConfig())
+	if err := cache.Apply(clearTestSnapshot(), time.Now().UTC()); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	cache.MarkFetchFailed(ErrNotConfigured)
+
+	snapshot, status, ok := cache.CurrentSnapshot()
+	if !ok || snapshot.Hash != "hash-3" {
+		t.Fatalf("CurrentSnapshot() = %+v, %v — snapshot must survive a 404", snapshot, ok)
+	}
+	if !status.Stale {
+		t.Fatal("status should be stale after an unconfirmed refresh")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("persisted mirror must survive a 404: %v", err)
+	}
+}

--- a/internal/providerpolicy/client.go
+++ b/internal/providerpolicy/client.go
@@ -3,6 +3,7 @@ package providerpolicy
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,6 +11,12 @@ import (
 	"strings"
 	"time"
 )
+
+// ErrNotConfigured reports that the cloud has no snapshot surface for this
+// provider/org (HTTP 404) — expected when the org has not activated the
+// provider. Callers should treat it as "no policy" rather than a fetch
+// failure worth alarming on.
+var ErrNotConfigured = errors.New("policy snapshot not configured")
 
 // MaxSnapshotBodyBytes caps how large a snapshot response the client accepts.
 const MaxSnapshotBodyBytes = 4 << 20
@@ -44,6 +51,9 @@ func FetchSnapshot(ctx context.Context, client *http.Client, cloudURL, installTo
 		return Snapshot{}, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return Snapshot{}, fmt.Errorf("%s: %w", config.ProviderKey, ErrNotConfigured)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return Snapshot{}, fmt.Errorf("%s policy snapshot fetch failed: status %d", config.ProviderKey, resp.StatusCode)
 	}

--- a/internal/runtimehost/host.go
+++ b/internal/runtimehost/host.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
-	"github.com/kontext-security/kontext-cli/internal/githubpolicy"
 	"github.com/kontext-security/kontext-cli/internal/guard/app/server"
 	guardhookruntime "github.com/kontext-security/kontext-cli/internal/guard/hookruntime"
 	"github.com/kontext-security/kontext-cli/internal/guard/judge"
@@ -39,7 +38,7 @@ type Options struct {
 	JudgeConfigFromEnv        bool
 	JudgeManagedDefault       bool
 	JudgeDownloadProgress     judge.DownloadProgressHandler
-	GithubPolicy              githubpolicy.SnapshotProvider
+	ProviderPolicies          []server.ProviderPolicyBinding
 	EndpointID                string
 	Mode                      guardhookruntime.Mode
 	Diagnostic                diagnostic.Logger
@@ -115,7 +114,7 @@ func Start(ctx context.Context, opts Options) (*Host, error) {
 	}
 	localServer, closeStore, err := server.OpenDefaultServerWithOptions(dbPath, server.Options{
 		Judge:            localJudge,
-		GithubPolicy:     opts.GithubPolicy,
+		ProviderPolicies: opts.ProviderPolicies,
 		EndpointID:       opts.EndpointID,
 		CurrentSessionID: serverSessionID,
 		Mode:             string(mode),


### PR DESCRIPTION
## Summary

- explain the user-facing change
- link the issue or context if relevant

## Verification

- [ ] `go test ./...`
- [ ] `go test -race ./...`
- [ ] `go vet ./...`
- [ ] `buf generate` if protobuf or generated code changed

## Release notes

- [ ] conventional commit title matches semver intent
