### PR TITLE
feat: apply org payload capture mode from the policy snapshot

### DIFF
--- a/internal/githubpolicy/cache.go
+++ b/internal/githubpolicy/cache.go
@@ -109,12 +109,14 @@ func (c *Cache) Apply(snapshot Snapshot, fetchedAt time.Time) error {
 	// SchemaVersion is part of the identity check so a v2→v3 transition is
 	// adopted even if the server ever produced colliding hashes across
 	// versions — the CLI must not depend on that cross-version promise.
-	// PayloadCaptureMode is excluded from the server-side hash, so it needs
-	// its own identity term: a mode flip arrives on an unchanged hash and
-	// must still be adopted and persisted to survive an offline restart.
+	// Mode and PayloadCaptureMode are excluded from the server-side hash, so
+	// they need their own identity terms: a directive flip arrives on an
+	// unchanged hash and must still be adopted and persisted to survive an
+	// offline restart.
 	unchanged := c.loaded &&
 		c.snapshot.Hash == snapshot.Hash &&
 		c.snapshot.SchemaVersion == snapshot.SchemaVersion &&
+		c.snapshot.Mode == snapshot.Mode &&
 		c.snapshot.PayloadCaptureMode == snapshot.PayloadCaptureMode
 	if !unchanged {
 		c.snapshot = snapshot

--- a/internal/githubpolicy/cache.go
+++ b/internal/githubpolicy/cache.go
@@ -102,14 +102,20 @@ func (c *Cache) LoadPersisted() error {
 	return nil
 }
 
-// Apply installs a freshly fetched snapshot. When the hash is unchanged the
-// rules are not re-applied or re-persisted; only freshness is updated.
+// Apply installs a freshly fetched snapshot. When the identity is unchanged
+// the rules are not re-applied or re-persisted; only freshness is updated.
 func (c *Cache) Apply(snapshot Snapshot, fetchedAt time.Time) error {
 	c.mu.Lock()
 	// SchemaVersion is part of the identity check so a v2→v3 transition is
 	// adopted even if the server ever produced colliding hashes across
 	// versions — the CLI must not depend on that cross-version promise.
-	unchanged := c.loaded && c.snapshot.Hash == snapshot.Hash && c.snapshot.SchemaVersion == snapshot.SchemaVersion
+	// PayloadCaptureMode is excluded from the server-side hash, so it needs
+	// its own identity term: a mode flip arrives on an unchanged hash and
+	// must still be adopted and persisted to survive an offline restart.
+	unchanged := c.loaded &&
+		c.snapshot.Hash == snapshot.Hash &&
+		c.snapshot.SchemaVersion == snapshot.SchemaVersion &&
+		c.snapshot.PayloadCaptureMode == snapshot.PayloadCaptureMode
 	if !unchanged {
 		c.snapshot = snapshot
 	}

--- a/internal/githubpolicy/cache_test.go
+++ b/internal/githubpolicy/cache_test.go
@@ -199,3 +199,34 @@ func TestCacheAdoptsAndPersistsModeChangeOnUnchangedHash(t *testing.T) {
 		t.Fatalf("persisted PayloadCaptureMode = %q, %v; want %q to survive restart", persisted.PayloadCaptureMode, ok, "full")
 	}
 }
+
+// Snapshot.Mode (observe/enforce) is outside the server-side hash for the
+// same reason payloadCaptureMode is — same hazard, same guarantee: a flip on
+// an unchanged hash must be adopted and survive a restart.
+func TestCacheAdoptsAndPersistsEnforcementModeChangeOnUnchangedHash(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "github-policy-snapshot.json")
+	cache := NewCache(path)
+	if err := cache.Apply(testSnapshot(3, "hash-3"), time.Now().UTC()); err != nil {
+		t.Fatalf("Apply() first error = %v", err)
+	}
+
+	flipped := testSnapshot(3, "hash-3") // identical hash, only the mode flips
+	flipped.Mode = ModeEnforce
+	if err := cache.Apply(flipped, time.Now().UTC()); err != nil {
+		t.Fatalf("Apply() flipped error = %v", err)
+	}
+
+	snapshot, _, _ := cache.CurrentSnapshot()
+	if !snapshot.Enforce() {
+		t.Fatalf("in-memory Mode = %q, want %q after flip on unchanged hash", snapshot.Mode, ModeEnforce)
+	}
+
+	reloaded := NewCache(path)
+	if err := reloaded.LoadPersisted(); err != nil {
+		t.Fatalf("LoadPersisted() error = %v", err)
+	}
+	persisted, _, ok := reloaded.CurrentSnapshot()
+	if !ok || !persisted.Enforce() {
+		t.Fatalf("persisted Mode = %q, %v; want %q to survive restart", persisted.Mode, ok, ModeEnforce)
+	}
+}

--- a/internal/githubpolicy/cache_test.go
+++ b/internal/githubpolicy/cache_test.go
@@ -125,3 +125,77 @@ func TestCacheKeepsServingStaleSnapshotOnFetchFailure(t *testing.T) {
 		t.Fatalf("status = %+v, want stale with recorded error", status)
 	}
 }
