### PR TITLE
feat: record captured tool payloads in the local ledger

### DIFF
--- a/internal/guard/store/sqlite/githubdryrun.go
+++ b/internal/guard/store/sqlite/githubdryrun.go
@@ -126,12 +126,16 @@ func githubDryRunActionValues(actionID, sessionID string, event risk.HookEvent, 
 		"output_summary":           "",
 		"output_hash":              "",
 		"error_redacted":           "",
-		"proposed_at":              nil,
-		"decision_at":              nullIfEmpty(timestamp),
-		"completed_at":             nil,
-		"created_at":               timestamp,
-		"updated_at":               timestamp,
-		"updated_at_cursor_key":    ledgerTimestampCursorKeyFromValues(timestamp),
+		// Dry-run evaluations never capture payloads in any mode; the real
+		// tool call's own rows carry them.
+		"tool_input_captured_json":  nil,
+		"tool_output_captured_json": nil,
+		"proposed_at":               nil,
+		"decision_at":               nullIfEmpty(timestamp),
+		"completed_at":              nil,
+		"created_at":                timestamp,
+		"updated_at":                timestamp,
+		"updated_at_cursor_key":     ledgerTimestampCursorKeyFromValues(timestamp),
 	}, nil
 }
 

--- a/internal/guard/store/sqlite/ledger.go
+++ b/internal/guard/store/sqlite/ledger.go
@@ -54,6 +54,7 @@ select id, session_id, turn_id, tool_use_id, trace_id, span_id, parent_span_id,
   matched_rules_json, risk_signals_json, risk_event_json, modifications_json,
   approval_context_json, approval_channel, approval_request_id, approval_expires_at,
   deferral_context_json, status, outcome, output_summary, output_hash, error_redacted,
