### PR TITLE
feat: write daemon-status.json breadcrumb at daemon startup

### DIFF
--- a/internal/managedobserve/autherr.go
+++ b/internal/managedobserve/autherr.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -43,16 +44,20 @@ func WriteStartupError(dbPath string, message string) error {
 
 func writeBreadcrumb(dbPath string, breadcrumb AuthError) error {
 	breadcrumb.At = time.Now().UTC().Format(time.RFC3339)
-	data, err := json.Marshal(breadcrumb)
+	return writeJSONBreadcrumb(AuthErrorPath(dbPath), breadcrumb)
+}
+
+func writeJSONBreadcrumb(path string, v any) error {
+	data, err := json.Marshal(v)
 	if err != nil {
 		return err
 	}
-	path := AuthErrorPath(dbPath)
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}
 	data = append(data, '\n')
-	temp, err := os.CreateTemp(filepath.Dir(path), ".last-auth-error-*.tmp")
+	stem := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	temp, err := os.CreateTemp(filepath.Dir(path), "."+stem+"-*.tmp")
 	if err != nil {
 		return err
 	}

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -153,6 +153,9 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 		return err
 	}
 	defer host.Close(context.Background())
+	if err := WriteDaemonStatus(dbPath, binaryVersion); err != nil {
+		opts.Diagnostic.Printf("write daemon-status breadcrumb: %v\n", err)
+	}
 
 	// Restore the capture mode from the persisted snapshot before the first
 	// fetch completes, so an offline restart keeps the org's last-known

--- a/internal/managedobserve/daemon_test.go
+++ b/internal/managedobserve/daemon_test.go
@@ -23,6 +23,9 @@ import (
 
 func TestDaemonPreservesHookSessionIDs(t *testing.T) {
 	socketPath, dbPath, stop := startTestDaemon(t)
+	if status := LoadDaemonStatus(dbPath); status == nil || status.PID == 0 {
+		t.Fatalf("LoadDaemonStatus = %+v, want non-zero PID", status)
+	}
 
 	client := localruntime.NewClient(socketPath)
 	client.Timeout = time.Second

--- a/internal/managedobserve/status.go
+++ b/internal/managedobserve/status.go
@@ -1,0 +1,46 @@
+package managedobserve
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// DaemonStatus is the on-disk breadcrumb a daemon leaves after its socket is
+// serving. It is written once at daemon startup; readers must verify the PID is
+// alive before trusting it. A stale file from a dead daemon is expected and
+// harmless.
+// ponytail: PID-reuse false positive possible; add a heartbeat-refreshed updated_at if it ever bites.
+type DaemonStatus struct {
+	Version   string `json:"version"`
+	PID       int    `json:"pid"`
+	StartedAt string `json:"started_at"`
+}
+
+// DaemonStatusPath puts the breadcrumb next to the observe database — the one
+// directory both the daemon and doctor can always derive.
+func DaemonStatusPath(dbPath string) string {
+	return filepath.Join(filepath.Dir(dbPath), "daemon-status.json")
+}
+
+func WriteDaemonStatus(dbPath, version string) error {
+	return writeJSONBreadcrumb(DaemonStatusPath(dbPath), DaemonStatus{
+		Version:   version,
+		PID:       os.Getpid(),
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	})
+}
+
+func LoadDaemonStatus(dbPath string) *DaemonStatus {
+	data, err := os.ReadFile(DaemonStatusPath(dbPath))
+	if err != nil {
+		return nil
+	}
+	var status DaemonStatus
+	// Doctor treats missing, unreadable, and bad status as the same no-status case.
+	if err := json.Unmarshal(data, &status); err != nil {
+		return nil
+	}
+	return &status
+}

--- a/internal/managedobserve/status_test.go
+++ b/internal/managedobserve/status_test.go
@@ -1,0 +1,57 @@
+package managedobserve
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestDaemonStatusRoundTrip(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "guard.db")
+
+	if err := WriteDaemonStatus(dbPath, "1.2.3"); err != nil {
+		t.Fatal(err)
+	}
+	got := LoadDaemonStatus(dbPath)
+	if got == nil || got.Version != "1.2.3" || got.PID != os.Getpid() || got.StartedAt == "" {
+		t.Fatalf("LoadDaemonStatus = %+v", got)
+	}
+	if _, err := time.Parse(time.RFC3339, got.StartedAt); err != nil {
+		t.Fatalf("StartedAt = %q, want RFC3339: %v", got.StartedAt, err)
+	}
+}
+
+func TestLoadDaemonStatusMissingFile(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "guard.db")
+
+	if got := LoadDaemonStatus(dbPath); got != nil {
+		t.Fatalf("LoadDaemonStatus missing = %+v, want nil", got)
+	}
+}
+
+func TestLoadDaemonStatusCorruptFile(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "guard.db")
+	if err := os.WriteFile(DaemonStatusPath(dbPath), []byte("garbage"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := LoadDaemonStatus(dbPath); got != nil {
+		t.Fatalf("LoadDaemonStatus corrupt = %+v, want nil", got)
+	}
+}
+
+func TestDaemonStatusFileMode(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "guard.db")
+
+	if err := WriteDaemonStatus(dbPath, "1.2.3"); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(DaemonStatusPath(dbPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("daemon status mode = %v, want 0600", got)
+	}
+}


### PR DESCRIPTION
Part 2/3 of [ENG-516](https://linear.app/cobrowser/issue/ENG-516/brew-upgrade-leaves-managed-observe-daemon-on-old-binary-trace-export). Stacked on #373.

## What

The daemon writes `daemon-status.json` (version, pid, started_at) next to `guard.db` once its socket is serving — same breadcrumb pattern as `last-auth-error.json`, sharing the extracted atomic temp+rename writer.

**Freshness contract:** written once at startup, no refresh loop. Readers must verify the PID is alive before trusting it; a stale file from a dead daemon is expected and harmless. This is what lets `kontext doctor` (PR3) distinguish "running v0.13.0 under a v0.14.1 install" from "running current".

## Testing

`go test -race ./internal/managedobserve/...` — write/load round-trip, missing/corrupt file → nil, 0600 mode, and a status assertion inside the existing real-daemon boot test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)