+
+func TestSnapshotDecodesPayloadCaptureMode(t *testing.T) {
+	var withField Snapshot
+	if err := json.Unmarshal([]byte(`{"schemaVersion":"github-policy-snapshot-v2","hash":"h","payloadCaptureMode":"full"}`), &withField); err != nil {
+		t.Fatalf("unmarshal with field: %v", err)
+	}
+	if withField.PayloadCaptureMode != "full" {
+		t.Fatalf("PayloadCaptureMode = %q, want %q", withField.PayloadCaptureMode, "full")
+	}
+
+	// Pre-capture server: field absent must decode to "" (normalized to
+	// "summary" downstream), not an error.
+	var withoutField Snapshot
+	if err := json.Unmarshal([]byte(`{"schemaVersion":"github-policy-snapshot-v2","hash":"h"}`), &withoutField); err != nil {
+		t.Fatalf("unmarshal without field: %v", err)
+	}
+	if withoutField.PayloadCaptureMode != "" {
+		t.Fatalf("PayloadCaptureMode = %q, want empty", withoutField.PayloadCaptureMode)
+	}
+}
+
+func TestCachePersistsPayloadCaptureModeAcrossReload(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "github-policy-snapshot.json")
+	cache := NewCache(path)
+	snapshot := testSnapshot(3, "hash-3")
+	snapshot.PayloadCaptureMode = "full"
+	if err := cache.Apply(snapshot, time.Now().UTC()); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	reloaded := NewCache(path)
+	if err := reloaded.LoadPersisted(); err != nil {
+		t.Fatalf("LoadPersisted() error = %v", err)
+	}
+	persisted, _, ok := reloaded.CurrentSnapshot()
+	if !ok || persisted.PayloadCaptureMode != "full" {
+		t.Fatalf("persisted PayloadCaptureMode = %q, %v; want %q", persisted.PayloadCaptureMode, ok, "full")
+	}
+}
+
+// Regression test for the hash-exclusion hazard: payloadCaptureMode is
+// deliberately excluded from the server-side snapshot hash, so a mode flip
+// arrives on a snapshot whose hash is UNCHANGED. The cache must adopt and
+// persist it anyway — a hash-equality short-circuit that drops the new mode
+// would freeze the org's capture directive until the next policy edit.
+func TestCacheAdoptsAndPersistsModeChangeOnUnchangedHash(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "github-policy-snapshot.json")
+	cache := NewCache(path)
+	first := testSnapshot(3, "hash-3")
+	first.PayloadCaptureMode = "summary"
+	if err := cache.Apply(first, time.Now().UTC()); err != nil {
+		t.Fatalf("Apply() first error = %v", err)
+	}
+
+	second := testSnapshot(3, "hash-3") // identical hash, only the mode flips
+	second.PayloadCaptureMode = "full"
+	if err := cache.Apply(second, time.Now().UTC()); err != nil {
+		t.Fatalf("Apply() second error = %v", err)
+	}
+
+	snapshot, _, _ := cache.CurrentSnapshot()
+	if snapshot.PayloadCaptureMode != "full" {
+		t.Fatalf("in-memory PayloadCaptureMode = %q, want %q after mode flip on unchanged hash", snapshot.PayloadCaptureMode, "full")
+	}
+
+	reloaded := NewCache(path)
+	if err := reloaded.LoadPersisted(); err != nil {
+		t.Fatalf("LoadPersisted() error = %v", err)
+	}
+	persisted, _, ok := reloaded.CurrentSnapshot()
+	if !ok || persisted.PayloadCaptureMode != "full" {
+		t.Fatalf("persisted PayloadCaptureMode = %q, %v; want %q to survive restart", persisted.PayloadCaptureMode, ok, "full")
+	}
+}

