### PR TITLE
ci: only arm auto-merge on PRs targeting main

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -7,9 +7,11 @@ name: Auto-merge
 # main-only on purpose: required reviews only protect main, so arming a PR
 # that targets a feature branch (e.g. a Graphite stack child) would merge it
 # into its parent on CI green alone, with no human approval.
+# `edited` re-checks when a stacked child gets retargeted to main after its
+# parent merges — arming is idempotent, spurious title/body edits are cheap.
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened, ready_for_review, edited]
 
 permissions: {}
 

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,8 +1,12 @@
 name: Auto-merge
 
-# Arms GitHub auto-merge on every non-draft PR so it merges the moment
-# approval + required checks land. Uses the release app token because
-# merges armed with GITHUB_TOKEN don't trigger downstream workflows.
+# Arms GitHub auto-merge on every non-draft PR targeting main, so it merges
+# the moment approval + required checks land. Uses the release app token
+# because merges armed with GITHUB_TOKEN don't trigger downstream workflows.
+#
+# main-only on purpose: required reviews only protect main, so arming a PR
+# that targets a feature branch (e.g. a Graphite stack child) would merge it
+# into its parent on CI green alone, with no human approval.
 on:
   pull_request:
     types: [opened, ready_for_review]
@@ -11,7 +15,7 @@ permissions: {}
 
 jobs:
   arm:
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && github.event.pull_request.base.ref == 'main' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0


### PR DESCRIPTION
Required reviews only protect `main`. The auto-merge workflow armed every non-draft PR regardless of base, so PRs targeting feature branches (Graphite stack children) merged into their parents on CI green alone — no human approval involved. That collapsed the ENG-516 stack (#374, #375 merged into their base branches) the moment the stack left draft.

One-line guard: `base.ref == 'main'`. Stacked children now stay unarmed until they're retargeted to main (which GitHub does automatically as parents merge).

Left as draft deliberately so it doesn't arm itself — mark ready when you've eyeballed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)