+  tool_input_captured_json, tool_output_captured_json,
   proposed_at, decision_at, completed_at, created_at, updated_at
 from authorization_actions`
 
@@ -262,12 +263,24 @@ func queryLedgerRecords(ctx context.Context, db *sql.DB, query string, args ...a
 		}
 		record := LedgerRecord{}
 		for i, column := range columns {
-			record[column] = normalizeLedgerValue(column, values[i])
+			value := normalizeLedgerValue(column, values[i])
+			// Captured payload fields are optional on the wire: consumers
+			// that predate them reject records carrying unknown fields, so
+			// rows that captured nothing must not mention them at all.
+			if value == nil && omitWhenEmptyLedgerColumns[column] {
+				continue
+			}
+			record[column] = value
 		}
 		normalizeLedgerRecord(record)
 		records = append(records, record)
 	}
 	return records, rows.Err()
+}
+
+var omitWhenEmptyLedgerColumns = map[string]bool{
+	"tool_input_captured_json":  true,
+	"tool_output_captured_json": true,
 }
 
 func normalizeLedgerValue(column string, value any) any {

--- a/internal/guard/store/sqlite/store.go
+++ b/internal/guard/store/sqlite/store.go
@@ -10,18 +10,41 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
 	_ "modernc.org/sqlite"
 
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
+	"github.com/kontext-security/kontext-cli/internal/payloadcapture"
 )
 
 type Store struct {
 	db     *sql.DB
 	path   string
 	signer receiptSigner
+
+	captureMu   sync.RWMutex
+	captureMode payloadcapture.Mode
+}
+
+// SetPayloadCaptureMode sets how tool payloads are captured on subsequently
+// recorded actions. The zero value keeps capture off ("summary" behavior):
+// unset or unrecognized modes never record payload content.
+func (s *Store) SetPayloadCaptureMode(mode payloadcapture.Mode) {
+	s.captureMu.Lock()
+	defer s.captureMu.Unlock()
+	s.captureMode = mode
+}
+
+func (s *Store) payloadCaptureMode() payloadcapture.Mode {
+	s.captureMu.RLock()
+	defer s.captureMu.RUnlock()
+	if s.captureMode == "" {
+		return payloadcapture.ModeSummary
+	}
+	return s.captureMode
 }
 
 type DecisionRecord struct {
@@ -204,6 +227,8 @@ func (s *Store) migrate(ctx context.Context) error {
 	  output_summary text,
 	  output_hash text,
 	  error_redacted text,
+	  tool_input_captured_json text,
+	  tool_output_captured_json text,
 
 	  proposed_at text,
 	  decision_at text,
@@ -435,6 +460,8 @@ func (s *Store) ensureAuthorizationActionsDecisionNullable(ctx context.Context) 
 	  output_summary text,
 	  output_hash text,
 	  error_redacted text,
+	  tool_input_captured_json text,
+	  tool_output_captured_json text,
 
 	  proposed_at text,
 	  decision_at text,
@@ -536,6 +563,8 @@ var authorizationActionColumns = []authorizationActionColumn{
 	{name: "output_summary", defaultExpr: "null"},
 	{name: "output_hash", defaultExpr: "null"},
 	{name: "error_redacted", defaultExpr: "null"},
+	{name: "tool_input_captured_json", defaultExpr: "null"},
+	{name: "tool_output_captured_json", defaultExpr: "null"},
 	{name: "proposed_at", defaultExpr: "null"},
 	{name: "decision_at", defaultExpr: "null"},
 	{name: "completed_at", defaultExpr: "null"},
@@ -773,7 +802,7 @@ on conflict(id) do update set
 }
 
 func (s *Store) insertAction(ctx context.Context, tx *sql.Tx, actionID, sessionID string, event risk.HookEvent, decision risk.RiskDecision, canonicalEvent, receiptType string, now time.Time) error {
-	action, err := actionValues(actionID, sessionID, event, decision, canonicalEvent, now)
+	action, err := actionValues(actionID, sessionID, event, decision, canonicalEvent, s.payloadCaptureMode(), now)
 	if err != nil {
 		return err
 	}
@@ -799,6 +828,7 @@ func (s *Store) insertActionRecord(ctx context.Context, tx *sql.Tx, action map[s
 		"risk_level", "risk_score", "risk_threshold", "model_version", "confidence", "matched_rules_json", "risk_signals_json", "risk_event_json",
 		"modifications_json", "approval_context_json", "approval_channel", "approval_request_id", "deferral_context_json",
 		"status", "outcome", "output_summary", "output_hash", "error_redacted",
+		"tool_input_captured_json", "tool_output_captured_json",
 		"proposed_at", "decision_at", "completed_at", "created_at", "updated_at", "updated_at_cursor_key",
 	}
 	values := []any{
@@ -810,6 +840,7 @@ func (s *Store) insertActionRecord(ctx context.Context, tx *sql.Tx, action map[s
 		action["risk_level"], action["risk_score"], action["risk_threshold"], action["model_version"], action["confidence"], action["matched_rules_json"], action["risk_signals_json"], action["risk_event_json"],
 		action["modifications_json"], action["approval_context_json"], action["approval_channel"], action["approval_request_id"], action["deferral_context_json"],
 		action["status"], action["outcome"], action["output_summary"], action["output_hash"], action["error_redacted"],
+		action["tool_input_captured_json"], action["tool_output_captured_json"],
 		action["proposed_at"], action["decision_at"], action["completed_at"], action["created_at"], action["updated_at"], action["updated_at_cursor_key"],
 	}
 	placeholders := strings.TrimRight(strings.Repeat("?,", len(columns)), ",")
@@ -822,7 +853,26 @@ func (s *Store) insertActionRecord(ctx context.Context, tx *sql.Tx, action map[s
 	return s.appendReceipt(ctx, tx, receiptInputFromAction(action, receiptType, now))
 }
 
-func actionValues(actionID, sessionID string, event risk.HookEvent, decision risk.RiskDecision, canonicalEvent string, now time.Time) (map[string]any, error) {
+// capturedPayloadJSON returns the serialized captured payload record, or nil
+// when nothing is recorded. Tool input is recorded once per tool call (on the
+// request.proposed row, not again on the decision row); tool output on the
+// observed/failed rows.
+func capturedPayloadJSON(payload map[string]any, mode payloadcapture.Mode, applies bool) any {
+	if !applies {
+		return nil
+	}
+	record := payloadcapture.Capture(payload, mode)
+	if record == nil {
+		return nil
+	}
+	raw, err := record.MarshalJSON()
+	if err != nil {
+		return nil
+	}
+	return string(raw)
+}
+
+func actionValues(actionID, sessionID string, event risk.HookEvent, decision risk.RiskDecision, canonicalEvent string, captureMode payloadcapture.Mode, now time.Time) (map[string]any, error) {
 	riskEvent := decision.RiskEvent
 	if canonicalEvent != canonicalEventRequestDecided {
 		riskEvent.Decision = ""
@@ -882,6 +932,14 @@ func actionValues(actionID, sessionID string, event risk.HookEvent, decision ris
 		decisionResult = canonicalDecisionResult(decision.Decision)
 	}
 	outcome, outputSummary, outputHash, errorRedacted := outcomeValues(event, decision)
+	toolInputCaptured := capturedPayloadJSON(
+		event.ToolInput, captureMode,
+		canonicalEvent == canonicalEventRequestProposed,
+	)
+	toolOutputCaptured := capturedPayloadJSON(
+		event.ToolResponse, captureMode,
+		canonicalEvent == canonicalEventRequestObserved || canonicalEvent == canonicalEventRequestFailed,
+	)
 	proposedAt := ""
 	decisionAt := ""
 	completedAt := ""
@@ -916,57 +974,59 @@ func actionValues(actionID, sessionID string, event risk.HookEvent, decision ris
 	updatedAt := now.Format(time.RFC3339Nano)
 
 	return map[string]any{
-		"id":                       actionID,
-		"session_id":               sessionID,
-		"tool_use_id":              event.ToolUseID,
-		"canonical_event_type":     canonicalEvent,
-		"adapter_event_name":       event.HookEventName,
-		"correlation_key":          correlationKey(event),
-		"tool_name":                event.ToolName,
-		"provider":                 provider,
-		"operation":                riskEvent.Operation,
-		"operation_class":          riskEvent.OperationClass,
-		"resource_class":           riskEvent.ResourceClass,
-		"resource_id":              nullIfEmpty(resourceID),
-		"parameters_redacted_json": parametersJSON,
-		"parameters_hash":          parametersHash,
-		"identity_context_json":    identityJSON,
-		"identity_hash":            identityHash,
-		"context_json":             contextJSON,
-		"context_hash":             contextHash,
-		"policy_id":                policyID,
-		"policy_version":           policyVersion,
-		"policy_hash":              actionPolicyHash,
-		"default_posture":          "",
-		"decision_result":          decisionResult,
-		"decision_category":        decisionCategoryValue,
-		"adapter_decision":         adapterDecisionValue,
-		"reason_code":              reasonCode,
-		"reason":                   reasonText,
-		"risk_level":               strings.ToUpper(riskEvent.JudgeRiskLevel),
-		"risk_score":               nullableFloat(decision.RiskScore),
-		"risk_threshold":           nullableFloat(decision.Threshold),
-		"model_version":            decision.ModelVersion,
-		"confidence":               riskEvent.Confidence,
-		"matched_rules_json":       matchedRulesJSON,
-		"risk_signals_json":        riskSignalsJSON,
-		"risk_event_json":          riskEventJSON,
-		"modifications_json":       emptyObject,
-		"approval_context_json":    emptyObject,
-		"approval_channel":         "",
-		"approval_request_id":      "",
-		"deferral_context_json":    emptyObject,
-		"status":                   actionStatus(canonicalEvent, stringValue(decisionResult)),
-		"outcome":                  outcome,
-		"output_summary":           outputSummary,
-		"output_hash":              outputHash,
-		"error_redacted":           errorRedacted,
-		"proposed_at":              nullIfEmpty(proposedAt),
-		"decision_at":              nullIfEmpty(decisionAt),
-		"completed_at":             nullIfEmpty(completedAt),
-		"created_at":               updatedAt,
-		"updated_at":               updatedAt,
-		"updated_at_cursor_key":    ledgerTimestampCursorKeyFromValues(updatedAt),
+		"id":                        actionID,
+		"session_id":                sessionID,
+		"tool_use_id":               event.ToolUseID,
+		"canonical_event_type":      canonicalEvent,
+		"adapter_event_name":        event.HookEventName,
+		"correlation_key":           correlationKey(event),
+		"tool_name":                 event.ToolName,
+		"provider":                  provider,
+		"operation":                 riskEvent.Operation,
+		"operation_class":           riskEvent.OperationClass,
+		"resource_class":            riskEvent.ResourceClass,
+		"resource_id":               nullIfEmpty(resourceID),
+		"parameters_redacted_json":  parametersJSON,
+		"parameters_hash":           parametersHash,
+		"identity_context_json":     identityJSON,
+		"identity_hash":             identityHash,
+		"context_json":              contextJSON,
+		"context_hash":              contextHash,
+		"policy_id":                 policyID,
+		"policy_version":            policyVersion,
+		"policy_hash":               actionPolicyHash,
+		"default_posture":           "",
+		"decision_result":           decisionResult,
+		"decision_category":         decisionCategoryValue,
+		"adapter_decision":          adapterDecisionValue,
+		"reason_code":               reasonCode,
+		"reason":                    reasonText,
+		"risk_level":                strings.ToUpper(riskEvent.JudgeRiskLevel),
+		"risk_score":                nullableFloat(decision.RiskScore),
+		"risk_threshold":            nullableFloat(decision.Threshold),
+		"model_version":             decision.ModelVersion,
+		"confidence":                riskEvent.Confidence,
+		"matched_rules_json":        matchedRulesJSON,
+		"risk_signals_json":         riskSignalsJSON,
+		"risk_event_json":           riskEventJSON,
+		"modifications_json":        emptyObject,
+		"approval_context_json":     emptyObject,
+		"approval_channel":          "",
+		"approval_request_id":       "",
+		"deferral_context_json":     emptyObject,
+		"status":                    actionStatus(canonicalEvent, stringValue(decisionResult)),
+		"outcome":                   outcome,
+		"output_summary":            outputSummary,
+		"output_hash":               outputHash,
+		"error_redacted":            errorRedacted,
+		"tool_input_captured_json":  toolInputCaptured,
+		"tool_output_captured_json": toolOutputCaptured,
+		"proposed_at":               nullIfEmpty(proposedAt),
+		"decision_at":               nullIfEmpty(decisionAt),
+		"completed_at":              nullIfEmpty(completedAt),
+		"created_at":                updatedAt,
+		"updated_at":                updatedAt,
+		"updated_at_cursor_key":     ledgerTimestampCursorKeyFromValues(updatedAt),
 	}, nil
 }
 

--- a/internal/guard/store/sqlite/store.go
+++ b/internal/guard/store/sqlite/store.go
@@ -25,6 +25,9 @@ type Store struct {
 	path   string
 	signer receiptSigner
 
+	// captureMode lives on Store (a mutable setter) rather than flowing
+	// through the policy-provider chain: what gets persisted is a storage
+	// concern, and the synced-policy layer only needs to flip it.
 	captureMu   sync.RWMutex
 	captureMode payloadcapture.Mode
 }
@@ -762,20 +765,24 @@ on conflict(id) do update set
 		return DecisionRecord{}, err
 	}
 
+	// Snapshot the mode once so every row of this decision is captured
+	// under the same policy, even if the mode flips concurrently.
+	captureMode := s.payloadCaptureMode()
+
 	actionID := "act_" + uuid.NewString()
 	if event.HookEventName == "PreToolUse" {
 		proposedID := "act_" + uuid.NewString()
-		if err := s.insertAction(ctx, tx, proposedID, sessionID, event, decision, canonicalEventRequestProposed, "event", now); err != nil {
+		if err := s.insertAction(ctx, tx, proposedID, sessionID, event, decision, canonicalEventRequestProposed, "event", captureMode, now); err != nil {
 			return DecisionRecord{}, err
 		}
-		if err := s.insertAction(ctx, tx, actionID, sessionID, event, decision, canonicalEventRequestDecided, "decision", now.Add(time.Millisecond)); err != nil {
+		if err := s.insertAction(ctx, tx, actionID, sessionID, event, decision, canonicalEventRequestDecided, "decision", captureMode, now.Add(time.Millisecond)); err != nil {
 			return DecisionRecord{}, err
 		}
 		if err := s.insertGithubDryRunActions(ctx, tx, sessionID, event, decision, now.Add(2*time.Millisecond)); err != nil {
 			return DecisionRecord{}, err
 		}
 	} else {
-		if err := s.insertAction(ctx, tx, actionID, sessionID, event, decision, canonicalEventType(event.HookEventName), "outcome", now); err != nil {
+		if err := s.insertAction(ctx, tx, actionID, sessionID, event, decision, canonicalEventType(event.HookEventName), "outcome", captureMode, now); err != nil {
 			return DecisionRecord{}, err
 		}
 	}
@@ -801,8 +808,8 @@ on conflict(id) do update set
 	}, nil
 }
 
-func (s *Store) insertAction(ctx context.Context, tx *sql.Tx, actionID, sessionID string, event risk.HookEvent, decision risk.RiskDecision, canonicalEvent, receiptType string, now time.Time) error {
-	action, err := actionValues(actionID, sessionID, event, decision, canonicalEvent, s.payloadCaptureMode(), now)
+func (s *Store) insertAction(ctx context.Context, tx *sql.Tx, actionID, sessionID string, event risk.HookEvent, decision risk.RiskDecision, canonicalEvent, receiptType string, captureMode payloadcapture.Mode, now time.Time) error {
+	action, err := actionValues(actionID, sessionID, event, decision, canonicalEvent, captureMode, now)
 	if err != nil {
 		return err
 	}
@@ -853,21 +860,35 @@ func (s *Store) insertActionRecord(ctx context.Context, tx *sql.Tx, action map[s
 	return s.appendReceipt(ctx, tx, receiptInputFromAction(action, receiptType, now))
 }
 
-// capturedPayloadJSON returns the serialized captured payload record, or nil
-// when nothing is recorded. Tool input is recorded once per tool call (on the
-// request.proposed row, not again on the decision row); tool output on the
-// observed/failed rows.
-func capturedPayloadJSON(payload map[string]any, mode payloadcapture.Mode, applies bool) any {
-	if !applies {
+// capturedInputJSON records tool input once per tool call, on the
+// request.proposed row — the decision row correlates via tool_use_id and
+// must not duplicate it.
+func capturedInputJSON(event risk.HookEvent, canonicalEvent string, mode payloadcapture.Mode) any {
+	if canonicalEvent != canonicalEventRequestProposed {
 		return nil
 	}
+	return capturedRecordJSON(event.ToolInput, mode)
+}
+
+// capturedOutputJSON records tool output on the observed/failed rows.
+func capturedOutputJSON(event risk.HookEvent, canonicalEvent string, mode payloadcapture.Mode) any {
+	if canonicalEvent != canonicalEventRequestObserved && canonicalEvent != canonicalEventRequestFailed {
+		return nil
+	}
+	return capturedRecordJSON(event.ToolResponse, mode)
+}
+
+func capturedRecordJSON(payload map[string]any, mode payloadcapture.Mode) any {
 	record := payloadcapture.Capture(payload, mode)
 	if record == nil {
 		return nil
 	}
 	raw, err := record.MarshalJSON()
 	if err != nil {
-		return nil
+		// Unreachable for records produced by Capture; if it ever happens,
+		// surface the failure in the ledger rather than dropping silently —
+		// the ledger is this package's log.
+		return `{"mode":"capture_failed","reason":"serialization_error"}`
 	}
 	return string(raw)
 }
@@ -932,14 +953,8 @@ func actionValues(actionID, sessionID string, event risk.HookEvent, decision ris
 		decisionResult = canonicalDecisionResult(decision.Decision)
 	}
 	outcome, outputSummary, outputHash, errorRedacted := outcomeValues(event, decision)
-	toolInputCaptured := capturedPayloadJSON(
-		event.ToolInput, captureMode,
-		canonicalEvent == canonicalEventRequestProposed,
-	)
-	toolOutputCaptured := capturedPayloadJSON(
-		event.ToolResponse, captureMode,
-		canonicalEvent == canonicalEventRequestObserved || canonicalEvent == canonicalEventRequestFailed,
-	)
+	toolInputCaptured := capturedInputJSON(event, canonicalEvent, captureMode)
+	toolOutputCaptured := capturedOutputJSON(event, canonicalEvent, captureMode)
 	proposedAt := ""
 	decisionAt := ""
 	completedAt := ""

--- a/internal/guard/store/sqlite/store_capture_test.go
+++ b/internal/guard/store/sqlite/store_capture_test.go
@@ -106,8 +106,13 @@ func TestSaveDecisionDefaultModeWritesNoCapturedPayloads(t *testing.T) {
 	saveCaptureFixtureDecision(t, store, "PreToolUse", map[string]any{
 		"command": "git status",
 	}, nil)
+	saveCaptureFixtureDecision(t, store, "PostToolUse", map[string]any{
+		"command": "git status",
+	}, map[string]any{
+		"content": "clean working tree",
+	})
 
-	for _, canonicalEvent := range []string{"request.proposed", "request.decided"} {
+	for _, canonicalEvent := range []string{"request.proposed", "request.decided", "request.observed"} {
 		for _, column := range []string{"tool_input_captured_json", "tool_output_captured_json"} {
 			if value := capturedColumn(t, store, canonicalEvent, column); value.Valid {
 				t.Fatalf("%s.%s = %q, want NULL in default mode", canonicalEvent, column, value.String)
@@ -233,5 +238,23 @@ select count(*) from pragma_table_info('authorization_actions') where name = ?
 
 	if value := capturedColumn(t, store, "request.decided", "tool_input_captured_json"); value.Valid {
 		t.Fatalf("pre-capture row gained a value: %q", value.String)
+	}
+}
+
+// capturedRecordJSON falls back to a hardcoded capture_failed literal when
+// MarshalJSON fails — a path unreachable for records produced by Capture, so
+// it cannot be exercised end-to-end. Pin the literal to the wire format the
+// package actually emits so the two cannot drift apart silently.
+func TestCaptureFailedFallbackLiteralMatchesWireFormat(t *testing.T) {
+	canonical, err := payloadcapture.Payload{
+		Mode:   "capture_failed",
+		Reason: payloadcapture.ReasonSerializationError,
+	}.MarshalJSON()
+	if err != nil {
+		t.Fatalf("marshal canonical capture_failed record: %v", err)
+	}
+	const fallback = `{"mode":"capture_failed","reason":"serialization_error"}`
+	if string(canonical) != fallback {
+		t.Fatalf("fallback literal diverged from wire format:\nliteral: %s\nwire:    %s", fallback, canonical)
 	}
 }

--- a/internal/guard/store/sqlite/store_capture_test.go
+++ b/internal/guard/store/sqlite/store_capture_test.go
@@ -1,0 +1,237 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/guard/risk"
+	"github.com/kontext-security/kontext-cli/internal/payloadcapture"
+)
+
+func saveCaptureFixtureDecision(t *testing.T, store *Store, hookEvent string, toolInput, toolResponse map[string]any) {
+	t.Helper()
+	_, err := store.SaveDecision(context.Background(), risk.HookEvent{
+		SessionID:     "s-capture",
+		Agent:         "claude-code",
+		HookEventName: hookEvent,
+		ToolName:      "Bash",
+		ToolUseID:     "tool-capture-1",
+		CWD:           "/tmp/project",
+		ToolInput:     toolInput,
+		ToolResponse:  toolResponse,
+	}, risk.RiskDecision{
+		Decision:   risk.DecisionAllow,
+		Reason:     "normal command",
+		ReasonCode: "normal_tool_call",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func capturedColumn(t *testing.T, store *Store, canonicalEvent, column string) sql.NullString {
+	t.Helper()
+	var value sql.NullString
+	err := store.db.QueryRowContext(context.Background(),
+		"select "+column+" from authorization_actions where canonical_event_type = ?",
+		canonicalEvent,
+	).Scan(&value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return value
+}
+
+func TestSaveDecisionCapturesPayloadsInFullMode(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	store.SetPayloadCaptureMode(payloadcapture.ModeFull)
+
+	saveCaptureFixtureDecision(t, store, "PreToolUse", map[string]any{
+		"command": "GITHUB_TOKEN=super-secret-raw-value gh api /user",
+	}, nil)
+	saveCaptureFixtureDecision(t, store, "PostToolUse", map[string]any{
+		"command": "GITHUB_TOKEN=super-secret-raw-value gh api /user",
+	}, map[string]any{
+		"content": "api_key=another-raw-secret ok",
+	})
+
+	// Input is recorded once, on the proposed row only.
+	proposedInput := capturedColumn(t, store, "request.proposed", "tool_input_captured_json")
+	if !proposedInput.Valid {
+		t.Fatal("proposed row is missing the captured tool input")
+	}
+	var inputRecord map[string]any
+	if err := json.Unmarshal([]byte(proposedInput.String), &inputRecord); err != nil {
+		t.Fatal(err)
+	}
+	if inputRecord["mode"] != "full" || inputRecord["redacted"] != true {
+		t.Fatalf("unexpected input record: %v", inputRecord)
+	}
+	if strings.Contains(proposedInput.String, "super-secret-raw-value") {
+		t.Fatal("raw secret survived into the stored input record")
+	}
+	if decidedInput := capturedColumn(t, store, "request.decided", "tool_input_captured_json"); decidedInput.Valid {
+		t.Fatal("decision row must not duplicate the captured input")
+	}
+
+	// Output is recorded on the observed row.
+	observedOutput := capturedColumn(t, store, "request.observed", "tool_output_captured_json")
+	if !observedOutput.Valid {
+		t.Fatal("observed row is missing the captured tool output")
+	}
+	if strings.Contains(observedOutput.String, "another-raw-secret") {
+		t.Fatal("raw secret survived into the stored output record")
+	}
+	if observedInput := capturedColumn(t, store, "request.observed", "tool_input_captured_json"); observedInput.Valid {
+		t.Fatal("observed row must not carry captured input")
+	}
+}
+
+func TestSaveDecisionDefaultModeWritesNoCapturedPayloads(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	// No SetPayloadCaptureMode call: the default must be byte-identical to
+	// the pre-capture behavior.
+
+	saveCaptureFixtureDecision(t, store, "PreToolUse", map[string]any{
+		"command": "git status",
+	}, nil)
+
+	for _, canonicalEvent := range []string{"request.proposed", "request.decided"} {
+		for _, column := range []string{"tool_input_captured_json", "tool_output_captured_json"} {
+			if value := capturedColumn(t, store, canonicalEvent, column); value.Valid {
+				t.Fatalf("%s.%s = %q, want NULL in default mode", canonicalEvent, column, value.String)
+			}
+		}
+	}
+}
+
+func TestLedgerExportOmitsEmptyCapturedPayloadFields(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	saveCaptureFixtureDecision(t, store, "PreToolUse", map[string]any{
+		"command": "git status",
+	}, nil)
+
+	records, err := store.AuthorizationActions(context.Background(), LedgerExportOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) == 0 {
+		t.Fatal("expected exported action records")
+	}
+	for _, record := range records {
+		for _, key := range []string{"tool_input_captured_json", "tool_output_captured_json"} {
+			if _, present := record[key]; present {
+				t.Fatalf("record %v mentions %s; empty captured fields must stay off the wire", record["id"], key)
+			}
+		}
+	}
+}
+
+func TestLedgerExportDecodesCapturedPayloadRecords(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	store.SetPayloadCaptureMode(payloadcapture.ModeFull)
+
+	saveCaptureFixtureDecision(t, store, "PreToolUse", map[string]any{
+		"command": "curl https://example.test",
+	}, nil)
+
+	records, err := store.AuthorizationActions(context.Background(), LedgerExportOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var captured map[string]any
+	for _, record := range records {
+		if record["canonical_event_type"] != "request.proposed" {
+			continue
+		}
+		decoded, ok := record["tool_input_captured_json"].(map[string]any)
+		if !ok {
+			t.Fatalf("captured input is %T, want decoded object", record["tool_input_captured_json"])
+		}
+		captured = decoded
+	}
+	if captured == nil {
+		t.Fatal("no proposed record with captured input exported")
+	}
+	if captured["mode"] != "full" {
+		t.Fatalf("captured mode = %v", captured["mode"])
+	}
+	if _, hasValue := captured["value"]; !hasValue {
+		t.Fatal("captured record is missing its value")
+	}
+}
+
+func TestMigrationAddsCapturedPayloadColumns(t *testing.T) {
+	path := t.TempDir() + "/guard.db"
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.ExecContext(context.Background(), `
+create table authorization_actions (
+  id text primary key,
+  session_id text not null,
+  canonical_event_type text not null,
+  decision_result text,
+  status text not null,
+  created_at text not null,
+  updated_at text not null
+);
+insert into authorization_actions (
+  id, session_id, canonical_event_type, decision_result, status, created_at, updated_at
+) values (
+  'act_precapture', 's1', 'request.decided', 'allow', 'authorized',
+  '2026-05-26T10:00:00Z', '2026-05-26T10:00:00Z'
+);
+`)
+	if err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := OpenStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	for _, column := range []string{"tool_input_captured_json", "tool_output_captured_json"} {
+		var count int
+		err := store.db.QueryRowContext(context.Background(), `
+select count(*) from pragma_table_info('authorization_actions') where name = ?
+		`, column).Scan(&count)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count != 1 {
+			t.Fatalf("column %s missing after migration", column)
+		}
+	}
+
+	if value := capturedColumn(t, store, "request.decided", "tool_input_captured_json"); value.Valid {
+		t.Fatalf("pre-capture row gained a value: %q", value.String)
+	}
+}


### PR DESCRIPTION
## Summary

Wires the payload capture library (#365) into the local authorization ledger. With this change the daemon can record what went into and came out of tool calls, but records nothing new by default: capture stays off until a mode is explicitly set on the store. A follow-up connects that switch to org policy.

### What changes

- **Two new nullable columns** on `authorization_actions`: `tool_input_captured_json` and `tool_output_captured_json`. Existing databases gain them through the established rebuild migration; pre-existing rows stay NULL.
- **Where records land**: tool input is captured **once per tool call**, on the `request.proposed` row, not duplicated onto the decision row. Tool output is captured on the `request.observed` / `request.failed` rows. Everything else, including summaries, hashes, and receipts, is untouched in every mode.
- **The gate**: `Store.SetPayloadCaptureMode(...)`. Unset or unrecognized means off, so unknown never means "record content".

### Compatibility rule

Ledger exports omit the new fields entirely when empty instead of sending nulls. Consumers that predate these fields can reject uploads carrying unknown fields wholesale, so a default-mode install must produce uploads indistinguishable from today. A test asserts exported records do not mention the keys until capture is active. When capture is active, the fields ride the existing export path as ordinary JSON objects.

### Tests

Full mode round-trip covers input on proposed only, output on observed only, and raw secrets absent from stored records. Default mode writes NULLs and exports byte-compatible records. Export tests assert active captures decode as objects. Migration tests assert legacy schemas gain the columns without touching old rows.

**Stack:** #365 (capture library) -> this PR (ledger wiring). A follow-up reads the capture mode from synced policy and completes the chain.

## Verification

- [x] `go test ./...`
- [x] `go test ./internal/guard/store/sqlite ./internal/payloadcapture -count=1`
- [x] `go test -race ./internal/guard/store/sqlite ./internal/payloadcapture -count=1`
- [x] `go vet ./...`
- [ ] `buf generate` - n/a, no protobuf/generated code changed

## Release notes

- [x] conventional commit title matches semver intent (`feat:`, minor)