--- a/internal/githubpolicy/snapshot.go
+++ b/internal/githubpolicy/snapshot.go
@@ -109,6 +109,14 @@ type Snapshot struct {
 	// unchanged hash.
 	Hash  string `json:"hash"`
 	Rules []Rule `json:"rules"`
+	// PayloadCaptureMode is the org's tool-payload capture directive
+	// ("omitted" | "summary" | "full"). Absent on pre-capture servers.
+	// Deliberately EXCLUDED from Hash (server-side decision), so a mode
+	// flip arrives on a snapshot whose hash is unchanged — consumers must
+	// not gate mode application on hash inequality (see Cache.Apply).
+	// Normalize via payloadcapture.NormalizeMode; unknown values fall back
+	// to "summary" (never capture on an unrecognized directive).
+	PayloadCaptureMode string `json:"payloadCaptureMode,omitempty"`
 	// EndpointDirectory is this endpoint's resolved directory identity (v3
 	// only; nil on v2 or when the request carried no installation id).
 	EndpointDirectory *EndpointDirectory `json:"endpointDirectory,omitempty"`

--- a/internal/guard/app/server/server.go
+++ b/internal/guard/app/server/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
 	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
 	dashboardassets "github.com/kontext-security/kontext-cli/internal/guard/web/assets"
+	"github.com/kontext-security/kontext-cli/internal/payloadcapture"
 	"github.com/kontext-security/kontext-cli/internal/runtimecore"
 )
 
@@ -75,6 +76,13 @@ type ActivatePolicyProfileRequest struct {
 
 func NewServer(store *sqlite.Store) (*Server, error) {
 	return NewServerWithOptions(store, Options{})
+}
+
+// SetPayloadCaptureMode forwards the org's payload-capture directive to the
+// store, which reads it per recorded action. Called by the managed daemon's
+// policy refresh cycle whenever a snapshot is fetched or restored from disk.
+func (s *Server) SetPayloadCaptureMode(mode payloadcapture.Mode) {
+	s.store.SetPayloadCaptureMode(mode)
 }
 
 func NewServerWithOptions(store *sqlite.Store, opts Options) (*Server, error) {

--- a/internal/guard/store/sqlite/store_capture_test.go
+++ b/internal/guard/store/sqlite/store_capture_test.go
@@ -258,3 +258,46 @@ func TestCaptureFailedFallbackLiteralMatchesWireFormat(t *testing.T) {
 		t.Fatalf("fallback literal diverged from wire format:\nliteral: %s\nwire:    %s", fallback, canonical)
 	}
 }
+
+// The managed daemon flips the capture mode via SetPayloadCaptureMode whenever
+// the policy snapshot refreshes (~60s). The store must read the CURRENT mode
+// per recorded event — no restart, no per-session pinning.
+func TestSaveDecisionModeChangeAppliesToNextEvent(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	capturedProposedRows := func() int {
+		t.Helper()
+		var count int
+		err := store.db.QueryRowContext(context.Background(),
+			"select count(*) from authorization_actions where canonical_event_type = 'request.proposed' and tool_input_captured_json is not null",
+		).Scan(&count)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return count
+	}
+
+	// Default (summary): nothing captured.
+	saveCaptureFixtureDecision(t, store, "PreToolUse", map[string]any{"command": "git status"}, nil)
+	if got := capturedProposedRows(); got != 0 {
+		t.Fatalf("captured rows before mode flip = %d, want 0", got)
+	}
+
+	// Snapshot flips to full: the very next event captures.
+	store.SetPayloadCaptureMode(payloadcapture.ModeFull)
+	saveCaptureFixtureDecision(t, store, "PreToolUse", map[string]any{"command": "git diff"}, nil)
+	if got := capturedProposedRows(); got != 1 {
+		t.Fatalf("captured rows after flip to full = %d, want 1", got)
+	}
+
+	// Snapshot flips back to summary: capture stops again.
+	store.SetPayloadCaptureMode(payloadcapture.ModeSummary)
+	saveCaptureFixtureDecision(t, store, "PreToolUse", map[string]any{"command": "git log"}, nil)
+	if got := capturedProposedRows(); got != 1 {
+		t.Fatalf("captured rows after flip back to summary = %d, want 1", got)
+	}
+}

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/installation"
 	"github.com/kontext-security/kontext-cli/internal/managedconfig"
 	"github.com/kontext-security/kontext-cli/internal/managedstream"
+	"github.com/kontext-security/kontext-cli/internal/payloadcapture"
 	"github.com/kontext-security/kontext-cli/internal/runtimehost"
 )
 
