### PR TITLE
fix: managed-observe stale-daemon recovery — binary watchdog, status breadcrumb, doctor + --fix (ENG-516)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ kontext setup
 
 Re-run `kontext setup` to rotate the stored token. Run `kontext setup --uninstall` to remove the user-level config, hooks, LaunchAgent, and keychain token that setup installed; local logs and observe data are kept, and organization-managed hooks are left in place. Self-serve setup is currently macOS only.
 
+Run `kontext doctor` to inspect the daemon version, heartbeat, and export backlog. When upgrading from a release that predates automatic stale-binary recovery, run `kontext doctor --fix` once if doctor reports an old or unknown daemon version; subsequent Homebrew upgrades restart the daemon automatically.
+
 ## Core features
 
 Kontext balances security and utility for AI agents: low-risk actions keep moving, and unsafe actions can be blocked before they execute.

--- a/cmd/kontext/main.go
+++ b/cmd/kontext/main.go
@@ -64,15 +64,42 @@ func main() {
 }
 
 func doctorCmd() *cobra.Command {
-	return &cobra.Command{
+	var fix bool
+	cmd := &cobra.Command{
 		Use:   "doctor",
 		Short: "Inspect local Kontext CLI setup",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			guardcli.PrintHookStatus(cmd.OutOrStdout())
-			managedobserve.PrintStatus(cmd.OutOrStdout())
+			staleDaemon := managedobserve.PrintStatus(cmd.OutOrStdout(), version)
+			if fix {
+				if !staleDaemon {
+					fmt.Fprintln(cmd.OutOrStdout(), "nothing to fix")
+					return nil
+				}
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				if err := managedobserve.KickstartLaunchdKill(ctx, managedobserve.DefaultLabel()); err != nil {
+					fmt.Fprintf(cmd.ErrOrStderr(), "failed to restart managed-observe daemon: %v\n", err)
+					return err
+				}
+				// launchd accepting the kickstart is not a comeback: the new
+				// daemon can exit immediately (unreadable token, codesigning
+				// kill). Only report success once the restarted daemon is
+				// serving on the installed version.
+				waitCtx, waitCancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer waitCancel()
+				status, err := managedobserve.WaitForDaemonRestart(waitCtx, managedobserve.DefaultDBPath(), managedobserve.DefaultSocketPath(), version)
+				if err != nil {
+					fmt.Fprintln(cmd.ErrOrStderr(), "daemon has not come back within 10s — it may still be restarting; re-run `kontext doctor` in a minute and check ~/Library/Logs/Kontext/managed-observe.log")
+					return err
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "restarted managed-observe daemon (v%s, pid %d)\n", status.Version, status.PID)
+			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&fix, "fix", false, "restart the managed-observe daemon when it is running a stale binary")
+	return cmd
 }
 
 func guardCmd() *cobra.Command {

--- a/cmd/kontext/main.go
+++ b/cmd/kontext/main.go
@@ -404,10 +404,11 @@ func managedObserveDaemonCmd() *cobra.Command {
 				timeout = parsed
 			}
 			return managedobserve.RunDaemon(context.Background(), managedobserve.DaemonOptions{
-				SocketPath:  socketPath,
-				DBPath:      dbPath,
-				IdleTimeout: timeout,
-				Diagnostic:  diagnostic.New(cmd.ErrOrStderr(), diagnostic.EnabledFromEnv()),
+				SocketPath:    socketPath,
+				DBPath:        dbPath,
+				IdleTimeout:   timeout,
+				Diagnostic:    diagnostic.New(cmd.ErrOrStderr(), diagnostic.EnabledFromEnv()),
+				BinaryVersion: version,
 				// "cli-" prefix lets the dashboard distinguish self-serve brew
 				// installs (no MDM deployment-version marker) from packages.
 				FallbackDeploymentVersion: "cli-" + version,

--- a/cmd/kontext/main.go
+++ b/cmd/kontext/main.go
@@ -88,7 +88,12 @@ func doctorCmd() *cobra.Command {
 				// serving on the installed version.
 				waitCtx, waitCancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer waitCancel()
-				status, err := managedobserve.WaitForDaemonRestart(waitCtx, managedobserve.DefaultDBPath(), managedobserve.DefaultSocketPath(), version)
+				status, err := managedobserve.WaitForDaemonRestart(
+					waitCtx,
+					managedobserve.DefaultDBPath(),
+					managedobserve.DefaultSocketPath(),
+					version,
+				)
 				if err != nil {
 					fmt.Fprintln(cmd.ErrOrStderr(), "daemon has not come back within 10s — it may still be restarting; re-run `kontext doctor` in a minute and check ~/Library/Logs/Kontext/managed-observe.log")
 					return err

--- a/internal/guard/store/sqlite/lag.go
+++ b/internal/guard/store/sqlite/lag.go
@@ -1,0 +1,61 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"time"
+)
+
+// LedgerLag reports export backlog without opening the store read-write:
+// newest is the max updated_at cursor timestamp in authorization_actions
+// (nil when the table is empty), pending counts rows past the given cursor.
+// Read-only on purpose — doctor must never migrate a database out from
+// under a running (possibly older) daemon.
+func LedgerLag(ctx context.Context, dbPath string, cursor *LedgerCursor) (newest *time.Time, pending int, err error) {
+	if _, err := os.Stat(dbPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, 0, nil
+		}
+		return nil, 0, err
+	}
+	db, err := sql.Open("sqlite", "file:"+dbPath+"?mode=ro")
+	if err != nil {
+		return nil, 0, err
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+	if _, err := db.ExecContext(ctx, "pragma busy_timeout = 5000"); err != nil {
+		return nil, 0, err
+	}
+
+	var rawNewest sql.NullString
+	if err := db.QueryRowContext(ctx, "select max(updated_at_cursor_key) from authorization_actions").Scan(&rawNewest); err != nil {
+		return nil, 0, err
+	}
+	if rawNewest.Valid && rawNewest.String != "" {
+		parsed, err := parseLedgerTimestamp(rawNewest.String)
+		if err != nil {
+			return nil, 0, err
+		}
+		newest = &parsed
+	}
+
+	query := "select count(*) from authorization_actions"
+	args := []any{}
+	if cursor != nil {
+		updatedAfter := ledgerTimestampCursorKeyFromTime(cursor.UpdatedAt)
+		if cursor.ActionID != "" {
+			query += " where updated_at_cursor_key > ? or (updated_at_cursor_key = ? and id > ?)"
+			args = append(args, updatedAfter, updatedAfter, cursor.ActionID)
+		} else {
+			query += " where updated_at_cursor_key > ?"
+			args = append(args, updatedAfter)
+		}
+	}
+	if err := db.QueryRowContext(ctx, query, args...).Scan(&pending); err != nil {
+		return nil, 0, err
+	}
+	return newest, pending, nil
+}

--- a/internal/guard/store/sqlite/lag_test.go
+++ b/internal/guard/store/sqlite/lag_test.go
@@ -1,0 +1,82 @@
+package sqlite
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/guard/risk"
+)
+
+func TestLedgerLag(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "guard.db")
+	store, err := OpenStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	first, err := store.SaveDecision(ctx, risk.HookEvent{SessionID: "s1", HookEventName: "SessionStart"}, risk.RiskDecision{Decision: risk.DecisionAllow, Reason: "ok", ReasonCode: "normal_tool_call", RiskEvent: risk.RiskEvent{Type: risk.EventNormalToolCall}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := store.SaveDecision(ctx, risk.HookEvent{SessionID: "s1", HookEventName: "PostToolUse", ToolName: "Read", ToolUseID: "tool-1"}, risk.RiskDecision{Decision: risk.DecisionAllow, Reason: "ok", ReasonCode: "normal_tool_call", RiskEvent: risk.RiskEvent{Type: risk.EventNormalToolCall}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	third, err := store.SaveDecision(ctx, risk.HookEvent{SessionID: "s1", HookEventName: "SessionEnd"}, risk.RiskDecision{Decision: risk.DecisionAllow, Reason: "ok", ReasonCode: "normal_tool_call", RiskEvent: risk.RiskEvent{Type: risk.EventNormalToolCall}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	times := []time.Time{
+		time.Date(2026, 7, 9, 10, 0, 0, 0, time.UTC),
+		time.Date(2026, 7, 9, 10, 5, 0, 0, time.UTC),
+		time.Date(2026, 7, 9, 10, 10, 0, 0, time.UTC),
+	}
+	ids := []string{first.ID, second.ID, third.ID}
+	for i, id := range ids {
+		if _, err := store.db.ExecContext(ctx, `
+update authorization_actions
+set updated_at = ?,
+    updated_at_cursor_key = ?
+where id = ?
+		`, times[i].Format(time.RFC3339Nano), ledgerTimestampCursorKeyFromTime(times[i]), id); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	newest, pending, err := LedgerLag(ctx, dbPath, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if newest == nil || !newest.Equal(times[2]) || pending != 3 {
+		t.Fatalf("LedgerLag nil cursor = newest %v pending %d, want %v and 3", newest, pending, times[2])
+	}
+
+	newest, pending, err = LedgerLag(ctx, dbPath, &LedgerCursor{UpdatedAt: times[1], ActionID: second.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if newest == nil || !newest.Equal(times[2]) || pending != 1 {
+		t.Fatalf("LedgerLag mid cursor = newest %v pending %d, want %v and 1", newest, pending, times[2])
+	}
+
+	newest, pending, err = LedgerLag(ctx, dbPath, &LedgerCursor{UpdatedAt: times[2], ActionID: third.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if newest == nil || !newest.Equal(times[2]) || pending != 0 {
+		t.Fatalf("LedgerLag past cursor = newest %v pending %d, want %v and 0", newest, pending, times[2])
+	}
+
+	newest, pending, err = LedgerLag(ctx, filepath.Join(t.TempDir(), "missing.db"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if newest != nil || pending != 0 {
+		t.Fatalf("LedgerLag missing DB = newest %v pending %d, want nil and 0", newest, pending)
+	}
+}

--- a/internal/managedobserve/autherr.go
+++ b/internal/managedobserve/autherr.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -43,16 +44,20 @@ func WriteStartupError(dbPath string, message string) error {
 
 func writeBreadcrumb(dbPath string, breadcrumb AuthError) error {
 	breadcrumb.At = time.Now().UTC().Format(time.RFC3339)
-	data, err := json.Marshal(breadcrumb)
+	return writeJSONBreadcrumb(AuthErrorPath(dbPath), breadcrumb)
+}
+
+func writeJSONBreadcrumb(path string, v any) error {
+	data, err := json.Marshal(v)
 	if err != nil {
 		return err
 	}
-	path := AuthErrorPath(dbPath)
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}
 	data = append(data, '\n')
-	temp, err := os.CreateTemp(filepath.Dir(path), ".last-auth-error-*.tmp")
+	stem := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	temp, err := os.CreateTemp(filepath.Dir(path), "."+stem+"-*.tmp")
 	if err != nil {
 		return err
 	}

--- a/internal/managedobserve/binarywatch.go
+++ b/internal/managedobserve/binarywatch.go
@@ -1,0 +1,114 @@
+package managedobserve
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/diagnostic"
+)
+
+const (
+	envBinaryWatchInterval     = "KONTEXT_BINARY_WATCH_INTERVAL"
+	defaultBinaryWatchInterval = 2 * time.Minute
+)
+
+// startBinaryWatchdog exits after launchd KeepAlive leaves an old deleted
+// binary running across brew upgrades; a clean exit lets launchd respawn the
+// new binary.
+func startBinaryWatchdog(ctx context.Context, log diagnostic.Logger) <-chan struct{} {
+	replaced := make(chan struct{}, 1)
+	resolved, initialInfo, ok := binaryWatchdogConfig(log)
+	if !ok {
+		close(replaced)
+		return replaced
+	}
+	// Capture the stat seam once so the goroutine never reads package state
+	// concurrently with tests swapping the seams.
+	stat := statPath
+	go runBinaryWatchdog(ctx, resolved, initialInfo, binaryWatchInterval(), stat, log, replaced)
+	return replaced
+}
+
+func binaryWatchdogConfig(log diagnostic.Logger) (string, os.FileInfo, bool) {
+	if runtimeGOOS != "darwin" {
+		return "", nil, false
+	}
+	exe, err := executablePath()
+	if err != nil {
+		logAlways(log, "binary watchdog eligibility: executable path: %v\n", err)
+		return "", nil, false
+	}
+	resolved, err := evalSymlinksPath(exe)
+	if err != nil {
+		logAlways(log, "binary watchdog eligibility: resolve executable: %v\n", err)
+		return "", nil, false
+	}
+	info, err := statPath(resolved)
+	if err != nil {
+		logAlways(log, "binary watchdog eligibility: stat %s: %v\n", resolved, err)
+		return "", nil, false
+	}
+	return resolved, info, true
+}
+
+func runBinaryWatchdog(ctx context.Context, resolved string, initialInfo os.FileInfo, interval time.Duration, stat func(string) (os.FileInfo, error), log diagnostic.Logger, replaced chan<- struct{}) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	loggedStatErr := false
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			currentInfo, err := stat(resolved)
+			if errors.Is(err, fs.ErrNotExist) {
+				signalBinaryReplaced(resolved, log, replaced)
+				return
+			}
+			if err != nil {
+				if !loggedStatErr {
+					logAlways(log, "binary watchdog: stat %s: %v\n", resolved, err)
+					loggedStatErr = true
+				}
+				continue
+			}
+			if !os.SameFile(initialInfo, currentInfo) {
+				signalBinaryReplaced(resolved, log, replaced)
+				return
+			}
+		}
+	}
+}
+
+func signalBinaryReplaced(resolved string, log diagnostic.Logger, replaced chan<- struct{}) {
+	logAlways(log, "binary watchdog: %s was replaced on disk; exiting for launchd restart\n", resolved)
+	select {
+	case replaced <- struct{}{}:
+	default:
+	}
+}
+
+func binaryWatchInterval() time.Duration {
+	raw := strings.TrimSpace(os.Getenv(envBinaryWatchInterval))
+	if raw == "" {
+		return defaultBinaryWatchInterval
+	}
+	interval, err := time.ParseDuration(raw)
+	if err != nil || interval <= 0 {
+		return defaultBinaryWatchInterval
+	}
+	return interval
+}
+
+func logAlways(log diagnostic.Logger, format string, args ...any) {
+	if log.Enabled() {
+		log.Printf(format, args...)
+		return
+	}
+	fmt.Fprint(os.Stderr, diagnostic.Redact(fmt.Sprintf(format, args...)))
+}

--- a/internal/managedobserve/binarywatch.go
+++ b/internal/managedobserve/binarywatch.go
@@ -19,44 +19,49 @@ const (
 
 // startBinaryWatchdog exits after launchd KeepAlive leaves an old deleted
 // binary running across brew upgrades; a clean exit lets launchd respawn the
-// new binary.
+// new binary. Replacement is detected three ways: the resolved binary file
+// disappears (brew removes the old Cellar version dir), its inode changes
+// (in-place overwrite), or the launch path resolves to a different target
+// (brew retargets the bin symlink but keeps the old keg, e.g. under
+// HOMEBREW_NO_INSTALL_CLEANUP).
 func startBinaryWatchdog(ctx context.Context, log diagnostic.Logger) <-chan struct{} {
 	replaced := make(chan struct{}, 1)
-	resolved, initialInfo, ok := binaryWatchdogConfig(log)
+	exe, resolved, initialInfo, ok := binaryWatchdogConfig(log)
 	if !ok {
 		close(replaced)
 		return replaced
 	}
-	// Capture the stat seam once so the goroutine never reads package state
+	// Capture the seams once so the goroutine never reads package state
 	// concurrently with tests swapping the seams.
 	stat := statPath
-	go runBinaryWatchdog(ctx, resolved, initialInfo, binaryWatchInterval(), stat, log, replaced)
+	resolve := evalSymlinksPath
+	go runBinaryWatchdog(ctx, exe, resolved, initialInfo, binaryWatchInterval(), stat, resolve, log, replaced)
 	return replaced
 }
 
-func binaryWatchdogConfig(log diagnostic.Logger) (string, os.FileInfo, bool) {
+func binaryWatchdogConfig(log diagnostic.Logger) (string, string, os.FileInfo, bool) {
 	if runtimeGOOS != "darwin" {
-		return "", nil, false
+		return "", "", nil, false
 	}
 	exe, err := executablePath()
 	if err != nil {
 		logAlways(log, "binary watchdog eligibility: executable path: %v\n", err)
-		return "", nil, false
+		return "", "", nil, false
 	}
 	resolved, err := evalSymlinksPath(exe)
 	if err != nil {
 		logAlways(log, "binary watchdog eligibility: resolve executable: %v\n", err)
-		return "", nil, false
+		return "", "", nil, false
 	}
 	info, err := statPath(resolved)
 	if err != nil {
 		logAlways(log, "binary watchdog eligibility: stat %s: %v\n", resolved, err)
-		return "", nil, false
+		return "", "", nil, false
 	}
-	return resolved, info, true
+	return exe, resolved, info, true
 }
 
-func runBinaryWatchdog(ctx context.Context, resolved string, initialInfo os.FileInfo, interval time.Duration, stat func(string) (os.FileInfo, error), log diagnostic.Logger, replaced chan<- struct{}) {
+func runBinaryWatchdog(ctx context.Context, exe, resolved string, initialInfo os.FileInfo, interval time.Duration, stat func(string) (os.FileInfo, error), resolve func(string) (string, error), log diagnostic.Logger, replaced chan<- struct{}) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	loggedStatErr := false
@@ -78,6 +83,13 @@ func runBinaryWatchdog(ctx context.Context, resolved string, initialInfo os.File
 				continue
 			}
 			if !os.SameFile(initialInfo, currentInfo) {
+				signalBinaryReplaced(resolved, log, replaced)
+				return
+			}
+			// Resolve errors are transient (brew swaps the symlink
+			// non-atomically); only a successful resolve to a new target
+			// counts as replacement.
+			if current, err := resolve(exe); err == nil && current != resolved {
 				signalBinaryReplaced(resolved, log, replaced)
 				return
 			}

--- a/internal/managedobserve/binarywatch.go
+++ b/internal/managedobserve/binarywatch.go
@@ -17,52 +17,74 @@ const (
 	defaultBinaryWatchInterval = 2 * time.Minute
 )
 
+var errBinaryWatchdogUnsupported = errors.New("binary watchdog is only supported on macOS")
+
+type binaryWatchdogConfigValue struct {
+	exe         string
+	resolved    string
+	initialInfo os.FileInfo
+	interval    time.Duration
+	stat        func(string) (os.FileInfo, error)
+	resolve     func(string) (string, error)
+}
+
 // startBinaryWatchdog exits after launchd KeepAlive leaves an old deleted
 // binary running across brew upgrades; a clean exit lets launchd respawn the
 // new binary. Replacement is detected three ways: the resolved binary file
 // disappears (brew removes the old Cellar version dir), its inode changes
-// (in-place overwrite), or the launch path resolves to a different target
+// (inode replacement), or the launch path resolves to a different target
 // (brew retargets the bin symlink but keeps the old keg, e.g. under
 // HOMEBREW_NO_INSTALL_CLEANUP).
 func startBinaryWatchdog(ctx context.Context, log diagnostic.Logger) <-chan struct{} {
 	replaced := make(chan struct{}, 1)
-	exe, resolved, initialInfo, ok := binaryWatchdogConfig(log)
-	if !ok {
+	cfg, err := binaryWatchdogConfig()
+	if errors.Is(err, fs.ErrNotExist) {
+		// The old binary can disappear after launchd starts this process but
+		// before the watchdog captures its baseline. That is already proof of an
+		// upgrade, so exit instead of disabling the watchdog for this run.
+		signalBinaryReplaced(cfg.exe, log, replaced)
+		return replaced
+	}
+	if err != nil {
+		if !errors.Is(err, errBinaryWatchdogUnsupported) {
+			logAlways(log, "binary watchdog eligibility: %v\n", err)
+		}
 		close(replaced)
 		return replaced
 	}
-	// Capture the seams once so the goroutine never reads package state
-	// concurrently with tests swapping the seams.
-	stat := statPath
-	resolve := evalSymlinksPath
-	go runBinaryWatchdog(ctx, exe, resolved, initialInfo, binaryWatchInterval(), stat, resolve, log, replaced)
+	go runBinaryWatchdog(ctx, cfg, log, replaced)
 	return replaced
 }
 
-func binaryWatchdogConfig(log diagnostic.Logger) (string, string, os.FileInfo, bool) {
+func binaryWatchdogConfig() (binaryWatchdogConfigValue, error) {
+	cfg := binaryWatchdogConfigValue{
+		interval: binaryWatchInterval(),
+		stat:     statPath,
+		resolve:  evalSymlinksPath,
+	}
 	if runtimeGOOS != "darwin" {
-		return "", "", nil, false
+		return cfg, errBinaryWatchdogUnsupported
 	}
 	exe, err := executablePath()
+	cfg.exe = exe
 	if err != nil {
-		logAlways(log, "binary watchdog eligibility: executable path: %v\n", err)
-		return "", "", nil, false
+		return cfg, fmt.Errorf("executable path: %w", err)
 	}
-	resolved, err := evalSymlinksPath(exe)
+	resolved, err := cfg.resolve(exe)
+	cfg.resolved = resolved
 	if err != nil {
-		logAlways(log, "binary watchdog eligibility: resolve executable: %v\n", err)
-		return "", "", nil, false
+		return cfg, fmt.Errorf("resolve executable %s: %w", exe, err)
 	}
-	info, err := statPath(resolved)
+	info, err := cfg.stat(resolved)
+	cfg.initialInfo = info
 	if err != nil {
-		logAlways(log, "binary watchdog eligibility: stat %s: %v\n", resolved, err)
-		return "", "", nil, false
+		return cfg, fmt.Errorf("stat executable %s: %w", resolved, err)
 	}
-	return exe, resolved, info, true
+	return cfg, nil
 }
 
-func runBinaryWatchdog(ctx context.Context, exe, resolved string, initialInfo os.FileInfo, interval time.Duration, stat func(string) (os.FileInfo, error), resolve func(string) (string, error), log diagnostic.Logger, replaced chan<- struct{}) {
-	ticker := time.NewTicker(interval)
+func runBinaryWatchdog(ctx context.Context, cfg binaryWatchdogConfigValue, log diagnostic.Logger, replaced chan<- struct{}) {
+	ticker := time.NewTicker(cfg.interval)
 	defer ticker.Stop()
 	loggedStatErr := false
 	for {
@@ -70,27 +92,30 @@ func runBinaryWatchdog(ctx context.Context, exe, resolved string, initialInfo os
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			currentInfo, err := stat(resolved)
+			currentInfo, err := cfg.stat(cfg.resolved)
 			if errors.Is(err, fs.ErrNotExist) {
-				signalBinaryReplaced(resolved, log, replaced)
+				signalBinaryReplaced(cfg.resolved, log, replaced)
 				return
 			}
 			if err != nil {
+				// Log once per error burst; reset below so a recurrence
+				// after recovery is surfaced again.
 				if !loggedStatErr {
-					logAlways(log, "binary watchdog: stat %s: %v\n", resolved, err)
+					logAlways(log, "binary watchdog: stat %s: %v\n", cfg.resolved, err)
 					loggedStatErr = true
 				}
 				continue
 			}
-			if !os.SameFile(initialInfo, currentInfo) {
-				signalBinaryReplaced(resolved, log, replaced)
+			loggedStatErr = false
+			if !os.SameFile(cfg.initialInfo, currentInfo) {
+				signalBinaryReplaced(cfg.resolved, log, replaced)
 				return
 			}
 			// Resolve errors are transient (brew swaps the symlink
 			// non-atomically); only a successful resolve to a new target
 			// counts as replacement.
-			if current, err := resolve(exe); err == nil && current != resolved {
-				signalBinaryReplaced(resolved, log, replaced)
+			if current, err := cfg.resolve(cfg.exe); err == nil && current != cfg.resolved {
+				signalBinaryReplaced(cfg.resolved, log, replaced)
 				return
 			}
 		}

--- a/internal/managedobserve/binarywatch_test.go
+++ b/internal/managedobserve/binarywatch_test.go
@@ -1,0 +1,137 @@
+package managedobserve
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/diagnostic"
+)
+
+func TestBinaryWatchdogFiresWhenFileDeleted(t *testing.T) {
+	resetUpdaterSeams(t)
+	t.Setenv(envBinaryWatchInterval, "10ms")
+	runtimeGOOS = "darwin"
+	path := writeWatchdogBinary(t)
+	executablePath = func() (string, error) { return path, nil }
+	evalSymlinksPath = filepath.EvalSymlinks
+
+	replaced := startBinaryWatchdog(context.Background(), diagnostic.Logger{})
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+	assertWatchdogFires(t, replaced)
+}
+
+func TestBinaryWatchdogFiresWhenFileReplaced(t *testing.T) {
+	resetUpdaterSeams(t)
+	t.Setenv(envBinaryWatchInterval, "10ms")
+	runtimeGOOS = "darwin"
+	path := writeWatchdogBinary(t)
+	executablePath = func() (string, error) { return path, nil }
+	evalSymlinksPath = filepath.EvalSymlinks
+
+	replaced := startBinaryWatchdog(context.Background(), diagnostic.Logger{})
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+	if err := os.WriteFile(path, []byte("new"), 0o755); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	assertWatchdogFires(t, replaced)
+}
+
+func TestBinaryWatchdogDoesNotFireWhenFileUnchanged(t *testing.T) {
+	resetUpdaterSeams(t)
+	t.Setenv(envBinaryWatchInterval, "10ms")
+	runtimeGOOS = "darwin"
+	path := writeWatchdogBinary(t)
+	executablePath = func() (string, error) { return path, nil }
+	evalSymlinksPath = filepath.EvalSymlinks
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	replaced := startBinaryWatchdog(ctx, diagnostic.Logger{})
+	assertWatchdogDoesNotFire(t, replaced)
+}
+
+func TestBinaryWatchdogSkipsNonDarwin(t *testing.T) {
+	resetUpdaterSeams(t)
+	runtimeGOOS = "linux"
+
+	replaced := startBinaryWatchdog(context.Background(), diagnostic.Logger{})
+	assertWatchdogClosed(t, replaced)
+}
+
+func TestBinaryWatchdogSkipsExecutablePathError(t *testing.T) {
+	resetUpdaterSeams(t)
+	runtimeGOOS = "darwin"
+	executablePath = func() (string, error) { return "", errors.New("missing executable") }
+
+	replaced := startBinaryWatchdog(context.Background(), diagnostic.Logger{})
+	assertWatchdogClosed(t, replaced)
+}
+
+func TestBinaryWatchdogStopsWhenContextCancelled(t *testing.T) {
+	resetUpdaterSeams(t)
+	t.Setenv(envBinaryWatchInterval, "10ms")
+	runtimeGOOS = "darwin"
+	path := writeWatchdogBinary(t)
+	executablePath = func() (string, error) { return path, nil }
+	evalSymlinksPath = filepath.EvalSymlinks
+	ctx, cancel := context.WithCancel(context.Background())
+
+	replaced := startBinaryWatchdog(ctx, diagnostic.Logger{})
+	cancel()
+	time.Sleep(30 * time.Millisecond)
+	select {
+	case <-replaced:
+		t.Fatal("watchdog fired after context cancellation")
+	default:
+	}
+}
+
+func writeWatchdogBinary(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "kontext")
+	if err := os.WriteFile(path, []byte("old"), 0o755); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	return path
+}
+
+func assertWatchdogFires(t *testing.T, replaced <-chan struct{}) {
+	t.Helper()
+	select {
+	case _, ok := <-replaced:
+		if !ok {
+			t.Fatal("watchdog channel closed without firing")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("watchdog did not fire")
+	}
+}
+
+func assertWatchdogDoesNotFire(t *testing.T, replaced <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-replaced:
+		t.Fatal("watchdog fired")
+	case <-time.After(30 * time.Millisecond):
+	}
+}
+
+func assertWatchdogClosed(t *testing.T, replaced <-chan struct{}) {
+	t.Helper()
+	select {
+	case _, ok := <-replaced:
+		if ok {
+			t.Fatal("watchdog fired")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("watchdog channel did not close")
+	}
+}

--- a/internal/managedobserve/binarywatch_test.go
+++ b/internal/managedobserve/binarywatch_test.go
@@ -3,6 +3,7 @@ package managedobserve
 import (
 	"context"
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -35,11 +36,14 @@ func TestBinaryWatchdogFiresWhenFileReplaced(t *testing.T) {
 	evalSymlinksPath = filepath.EvalSymlinks
 
 	replaced := startBinaryWatchdog(context.Background(), diagnostic.Logger{})
-	if err := os.Remove(path); err != nil {
-		t.Fatalf("Remove() error = %v", err)
-	}
-	if err := os.WriteFile(path, []byte("new"), 0o755); err != nil {
+	// Rename over the original (like a real installer) — remove+rewrite can
+	// reuse the inode on some filesystems and defeat os.SameFile.
+	tmp := path + ".new"
+	if err := os.WriteFile(tmp, []byte("new"), 0o755); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		t.Fatalf("Rename() error = %v", err)
 	}
 	assertWatchdogFires(t, replaced)
 }
@@ -106,6 +110,38 @@ func TestBinaryWatchdogSkipsExecutablePathError(t *testing.T) {
 	assertWatchdogClosed(t, replaced)
 }
 
+func TestBinaryWatchdogFiresWhenBinaryDisappearsDuringInitialization(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		setup func(string)
+	}{
+		{
+			name: "resolve",
+			setup: func(string) {
+				evalSymlinksPath = func(string) (string, error) { return "", fs.ErrNotExist }
+			},
+		},
+		{
+			name: "stat",
+			setup: func(path string) {
+				evalSymlinksPath = func(string) (string, error) { return path, nil }
+				statPath = func(string) (os.FileInfo, error) { return nil, fs.ErrNotExist }
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resetUpdaterSeams(t)
+			runtimeGOOS = "darwin"
+			path := writeWatchdogBinary(t)
+			executablePath = func() (string, error) { return path, nil }
+			tc.setup(path)
+
+			replaced := startBinaryWatchdog(context.Background(), diagnostic.Logger{})
+			assertWatchdogFires(t, replaced)
+		})
+	}
+}
+
 func TestBinaryWatchdogStopsWhenContextCancelled(t *testing.T) {
 	resetUpdaterSeams(t)
 	t.Setenv(envBinaryWatchInterval, "10ms")
@@ -115,12 +151,25 @@ func TestBinaryWatchdogStopsWhenContextCancelled(t *testing.T) {
 	evalSymlinksPath = filepath.EvalSymlinks
 	ctx, cancel := context.WithCancel(context.Background())
 
-	replaced := startBinaryWatchdog(ctx, diagnostic.Logger{})
+	cfg, err := binaryWatchdogConfig()
+	if err != nil {
+		t.Fatalf("binaryWatchdogConfig() error = %v", err)
+	}
+	replaced := make(chan struct{}, 1)
+	done := make(chan struct{})
+	go func() {
+		runBinaryWatchdog(ctx, cfg, diagnostic.Logger{}, replaced)
+		close(done)
+	}()
 	cancel()
-	time.Sleep(30 * time.Millisecond)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("watchdog did not stop after context cancellation")
+	}
 	select {
 	case <-replaced:
-		t.Fatal("watchdog fired after context cancellation")
+		t.Fatal("watchdog fired while stopping")
 	default:
 	}
 }

--- a/internal/managedobserve/binarywatch_test.go
+++ b/internal/managedobserve/binarywatch_test.go
@@ -44,6 +44,37 @@ func TestBinaryWatchdogFiresWhenFileReplaced(t *testing.T) {
 	assertWatchdogFires(t, replaced)
 }
 
+func TestBinaryWatchdogFiresWhenSymlinkRetargeted(t *testing.T) {
+	resetUpdaterSeams(t)
+	t.Setenv(envBinaryWatchInterval, "10ms")
+	runtimeGOOS = "darwin"
+	dir := t.TempDir()
+	oldKeg := filepath.Join(dir, "Cellar-old-kontext")
+	newKeg := filepath.Join(dir, "Cellar-new-kontext")
+	link := filepath.Join(dir, "kontext")
+	for _, path := range []string{oldKeg, newKeg} {
+		if err := os.WriteFile(path, []byte(path), 0o755); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+	}
+	if err := os.Symlink(oldKeg, link); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+	executablePath = func() (string, error) { return link, nil }
+	evalSymlinksPath = filepath.EvalSymlinks
+
+	replaced := startBinaryWatchdog(context.Background(), diagnostic.Logger{})
+	// brew retargets the bin symlink but keeps the old keg (e.g. under
+	// HOMEBREW_NO_INSTALL_CLEANUP) — the watched file itself never changes.
+	if err := os.Remove(link); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+	if err := os.Symlink(newKeg, link); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+	assertWatchdogFires(t, replaced)
+}
+
 func TestBinaryWatchdogDoesNotFireWhenFileUnchanged(t *testing.T) {
 	resetUpdaterSeams(t)
 	t.Setenv(envBinaryWatchInterval, "10ms")

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -38,10 +38,14 @@ type DaemonOptions struct {
 	PolicyRefreshInterval time.Duration
 	PolicyHTTPClient      *http.Client
 	Diagnostic            diagnostic.Logger
+	// BinaryVersion is the CLI binary version, for startup logging and future
+	// status reporting.
+	BinaryVersion string
 	// FallbackDeploymentVersion is reported to the ledger when no MDM
 	// deployment-version marker exists (self-serve brew installs).
 	FallbackDeploymentVersion string
 	HomebrewUpdater           func(context.Context, managedconfig.LoadedConfig, diagnostic.Logger) <-chan struct{}
+	BinaryWatchdog            func(context.Context, diagnostic.Logger) <-chan struct{}
 }
 
 var (
@@ -50,6 +54,12 @@ var (
 )
 
 func RunDaemon(ctx context.Context, opts DaemonOptions) error {
+	binaryVersion := opts.BinaryVersion
+	if binaryVersion == "" {
+		binaryVersion = "dev"
+	}
+	logAlways(opts.Diagnostic, "managed-observe daemon %s (pid %d) started\n", binaryVersion, os.Getpid())
+
 	loadedConfig, err := managedconfig.Load()
 	if err != nil {
 		if errors.Is(err, managedconfig.ErrNotManaged) {
@@ -171,6 +181,12 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 	}
 	upgraded := startUpdater(ctx, loadedConfig, opts.Diagnostic)
 
+	startWatchdog := opts.BinaryWatchdog
+	if startWatchdog == nil {
+		startWatchdog = startBinaryWatchdog
+	}
+	binaryReplaced := startWatchdog(ctx, opts.Diagnostic)
+
 	idleTimeout := opts.IdleTimeout
 	if idleTimeout == 0 {
 		idleTimeout = DefaultIdleTimeout()
@@ -187,9 +203,14 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 				return nil
 			}
 			upgraded = nil
+		case _, ok := <-binaryReplaced:
+			if ok {
+				return nil
+			}
+			binaryReplaced = nil
 		case err := <-streamErr:
 			if err != nil {
-				opts.Diagnostic.Printf("managed stream exited: %v\n", err)
+				logAlways(opts.Diagnostic, "managed stream exited: %v\n", err)
 				return fmt.Errorf("managed stream failed: %w", err)
 			}
 			return nil

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -153,6 +153,9 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 		return err
 	}
 	defer host.Close(context.Background())
+	if err := WriteDaemonStatus(dbPath, binaryVersion); err != nil {
+		opts.Diagnostic.Printf("write daemon-status breadcrumb: %v\n", err)
+	}
 
 	// Restore the capture mode from the persisted snapshot before the first
 	// fetch completes, so an offline restart keeps the org's last-known

--- a/internal/managedobserve/daemon_test.go
+++ b/internal/managedobserve/daemon_test.go
@@ -23,6 +23,9 @@ import (
 
 func TestDaemonPreservesHookSessionIDs(t *testing.T) {
 	socketPath, dbPath, stop := startTestDaemon(t)
+	if status := LoadDaemonStatus(dbPath); status == nil || status.PID == 0 {
+		t.Fatalf("LoadDaemonStatus = %+v, want non-zero PID", status)
+	}
 
 	client := localruntime.NewClient(socketPath)
 	client.Timeout = time.Second

--- a/internal/managedobserve/doctor.go
+++ b/internal/managedobserve/doctor.go
@@ -194,7 +194,10 @@ func WaitForDaemonRestart(ctx context.Context, dbPath, socketPath, wantVersion s
 }
 
 func pidAlive(pid int) bool {
-	if pid <= 0 || runtime.GOOS == "windows" {
+	if pid <= 0 {
+		return false
+	}
+	if runtime.GOOS == "windows" {
 		return true
 	}
 	proc, err := os.FindProcess(pid)

--- a/internal/managedobserve/doctor.go
+++ b/internal/managedobserve/doctor.go
@@ -8,27 +8,60 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
 	"time"
 
+	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
 	"github.com/kontext-security/kontext-cli/internal/installation"
 	"github.com/kontext-security/kontext-cli/internal/managedconfig"
+	"github.com/kontext-security/kontext-cli/internal/managedstream"
 )
 
 // PrintStatus reports the managed-observe state for `kontext doctor`:
 // which managed config (if any) this machine resolves, the installation
 // identity, whether the daemon is reachable, the self-serve LaunchAgent, and
 // any token-rejection breadcrumb the daemon left behind.
-func PrintStatus(out io.Writer) {
+func PrintStatus(out io.Writer, installedVersion string) (staleDaemon bool) {
+	return printStatus(out, installedVersion, doctorOptions{
+		DBPath:     DefaultDBPath(),
+		SocketPath: DefaultSocketPath(),
+		Now:        time.Now,
+	})
+}
+
+type doctorOptions struct {
+	DBPath     string
+	SocketPath string
+	Dial       func(network, address string, timeout time.Duration) (net.Conn, error)
+	Now        func() time.Time
+}
+
+func printStatus(out io.Writer, installedVersion string, opts doctorOptions) (staleDaemon bool) {
+	if opts.DBPath == "" {
+		opts.DBPath = DefaultDBPath()
+	}
+	if opts.SocketPath == "" {
+		opts.SocketPath = DefaultSocketPath()
+	}
+	if opts.Dial == nil {
+		opts.Dial = net.DialTimeout
+	}
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+
 	fmt.Fprintln(out, "Managed observe:")
 
 	loaded, err := managedconfig.Load()
 	if errors.Is(err, managedconfig.ErrNotManaged) {
 		fmt.Fprintln(out, "  config: not configured (run `kontext setup` to connect this Mac to a workspace)")
-		return
+		return false
 	}
 	if err != nil {
 		fmt.Fprintf(out, "  config: ERROR %v\n", err)
-		return
+		return false
 	}
 
 	fmt.Fprintf(out, "  config: %s (%s)\n", loaded.Path, describeScope(loaded.Scope))
@@ -53,11 +86,39 @@ func PrintStatus(out io.Writer) {
 		fmt.Fprintf(out, "  WARNING: install token is not readable (%v) — the agent cannot stream; re-run `kontext setup` or unlock your login keychain\n", err)
 	}
 
-	if conn, err := net.DialTimeout("unix", DefaultSocketPath(), 500*time.Millisecond); err == nil {
+	if conn, err := opts.Dial("unix", opts.SocketPath, 500*time.Millisecond); err == nil {
 		conn.Close()
-		fmt.Fprintln(out, "  daemon: running")
+		if status := LoadDaemonStatus(opts.DBPath); status != nil && pidAlive(status.PID) {
+			fmt.Fprintf(out, "  daemon: running (v%s, pid %d)\n", status.Version, status.PID)
+			if comparableVersion(status.Version) && comparableVersion(installedVersion) && status.Version != installedVersion {
+				fmt.Fprintf(out, "  WARNING: daemon is running v%s but v%s is installed — run 'kontext doctor --fix' to restart it\n", status.Version, installedVersion)
+				staleDaemon = true
+			}
+		} else {
+			fmt.Fprintln(out, "  daemon: running")
+			// A serving daemon with no live status breadcrumb predates the
+			// breadcrumb feature — which makes it older than the installed
+			// binary by definition. This is exactly the first upgrade into
+			// this feature, so it must be fixable; a verified restart of an
+			// already-current daemon is the harmless worst case.
+			if comparableVersion(installedVersion) {
+				fmt.Fprintf(out, "  WARNING: daemon version is unknown — it likely predates v%s; run 'kontext doctor --fix' to restart it\n", installedVersion)
+				staleDaemon = true
+			}
+		}
 	} else {
 		fmt.Fprintln(out, "  daemon: not running (it starts with your next Claude Code session)")
+	}
+
+	exportCtx, exportCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer exportCancel()
+	state, err := managedstream.LoadState(managedstream.DefaultStatePathForDB(opts.DBPath))
+	if err != nil {
+		fmt.Fprintf(out, "  heartbeat: ERROR %v\n", err)
+		fmt.Fprintf(out, "  export: ERROR %v\n", err)
+	} else {
+		printHeartbeat(out, state, opts.Now())
+		printExportLag(exportCtx, out, opts.DBPath, state)
 	}
 
 	// Self-serve installs have a user LaunchAgent; MDM installs manage theirs
@@ -76,7 +137,7 @@ func PrintStatus(out io.Writer) {
 	// The LaunchAgent runs the daemon without --db, so the breadcrumb always
 	// sits next to the default database. A custom --db (dev-only hidden flag)
 	// is invisible here — acceptable for a diagnostics readout.
-	if authErr := LoadAuthError(DefaultDBPath()); authErr != nil {
+	if authErr := LoadAuthError(opts.DBPath); authErr != nil {
 		switch authErr.Kind {
 		case "startup":
 			fmt.Fprintf(out, "  WARNING: the agent failed to start — %s (%s)\n", authErr.Message, authErr.At)
@@ -90,6 +151,7 @@ func PrintStatus(out io.Writer) {
 			fmt.Fprintf(out, "  WARNING: hosted ingest is failing — install token rejected%s; run `kontext setup` with a new token from the dashboard\n", detail)
 		}
 	}
+	return staleDaemon
 }
 
 func describeScope(scope managedconfig.Scope) string {
@@ -103,4 +165,112 @@ func describeScope(scope managedconfig.Scope) string {
 	default:
 		return string(scope)
 	}
+}
+
+// WaitForDaemonRestart polls until the socket is serving AND the status
+// breadcrumb reports a live daemon on wantVersion (any live daemon when the
+// version is not comparable, e.g. dev builds). `doctor --fix` uses it so
+// "restarted" is only printed for a verified comeback — launchd can accept a
+// kickstart and still have the new daemon exit immediately (unreadable token,
+// missing Cellar path).
+func WaitForDaemonRestart(ctx context.Context, dbPath, socketPath, wantVersion string) (*DaemonStatus, error) {
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if conn, err := net.DialTimeout("unix", socketPath, 500*time.Millisecond); err == nil {
+			conn.Close()
+			if status := LoadDaemonStatus(dbPath); status != nil && pidAlive(status.PID) {
+				if !comparableVersion(wantVersion) || status.Version == wantVersion {
+					return status, nil
+				}
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func pidAlive(pid int) bool {
+	if pid <= 0 || runtime.GOOS == "windows" {
+		return true
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}
+
+func comparableVersion(version string) bool {
+	version = strings.TrimSpace(version)
+	return version != "" && version != "dev"
+}
+
+func printHeartbeat(out io.Writer, state managedstream.State, now time.Time) {
+	if strings.TrimSpace(state.LastHeartbeatAt) == "" {
+		fmt.Fprintln(out, "  heartbeat: none recorded yet")
+		return
+	}
+	last, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(state.LastHeartbeatAt))
+	if err != nil {
+		fmt.Fprintln(out, "  heartbeat: none recorded yet")
+		return
+	}
+	age := now.Sub(last)
+	if age < 0 {
+		age = 0
+	}
+	fmt.Fprintf(out, "  heartbeat: %s ago\n", doctorDuration(age))
+	if age > 5*time.Minute {
+		fmt.Fprintf(out, "  WARNING: last heartbeat was %s ago — the daemon may be stalled\n", doctorDuration(age))
+	}
+}
+
+func printExportLag(ctx context.Context, out io.Writer, dbPath string, state managedstream.State) {
+	var cursor *sqlite.LedgerCursor
+	if state.UpdatedAfter != nil {
+		cursor = &sqlite.LedgerCursor{UpdatedAt: *state.UpdatedAfter, ActionID: state.ActionID}
+	}
+	newest, pending, err := sqlite.LedgerLag(ctx, dbPath, cursor)
+	if err != nil {
+		fmt.Fprintf(out, "  export: ERROR %v\n", err)
+		return
+	}
+	if newest == nil {
+		fmt.Fprintln(out, "  export: no ledger events yet")
+		return
+	}
+	if cursor == nil {
+		// Events exist but no export cursor yet — normal in the first seconds
+		// after setup, so report without warning.
+		fmt.Fprintf(out, "  export: not started yet (%d pending)\n", pending)
+		return
+	}
+	lag := newest.Sub(cursor.UpdatedAt)
+	if lag < 0 {
+		lag = 0
+	}
+	// The export cursor rides 30s behind newest by design (cursorSafetyLag),
+	// hence the 10m warning threshold.
+	if lag > 10*time.Minute && pending > 0 {
+		fmt.Fprintf(out, "  WARNING: export lagging %s (%d events pending) — the daemon may be stalled\n", doctorDuration(lag), pending)
+		return
+	}
+	if pending == 0 {
+		fmt.Fprintln(out, "  export: up to date (0 pending)")
+		return
+	}
+	// Never claim "up to date" while rows are waiting — report the facts and
+	// let the operator judge.
+	fmt.Fprintf(out, "  export: %d pending (cursor %s behind newest)\n", pending, doctorDuration(lag))
+}
+
+func doctorDuration(d time.Duration) string {
+	if d < time.Minute {
+		return d.Round(time.Second).String()
+	}
+	return d.Round(time.Minute).String()
 }

--- a/internal/managedobserve/doctor_test.go
+++ b/internal/managedobserve/doctor_test.go
@@ -2,13 +2,19 @@ package managedobserve
 
 import (
 	"bytes"
+	"context"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/kontext-security/kontext-cli/internal/guard/risk"
+	sqlitestore "github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
 	"github.com/kontext-security/kontext-cli/internal/installation"
 	"github.com/kontext-security/kontext-cli/internal/managedconfig"
+	"github.com/kontext-security/kontext-cli/internal/managedstream"
 )
 
 func TestPrintStatusReportsInstallationLoadError(t *testing.T) {
@@ -25,7 +31,7 @@ func TestPrintStatusReportsInstallationLoadError(t *testing.T) {
 	t.Setenv("KONTEXT_INSTALL_TOKEN", "test-install-token")
 
 	var out bytes.Buffer
-	PrintStatus(&out)
+	PrintStatus(&out, "1.2.3")
 	output := out.String()
 	if !strings.Contains(output, "installation: ERROR") {
 		t.Fatalf("PrintStatus() output = %q, want installation error", output)
@@ -36,4 +42,317 @@ func TestPrintStatusReportsInstallationLoadError(t *testing.T) {
 	if strings.Contains(output, "\n  organization:") {
 		t.Fatalf("PrintStatus() output = %q, must not print local organization", output)
 	}
+}
+
+func TestPrintStatusDaemonVersionMatch(t *testing.T) {
+	env := newDoctorTestEnv(t)
+	env.writeDaemonStatus(t, os.Getpid(), "1.2.3")
+
+	var out bytes.Buffer
+	stale := printStatus(&out, "1.2.3", env.options())
+
+	output := out.String()
+	if stale {
+		t.Fatal("staleDaemon = true, want false")
+	}
+	if !strings.Contains(output, "  daemon: running (v1.2.3, pid ") {
+		t.Fatalf("output = %q, want daemon version and pid", output)
+	}
+	if strings.Contains(output, "WARNING: daemon is running") {
+		t.Fatalf("output = %q, want no version warning", output)
+	}
+}
+
+func TestPrintStatusDaemonVersionMismatch(t *testing.T) {
+	env := newDoctorTestEnv(t)
+	env.writeDaemonStatus(t, os.Getpid(), "1.2.2")
+
+	var out bytes.Buffer
+	stale := printStatus(&out, "1.2.3", env.options())
+
+	output := out.String()
+	if !stale {
+		t.Fatal("staleDaemon = false, want true")
+	}
+	if !strings.Contains(output, "WARNING: daemon is running v1.2.2 but v1.2.3 is installed") {
+		t.Fatalf("output = %q, want mismatch warning", output)
+	}
+}
+
+func TestPrintStatusDaemonDevVersionDoesNotWarn(t *testing.T) {
+	env := newDoctorTestEnv(t)
+	env.writeDaemonStatus(t, os.Getpid(), "dev")
+
+	var out bytes.Buffer
+	stale := printStatus(&out, "1.2.3", env.options())
+
+	output := out.String()
+	if stale {
+		t.Fatal("staleDaemon = true, want false")
+	}
+	if strings.Contains(output, "WARNING: daemon is running") {
+		t.Fatalf("output = %q, want no dev mismatch warning", output)
+	}
+}
+
+func TestPrintStatusDaemonDeadPIDTreatedAsUnknownAndFixable(t *testing.T) {
+	env := newDoctorTestEnv(t)
+	env.writeDaemonStatus(t, deadPID(t), "1.2.2")
+
+	var out bytes.Buffer
+	stale := printStatus(&out, "1.2.3", env.options())
+
+	output := out.String()
+	if !stale {
+		t.Fatal("staleDaemon = false, want true")
+	}
+	if !strings.Contains(output, "  daemon: running\n") {
+		t.Fatalf("output = %q, want plain running line", output)
+	}
+	if strings.Contains(output, "pid ") {
+		t.Fatalf("output = %q, want no dead-pid status details", output)
+	}
+	if !strings.Contains(output, "WARNING: daemon version is unknown") {
+		t.Fatalf("output = %q, want unknown-version warning", output)
+	}
+}
+
+func TestPrintStatusDaemonWithoutBreadcrumbIsFixable(t *testing.T) {
+	// A serving daemon that never wrote daemon-status.json predates the
+	// breadcrumb feature — the first-upgrade case doctor --fix must handle.
+	env := newDoctorTestEnv(t)
+
+	var out bytes.Buffer
+	stale := printStatus(&out, "1.2.3", env.options())
+
+	output := out.String()
+	if !stale {
+		t.Fatal("staleDaemon = false, want true")
+	}
+	if !strings.Contains(output, "WARNING: daemon version is unknown — it likely predates v1.2.3") {
+		t.Fatalf("output = %q, want unknown-version warning", output)
+	}
+}
+
+func TestPrintStatusDaemonWithoutBreadcrumbDevInstallDoesNotWarn(t *testing.T) {
+	env := newDoctorTestEnv(t)
+
+	var out bytes.Buffer
+	stale := printStatus(&out, "dev", env.options())
+
+	output := out.String()
+	if stale {
+		t.Fatal("staleDaemon = true, want false")
+	}
+	if strings.Contains(output, "WARNING: daemon version is unknown") {
+		t.Fatalf("output = %q, want no warning for dev install", output)
+	}
+}
+
+func TestPrintStatusHeartbeatFreshAndExportUpToDate(t *testing.T) {
+	env := newDoctorTestEnv(t)
+	env.writeDaemonStatus(t, os.Getpid(), "1.2.3")
+	cursor := env.seedLedger(t)
+	if err := managedstream.SaveState(managedstream.DefaultStatePathForDB(env.dbPath), managedstream.State{
+		UpdatedAfter:    &cursor.UpdatedAt,
+		ActionID:        cursor.ActionID,
+		LastHeartbeatAt: env.now.Add(-20 * time.Second).Format(time.RFC3339Nano),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	stale := printStatus(&out, "1.2.3", env.options())
+
+	output := out.String()
+	if stale {
+		t.Fatal("staleDaemon = true, want false")
+	}
+	if !strings.Contains(output, "  heartbeat: 20s ago") {
+		t.Fatalf("output = %q, want fresh heartbeat", output)
+	}
+	if !strings.Contains(output, "  export: up to date (0 pending)") {
+		t.Fatalf("output = %q, want export up to date", output)
+	}
+}
+
+func TestPrintStatusHeartbeatOldAndExportLagging(t *testing.T) {
+	env := newDoctorTestEnv(t)
+	env.writeDaemonStatus(t, os.Getpid(), "1.2.3")
+	env.seedLedger(t)
+	updatedAfter := time.Unix(0, 0).UTC()
+	if err := managedstream.SaveState(managedstream.DefaultStatePathForDB(env.dbPath), managedstream.State{
+		UpdatedAfter:    &updatedAfter,
+		LastHeartbeatAt: env.now.Add(-6 * time.Minute).Format(time.RFC3339Nano),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	stale := printStatus(&out, "1.2.3", env.options())
+
+	output := out.String()
+	if stale {
+		t.Fatal("staleDaemon = true, want false")
+	}
+	if !strings.Contains(output, "WARNING: last heartbeat was 6m0s ago") {
+		t.Fatalf("output = %q, want old heartbeat warning", output)
+	}
+	if !strings.Contains(output, "WARNING: export lagging") || !strings.Contains(output, "events pending") {
+		t.Fatalf("output = %q, want export lag warning", output)
+	}
+}
+
+func TestPrintStatusExportPendingWithinThresholdReportsFacts(t *testing.T) {
+	env := newDoctorTestEnv(t)
+	env.writeDaemonStatus(t, os.Getpid(), "1.2.3")
+	env.seedLedger(t)
+	// Cursor a minute behind the just-seeded event: pending but not lagging.
+	updatedAfter := time.Now().UTC().Add(-time.Minute)
+	if err := managedstream.SaveState(managedstream.DefaultStatePathForDB(env.dbPath), managedstream.State{
+		UpdatedAfter:    &updatedAfter,
+		LastHeartbeatAt: env.now.Add(-20 * time.Second).Format(time.RFC3339Nano),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	printStatus(&out, "1.2.3", env.options())
+
+	output := out.String()
+	if !strings.Contains(output, "pending (cursor ") {
+		t.Fatalf("output = %q, want pending facts line", output)
+	}
+	if strings.Contains(output, "export: up to date") {
+		t.Fatalf("output = %q, want no up-to-date claim while rows are pending", output)
+	}
+	if strings.Contains(output, "WARNING: export lagging") {
+		t.Fatalf("output = %q, want no lag warning under threshold", output)
+	}
+}
+
+func TestWaitForDaemonRestartSucceeds(t *testing.T) {
+	env := newDoctorTestEnv(t)
+	env.writeDaemonStatus(t, os.Getpid(), "1.2.3")
+	// Unix socket paths cap at 104 bytes on macOS; t.TempDir is too deep.
+	socketDir, err := os.MkdirTemp("/tmp", "kontext-doctor-test-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp() error = %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	socketPath := filepath.Join(socketDir, "kontext.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Listen() error = %v", err)
+	}
+	t.Cleanup(func() { listener.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	status, err := WaitForDaemonRestart(ctx, env.dbPath, socketPath, "1.2.3")
+	if err != nil {
+		t.Fatalf("WaitForDaemonRestart() error = %v", err)
+	}
+	if status.Version != "1.2.3" || status.PID != os.Getpid() {
+		t.Fatalf("status = %+v, want current pid on v1.2.3", status)
+	}
+}
+
+func TestWaitForDaemonRestartTimesOutWithoutDaemon(t *testing.T) {
+	env := newDoctorTestEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	if _, err := WaitForDaemonRestart(ctx, env.dbPath, env.socketPath, "1.2.3"); err == nil {
+		t.Fatal("WaitForDaemonRestart() error = nil, want timeout")
+	}
+}
+
+type doctorTestEnv struct {
+	dir        string
+	dbPath     string
+	socketPath string
+	now        time.Time
+}
+
+func newDoctorTestEnv(t *testing.T) doctorTestEnv {
+	t.Helper()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "managed.json")
+	installationPath := filepath.Join(dir, "installation.json")
+	writeTestManagedConfig(t, configPath)
+	writeTestInstallation(t, installationPath)
+	t.Setenv(installation.EnvPath, installationPath)
+	t.Setenv("HOME", dir)
+	return doctorTestEnv{
+		dir:        dir,
+		dbPath:     filepath.Join(dir, "guard.db"),
+		socketPath: filepath.Join(dir, "kontext.sock"),
+		now:        time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+func (e doctorTestEnv) options() doctorOptions {
+	return doctorOptions{
+		DBPath:     e.dbPath,
+		SocketPath: e.socketPath,
+		Dial: func(string, string, time.Duration) (net.Conn, error) {
+			client, server := net.Pipe()
+			_ = server.Close()
+			return client, nil
+		},
+		Now: func() time.Time { return e.now },
+	}
+}
+
+func (e doctorTestEnv) writeDaemonStatus(t *testing.T, pid int, version string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(DaemonStatusPath(e.dbPath)), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	data := []byte(`{"version":"` + version + `","pid":` + itoa(pid) + `,"started_at":"2026-07-09T12:00:00Z"}` + "\n")
+	if err := os.WriteFile(DaemonStatusPath(e.dbPath), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (e doctorTestEnv) seedLedger(t *testing.T) *sqlitestore.LedgerCursor {
+	t.Helper()
+	store, err := sqlitestore.OpenStore(e.dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if _, err := store.SaveDecision(context.Background(), risk.HookEvent{
+		SessionID:     "s1",
+		HookEventName: "PreToolUse",
+		ToolName:      "Read",
+		ToolUseID:     "tool-1",
+	}, risk.RiskDecision{
+		Decision:   risk.DecisionAllow,
+		Reason:     "ok",
+		ReasonCode: "normal_tool_call",
+		RiskEvent:  risk.RiskEvent{Type: risk.EventNormalToolCall},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	batch, err := store.LedgerBatch(context.Background(), sqlitestore.LedgerExportOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if batch.Cursor == nil {
+		t.Fatal("LedgerBatch cursor = nil")
+	}
+	return batch.Cursor
+}
+
+func deadPID(t *testing.T) int {
+	t.Helper()
+	for pid := os.Getpid() + 100000; pid < os.Getpid()+101000; pid++ {
+		if !pidAlive(pid) {
+			return pid
+		}
+	}
+	t.Fatal("could not find a dead pid")
+	return 0
 }

--- a/internal/managedobserve/doctor_test.go
+++ b/internal/managedobserve/doctor_test.go
@@ -117,6 +117,14 @@ func TestPrintStatusDaemonDeadPIDTreatedAsUnknownAndFixable(t *testing.T) {
 	}
 }
 
+func TestPIDAliveRejectsNonPositivePID(t *testing.T) {
+	for _, pid := range []int{0, -1} {
+		if pidAlive(pid) {
+			t.Fatalf("pidAlive(%d) = true, want false", pid)
+		}
+	}
+}
+
 func TestPrintStatusDaemonWithoutBreadcrumbIsFixable(t *testing.T) {
 	// A serving daemon that never wrote daemon-status.json predates the
 	// breadcrumb feature — the first-upgrade case doctor --fix must handle.
@@ -310,8 +318,11 @@ func (e doctorTestEnv) writeDaemonStatus(t *testing.T, pid int, version string) 
 	if err := os.MkdirAll(filepath.Dir(DaemonStatusPath(e.dbPath)), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	data := []byte(`{"version":"` + version + `","pid":` + itoa(pid) + `,"started_at":"2026-07-09T12:00:00Z"}` + "\n")
-	if err := os.WriteFile(DaemonStatusPath(e.dbPath), data, 0o600); err != nil {
+	if err := writeJSONBreadcrumb(DaemonStatusPath(e.dbPath), DaemonStatus{
+		Version:   version,
+		PID:       pid,
+		StartedAt: "2026-07-09T12:00:00Z",
+	}); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/managedobserve/lifecycle.go
+++ b/internal/managedobserve/lifecycle.go
@@ -162,13 +162,28 @@ func deadlineOr(ctx context.Context, fallback time.Time) time.Time {
 }
 
 func KickstartLaunchd(ctx context.Context, label string) error {
+	return kickstartLaunchd(ctx, label, false)
+}
+
+// KickstartLaunchdKill runs launchctl kickstart with -k, which kills the
+// running instance first; used to replace a daemon still running a stale binary.
+func KickstartLaunchdKill(ctx context.Context, label string) error {
+	return kickstartLaunchd(ctx, label, true)
+}
+
+func kickstartLaunchd(ctx context.Context, label string, kill bool) error {
 	if runtime.GOOS != "darwin" {
 		return nil
 	}
 	if label == "" {
 		return errors.New("launchd label is required")
 	}
-	cmd := exec.CommandContext(ctx, "launchctl", "kickstart", "gui/"+itoa(os.Getuid())+"/"+label)
+	args := []string{"kickstart"}
+	if kill {
+		args = append(args, "-k")
+	}
+	args = append(args, "gui/"+itoa(os.Getuid())+"/"+label)
+	cmd := exec.CommandContext(ctx, "launchctl", args...)
 	return cmd.Run()
 }
 

--- a/internal/managedobserve/status.go
+++ b/internal/managedobserve/status.go
@@ -11,7 +11,6 @@ import (
 // serving. It is written once at daemon startup; readers must verify the PID is
 // alive before trusting it. A stale file from a dead daemon is expected and
 // harmless.
-// ponytail: PID-reuse false positive possible; add a heartbeat-refreshed updated_at if it ever bites.
 type DaemonStatus struct {
 	Version   string `json:"version"`
 	PID       int    `json:"pid"`

--- a/internal/managedobserve/status.go
+++ b/internal/managedobserve/status.go
@@ -1,0 +1,46 @@
+package managedobserve
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// DaemonStatus is the on-disk breadcrumb a daemon leaves after its socket is
+// serving. It is written once at daemon startup; readers must verify the PID is
+// alive before trusting it. A stale file from a dead daemon is expected and
+// harmless.
+// ponytail: PID-reuse false positive possible; add a heartbeat-refreshed updated_at if it ever bites.
+type DaemonStatus struct {
+	Version   string `json:"version"`
+	PID       int    `json:"pid"`
+	StartedAt string `json:"started_at"`
+}
+
+// DaemonStatusPath puts the breadcrumb next to the observe database — the one
+// directory both the daemon and doctor can always derive.
+func DaemonStatusPath(dbPath string) string {
+	return filepath.Join(filepath.Dir(dbPath), "daemon-status.json")
+}
+
+func WriteDaemonStatus(dbPath, version string) error {
+	return writeJSONBreadcrumb(DaemonStatusPath(dbPath), DaemonStatus{
+		Version:   version,
+		PID:       os.Getpid(),
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	})
+}
+
+func LoadDaemonStatus(dbPath string) *DaemonStatus {
+	data, err := os.ReadFile(DaemonStatusPath(dbPath))
+	if err != nil {
+		return nil
+	}
+	var status DaemonStatus
+	// Doctor treats missing, unreadable, and bad status as the same no-status case.
+	if err := json.Unmarshal(data, &status); err != nil {
+		return nil
+	}
+	return &status
+}

--- a/internal/managedobserve/status_test.go
+++ b/internal/managedobserve/status_test.go
@@ -1,0 +1,57 @@
+package managedobserve
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestDaemonStatusRoundTrip(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "guard.db")
+
+	if err := WriteDaemonStatus(dbPath, "1.2.3"); err != nil {
+		t.Fatal(err)
+	}
+	got := LoadDaemonStatus(dbPath)
+	if got == nil || got.Version != "1.2.3" || got.PID != os.Getpid() || got.StartedAt == "" {
+		t.Fatalf("LoadDaemonStatus = %+v", got)
+	}
+	if _, err := time.Parse(time.RFC3339, got.StartedAt); err != nil {
+		t.Fatalf("StartedAt = %q, want RFC3339: %v", got.StartedAt, err)
+	}
+}
+
+func TestLoadDaemonStatusMissingFile(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "guard.db")
+
+	if got := LoadDaemonStatus(dbPath); got != nil {
+		t.Fatalf("LoadDaemonStatus missing = %+v, want nil", got)
+	}
+}
+
+func TestLoadDaemonStatusCorruptFile(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "guard.db")
+	if err := os.WriteFile(DaemonStatusPath(dbPath), []byte("garbage"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := LoadDaemonStatus(dbPath); got != nil {
+		t.Fatalf("LoadDaemonStatus corrupt = %+v, want nil", got)
+	}
+}
+
+func TestDaemonStatusFileMode(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "guard.db")
+
+	if err := WriteDaemonStatus(dbPath, "1.2.3"); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(DaemonStatusPath(dbPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("daemon status mode = %v, want 0600", got)
+	}
+}

--- a/internal/managedobserve/updater.go
+++ b/internal/managedobserve/updater.go
@@ -188,9 +188,5 @@ func runCommandOutput(ctx context.Context, path string, args ...string) (string,
 }
 
 func logHomebrewUpdater(log diagnostic.Logger, format string, args ...any) {
-	if log.Enabled() {
-		log.Printf(format, args...)
-		return
-	}
-	fmt.Fprint(os.Stderr, diagnostic.Redact(fmt.Sprintf(format, args...)))
+	logAlways(log, format, args...)
 }


### PR DESCRIPTION
Ships the complete [ENG-516](https://linear.app/cobrowser/issue/ENG-516/brew-upgrade-leaves-managed-observe-daemon-on-old-binary-trace-export) fix. Originally a 3-PR Graphite stack (#373 → #374 → #375); the stacked children auto-merged into this branch (auto-merge arms on any non-draft PR and feature-branch bases have no review protection), so this PR now carries the full feature. Content is unchanged from the reviewed stack.

## Problem

`brew upgrade` swaps the binary but never restarts the launchd service — `KeepAlive` kept a deleted 0.13.0 binary running for ~38h with trace export silently stalled, while `kontext doctor` said `daemon: running`.

## What ships

1. **Binary watchdog** — daemon stats its own resolved executable every 2m and exits cleanly (→ KeepAlive respawns the new binary) on: file deleted (brew removes old Cellar dir), inode changed (in-place overwrite), or launch-path symlink retargeted while the old keg survives (`HOMEBREW_NO_INSTALL_CLEANUP`). Plus unconditional startup/error logging so the plist log is no longer 0 bytes.
2. **`daemon-status.json` breadcrumb** — version/pid/started_at, written once at startup, PID-alive freshness contract.
3. **Doctor enrichment + `--fix`** — `daemon: running (vX, pid N)` with stale-version WARNING (incl. unknown-version daemons that predate the breadcrumb — the first-upgrade case); heartbeat age (warn >5m); export cursor lag vs newest ledger event via read-only `sqlite.LedgerLag` (never migrates under a running daemon; warn >10m; never claims "up to date" with rows pending). `kontext doctor --fix` runs `launchctl kickstart -k` and only reports success after verifying the restarted daemon serves on the installed version.

## Verification

- `go test -race` green across `managedobserve`, `guard/store/sqlite`, `cmd`.
- 3-round adversarial review loop (Codex gpt-5.5, xhigh): rounds 1–2 findings all fixed with tests; round 3 verdict **MERGE_READY, zero findings**.
- New doctor smoke-tested against a live daemon.
- Post-release: live brew-upgrade respawn check rides the first release containing this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)