### PR TITLE
ci: arm auto-merge on every non-draft PR

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,28 @@
+name: Auto-merge
+
+# Arms GitHub auto-merge on every non-draft PR so it merges the moment
+# approval + required checks land. Uses the release app token because
+# merges armed with GITHUB_TOKEN don't trigger downstream workflows.
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+permissions: {}
+
+jobs:
+  arm:
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ vars.KONTEXT_RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.KONTEXT_RELEASE_APP_PRIVATE_KEY }}
+          repositories: kontext-cli
+          permission-contents: write
+          permission-pull-requests: write
+      - run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Arms GitHub auto-merge (squash) on every PR when opened or marked ready for review. With the existing ruleset (1 approval + verify/proto/dependency-review), this means **approval = merge** — no more approved-but-sitting PRs.

Uses the release app token instead of `GITHUB_TOKEN` so the resulting merge push still triggers downstream workflows.

Drafts are skipped; mark ready-for-review to arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)