@@ -140,9 +141,16 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 	}
 	defer host.Close(context.Background())
 
+	// Restore the capture mode from the persisted snapshot before the first
+	// fetch completes, so an offline restart keeps the org's last-known
+	// directive instead of silently reverting to the "summary" default.
+	if snapshot, _, ok := policyCache.CurrentSnapshot(); ok {
+		host.SetPayloadCaptureMode(payloadcapture.NormalizeMode(snapshot.PayloadCaptureMode))
+	}
+
 	policyCtx, stopPolicyRefresh := context.WithCancel(ctx)
 	defer stopPolicyRefresh()
-	go runGithubPolicy(policyCtx, opts, policyCache, installationState.InstallationID)
+	go runGithubPolicy(policyCtx, opts, policyCache, installationState.InstallationID, host.SetPayloadCaptureMode)
 
 	streamCtx, stopStream := context.WithCancel(ctx)
 	defer stopStream()
@@ -273,12 +281,12 @@ func loadManagedConfig(ctx context.Context) (managedconfig.LoadedConfig, string,
 	return loadedConfig, installToken, nil
 }
 
-func runGithubPolicy(ctx context.Context, opts DaemonOptions, cache *githubpolicy.Cache, installationID string) {
+func runGithubPolicy(ctx context.Context, opts DaemonOptions, cache *githubpolicy.Cache, installationID string, applyCaptureMode func(payloadcapture.Mode)) {
 	interval := opts.GithubPolicyInterval
 	if interval == 0 {
 		interval = githubpolicy.DefaultIntervalFromEnv()
 	}
-	refreshGithubPolicy(ctx, opts, cache, installationID)
+	refreshGithubPolicy(ctx, opts, cache, installationID, applyCaptureMode)
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
@@ -286,12 +294,12 @@ func runGithubPolicy(ctx context.Context, opts DaemonOptions, cache *githubpolic
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			refreshGithubPolicy(ctx, opts, cache, installationID)
+			refreshGithubPolicy(ctx, opts, cache, installationID, applyCaptureMode)
 		}
 	}
 }
 
-func refreshGithubPolicy(ctx context.Context, opts DaemonOptions, cache *githubpolicy.Cache, installationID string) {
+func refreshGithubPolicy(ctx context.Context, opts DaemonOptions, cache *githubpolicy.Cache, installationID string, applyCaptureMode func(payloadcapture.Mode)) {
 	loadedConfig, installToken, err := loadManagedConfig(ctx)
 	if err != nil {
 		cache.MarkFetchFailed(err)
@@ -306,6 +314,12 @@ func refreshGithubPolicy(ctx context.Context, opts DaemonOptions, cache *githubp
 	}
 	if err := cache.Apply(snapshot, time.Now().UTC()); err != nil {
 		opts.Diagnostic.Printf("github policy persist: %v\n", err)
+	}
+	// Applied from the freshly fetched snapshot, not re-read from the cache:
+	// payloadCaptureMode is excluded from the snapshot hash, so the fetched
+	// value must win regardless of any hash-based short-circuit.
+	if applyCaptureMode != nil {
+		applyCaptureMode(payloadcapture.NormalizeMode(snapshot.PayloadCaptureMode))
 	}
 }
 

--- a/internal/payloadcapture/capture.go
+++ b/internal/payloadcapture/capture.go
@@ -22,6 +22,18 @@ const (
 	ModeFull Mode = "full"
 )
 
+// NormalizeMode maps an org-policy mode string to a Mode. Absent ("") or
+// unrecognized values normalize to ModeSummary: an unknown mode must never
+// mean "send content".
+func NormalizeMode(raw string) Mode {
+	switch Mode(raw) {
+	case ModeOmitted, ModeSummary, ModeFull:
+		return Mode(raw)
+	default:
+		return ModeSummary
+	}
+}
+
 // FailureReason explains a capture_failed record. Failures never carry
 // payload content.
 type FailureReason string

--- a/internal/payloadcapture/capture_test.go
+++ b/internal/payloadcapture/capture_test.go
@@ -404,3 +404,25 @@ func TestTruncatedPayloadAlwaysCutsContent(t *testing.T) {
 		t.Fatalf("preview content %q is not a prefix of the canonical content", content)
 	}
 }
+
+func TestNormalizeMode(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		raw  string
+		want Mode
+	}{
+		{"omitted", ModeOmitted},
+		{"summary", ModeSummary},
+		{"full", ModeFull},
+		{"", ModeSummary},     // pre-capture server: field absent
+		{"FULL", ModeSummary}, // case-sensitive: no fuzzy matching toward capture
+		{"everything", ModeSummary},
+		{" full", ModeSummary},
+	}
+	for _, tc := range cases {
+		if got := NormalizeMode(tc.raw); got != tc.want {
+			t.Errorf("NormalizeMode(%q) = %q, want %q", tc.raw, got, tc.want)
+		}
+	}
+}

