### PR TITLE
fix(managedstream): raise flush client timeout to 30s, env-tunable

### DIFF
--- a/internal/managedstream/stream.go
+++ b/internal/managedstream/stream.go
@@ -28,6 +28,7 @@ const (
 	DefaultBatchLimit        = 100
 	MaxPayloadBytes          = 192 * 1024
 	DefaultInterval          = 10 * time.Second
+	DefaultTimeout           = 30 * time.Second
 	DefaultHeartbeatInterval = 60 * time.Second
 
 	// cursorSafetyLag holds the persisted export cursor this far behind the
@@ -47,6 +48,7 @@ const (
 
 	envStatePath = "KONTEXT_MANAGED_STREAM_STATE"
 	envInterval  = "KONTEXT_MANAGED_STREAM_INTERVAL"
+	envTimeout   = "KONTEXT_MANAGED_STREAM_TIMEOUT"
 )
 
 var hostedErrorSecretPattern = regexp.MustCompile(`(?i)("(?:[^"]*(?:api[_-]?key|authorization|client[_-]?secret|credential|install[_-]?token|password|secret|token)[^"]*)"\s*:\s*")([^"]*)(")`)
@@ -331,7 +333,7 @@ func post(ctx context.Context, opts Options, body []byte) error {
 
 	client := opts.HTTPClient
 	if client == nil {
-		client = &http.Client{Timeout: 5 * time.Second}
+		client = &http.Client{Timeout: DefaultTimeoutFromEnv()}
 	}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -525,6 +527,15 @@ func DefaultIntervalFromEnv() time.Duration {
 		}
 	}
 	return DefaultInterval
+}
+
+func DefaultTimeoutFromEnv() time.Duration {
+	if value := strings.TrimSpace(os.Getenv(envTimeout)); value != "" {
+		if parsed, err := time.ParseDuration(value); err == nil && parsed > 0 {
+			return parsed
+		}
+	}
+	return DefaultTimeout
 }
 
 func heartbeatInterval(value time.Duration) time.Duration {

--- a/internal/managedstream/stream_test.go
+++ b/internal/managedstream/stream_test.go
@@ -19,6 +19,23 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
 )
 
+func TestDefaultTimeoutFromEnv(t *testing.T) {
+	t.Setenv(envTimeout, "")
+	if got := DefaultTimeoutFromEnv(); got != 30*time.Second {
+		t.Fatalf("DefaultTimeoutFromEnv() = %s, want 30s", got)
+	}
+
+	t.Setenv(envTimeout, "45s")
+	if got := DefaultTimeoutFromEnv(); got != 45*time.Second {
+		t.Fatalf("DefaultTimeoutFromEnv(valid) = %s, want 45s", got)
+	}
+
+	t.Setenv(envTimeout, "garbage")
+	if got := DefaultTimeoutFromEnv(); got != DefaultTimeout {
+		t.Fatalf("DefaultTimeoutFromEnv(invalid) = %s, want %s", got, DefaultTimeout)
+	}
+}
+
 func TestFlushPostsLedgerBatchWithInstallationIdentity(t *testing.T) {
 	store, dbPath := testStore(t)
 	saveTestDecision(t, store, "session-1", "toolu_1")


### PR DESCRIPTION
Fixes [ENG-514](https://linear.app/cobrowser/issue/ENG-514) — fleet-wide ingest stall.

The hosted batches endpoint currently takes 8–11s per POST (payload-capture made batches heavy). The hardcoded 5s client timeout meant every endpoint timed out *after* the server committed, never advanced its stream cursor, and re-sent the same batch every 10s — no dashboard sessions fleet-wide since 11:24Z.

- `DefaultTimeout = 30s` fallback for the flush HTTP client (was 5s inline)
- env-tunable via `KONTEXT_MANAGED_STREAM_TIMEOUT` (duration string), mirroring `KONTEXT_MANAGED_STREAM_INTERVAL`
- production wiring passes a nil `StreamHTTPClient`, so the fallback is the live path — no daemon changes needed

Tests: env parsing coverage (default / valid / garbage); full `managedstream` + `managedobserve` suites green.

Ship: merge → release-please 0.14.1 → brew + rebuild Katana 0.5.0 pkg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)