--- a/internal/runtimehost/host.go
+++ b/internal/runtimehost/host.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/guard/judgeruntime"
 	"github.com/kontext-security/kontext-cli/internal/hook"
 	"github.com/kontext-security/kontext-cli/internal/localruntime"
+	"github.com/kontext-security/kontext-cli/internal/payloadcapture"
 	"github.com/kontext-security/kontext-cli/internal/runtimecore"
 )
 
@@ -235,6 +236,15 @@ func clientResultTransform(mode guardhookruntime.Mode) func(hook.Event, hook.Res
 		result.Decision = hook.DecisionAllow
 		return result
 	}
+}
+
+// SetPayloadCaptureMode forwards the org's payload-capture directive to the
+// guard server's store. Safe on a nil host (no-op).
+func (h *Host) SetPayloadCaptureMode(mode payloadcapture.Mode) {
+	if h == nil || h.server == nil {
+		return
+	}
+	h.server.SetPayloadCaptureMode(mode)
 }
 
 func (h *Host) Close(ctx context.Context) error {


### PR DESCRIPTION
## Summary

Completes the payload-capture chain (#365 capture library -> #366 ledger wiring -> this PR): the org's payload capture mode now reaches the store's capture gate, which #366 left defaulting to off.

### What changes

- **Snapshot contract**: `Snapshot.PayloadCaptureMode` (`payloadCaptureMode`, optional). Absent on servers that predate the field.
- **Normalization in one place**: `payloadcapture.NormalizeMode` maps absent or unrecognized values to `summary` — an unknown directive never means "record content".
- **Cache identity fix**: `payloadCaptureMode` is not covered by the snapshot `hash`, so a mode flip arrives on an *unchanged* hash. `Cache.Apply` previously short-circuited on hash equality and would have dropped the flip, in memory and on disk. The mode is now part of the identity check: a flip is adopted, persisted, and survives an offline daemon restart.
- **Plumbing**: the managed daemon applies the mode on startup from the persisted snapshot and after every successful refresh, taking it from the freshly fetched snapshot rather than re-reading the cache. It flows `daemon → Host → Server → Store.SetPayloadCaptureMode` (the #366 gate); the store reads the current mode per recorded event, so flips take effect within one refresh interval without a restart. No local override: the synced policy is authoritative.

### Behavior matrix

| Snapshot | Effective mode | Captured fields emitted |
| -- | -- | -- |
| no field | `summary` | none (existing behavior, byte-identical) |
| `"summary"` | `summary` | none |
| `"omitted"` | `omitted` | envelope only |
| `"full"` | `full` | full / full_truncated / capture_failed |
| unrecognized value | `summary` | none |

### Tests

- `NormalizeMode` table test (absent, valid, case-mismatch, garbage).
- Snapshot decode with and without the field; disk round-trip through `LoadPersisted`.
- Regression test for the hash short-circuit: two consecutive `Apply` calls with identical hash but different `payloadCaptureMode` — the second mode takes effect in memory *and* on disk.
- Mode-change-within-session: flip the gate between events; the very next event follows the new mode.

### Note for review

`Snapshot.Mode` (observe/enforce) is likewise outside the hash and originally rode the old short-circuit. Now included in the identity check as well (pre-emptive hardening, per review): no behavior change while only observe is emitted, but an enforce flip on an unchanged policy will be adopted and persisted like a capture-mode flip.

## Verification

- [x] `make test` (full suite, 38 packages)
- [x] `go vet` on touched packages
- [x] `gofmt` clean

ENG-495

🤖 Generated with [Claude Code](https://claude.com/claude-code)
