### PR TITLE
feat(policy): add Go Cedar evaluator conformance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.12
 
 require (
 	connectrpc.com/connect v1.19.2
+	github.com/cedar-policy/cedar-go v1.8.0
 	github.com/cli/browser v1.3.0
 	github.com/google/uuid v1.6.0
 	github.com/gowebpki/jcs v1.0.1
@@ -25,6 +26,7 @@ require (
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
+	golang.org/x/exp v0.0.0-20220921023135-46d9e7742f1e // indirect
 	modernc.org/libc v1.72.3 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 connectrpc.com/connect v1.19.2 h1:McQ83FGdzL+t60peksi0gXC7MQ/iLKgLduAnThbM0mo=
 connectrpc.com/connect v1.19.2/go.mod h1:tN20fjdGlewnSFeZxLKb0xwIZ6ozc3OQs2hTXy4du9w=
+github.com/cedar-policy/cedar-go v1.8.0 h1:9gcU7EHXwHC2RMdpph68yTAkdB3behTTssC+kt4GoS8=
+github.com/cedar-policy/cedar-go v1.8.0/go.mod h1:h5+3CVW1oI5LXVskJG+my9TFCYI5yjh/+Ul3EJie6MI=
 github.com/cli/browser v1.3.0 h1:LejqCrpWr+1pRqmEPDGnTZOjsMe7sehifLynZJuqJpo=
 github.com/cli/browser v1.3.0/go.mod h1:HH8s+fOAxjhQoBUAsKuPCbqUuxZDhQ2/aD+SzsEfBTk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
@@ -46,6 +48,8 @@ github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD
 github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
 github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/exp v0.0.0-20220921023135-46d9e7742f1e h1:Ctm9yurWsg7aWwIpH9Bnap/IdSVxixymIb3MhiMEQQA=
+golang.org/x/exp v0.0.0-20220921023135-46d9e7742f1e/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/mod v0.33.0 h1:tHFzIWbBifEmbwtGz65eaWyGiGZatSrT9prnU8DbVL8=
 golang.org/x/mod v0.33.0/go.mod h1:swjeQEj+6r7fODbD2cqrnje9PnziFuw4bmLbBZFrQ5w=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=

--- a/internal/cedareval/context.go
+++ b/internal/cedareval/context.go
@@ -1,0 +1,251 @@
+package cedareval
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+
+	cedar "github.com/cedar-policy/cedar-go"
+)
+
+const (
+	ContextMaxDepth  = 32
+	ContextMaxValues = 10_000
+	maxSafeInteger   = int64(9_007_199_254_740_991)
+)
+
+type ContextDiagnostic struct {
+	Code string `json:"code"`
+	Path string `json:"path"`
+}
+
+type ConversionError struct {
+	Code string
+	Path string
+	msg  string
+}
+
+func (e *ConversionError) Error() string {
+	return e.msg
+}
+
+type conversionState struct {
+	diagnostics []ContextDiagnostic
+	valuesSeen  int
+}
+
+func ConvertToolInput(toolInput map[string]any) (cedar.Record, []ContextDiagnostic, error) {
+	state := conversionState{diagnostics: make([]ContextDiagnostic, 0)}
+	value, err := convertValue(toolInput, "", 0, &state, false)
+	if err != nil {
+		return cedar.Record{}, nil, err
+	}
+	record, ok := value.(cedar.Record)
+	if !ok {
+		return cedar.Record{}, nil, newConversionError(
+			"invalid_json_value",
+			"",
+			"cedar context root must be an object",
+		)
+	}
+	sort.Slice(state.diagnostics, func(i, j int) bool {
+		return state.diagnostics[i].Path < state.diagnostics[j].Path
+	})
+	return record, state.diagnostics, nil
+}
+
+func convertValue(value any, path string, depth int, state *conversionState, insideSet bool) (cedar.Value, error) {
+	if depth > ContextMaxDepth {
+		return nil, newConversionError(
+			"maximum_depth_exceeded",
+			path,
+			fmt.Sprintf("cedar context exceeds depth %d", ContextMaxDepth),
+		)
+	}
+
+	state.valuesSeen++
+	if state.valuesSeen > ContextMaxValues {
+		return nil, newConversionError(
+			"maximum_values_exceeded",
+			path,
+			fmt.Sprintf("cedar context exceeds %d values", ContextMaxValues),
+		)
+	}
+
+	if value == nil {
+		if insideSet {
+			return nil, newConversionError(
+				"null_in_set",
+				path,
+				"json null cannot be represented in a cedar set",
+			)
+		}
+		state.diagnostics = append(state.diagnostics, ContextDiagnostic{
+			Code: "null_omitted",
+			Path: path,
+		})
+		return nil, nil
+	}
+
+	switch v := value.(type) {
+	case string:
+		return cedar.String(v), nil
+	case bool:
+		return cedar.Boolean(v), nil
+	case json.Number:
+		return convertNumber(v.String(), path)
+	case float64:
+		return convertFloat(v, path)
+	case float32:
+		return convertFloat(float64(v), path)
+	case int:
+		return convertSigned(int64(v), path)
+	case int8:
+		return convertSigned(int64(v), path)
+	case int16:
+		return convertSigned(int64(v), path)
+	case int32:
+		return convertSigned(int64(v), path)
+	case int64:
+		return convertSigned(v, path)
+	case uint:
+		return convertUnsigned(uint64(v), path)
+	case uint8:
+		return convertUnsigned(uint64(v), path)
+	case uint16:
+		return convertUnsigned(uint64(v), path)
+	case uint32:
+		return convertUnsigned(uint64(v), path)
+	case uint64:
+		return convertUnsigned(v, path)
+	case []any:
+		values := make([]cedar.Value, len(v))
+		for i, item := range v {
+			converted, err := convertValue(item, pointer(path, strconv.Itoa(i)), depth+1, state, true)
+			if err != nil {
+				return nil, err
+			}
+			if converted == nil {
+				return nil, newConversionError(
+					"null_in_set",
+					pointer(path, strconv.Itoa(i)),
+					"null cannot appear in a cedar set",
+				)
+			}
+			values[i] = converted
+		}
+		return cedar.NewSet(values...), nil
+	case map[string]any:
+		if _, ok := v["__entity"]; ok {
+			return nil, reservedEscapeError(path)
+		}
+		if _, ok := v["__extn"]; ok {
+			return nil, reservedEscapeError(path)
+		}
+
+		keys := make([]string, 0, len(v))
+		for key := range v {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+
+		record := make(cedar.RecordMap, len(v))
+		for _, key := range keys {
+			nested := v[key]
+			converted, err := convertValue(nested, pointer(path, key), depth+1, state, false)
+			if err != nil {
+				return nil, err
+			}
+			if converted != nil {
+				record[cedar.String(key)] = converted
+			}
+		}
+		return cedar.NewRecord(record), nil
+	default:
+		return nil, newConversionError(
+			"invalid_json_value",
+			path,
+			fmt.Sprintf("unsupported json value %T", value),
+		)
+	}
+}
+
+func convertNumber(number string, path string) (cedar.Value, error) {
+	value, err := strconv.ParseFloat(number, 64)
+	if err != nil {
+		return nil, newConversionError("invalid_json_value", path, "cedar context numbers must be finite")
+	}
+	return convertFloat(value, path)
+}
+
+func convertFloat(value float64, path string) (cedar.Value, error) {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return nil, newConversionError("invalid_json_value", path, "cedar context numbers must be finite")
+	}
+	if math.Trunc(value) == value {
+		if math.Abs(value) > float64(maxSafeInteger) {
+			return nil, unsafeIntegerError(path)
+		}
+		if value == 0 {
+			return cedar.Long(0), nil
+		}
+		return cedar.Long(int64(value)), nil
+	}
+
+	scaled := value * 10_000
+	if math.Trunc(scaled) != scaled || math.Abs(scaled) > float64(maxSafeInteger) {
+		return nil, newConversionError(
+			"unsupported_decimal",
+			path,
+			"cedar decimals must be exactly representable with at most four fractional digits within javascript safe-integer precision",
+		)
+	}
+	decimal, err := cedar.NewDecimal(int64(scaled), -4)
+	if err != nil {
+		return nil, newConversionError("unsupported_decimal", path, "cedar decimal is outside the portable range")
+	}
+	return decimal, nil
+}
+
+func convertSigned(value int64, path string) (cedar.Value, error) {
+	if value < -maxSafeInteger || value > maxSafeInteger {
+		return nil, unsafeIntegerError(path)
+	}
+	return cedar.Long(value), nil
+}
+
+func convertUnsigned(value uint64, path string) (cedar.Value, error) {
+	if value > uint64(maxSafeInteger) {
+		return nil, unsafeIntegerError(path)
+	}
+	return cedar.Long(value), nil
+}
+
+func unsafeIntegerError(path string) error {
+	return newConversionError(
+		"unsafe_integer",
+		path,
+		"cedar long input must be exactly representable as a javascript safe integer",
+	)
+}
+
+func reservedEscapeError(path string) error {
+	return newConversionError(
+		"reserved_cedar_escape",
+		path,
+		"raw tool input cannot inject cedar __entity or __extn escape objects",
+	)
+}
+
+func newConversionError(code, path, message string) *ConversionError {
+	return &ConversionError{Code: code, Path: path, msg: message}
+}
+
+func pointer(path, segment string) string {
+	escaped := strings.ReplaceAll(segment, "~", "~0")
+	escaped = strings.ReplaceAll(escaped, "/", "~1")
+	return path + "/" + escaped
+}

--- a/internal/cedareval/context.go
+++ b/internal/cedareval/context.go
@@ -128,13 +128,6 @@ func convertValue(value any, path string, depth int, state *conversionState, ins
 			if err != nil {
 				return nil, err
 			}
-			if converted == nil {
-				return nil, newConversionError(
-					"null_in_set",
-					pointer(path, strconv.Itoa(i)),
-					"null cannot appear in a cedar set",
-				)
-			}
 			values[i] = converted
 		}
 		return cedar.NewSet(values...), nil
@@ -174,6 +167,10 @@ func convertValue(value any, path string, depth int, state *conversionState, ins
 }
 
 func convertNumber(number string, path string) (cedar.Value, error) {
+	// Request-contract v1 gives JSON numbers their interoperable binary64
+	// meaning, matching JSON.parse in the TypeScript contract runtime. The
+	// lexical spellings 1e-4 and 0.00010000000000000001 therefore both denote
+	// the same binary64 value before Cedar's decimal range is checked.
 	value, err := strconv.ParseFloat(number, 64)
 	if err != nil {
 		return nil, newConversionError("invalid_json_value", path, "cedar context numbers must be finite")
@@ -188,9 +185,6 @@ func convertFloat(value float64, path string) (cedar.Value, error) {
 	if math.Trunc(value) == value {
 		if math.Abs(value) > float64(maxSafeInteger) {
 			return nil, unsafeIntegerError(path)
-		}
-		if value == 0 {
-			return cedar.Long(0), nil
 		}
 		return cedar.Long(int64(value)), nil
 	}

--- a/internal/cedareval/context.go
+++ b/internal/cedareval/context.go
@@ -189,15 +189,31 @@ func convertFloat(value float64, path string) (cedar.Value, error) {
 		return cedar.Long(int64(value)), nil
 	}
 
-	scaled := value * 10_000
-	if math.Trunc(scaled) != scaled || math.Abs(scaled) > float64(maxSafeInteger) {
+	// Accept exactly the doubles that round-trip through their own four-digit
+	// decimal rendering. Scaling by 10^4 in binary64 injects rounding noise and
+	// makes acceptance depend on luck (0.07 * 10000 != 700 in binary64), and it
+	// collapses distinct doubles into one decimal. Only non-integers reach
+	// here, so the 'f' rendering is exact and bounded. TypeScript mirror uses
+	// Number(value.toFixed(4)) === value; exact-halfway doubles fail the
+	// round-trip in both runtimes, so tie-breaking rules can never disagree.
+	fixed := strconv.FormatFloat(value, 'f', 4, 64)
+	round, err := strconv.ParseFloat(fixed, 64)
+	if err != nil || round != value {
 		return nil, newConversionError(
 			"unsupported_decimal",
 			path,
-			"cedar decimals must be exactly representable with at most four fractional digits within javascript safe-integer precision",
+			"cedar decimals must be exactly representable with at most four fractional digits",
 		)
 	}
-	decimal, err := cedar.NewDecimal(int64(scaled), -4)
+	scaled, err := strconv.ParseInt(strings.Replace(fixed, ".", "", 1), 10, 64)
+	if err != nil {
+		return nil, newConversionError(
+			"unsupported_decimal",
+			path,
+			"cedar decimals must lie within -922337203685477.5808..922337203685477.5807",
+		)
+	}
+	decimal, err := cedar.NewDecimal(scaled, -4)
 	if err != nil {
 		return nil, newConversionError("unsupported_decimal", path, "cedar decimal is outside the portable range")
 	}

--- a/internal/cedareval/context.go
+++ b/internal/cedareval/context.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"math/big"
 	"sort"
 	"strconv"
 	"strings"
@@ -189,14 +190,18 @@ func convertFloat(value float64, path string) (cedar.Value, error) {
 		return cedar.Long(int64(value)), nil
 	}
 
-	// Accept exactly the doubles that round-trip through their own four-digit
-	// decimal rendering. Scaling by 10^4 in binary64 injects rounding noise and
-	// makes acceptance depend on luck (0.07 * 10000 != 700 in binary64), and it
-	// collapses distinct doubles into one decimal. Only non-integers reach
-	// here, so the 'f' rendering is exact and bounded. TypeScript mirror uses
-	// Number(value.toFixed(4)) === value; exact-halfway doubles fail the
-	// round-trip in both runtimes, so tie-breaking rules can never disagree.
-	fixed := strconv.FormatFloat(value, 'f', 4, 64)
+	// Match ECMAScript Number.prototype.toFixed(4) exactly before applying the
+	// same round-trip check as the TypeScript contract runtime. Go's 'f'
+	// formatter uses round-to-even while ECMAScript selects the larger integer
+	// on a tie, so using FormatFloat here would diverge for some large doubles.
+	fixed, scaled, ok := ecmaFixed4(value)
+	if !ok {
+		return nil, newConversionError(
+			"unsupported_decimal",
+			path,
+			"cedar decimals must lie within -922337203685477.5808..922337203685477.5807",
+		)
+	}
 	round, err := strconv.ParseFloat(fixed, 64)
 	if err != nil || round != value {
 		return nil, newConversionError(
@@ -205,19 +210,41 @@ func convertFloat(value float64, path string) (cedar.Value, error) {
 			"cedar decimals must be exactly representable with at most four fractional digits",
 		)
 	}
-	scaled, err := strconv.ParseInt(strings.Replace(fixed, ".", "", 1), 10, 64)
-	if err != nil {
-		return nil, newConversionError(
-			"unsupported_decimal",
-			path,
-			"cedar decimals must lie within -922337203685477.5808..922337203685477.5807",
-		)
-	}
 	decimal, err := cedar.NewDecimal(scaled, -4)
 	if err != nil {
 		return nil, newConversionError("unsupported_decimal", path, "cedar decimal is outside the portable range")
 	}
 	return decimal, nil
+}
+
+func ecmaFixed4(value float64) (string, int64, bool) {
+	absolute := new(big.Rat).SetFloat64(math.Abs(value))
+	absolute.Mul(absolute, big.NewRat(10_000, 1))
+
+	scaled := new(big.Int)
+	remainder := new(big.Int)
+	scaled.QuoRem(absolute.Num(), absolute.Denom(), remainder)
+	twiceRemainder := new(big.Int).Lsh(new(big.Int).Set(remainder), 1)
+	if twiceRemainder.Cmp(absolute.Denom()) >= 0 {
+		scaled.Add(scaled, big.NewInt(1))
+	}
+	if math.Signbit(value) {
+		scaled.Neg(scaled)
+	}
+	if !scaled.IsInt64() {
+		return "", 0, false
+	}
+
+	digits := new(big.Int).Abs(new(big.Int).Set(scaled)).String()
+	if len(digits) < 5 {
+		digits = strings.Repeat("0", 5-len(digits)) + digits
+	}
+	separator := len(digits) - 4
+	fixed := digits[:separator] + "." + digits[separator:]
+	if scaled.Sign() < 0 {
+		fixed = "-" + fixed
+	}
+	return fixed, scaled.Int64(), true
 }
 
 func convertSigned(value int64, path string) (cedar.Value, error) {

--- a/internal/cedareval/evaluator.go
+++ b/internal/cedareval/evaluator.go
@@ -68,9 +68,6 @@ type Evaluator struct {
 }
 
 func New(policyText string) (*Evaluator, error) {
-	if policyText == "" {
-		return nil, fmt.Errorf("cedareval: policy text is empty")
-	}
 	if len([]byte(policyText)) > PolicyMaxBytes {
 		return nil, fmt.Errorf("cedareval: policy text exceeds %d bytes", PolicyMaxBytes)
 	}
@@ -79,14 +76,6 @@ func New(policyText string) (*Evaluator, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cedareval: parse policy: %w", err)
 	}
-	policyCount := 0
-	for range policies.All() {
-		policyCount++
-	}
-	if policyCount == 0 {
-		return nil, fmt.Errorf("cedareval: policy document contains no policies")
-	}
-
 	return &Evaluator{policies: policies}, nil
 }
 
@@ -193,6 +182,9 @@ func validateInput(input ToolUseInput) error {
 	}
 	if stringLength(input.ToolName) == 0 || stringLength(input.ToolName) > 4096 {
 		return fmt.Errorf("cedareval: tool name must contain 1 to 4096 characters")
+	}
+	if input.ToolInput == nil {
+		return fmt.Errorf("cedareval: tool input must be a JSON object")
 	}
 	return nil
 }

--- a/internal/cedareval/evaluator.go
+++ b/internal/cedareval/evaluator.go
@@ -76,7 +76,45 @@ func New(policyText string) (*Evaluator, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cedareval: parse policy: %w", err)
 	}
+	if err := validatePolicyMetadata(policies); err != nil {
+		return nil, err
+	}
 	return &Evaluator{policies: policies}, nil
+}
+
+func validatePolicyMetadata(policies *cedar.PolicySet) error {
+	policyIDs := make([]cedar.PolicyID, 0)
+	for policyID := range policies.All() {
+		policyIDs = append(policyIDs, policyID)
+	}
+	sort.Slice(policyIDs, func(i, j int) bool {
+		return string(policyIDs[i]) < string(policyIDs[j])
+	})
+
+	stableIDs := make(map[string]cedar.PolicyID, len(policyIDs))
+	for _, policyID := range policyIDs {
+		policy := policies.Get(policyID)
+		annotations := policy.Annotations()
+		stableID, ok := annotationValue(annotations, idAnnotation)
+		if !ok || stableID == "" {
+			return fmt.Errorf("cedareval: policy %q has no non-empty @id annotation", policyID)
+		}
+		if previousPolicyID, duplicate := stableIDs[stableID]; duplicate {
+			return fmt.Errorf(
+				"cedareval: policies %q and %q have duplicate @id %q",
+				previousPolicyID,
+				policyID,
+				stableID,
+			)
+		}
+		stableIDs[stableID] = policyID
+
+		ask, hasAsk := annotationValue(annotations, askAnnotation)
+		if hasAsk && ask != askAnnotationValue {
+			return fmt.Errorf("cedareval: policy %q has unsupported @ask value %q", stableID, ask)
+		}
+	}
+	return nil
 }
 
 func InputFromEvent(principal EvaluationPrincipal, event hook.Event) (ToolUseInput, error) {

--- a/internal/cedareval/evaluator.go
+++ b/internal/cedareval/evaluator.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"unicode/utf16"
+	"unicode/utf8"
 
 	cedar "github.com/cedar-policy/cedar-go"
 	"github.com/kontext-security/kontext-cli/internal/hook"
@@ -215,8 +216,14 @@ func validateInput(input ToolUseInput) error {
 			RequestContractVersion,
 		)
 	}
+	if !utf8.ValidString(input.EvaluationPrincipal.EntityID) {
+		return fmt.Errorf("cedareval: principal entity id must contain valid UTF-8")
+	}
 	if stringLength(input.EvaluationPrincipal.EntityID) == 0 || stringLength(input.EvaluationPrincipal.EntityID) > 1024 {
 		return fmt.Errorf("cedareval: principal entity id must contain 1 to 1024 characters")
+	}
+	if !utf8.ValidString(input.ToolName) {
+		return fmt.Errorf("cedareval: tool name must contain valid UTF-8")
 	}
 	if stringLength(input.ToolName) == 0 || stringLength(input.ToolName) > 4096 {
 		return fmt.Errorf("cedareval: tool name must contain 1 to 4096 characters")

--- a/internal/cedareval/evaluator.go
+++ b/internal/cedareval/evaluator.go
@@ -1,0 +1,223 @@
+package cedareval
+
+import (
+	"fmt"
+	"sort"
+	"unicode/utf16"
+
+	cedar "github.com/cedar-policy/cedar-go"
+	"github.com/kontext-security/kontext-cli/internal/hook"
+)
+
+const (
+	RequestContractVersion = 1
+	PrincipalEntityType    = "Kontext::User"
+	ActionEntityType       = "Kontext::Action"
+	ToolEntityType         = "Kontext::Tool"
+	ToolUseActionID        = "ToolUse"
+	PolicyMaxBytes         = 1_048_576
+	askAnnotation          = "ask"
+	askAnnotationValue     = "prompt"
+	idAnnotation           = "id"
+)
+
+type EvaluationPrincipal struct {
+	EntityType string `json:"entityType"`
+	EntityID   string `json:"entityId"`
+}
+
+type ToolUseInput struct {
+	EvaluationPrincipal EvaluationPrincipal `json:"evaluationPrincipal"`
+	ToolName            string              `json:"toolName"`
+	ToolInput           map[string]any      `json:"toolInput"`
+}
+
+type Decision string
+
+const (
+	DecisionAllow Decision = "allow"
+	DecisionDeny  Decision = "deny"
+)
+
+type EngineReason struct {
+	PolicyID string
+	Position cedar.Position
+}
+
+type EngineError struct {
+	PolicyID string
+	Position cedar.Position
+	Message  string
+}
+
+type EngineDiagnostics struct {
+	Reasons []EngineReason
+	Errors  []EngineError
+}
+
+type Result struct {
+	Decision             Decision
+	Ask                  bool
+	DeterminingPolicyIDs []string
+	ContextDiagnostics   []ContextDiagnostic
+	EngineDiagnostics    EngineDiagnostics
+}
+
+type Evaluator struct {
+	policies *cedar.PolicySet
+}
+
+func New(policyText string) (*Evaluator, error) {
+	if policyText == "" {
+		return nil, fmt.Errorf("cedareval: policy text is empty")
+	}
+	if len([]byte(policyText)) > PolicyMaxBytes {
+		return nil, fmt.Errorf("cedareval: policy text exceeds %d bytes", PolicyMaxBytes)
+	}
+
+	policies, err := cedar.NewPolicySetFromBytes("policy.cedar", []byte(policyText))
+	if err != nil {
+		return nil, fmt.Errorf("cedareval: parse policy: %w", err)
+	}
+	policyCount := 0
+	for range policies.All() {
+		policyCount++
+	}
+	if policyCount == 0 {
+		return nil, fmt.Errorf("cedareval: policy document contains no policies")
+	}
+
+	return &Evaluator{policies: policies}, nil
+}
+
+func InputFromEvent(principal EvaluationPrincipal, event hook.Event) (ToolUseInput, error) {
+	if event.HookName != hook.HookPreToolUse {
+		return ToolUseInput{}, fmt.Errorf("cedareval: hook event %q is not pre-tool-use", event.HookName)
+	}
+	return ToolUseInput{
+		EvaluationPrincipal: principal,
+		ToolName:            event.ToolName,
+		ToolInput:           event.ToolInput,
+	}, nil
+}
+
+func BuildRequest(input ToolUseInput) (cedar.Request, []ContextDiagnostic, error) {
+	if err := validateInput(input); err != nil {
+		return cedar.Request{}, nil, err
+	}
+
+	context, diagnostics, err := ConvertToolInput(input.ToolInput)
+	if err != nil {
+		return cedar.Request{}, nil, err
+	}
+	return cedar.Request{
+		Principal: cedar.NewEntityUID(
+			cedar.EntityType(input.EvaluationPrincipal.EntityType),
+			cedar.String(input.EvaluationPrincipal.EntityID),
+		),
+		Action: cedar.NewEntityUID(
+			cedar.EntityType(ActionEntityType),
+			cedar.String(ToolUseActionID),
+		),
+		Resource: cedar.NewEntityUID(
+			cedar.EntityType(ToolEntityType),
+			cedar.String(input.ToolName),
+		),
+		Context: context,
+	}, diagnostics, nil
+}
+
+func (e *Evaluator) Evaluate(input ToolUseInput) (Result, error) {
+	request, contextDiagnostics, err := BuildRequest(input)
+	if err != nil {
+		return Result{}, err
+	}
+
+	decision, diagnostic := cedar.Authorize(e.policies, nil, request)
+	engineDiagnostics := copyEngineDiagnostics(diagnostic)
+	determiningPolicyIDs := make([]string, 0, len(diagnostic.Reasons))
+	allAsk := len(diagnostic.Reasons) > 0
+	for _, reason := range diagnostic.Reasons {
+		policy := e.policies.Get(reason.PolicyID)
+		if policy == nil {
+			return Result{}, fmt.Errorf("cedareval: determining policy %q is missing", reason.PolicyID)
+		}
+		annotations := policy.Annotations()
+		stableID, ok := annotationValue(annotations, idAnnotation)
+		if !ok || stableID == "" {
+			return Result{}, fmt.Errorf("cedareval: determining policy %q has no @id annotation", reason.PolicyID)
+		}
+		determiningPolicyIDs = append(determiningPolicyIDs, stableID)
+
+		ask, hasAsk := annotationValue(annotations, askAnnotation)
+		if hasAsk && ask != askAnnotationValue {
+			return Result{}, fmt.Errorf(
+				"cedareval: unsupported @ask value on %s: %s",
+				stableID,
+				ask,
+			)
+		}
+		allAsk = allAsk && hasAsk
+	}
+	sort.Strings(determiningPolicyIDs)
+
+	result := Result{
+		Decision:             Decision(decision.String()),
+		Ask:                  decision == cedar.Allow && allAsk,
+		DeterminingPolicyIDs: determiningPolicyIDs,
+		ContextDiagnostics:   contextDiagnostics,
+		EngineDiagnostics:    engineDiagnostics,
+	}
+	return result, nil
+}
+
+func annotationValue(annotations cedar.Annotations, name string) (string, bool) {
+	for key, value := range annotations {
+		if string(key) == name {
+			return string(value), true
+		}
+	}
+	return "", false
+}
+
+func validateInput(input ToolUseInput) error {
+	if input.EvaluationPrincipal.EntityType != PrincipalEntityType {
+		return fmt.Errorf(
+			"cedareval: unsupported principal entity type %q for request contract v%d",
+			input.EvaluationPrincipal.EntityType,
+			RequestContractVersion,
+		)
+	}
+	if stringLength(input.EvaluationPrincipal.EntityID) == 0 || stringLength(input.EvaluationPrincipal.EntityID) > 1024 {
+		return fmt.Errorf("cedareval: principal entity id must contain 1 to 1024 characters")
+	}
+	if stringLength(input.ToolName) == 0 || stringLength(input.ToolName) > 4096 {
+		return fmt.Errorf("cedareval: tool name must contain 1 to 4096 characters")
+	}
+	return nil
+}
+
+func stringLength(value string) int {
+	return len(utf16.Encode([]rune(value)))
+}
+
+func copyEngineDiagnostics(diagnostic cedar.Diagnostic) EngineDiagnostics {
+	result := EngineDiagnostics{
+		Reasons: make([]EngineReason, len(diagnostic.Reasons)),
+		Errors:  make([]EngineError, len(diagnostic.Errors)),
+	}
+	for i, reason := range diagnostic.Reasons {
+		result.Reasons[i] = EngineReason{
+			PolicyID: string(reason.PolicyID),
+			Position: reason.Position,
+		}
+	}
+	for i, engineError := range diagnostic.Errors {
+		result.Errors[i] = EngineError{
+			PolicyID: string(engineError.PolicyID),
+			Position: engineError.Position,
+			Message:  engineError.Message,
+		}
+	}
+	return result
+}

--- a/internal/cedareval/evaluator_test.go
+++ b/internal/cedareval/evaluator_test.go
@@ -212,8 +212,6 @@ func TestNewRejectsInvalidPolicyDocuments(t *testing.T) {
 		name       string
 		policyText string
 	}{
-		{name: "empty", policyText: ""},
-		{name: "no policies", policyText: "\n"},
 		{name: "invalid", policyText: "permit("},
 		{name: "too large", policyText: strings.Repeat("x", PolicyMaxBytes+1)},
 	}
@@ -225,6 +223,44 @@ func TestNewRejectsInvalidPolicyDocuments(t *testing.T) {
 				t.Fatal("New() error = nil, want rejection")
 			}
 		})
+	}
+}
+
+func TestEmptyPolicySetDefaultsToDeny(t *testing.T) {
+	t.Parallel()
+
+	evaluator, err := New("")
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	result, err := evaluator.Evaluate(ToolUseInput{
+		EvaluationPrincipal: EvaluationPrincipal{
+			EntityType: PrincipalEntityType,
+			EntityID:   "alice@example.com",
+		},
+		ToolName:  "Read",
+		ToolInput: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	if result.Decision != DecisionDeny || result.Ask {
+		t.Fatalf("result = %#v, want default deny without ask", result)
+	}
+}
+
+func TestBuildRequestRejectsNilToolInput(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := BuildRequest(ToolUseInput{
+		EvaluationPrincipal: EvaluationPrincipal{
+			EntityType: PrincipalEntityType,
+			EntityID:   "alice@example.com",
+		},
+		ToolName: "Read",
+	})
+	if err == nil || !strings.Contains(err.Error(), "JSON object") {
+		t.Fatalf("BuildRequest() error = %v, want JSON object rejection", err)
 	}
 }
 

--- a/internal/cedareval/evaluator_test.go
+++ b/internal/cedareval/evaluator_test.go
@@ -160,6 +160,78 @@ func TestConvertToolInputNumericRepresentations(t *testing.T) {
 	}
 }
 
+func TestECMAFixed4UsesJavaScriptTieBreaking(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		value      float64
+		wantFixed  string
+		wantScaled int64
+	}{
+		{
+			name:       "positive exact halfway",
+			value:      549755813888.03125,
+			wantFixed:  "549755813888.0313",
+			wantScaled: 5497558138880313,
+		},
+		{
+			name:       "negative exact halfway",
+			value:      -549755813888.03125,
+			wantFixed:  "-549755813888.0313",
+			wantScaled: -5497558138880313,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fixed, scaled, ok := ecmaFixed4(tt.value)
+			if !ok {
+				t.Fatal("ecmaFixed4() ok = false, want true")
+			}
+			if fixed != tt.wantFixed || scaled != tt.wantScaled {
+				t.Fatalf("ecmaFixed4() = (%q, %d), want (%q, %d)", fixed, scaled, tt.wantFixed, tt.wantScaled)
+			}
+			if _, _, err := ConvertToolInput(map[string]any{"value": tt.value}); err != nil {
+				t.Fatalf("ConvertToolInput() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestBuildRequestRejectsInvalidUTF8Identifiers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		principal string
+		toolName  string
+	}{
+		{name: "principal", principal: string([]byte{0xff}), toolName: "Bash"},
+		{name: "tool", principal: "alice@example.com", toolName: string([]byte{0xff})},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := BuildRequest(ToolUseInput{
+				EvaluationPrincipal: EvaluationPrincipal{
+					EntityType: PrincipalEntityType,
+					EntityID:   tt.principal,
+				},
+				ToolName:  tt.toolName,
+				ToolInput: map[string]any{},
+			})
+			if err == nil || !strings.Contains(err.Error(), "valid UTF-8") {
+				t.Fatalf("BuildRequest() error = %v, want valid UTF-8 rejection", err)
+			}
+		})
+	}
+}
+
 func TestEvaluatorPreservesEngineDiagnostics(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cedareval/evaluator_test.go
+++ b/internal/cedareval/evaluator_test.go
@@ -144,6 +144,8 @@ func TestConvertToolInputNumericRepresentations(t *testing.T) {
 		{name: "go unsigned integer", value: uint64(42)},
 		{name: "float integer", value: float64(42)},
 		{name: "json decimal", value: json.Number("1.25")},
+		{name: "json long-tail binary64 decimal", value: json.Number("0.00010000000000000001")},
+		{name: "json exponent decimal", value: json.Number("1e-4")},
 		{name: "float decimal", value: 1.25},
 	}
 	for _, tt := range tests {
@@ -185,23 +187,45 @@ permit(principal, action, resource) when { context.command == "git status" };`)
 	}
 }
 
-func TestEvaluatorRejectsUnsupportedDeterminingAsk(t *testing.T) {
+func TestNewRejectsInvalidPolicyMetadata(t *testing.T) {
 	t.Parallel()
 
-	evaluator, err := New(`@id("bad_ask") @ask("true") permit(principal, action, resource);`)
-	if err != nil {
-		t.Fatalf("New() error = %v", err)
-	}
-	_, err = evaluator.Evaluate(ToolUseInput{
-		EvaluationPrincipal: EvaluationPrincipal{
-			EntityType: PrincipalEntityType,
-			EntityID:   "alice@example.com",
+	tests := []struct {
+		name       string
+		policyText string
+		wantError  string
+	}{
+		{
+			name:       "missing id",
+			policyText: `permit(principal, action, resource);`,
+			wantError:  "no non-empty @id annotation",
 		},
-		ToolName:  "Read",
-		ToolInput: map[string]any{},
-	})
-	if err == nil || !strings.Contains(err.Error(), "unsupported @ask value") {
-		t.Fatalf("Evaluate() error = %v, want unsupported @ask value", err)
+		{
+			name:       "empty id",
+			policyText: `@id("") permit(principal, action, resource);`,
+			wantError:  "no non-empty @id annotation",
+		},
+		{
+			name: "duplicate id",
+			policyText: `@id("duplicate") permit(principal, action, resource);
+@id("duplicate") forbid(principal, action, resource);`,
+			wantError: "duplicate @id",
+		},
+		{
+			name:       "unsupported ask",
+			policyText: `@id("bad_ask") @ask("true") permit(principal, action, resource);`,
+			wantError:  "unsupported @ask value",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := New(tt.policyText)
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("New() error = %v, want %q", err, tt.wantError)
+			}
+		})
 	}
 }
 

--- a/internal/cedareval/evaluator_test.go
+++ b/internal/cedareval/evaluator_test.go
@@ -1,0 +1,248 @@
+package cedareval
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/hook"
+)
+
+func TestBuildRequest(t *testing.T) {
+	t.Parallel()
+
+	request, diagnostics, err := BuildRequest(ToolUseInput{
+		EvaluationPrincipal: EvaluationPrincipal{
+			EntityType: PrincipalEntityType,
+			EntityID:   "alice@example.com",
+		},
+		ToolName:  "mcp__alias__Tool/With Unicode 🪵",
+		ToolInput: map[string]any{"command": "git status"},
+	})
+	if err != nil {
+		t.Fatalf("BuildRequest() error = %v", err)
+	}
+	if len(diagnostics) != 0 {
+		t.Fatalf("diagnostics = %v, want none", diagnostics)
+	}
+	if got := request.Principal.String(); got != `Kontext::User::"alice@example.com"` {
+		t.Errorf("Principal = %s, want exact structured user", got)
+	}
+	if got := request.Action.String(); got != `Kontext::Action::"ToolUse"` {
+		t.Errorf("Action = %s, want ToolUse", got)
+	}
+	if got := request.Resource.String(); got != `Kontext::Tool::"mcp__alias__Tool/With Unicode 🪵"` {
+		t.Errorf("Resource = %s, want exact tool name", got)
+	}
+}
+
+func TestInputFromEvent(t *testing.T) {
+	t.Parallel()
+
+	principal := EvaluationPrincipal{EntityType: PrincipalEntityType, EntityID: "alice@example.com"}
+	event := hook.Event{
+		Agent:     "claude",
+		HookName:  hook.HookPreToolUse,
+		ToolName:  "Bash",
+		ToolInput: map[string]any{"command": "git status"},
+		CWD:       "/private/project",
+	}
+	input, err := InputFromEvent(principal, event)
+	if err != nil {
+		t.Fatalf("InputFromEvent() error = %v", err)
+	}
+	want := ToolUseInput{
+		EvaluationPrincipal: principal,
+		ToolName:            "Bash",
+		ToolInput:           map[string]any{"command": "git status"},
+	}
+	if !reflect.DeepEqual(input, want) {
+		t.Fatalf("InputFromEvent() = %#v, want %#v", input, want)
+	}
+
+	_, err = InputFromEvent(principal, hook.Event{HookName: hook.HookPostToolUse})
+	if err == nil {
+		t.Fatal("InputFromEvent() error = nil, want non-pre-use rejection")
+	}
+}
+
+func TestConvertToolInputLimits(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		input        map[string]any
+		expectedCode string
+	}{
+		{
+			name:         "maximum depth",
+			input:        nestedInput(ContextMaxDepth + 1),
+			expectedCode: "maximum_depth_exceeded",
+		},
+		{
+			name:         "maximum values",
+			input:        wideInput(ContextMaxValues),
+			expectedCode: "maximum_values_exceeded",
+		},
+		{
+			name:         "invalid value",
+			input:        map[string]any{"channel": make(chan struct{})},
+			expectedCode: "invalid_json_value",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := ConvertToolInput(tt.input)
+			var conversionError *ConversionError
+			if !errors.As(err, &conversionError) {
+				t.Fatalf("ConvertToolInput() error = %v, want ConversionError", err)
+			}
+			if conversionError.Code != tt.expectedCode {
+				t.Fatalf("ConversionError.Code = %q, want %q", conversionError.Code, tt.expectedCode)
+			}
+		})
+	}
+}
+
+func TestConvertToolInputSortsDiagnosticsByJSONPointer(t *testing.T) {
+	t.Parallel()
+
+	_, diagnostics, err := ConvertToolInput(map[string]any{
+		"z": nil,
+		"a": map[string]any{
+			"~key/part": nil,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ConvertToolInput() error = %v", err)
+	}
+	want := []ContextDiagnostic{
+		{Code: "null_omitted", Path: "/a/~0key~1part"},
+		{Code: "null_omitted", Path: "/z"},
+	}
+	if !reflect.DeepEqual(diagnostics, want) {
+		t.Fatalf("diagnostics = %v, want %v", diagnostics, want)
+	}
+}
+
+func TestConvertToolInputNumericRepresentations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value any
+	}{
+		{name: "json integer", value: json.Number("42")},
+		{name: "json exponent integer", value: json.Number("1e3")},
+		{name: "go integer", value: int64(42)},
+		{name: "go unsigned integer", value: uint64(42)},
+		{name: "float integer", value: float64(42)},
+		{name: "json decimal", value: json.Number("1.25")},
+		{name: "float decimal", value: 1.25},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := ConvertToolInput(map[string]any{"value": tt.value})
+			if err != nil {
+				t.Fatalf("ConvertToolInput() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestEvaluatorPreservesEngineDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	evaluator, err := New(`@id("unguarded")
+permit(principal, action, resource) when { context.command == "git status" };`)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	result, err := evaluator.Evaluate(ToolUseInput{
+		EvaluationPrincipal: EvaluationPrincipal{
+			EntityType: PrincipalEntityType,
+			EntityID:   "alice@example.com",
+		},
+		ToolName:  "Bash",
+		ToolInput: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	if result.Decision != DecisionDeny {
+		t.Fatalf("Decision = %q, want deny", result.Decision)
+	}
+	if len(result.EngineDiagnostics.Errors) != 1 {
+		t.Fatalf("EngineDiagnostics.Errors = %v, want one error", result.EngineDiagnostics.Errors)
+	}
+}
+
+func TestEvaluatorRejectsUnsupportedDeterminingAsk(t *testing.T) {
+	t.Parallel()
+
+	evaluator, err := New(`@id("bad_ask") @ask("true") permit(principal, action, resource);`)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	_, err = evaluator.Evaluate(ToolUseInput{
+		EvaluationPrincipal: EvaluationPrincipal{
+			EntityType: PrincipalEntityType,
+			EntityID:   "alice@example.com",
+		},
+		ToolName:  "Read",
+		ToolInput: map[string]any{},
+	})
+	if err == nil || !strings.Contains(err.Error(), "unsupported @ask value") {
+		t.Fatalf("Evaluate() error = %v, want unsupported @ask value", err)
+	}
+}
+
+func TestNewRejectsInvalidPolicyDocuments(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		policyText string
+	}{
+		{name: "empty", policyText: ""},
+		{name: "no policies", policyText: "\n"},
+		{name: "invalid", policyText: "permit("},
+		{name: "too large", policyText: strings.Repeat("x", PolicyMaxBytes+1)},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := New(tt.policyText); err == nil {
+				t.Fatal("New() error = nil, want rejection")
+			}
+		})
+	}
+}
+
+func nestedInput(depth int) map[string]any {
+	root := map[string]any{}
+	current := root
+	for range depth {
+		next := map[string]any{}
+		current["next"] = next
+		current = next
+	}
+	return root
+}
+
+func wideInput(values int) map[string]any {
+	input := make(map[string]any, values)
+	for i := range values {
+		input[strconv.Itoa(i)] = true
+	}
+	return input
+}

--- a/internal/cedareval/fixtures_test.go
+++ b/internal/cedareval/fixtures_test.go
@@ -1,0 +1,354 @@
+package cedareval_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/agent"
+	"github.com/kontext-security/kontext-cli/internal/agent/claude"
+	"github.com/kontext-security/kontext-cli/internal/agent/codex"
+	"github.com/kontext-security/kontext-cli/internal/agent/cowork"
+	"github.com/kontext-security/kontext-cli/internal/cedareval"
+)
+
+const portableFixtureContractVersion = 1
+
+var fixtureDigests = map[string]string{
+	"authorization-v1.json":  "93d2053cffba8a59a6fe29a68f61cb8b6e7f2ecde0713fff2b790d293287d82d",
+	"context-errors-v1.json": "5c9d2bf34330cf084b8123a4bda9298edd5359e71579cf0b22a9df9b1cb8f0fe",
+	"hashing-v1.json":        "941cd2a42191a8c2817db8aba19831817ff9edf0d61f9ee98cadc908b09c3179",
+}
+
+type authorizationFixture struct {
+	Version     int                    `json:"version"`
+	Name        string                 `json:"name"`
+	Description string                 `json:"description"`
+	Policies    []string               `json:"policies"`
+	Request     cedareval.ToolUseInput `json:"request"`
+	Expected    struct {
+		Decision             cedareval.Decision            `json:"decision"`
+		Ask                  bool                          `json:"ask"`
+		DeterminingPolicyIDs []string                      `json:"determiningPolicyIds"`
+		ContextDiagnostics   []cedareval.ContextDiagnostic `json:"contextDiagnostics"`
+	} `json:"expected"`
+}
+
+type contextErrorFixture struct {
+	Version        int            `json:"version"`
+	Name           string         `json:"name"`
+	ToolInput      map[string]any `json:"toolInput"`
+	InputGenerator *struct {
+		Kind   string `json:"kind"`
+		Depth  int    `json:"depth"`
+		Length int    `json:"length"`
+	} `json:"inputGenerator"`
+	ExpectedCode string `json:"expectedCode"`
+	ExpectedPath string `json:"expectedPath"`
+}
+
+type hashFixture struct {
+	Version             int                           `json:"version"`
+	Name                string                        `json:"name"`
+	PolicyText          string                        `json:"policyText"`
+	Revision            string                        `json:"revision"`
+	RolloutMode         string                        `json:"rolloutMode"`
+	EvaluationPrincipal cedareval.EvaluationPrincipal `json:"evaluationPrincipal"`
+	ExpectedPolicyHash  string                        `json:"expectedPolicyHash"`
+	ExpectedPreimage    string                        `json:"expectedDeploymentPreimage"`
+	ExpectedIdentity    string                        `json:"expectedDeploymentIdentity"`
+}
+
+func TestPortableFixtureProvenance(t *testing.T) {
+	t.Parallel()
+
+	if portableFixtureContractVersion != cedareval.RequestContractVersion {
+		t.Fatalf(
+			"fixture contract version = %d, want request contract version %d",
+			portableFixtureContractVersion,
+			cedareval.RequestContractVersion,
+		)
+	}
+	for name, expected := range fixtureDigests {
+		name := name
+		expected := expected
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			contents, err := os.ReadFile(filepath.Join("testdata", "portable", "v1", name))
+			if err != nil {
+				t.Fatalf("ReadFile() error = %v", err)
+			}
+			sum := sha256.Sum256(contents)
+			if got := hex.EncodeToString(sum[:]); got != expected {
+				t.Fatalf("fixture digest = %s, want %s", got, expected)
+			}
+		})
+	}
+}
+
+func TestPortableAuthorizationFixtures(t *testing.T) {
+	var fixtures []authorizationFixture
+	readFixture(t, "authorization-v1.json", &fixtures)
+
+	for _, fixture := range fixtures {
+		fixture := fixture
+		t.Run(fixture.Name, func(t *testing.T) {
+			t.Parallel()
+			evaluator, err := cedareval.New(strings.Join(fixture.Policies, "\n\n"))
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			result, err := evaluator.Evaluate(fixture.Request)
+			if err != nil {
+				t.Fatalf("Evaluate() error = %v", err)
+			}
+			if result.Decision != fixture.Expected.Decision {
+				t.Errorf("Decision = %q, want %q", result.Decision, fixture.Expected.Decision)
+			}
+			if result.Ask != fixture.Expected.Ask {
+				t.Errorf("Ask = %v, want %v", result.Ask, fixture.Expected.Ask)
+			}
+			if !reflect.DeepEqual(result.DeterminingPolicyIDs, fixture.Expected.DeterminingPolicyIDs) {
+				t.Errorf("DeterminingPolicyIDs = %v, want %v", result.DeterminingPolicyIDs, fixture.Expected.DeterminingPolicyIDs)
+			}
+			if !reflect.DeepEqual(result.ContextDiagnostics, fixture.Expected.ContextDiagnostics) {
+				t.Errorf("ContextDiagnostics = %v, want %v", result.ContextDiagnostics, fixture.Expected.ContextDiagnostics)
+			}
+			if len(result.EngineDiagnostics.Errors) != 0 {
+				t.Errorf("EngineDiagnostics.Errors = %v, want none", result.EngineDiagnostics.Errors)
+			}
+		})
+	}
+}
+
+func TestPortableContextErrorFixtures(t *testing.T) {
+	var fixtures []contextErrorFixture
+	readFixture(t, "context-errors-v1.json", &fixtures)
+
+	for _, fixture := range fixtures {
+		fixture := fixture
+		t.Run(fixture.Name, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := cedareval.ConvertToolInput(contextErrorInput(t, fixture))
+			var conversionError *cedareval.ConversionError
+			if !errors.As(err, &conversionError) {
+				t.Fatalf("ConvertToolInput() error = %v, want ConversionError", err)
+			}
+			if conversionError.Code != fixture.ExpectedCode || conversionError.Path != fixture.ExpectedPath {
+				t.Fatalf(
+					"ConversionError = (%q, %q), want (%q, %q)",
+					conversionError.Code,
+					conversionError.Path,
+					fixture.ExpectedCode,
+					fixture.ExpectedPath,
+				)
+			}
+		})
+	}
+}
+
+func contextErrorInput(t *testing.T, fixture contextErrorFixture) map[string]any {
+	t.Helper()
+	if fixture.InputGenerator == nil {
+		return fixture.ToolInput
+	}
+
+	switch fixture.InputGenerator.Kind {
+	case "nested-record":
+		var value any = map[string]any{}
+		for range fixture.InputGenerator.Depth {
+			value = map[string]any{"value": value}
+		}
+		return value.(map[string]any)
+	case "wide-array":
+		values := make([]any, fixture.InputGenerator.Length)
+		for i := range values {
+			values[i] = i
+		}
+		return map[string]any{"values": values}
+	default:
+		t.Fatalf("unsupported input generator %q", fixture.InputGenerator.Kind)
+		return nil
+	}
+}
+
+func TestPortableHashFixtures(t *testing.T) {
+	var fixtures []hashFixture
+	readFixture(t, "hashing-v1.json", &fixtures)
+
+	for _, fixture := range fixtures {
+		fixture := fixture
+		t.Run(fixture.Name, func(t *testing.T) {
+			t.Parallel()
+			policyHash := cedareval.ComputePolicyHash(fixture.PolicyText)
+			if policyHash != fixture.ExpectedPolicyHash {
+				t.Fatalf("ComputePolicyHash() = %q, want %q", policyHash, fixture.ExpectedPolicyHash)
+			}
+			input := cedareval.DeploymentIdentityInput{
+				ResponseVersion:        1,
+				RequestContractVersion: cedareval.RequestContractVersion,
+				Revision:               fixture.Revision,
+				PolicyHash:             policyHash,
+				RolloutMode:            fixture.RolloutMode,
+				EvaluationPrincipal:    fixture.EvaluationPrincipal,
+			}
+			preimage, err := cedareval.DeploymentIdentityPreimage(input)
+			if err != nil {
+				t.Fatalf("DeploymentIdentityPreimage() error = %v", err)
+			}
+			if preimage != fixture.ExpectedPreimage {
+				t.Errorf("DeploymentIdentityPreimage() = %q, want %q", preimage, fixture.ExpectedPreimage)
+			}
+			identity, err := cedareval.ComputeDeploymentIdentity(input)
+			if err != nil {
+				t.Fatalf("ComputeDeploymentIdentity() error = %v", err)
+			}
+			if identity != fixture.ExpectedIdentity {
+				t.Errorf("ComputeDeploymentIdentity() = %q, want %q", identity, fixture.ExpectedIdentity)
+			}
+		})
+	}
+}
+
+func TestRegisteredAdapterBoundaries(t *testing.T) {
+	t.Parallel()
+
+	policy := `@id("allow_input")
+permit(principal, action == Kontext::Action::"ToolUse", resource == Kontext::Tool::"CustomTool")
+when { context has risk && context.risk == decimal("1.25") };`
+	evaluator, err := cedareval.New(policy)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	principal := cedareval.EvaluationPrincipal{
+		EntityType: cedareval.PrincipalEntityType,
+		EntityID:   "alice@example.com",
+	}
+	tests := []struct {
+		name    string
+		agent   agent.Agent
+		payload string
+	}{
+		{
+			name:    "claude",
+			agent:   &claude.Claude{},
+			payload: `{"hook_event_name":"PreToolUse","tool_name":"CustomTool","tool_input":{"risk":1.25}}`,
+		},
+		{
+			name:    "cowork",
+			agent:   &cowork.Cowork{},
+			payload: `{"hook_event_name":"PreToolUse","tool_name":"CustomTool","tool_input":{"risk":1.25}}`,
+		},
+		{
+			name:    "codex",
+			agent:   &codex.Codex{},
+			payload: `{"hook_event_name":"PreToolUse","tool_name":"CustomTool","tool_input":{"risk":1.25}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			event, err := tt.agent.DecodeHookInput([]byte(tt.payload))
+			if err != nil {
+				t.Fatalf("DecodeHookInput() error = %v", err)
+			}
+			input, err := cedareval.InputFromEvent(principal, event)
+			if err != nil {
+				t.Fatalf("InputFromEvent() error = %v", err)
+			}
+			result, err := evaluator.Evaluate(input)
+			if err != nil {
+				t.Fatalf("Evaluate() error = %v", err)
+			}
+			if result.Decision != cedareval.DecisionAllow {
+				t.Fatalf("Decision = %q, want allow", result.Decision)
+			}
+		})
+	}
+}
+
+func TestEvaluatorDoesNotMutateInputAndSupportsConcurrentUse(t *testing.T) {
+	t.Parallel()
+
+	evaluator, err := cedareval.New(`@id("allow") permit(principal, action, resource);`)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	input := cedareval.ToolUseInput{
+		EvaluationPrincipal: cedareval.EvaluationPrincipal{
+			EntityType: cedareval.PrincipalEntityType,
+			EntityID:   "alice@example.com",
+		},
+		ToolName: "CustomTool",
+		ToolInput: map[string]any{
+			"nested": map[string]any{"enabled": true},
+			"values": []any{"one", "one", "two"},
+			"unused": nil,
+		},
+	}
+	original := cloneJSONMap(t, input.ToolInput)
+
+	const workers = 32
+	var waitGroup sync.WaitGroup
+	errorsChannel := make(chan error, workers)
+	for range workers {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			result, err := evaluator.Evaluate(input)
+			if err != nil {
+				errorsChannel <- err
+				return
+			}
+			if result.Decision != cedareval.DecisionAllow {
+				errorsChannel <- errors.New("unexpected deny")
+			}
+		}()
+	}
+	waitGroup.Wait()
+	close(errorsChannel)
+	for err := range errorsChannel {
+		t.Errorf("concurrent Evaluate() error = %v", err)
+	}
+	if !reflect.DeepEqual(input.ToolInput, original) {
+		t.Fatalf("Evaluate() mutated input: got %v, want %v", input.ToolInput, original)
+	}
+}
+
+func readFixture(t *testing.T, name string, destination any) {
+	t.Helper()
+	contents, err := os.ReadFile(filepath.Join("testdata", "portable", "v1", name))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(contents))
+	decoder.UseNumber()
+	if err := decoder.Decode(destination); err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+}
+
+func cloneJSONMap(t *testing.T, value map[string]any) map[string]any {
+	t.Helper()
+	contents, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	var clone map[string]any
+	decoder := json.NewDecoder(bytes.NewReader(contents))
+	decoder.UseNumber()
+	if err := decoder.Decode(&clone); err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	return clone
+}

--- a/internal/cedareval/fixtures_test.go
+++ b/internal/cedareval/fixtures_test.go
@@ -24,9 +24,9 @@ import (
 const portableFixtureContractVersion = 1
 
 var fixtureDigests = map[string]string{
-	"authorization-v1.json":  "54efbd87f375620e84642e298239863bb5485e494fecbcdc685558bd27b38956",
+	"authorization-v1.json":  "11607132ded49c3fcbb826081bd5ec1a0aaf361c8b19e43c61afeebd948dee87",
 	"context-errors-v1.json": "5c9d2bf34330cf084b8123a4bda9298edd5359e71579cf0b22a9df9b1cb8f0fe",
-	"hashing-v1.json":        "941cd2a42191a8c2817db8aba19831817ff9edf0d61f9ee98cadc908b09c3179",
+	"hashing-v1.json":        "5179f41ae61872ee9f6a048cba4592dc12c0267fc8c8699a0c2afa886da62775",
 }
 
 type authorizationFixture struct {
@@ -60,7 +60,6 @@ type hashFixture struct {
 	Version             int                           `json:"version"`
 	Name                string                        `json:"name"`
 	PolicyText          string                        `json:"policyText"`
-	Revision            string                        `json:"revision"`
 	RolloutMode         string                        `json:"rolloutMode"`
 	EvaluationPrincipal cedareval.EvaluationPrincipal `json:"evaluationPrincipal"`
 	ExpectedPolicyHash  string                        `json:"expectedPolicyHash"`
@@ -196,7 +195,6 @@ func TestPortableHashFixtures(t *testing.T) {
 			input := cedareval.DeploymentIdentityInput{
 				ResponseVersion:        1,
 				RequestContractVersion: cedareval.RequestContractVersion,
-				Revision:               fixture.Revision,
 				PolicyHash:             policyHash,
 				RolloutMode:            fixture.RolloutMode,
 				EvaluationPrincipal:    fixture.EvaluationPrincipal,

--- a/internal/cedareval/fixtures_test.go
+++ b/internal/cedareval/fixtures_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -23,7 +24,7 @@ import (
 const portableFixtureContractVersion = 1
 
 var fixtureDigests = map[string]string{
-	"authorization-v1.json":  "93d2053cffba8a59a6fe29a68f61cb8b6e7f2ecde0713fff2b790d293287d82d",
+	"authorization-v1.json":  "54efbd87f375620e84642e298239863bb5485e494fecbcdc685558bd27b38956",
 	"context-errors-v1.json": "5c9d2bf34330cf084b8123a4bda9298edd5359e71579cf0b22a9df9b1cb8f0fe",
 	"hashing-v1.json":        "941cd2a42191a8c2817db8aba19831817ff9edf0d61f9ee98cadc908b09c3179",
 }
@@ -171,7 +172,7 @@ func contextErrorInput(t *testing.T, fixture contextErrorFixture) map[string]any
 	case "wide-array":
 		values := make([]any, fixture.InputGenerator.Length)
 		for i := range values {
-			values[i] = i
+			values[i] = 0
 		}
 		return map[string]any{"values": values}
 	default:
@@ -333,8 +334,12 @@ func readFixture(t *testing.T, name string, destination any) {
 	}
 	decoder := json.NewDecoder(bytes.NewReader(contents))
 	decoder.UseNumber()
+	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(destination); err != nil {
 		t.Fatalf("Decode() error = %v", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		t.Fatalf("Decode() trailing content error = %v", err)
 	}
 }
 

--- a/internal/cedareval/fixtures_test.go
+++ b/internal/cedareval/fixtures_test.go
@@ -24,9 +24,10 @@ import (
 const portableFixtureContractVersion = 1
 
 var fixtureDigests = map[string]string{
-	"authorization-v1.json":  "a335ed1e0cfa14776ea6f8a2464dcf4d1207aefa9f473231e5de42fcb16ba425",
-	"context-errors-v1.json": "945e6be23af02aa4d0c7bd382f5963b6342f46a02602bfbc8f134ae283b6773e",
-	"hashing-v1.json":        "5179f41ae61872ee9f6a048cba4592dc12c0267fc8c8699a0c2afa886da62775",
+	"authorization-v1.json":     "c7f8aaf5da2acbf9a5d832ebf2bcf3ca531a617cdea3a6aed1b6b1840c4735b5",
+	"context-errors-v1.json":    "945e6be23af02aa4d0c7bd382f5963b6342f46a02602bfbc8f134ae283b6773e",
+	"evaluation-errors-v1.json": "8318efcd613fd56645fac3bf49939d6b70f41af102a1f06df2a6cc9da75d8415",
+	"hashing-v1.json":           "5179f41ae61872ee9f6a048cba4592dc12c0267fc8c8699a0c2afa886da62775",
 }
 
 type authorizationFixture struct {
@@ -54,6 +55,20 @@ type contextErrorFixture struct {
 	} `json:"inputGenerator"`
 	ExpectedCode string `json:"expectedCode"`
 	ExpectedPath string `json:"expectedPath"`
+}
+
+type evaluationErrorFixture struct {
+	Version     int                    `json:"version"`
+	Name        string                 `json:"name"`
+	Description string                 `json:"description"`
+	Policies    []string               `json:"policies"`
+	Request     cedareval.ToolUseInput `json:"request"`
+	Expected    struct {
+		Decision             cedareval.Decision            `json:"decision"`
+		EngineErrorCount     int                           `json:"engineErrorCount"`
+		DeterminingPolicyIDs []string                      `json:"determiningPolicyIds"`
+		ContextDiagnostics   []cedareval.ContextDiagnostic `json:"contextDiagnostics"`
+	} `json:"expected"`
 }
 
 type hashFixture struct {
@@ -150,6 +165,38 @@ func TestPortableContextErrorFixtures(t *testing.T) {
 					fixture.ExpectedCode,
 					fixture.ExpectedPath,
 				)
+			}
+		})
+	}
+}
+
+func TestPortableEvaluationErrorFixtures(t *testing.T) {
+	var fixtures []evaluationErrorFixture
+	readFixture(t, "evaluation-errors-v1.json", &fixtures)
+
+	for _, fixture := range fixtures {
+		fixture := fixture
+		t.Run(fixture.Name, func(t *testing.T) {
+			t.Parallel()
+			evaluator, err := cedareval.New(strings.Join(fixture.Policies, "\n\n"))
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			result, err := evaluator.Evaluate(fixture.Request)
+			if err != nil {
+				t.Fatalf("Evaluate() error = %v", err)
+			}
+			if result.Decision != fixture.Expected.Decision {
+				t.Errorf("Decision = %q, want %q", result.Decision, fixture.Expected.Decision)
+			}
+			if len(result.EngineDiagnostics.Errors) != fixture.Expected.EngineErrorCount {
+				t.Errorf("EngineDiagnostics.Errors count = %d, want %d", len(result.EngineDiagnostics.Errors), fixture.Expected.EngineErrorCount)
+			}
+			if !reflect.DeepEqual(result.DeterminingPolicyIDs, fixture.Expected.DeterminingPolicyIDs) {
+				t.Errorf("DeterminingPolicyIDs = %v, want %v", result.DeterminingPolicyIDs, fixture.Expected.DeterminingPolicyIDs)
+			}
+			if !reflect.DeepEqual(result.ContextDiagnostics, fixture.Expected.ContextDiagnostics) {
+				t.Errorf("ContextDiagnostics = %v, want %v", result.ContextDiagnostics, fixture.Expected.ContextDiagnostics)
 			}
 		})
 	}

--- a/internal/cedareval/fixtures_test.go
+++ b/internal/cedareval/fixtures_test.go
@@ -24,8 +24,8 @@ import (
 const portableFixtureContractVersion = 1
 
 var fixtureDigests = map[string]string{
-	"authorization-v1.json":  "11607132ded49c3fcbb826081bd5ec1a0aaf361c8b19e43c61afeebd948dee87",
-	"context-errors-v1.json": "5c9d2bf34330cf084b8123a4bda9298edd5359e71579cf0b22a9df9b1cb8f0fe",
+	"authorization-v1.json":  "a335ed1e0cfa14776ea6f8a2464dcf4d1207aefa9f473231e5de42fcb16ba425",
+	"context-errors-v1.json": "945e6be23af02aa4d0c7bd382f5963b6342f46a02602bfbc8f134ae283b6773e",
 	"hashing-v1.json":        "5179f41ae61872ee9f6a048cba4592dc12c0267fc8c8699a0c2afa886da62775",
 }
 

--- a/internal/cedareval/fixtures_test.go
+++ b/internal/cedareval/fixtures_test.go
@@ -92,6 +92,18 @@ func TestPortableFixtureProvenance(t *testing.T) {
 			cedareval.RequestContractVersion,
 		)
 	}
+	entries, err := os.ReadDir(filepath.Join("testdata", "portable", "v1"))
+	if err != nil {
+		t.Fatalf("ReadDir() error = %v", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		if _, ok := fixtureDigests[entry.Name()]; !ok {
+			t.Errorf("portable fixture %q has no pinned digest", entry.Name())
+		}
+	}
 	for name, expected := range fixtureDigests {
 		name := name
 		expected := expected
@@ -385,6 +397,30 @@ func readFixture(t *testing.T, name string, destination any) {
 	}
 	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
 		t.Fatalf("Decode() trailing content error = %v", err)
+	}
+
+	type fixtureMetadata struct {
+		Version int `json:"version"`
+	}
+	var metadata []fixtureMetadata
+	if bytes.HasPrefix(bytes.TrimSpace(contents), []byte("{")) {
+		var fixture fixtureMetadata
+		if err := json.Unmarshal(contents, &fixture); err != nil {
+			t.Fatalf("Decode() fixture metadata error = %v", err)
+		}
+		metadata = append(metadata, fixture)
+	} else if err := json.Unmarshal(contents, &metadata); err != nil {
+		t.Fatalf("Decode() fixture metadata error = %v", err)
+	}
+	for index, fixture := range metadata {
+		if fixture.Version != portableFixtureContractVersion {
+			t.Fatalf(
+				"fixture %d version = %d, want %d",
+				index,
+				fixture.Version,
+				portableFixtureContractVersion,
+			)
+		}
 	}
 }
 

--- a/internal/cedareval/hashing.go
+++ b/internal/cedareval/hashing.go
@@ -1,22 +1,22 @@
 package cedareval
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
+	"unicode/utf8"
 )
 
 const (
 	PolicyHashDomain         = "kontext:cedar-policy:v1\x00"
-	DeploymentIdentityDomain = "kontext:cedar-deployment:v1"
+	DeploymentIdentityDomain = "kontext:cedar-deployment:v2"
 )
 
 type DeploymentIdentityInput struct {
 	ResponseVersion        int
 	RequestContractVersion int
-	Revision               string
 	PolicyHash             string
 	RolloutMode            string
 	EvaluationPrincipal    EvaluationPrincipal
@@ -28,24 +28,65 @@ func ComputePolicyHash(policyText string) string {
 }
 
 func DeploymentIdentityPreimage(input DeploymentIdentityInput) (string, error) {
-	value := []any{
-		DeploymentIdentityDomain,
-		input.ResponseVersion,
-		input.RequestContractVersion,
-		input.Revision,
+	stringsToValidate := []string{
 		input.PolicyHash,
 		input.RolloutMode,
 		input.EvaluationPrincipal.EntityType,
 		input.EvaluationPrincipal.EntityID,
 	}
-
-	var buffer bytes.Buffer
-	encoder := json.NewEncoder(&buffer)
-	encoder.SetEscapeHTML(false)
-	if err := encoder.Encode(value); err != nil {
-		return "", fmt.Errorf("cedareval: encode deployment identity: %w", err)
+	for _, value := range stringsToValidate {
+		if !utf8.ValidString(value) {
+			return "", fmt.Errorf("cedareval: deployment identity contains invalid utf-8")
+		}
 	}
-	return string(bytes.TrimSuffix(buffer.Bytes(), []byte("\n"))), nil
+
+	var builder strings.Builder
+	builder.WriteByte('[')
+	appendJSONString(&builder, DeploymentIdentityDomain)
+	builder.WriteByte(',')
+	builder.WriteString(strconv.Itoa(input.ResponseVersion))
+	builder.WriteByte(',')
+	builder.WriteString(strconv.Itoa(input.RequestContractVersion))
+	for _, value := range stringsToValidate {
+		builder.WriteByte(',')
+		appendJSONString(&builder, value)
+	}
+	builder.WriteByte(']')
+	return builder.String(), nil
+}
+
+// appendJSONString matches JSON.stringify for valid UTF-8 strings. In
+// particular it leaves HTML-sensitive characters and U+2028/U+2029 literal;
+// encoding/json intentionally escapes the latter and would change the
+// cross-runtime deployment identity preimage.
+func appendJSONString(builder *strings.Builder, value string) {
+	builder.WriteByte('"')
+	for _, char := range value {
+		switch char {
+		case '"', '\\':
+			builder.WriteByte('\\')
+			builder.WriteRune(char)
+		case '\b':
+			builder.WriteString(`\b`)
+		case '\t':
+			builder.WriteString(`\t`)
+		case '\n':
+			builder.WriteString(`\n`)
+		case '\f':
+			builder.WriteString(`\f`)
+		case '\r':
+			builder.WriteString(`\r`)
+		default:
+			if char < 0x20 {
+				builder.WriteString(`\u00`)
+				builder.WriteByte("0123456789abcdef"[byte(char)>>4])
+				builder.WriteByte("0123456789abcdef"[byte(char)&0x0f])
+				continue
+			}
+			builder.WriteRune(char)
+		}
+	}
+	builder.WriteByte('"')
 }
 
 func ComputeDeploymentIdentity(input DeploymentIdentityInput) (string, error) {

--- a/internal/cedareval/hashing.go
+++ b/internal/cedareval/hashing.go
@@ -1,0 +1,58 @@
+package cedareval
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+)
+
+const (
+	PolicyHashDomain         = "kontext:cedar-policy:v1\x00"
+	DeploymentIdentityDomain = "kontext:cedar-deployment:v1"
+)
+
+type DeploymentIdentityInput struct {
+	ResponseVersion        int
+	RequestContractVersion int
+	Revision               string
+	PolicyHash             string
+	RolloutMode            string
+	EvaluationPrincipal    EvaluationPrincipal
+}
+
+func ComputePolicyHash(policyText string) string {
+	sum := sha256.Sum256([]byte(PolicyHashDomain + policyText))
+	return hex.EncodeToString(sum[:])
+}
+
+func DeploymentIdentityPreimage(input DeploymentIdentityInput) (string, error) {
+	value := []any{
+		DeploymentIdentityDomain,
+		input.ResponseVersion,
+		input.RequestContractVersion,
+		input.Revision,
+		input.PolicyHash,
+		input.RolloutMode,
+		input.EvaluationPrincipal.EntityType,
+		input.EvaluationPrincipal.EntityID,
+	}
+
+	var buffer bytes.Buffer
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(value); err != nil {
+		return "", fmt.Errorf("cedareval: encode deployment identity: %w", err)
+	}
+	return string(bytes.TrimSuffix(buffer.Bytes(), []byte("\n"))), nil
+}
+
+func ComputeDeploymentIdentity(input DeploymentIdentityInput) (string, error) {
+	preimage, err := DeploymentIdentityPreimage(input)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256([]byte(preimage))
+	return hex.EncodeToString(sum[:]), nil
+}

--- a/internal/cedareval/testdata/portable/v1/README.md
+++ b/internal/cedareval/testdata/portable/v1/README.md
@@ -7,11 +7,16 @@ Request-contract v1 interprets JSON numbers using binary64 semantics, matching
 binary64 value are therefore the same policy input; callers that require exact
 textual precision must send a string.
 
-`hashing-v1.json` is copied byte-for-byte from the shared contract. Do not
-recreate equivalent hashing vectors independently in another runtime.
+`authorization-v1.json`, `context-errors-v1.json`,
+`evaluation-errors-v1.json`, and `hashing-v1.json` are copied byte-for-byte
+from the shared contract. Do not recreate equivalent vectors independently in
+another runtime. The evaluation-error corpus asserts diagnostic presence and
+count, never unstable engine error text.
 
 The hashing corpus pins the semantic seven-term
 `kontext:cedar-deployment:v2` identity. It contains no storage revision or
 endpoint operational configuration.
 
-`TestPortableFixtureProvenance` pins the contract version and SHA-256 digest of every file. Update the version and digests only when intentionally adopting a reviewed contract revision.
+`TestPortableFixtureProvenance` pins the contract version and SHA-256 digest of
+every portable JSON file. Update the version and digests only when intentionally
+adopting a reviewed contract revision.

--- a/internal/cedareval/testdata/portable/v1/README.md
+++ b/internal/cedareval/testdata/portable/v1/README.md
@@ -1,0 +1,5 @@
+# Portable Cedar fixtures v1
+
+These JSON files are the canonical portable corpus for request-contract v1.
+
+`TestPortableFixtureProvenance` pins the contract version and SHA-256 digest of every file. Update the version and digests only when intentionally adopting a reviewed contract revision.

--- a/internal/cedareval/testdata/portable/v1/README.md
+++ b/internal/cedareval/testdata/portable/v1/README.md
@@ -2,4 +2,16 @@
 
 These JSON files are the canonical portable corpus for request-contract v1.
 
+Request-contract v1 interprets JSON numbers using binary64 semantics, matching
+`JSON.parse`. Lexically different number tokens that decode to the same
+binary64 value are therefore the same policy input; callers that require exact
+textual precision must send a string.
+
+`hashing-v1.json` is copied byte-for-byte from the shared contract. Do not
+recreate equivalent hashing vectors independently in another runtime.
+
+The hashing corpus pins the semantic seven-term
+`kontext:cedar-deployment:v2` identity. It contains no storage revision or
+endpoint operational configuration.
+
 `TestPortableFixtureProvenance` pins the contract version and SHA-256 digest of every file. Update the version and digests only when intentionally adopting a reviewed contract revision.

--- a/internal/cedareval/testdata/portable/v1/authorization-v1.json
+++ b/internal/cedareval/testdata/portable/v1/authorization-v1.json
@@ -130,10 +130,10 @@
   },
   {
     "version": 1,
-    "name": "principal-is-structured-and-constrained",
-    "description": "A policy constrained to Alice does not match Bob's structured principal binding.",
+    "name": "principal-is-structured-and-unconstrained",
+    "description": "A structured principal binding evaluates against a validator-supported unconstrained principal scope.",
     "policies": [
-      "@id(\"alice_only\")\npermit(principal == Kontext::User::\"alice@example.com\", action == Kontext::Action::\"ToolUse\", resource);"
+      "@id(\"unconstrained_principal\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource);"
     ],
     "request": {
       "evaluationPrincipal": {
@@ -144,9 +144,9 @@
       "toolInput": {}
     },
     "expected": {
-      "decision": "deny",
+      "decision": "allow",
       "ask": false,
-      "determiningPolicyIds": [],
+      "determiningPolicyIds": ["unconstrained_principal"],
       "contextDiagnostics": []
     }
   },
@@ -156,7 +156,7 @@
     "description": "A satisfied forbid overrides a broad permit.",
     "policies": [
       "@id(\"allow_tools\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource);",
-      "@id(\"deny_rm\")\nforbid(principal, action == Kontext::Action::\"ToolUse\", resource == Kontext::Tool::\"Bash\") when { !(context has command) || context.command like \"rm *\" };"
+      "@id(\"deny_rm\")\nforbid(principal, action == Kontext::Action::\"ToolUse\", resource == Kontext::Tool::\"Bash\") when { !(context has command) || (context has command && context.command like \"rm *\") };"
     ],
     "request": {
       "evaluationPrincipal": {

--- a/internal/cedareval/testdata/portable/v1/authorization-v1.json
+++ b/internal/cedareval/testdata/portable/v1/authorization-v1.json
@@ -1,0 +1,210 @@
+[
+  {
+    "version": 1,
+    "name": "default-deny",
+    "description": "No satisfied permit produces Cedar's default deny.",
+    "policies": [
+      "@id(\"never\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource) when { false };"
+    ],
+    "request": {
+      "evaluationPrincipal": {
+        "entityType": "Kontext::User",
+        "entityId": "alice@example.com"
+      },
+      "toolName": "Read",
+      "toolInput": { "file_path": "/tmp/example.txt" }
+    },
+    "expected": {
+      "decision": "deny",
+      "ask": false,
+      "determiningPolicyIds": [],
+      "contextDiagnostics": []
+    }
+  },
+  {
+    "version": 1,
+    "name": "bash-command-allow",
+    "description": "A runtime-native command field can authorize an exact tool name.",
+    "policies": [
+      "@id(\"bash_status\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource == Kontext::Tool::\"Bash\") when { context has command && context.command like \"git status*\" };"
+    ],
+    "request": {
+      "evaluationPrincipal": {
+        "entityType": "Kontext::User",
+        "entityId": "alice@example.com"
+      },
+      "toolName": "Bash",
+      "toolInput": { "command": "git status --short" }
+    },
+    "expected": {
+      "decision": "allow",
+      "ask": false,
+      "determiningPolicyIds": ["bash_status"],
+      "contextDiagnostics": []
+    }
+  },
+  {
+    "version": 1,
+    "name": "exact-external-tool-name",
+    "description": "An external runtime tool name is preserved without provider canonicalization.",
+    "policies": [
+      "@id(\"create_pr\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource == Kontext::Tool::\"mcp__github__create_pull_request\") when { context has owner && context.owner == \"kontext-security\" };"
+    ],
+    "request": {
+      "evaluationPrincipal": {
+        "entityType": "Kontext::User",
+        "entityId": "alice@example.com"
+      },
+      "toolName": "mcp__github__create_pull_request",
+      "toolInput": {
+        "owner": "kontext-security",
+        "repo": "kontext"
+      }
+    },
+    "expected": {
+      "decision": "allow",
+      "ask": false,
+      "determiningPolicyIds": ["create_pr"],
+      "contextDiagnostics": []
+    }
+  },
+  {
+    "version": 1,
+    "name": "principal-is-structured-and-constrained",
+    "description": "A policy constrained to Alice does not match Bob's structured principal binding.",
+    "policies": [
+      "@id(\"alice_only\")\npermit(principal == Kontext::User::\"alice@example.com\", action == Kontext::Action::\"ToolUse\", resource);"
+    ],
+    "request": {
+      "evaluationPrincipal": {
+        "entityType": "Kontext::User",
+        "entityId": "bob@example.com"
+      },
+      "toolName": "Read",
+      "toolInput": {}
+    },
+    "expected": {
+      "decision": "deny",
+      "ask": false,
+      "determiningPolicyIds": [],
+      "contextDiagnostics": []
+    }
+  },
+  {
+    "version": 1,
+    "name": "forbid-overrides-permit",
+    "description": "A satisfied forbid overrides a broad permit.",
+    "policies": [
+      "@id(\"allow_tools\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource);",
+      "@id(\"deny_rm\")\nforbid(principal, action == Kontext::Action::\"ToolUse\", resource == Kontext::Tool::\"Bash\") when { !(context has command) || context.command like \"rm *\" };"
+    ],
+    "request": {
+      "evaluationPrincipal": {
+        "entityType": "Kontext::User",
+        "entityId": "alice@example.com"
+      },
+      "toolName": "Bash",
+      "toolInput": { "command": "rm -rf build" }
+    },
+    "expected": {
+      "decision": "deny",
+      "ask": false,
+      "determiningPolicyIds": ["deny_rm"],
+      "contextDiagnostics": []
+    }
+  },
+  {
+    "version": 1,
+    "name": "ask-only-allow",
+    "description": "An allow determined entirely by prompt permits derives ask.",
+    "policies": [
+      "@id(\"ask_bash\")\n@ask(\"prompt\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource == Kontext::Tool::\"Bash\");"
+    ],
+    "request": {
+      "evaluationPrincipal": {
+        "entityType": "Kontext::User",
+        "entityId": "alice@example.com"
+      },
+      "toolName": "Bash",
+      "toolInput": { "command": "git push" }
+    },
+    "expected": {
+      "decision": "allow",
+      "ask": true,
+      "determiningPolicyIds": ["ask_bash"],
+      "contextDiagnostics": []
+    }
+  },
+  {
+    "version": 1,
+    "name": "normal-permit-defeats-ask",
+    "description": "A normal determining permit independently authorizes a request that also matches an ask permit.",
+    "policies": [
+      "@id(\"ask_bash\")\n@ask(\"prompt\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource == Kontext::Tool::\"Bash\");",
+      "@id(\"allow_status\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource == Kontext::Tool::\"Bash\") when { context has command && context.command like \"git status*\" };"
+    ],
+    "request": {
+      "evaluationPrincipal": {
+        "entityType": "Kontext::User",
+        "entityId": "alice@example.com"
+      },
+      "toolName": "Bash",
+      "toolInput": { "command": "git status" }
+    },
+    "expected": {
+      "decision": "allow",
+      "ask": false,
+      "determiningPolicyIds": ["allow_status", "ask_bash"],
+      "contextDiagnostics": []
+    }
+  },
+  {
+    "version": 1,
+    "name": "open-nested-context",
+    "description": "Nested records, sets, decimals, and omitted nulls remain available without a closed context schema.",
+    "policies": [
+      "@id(\"structured_input\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource == Kontext::Tool::\"CustomTool\") when { context has risk && context.risk == decimal(\"1.25\") && context has options && context.options has force && context.options.force && context has tags && context.tags.contains(\"prod\") };"
+    ],
+    "request": {
+      "evaluationPrincipal": {
+        "entityType": "Kontext::User",
+        "entityId": "alice@example.com"
+      },
+      "toolName": "CustomTool",
+      "toolInput": {
+        "risk": 1.25,
+        "options": { "force": true },
+        "tags": ["prod", "prod", "reviewed"],
+        "unused": null
+      }
+    },
+    "expected": {
+      "decision": "allow",
+      "ask": false,
+      "determiningPolicyIds": ["structured_input"],
+      "contextDiagnostics": [{ "code": "null_omitted", "path": "/unused" }]
+    }
+  },
+  {
+    "version": 1,
+    "name": "missing-context-key",
+    "description": "Guarded access to an absent context key is non-applicable and falls through to deny.",
+    "policies": [
+      "@id(\"requires_command\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource) when { context has command && context.command like \"git status*\" };"
+    ],
+    "request": {
+      "evaluationPrincipal": {
+        "entityType": "Kontext::User",
+        "entityId": "alice@example.com"
+      },
+      "toolName": "Bash",
+      "toolInput": {}
+    },
+    "expected": {
+      "decision": "deny",
+      "ask": false,
+      "determiningPolicyIds": [],
+      "contextDiagnostics": []
+    }
+  }
+]

--- a/internal/cedareval/testdata/portable/v1/authorization-v1.json
+++ b/internal/cedareval/testdata/portable/v1/authorization-v1.json
@@ -34,7 +34,9 @@
       "toolName": "CustomTool",
       "toolInput": {
         "z": null,
-        "a": { "value": null }
+        "a": {
+          "value": null
+        }
       }
     },
     "expected": {
@@ -42,8 +44,14 @@
       "ask": false,
       "determiningPolicyIds": ["allow"],
       "contextDiagnostics": [
-        { "code": "null_omitted", "path": "/a/value" },
-        { "code": "null_omitted", "path": "/z" }
+        {
+          "code": "null_omitted",
+          "path": "/a/value"
+        },
+        {
+          "code": "null_omitted",
+          "path": "/z"
+        }
       ]
     }
   },
@@ -60,7 +68,9 @@
         "entityId": "alice@example.com"
       },
       "toolName": "Read",
-      "toolInput": { "file_path": "/tmp/example.txt" }
+      "toolInput": {
+        "file_path": "/tmp/example.txt"
+      }
     },
     "expected": {
       "decision": "deny",
@@ -82,7 +92,9 @@
         "entityId": "alice@example.com"
       },
       "toolName": "Bash",
-      "toolInput": { "command": "git status --short" }
+      "toolInput": {
+        "command": "git status --short"
+      }
     },
     "expected": {
       "decision": "allow",
@@ -152,7 +164,9 @@
         "entityId": "alice@example.com"
       },
       "toolName": "Bash",
-      "toolInput": { "command": "rm -rf build" }
+      "toolInput": {
+        "command": "rm -rf build"
+      }
     },
     "expected": {
       "decision": "deny",
@@ -174,7 +188,9 @@
         "entityId": "alice@example.com"
       },
       "toolName": "Bash",
-      "toolInput": { "command": "git push" }
+      "toolInput": {
+        "command": "git push"
+      }
     },
     "expected": {
       "decision": "allow",
@@ -197,7 +213,9 @@
         "entityId": "alice@example.com"
       },
       "toolName": "Bash",
-      "toolInput": { "command": "git status" }
+      "toolInput": {
+        "command": "git status"
+      }
     },
     "expected": {
       "decision": "allow",
@@ -221,7 +239,9 @@
       "toolName": "CustomTool",
       "toolInput": {
         "risk": 1.25,
-        "options": { "force": true },
+        "options": {
+          "force": true
+        },
         "tags": ["prod", "prod", "reviewed"],
         "unused": null
       }
@@ -230,7 +250,12 @@
       "decision": "allow",
       "ask": false,
       "determiningPolicyIds": ["structured_input"],
-      "contextDiagnostics": [{ "code": "null_omitted", "path": "/unused" }]
+      "contextDiagnostics": [
+        {
+          "code": "null_omitted",
+          "path": "/unused"
+        }
+      ]
     }
   },
   {
@@ -269,14 +294,38 @@
       },
       "toolName": "NumericTool",
       "toolInput": {
-        "longTail": 0.00010000000000000001,
-        "exponent": 1e-4
+        "longTail": 0.0001,
+        "exponent": 0.0001
       }
     },
     "expected": {
       "decision": "allow",
       "ask": false,
       "determiningPolicyIds": ["binary64_numbers"],
+      "contextDiagnostics": []
+    }
+  },
+  {
+    "version": 1,
+    "name": "decimal-two-fractional-digits",
+    "description": "Common two-fractional-digit doubles convert exactly; binary64 scaling noise (0.07 * 10000 is not an integer) must not reject them.",
+    "policies": [
+      "@id(\"decimal_two_digits\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource == Kontext::Tool::\"NumericTool\") when { context has price && context.price == decimal(\"0.07\") };"
+    ],
+    "request": {
+      "evaluationPrincipal": {
+        "entityType": "Kontext::User",
+        "entityId": "alice@example.com"
+      },
+      "toolName": "NumericTool",
+      "toolInput": {
+        "price": 0.07
+      }
+    },
+    "expected": {
+      "decision": "allow",
+      "ask": false,
+      "determiningPolicyIds": ["decimal_two_digits"],
       "contextDiagnostics": []
     }
   }

--- a/internal/cedareval/testdata/portable/v1/authorization-v1.json
+++ b/internal/cedareval/testdata/portable/v1/authorization-v1.json
@@ -1,6 +1,54 @@
 [
   {
     "version": 1,
+    "name": "empty-policy-set-default-deny",
+    "description": "An empty policy set is valid and produces Cedar's default deny.",
+    "policies": [],
+    "request": {
+      "evaluationPrincipal": {
+        "entityType": "Kontext::User",
+        "entityId": "alice@example.com"
+      },
+      "toolName": "Read",
+      "toolInput": {}
+    },
+    "expected": {
+      "decision": "deny",
+      "ask": false,
+      "determiningPolicyIds": [],
+      "contextDiagnostics": []
+    }
+  },
+  {
+    "version": 1,
+    "name": "multiple-null-diagnostics-sorted",
+    "description": "Omitted-null diagnostics are sorted by UTF-8 JSON Pointer.",
+    "policies": [
+      "@id(\"allow\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource);"
+    ],
+    "request": {
+      "evaluationPrincipal": {
+        "entityType": "Kontext::User",
+        "entityId": "alice@example.com"
+      },
+      "toolName": "CustomTool",
+      "toolInput": {
+        "z": null,
+        "a": { "value": null }
+      }
+    },
+    "expected": {
+      "decision": "allow",
+      "ask": false,
+      "determiningPolicyIds": ["allow"],
+      "contextDiagnostics": [
+        { "code": "null_omitted", "path": "/a/value" },
+        { "code": "null_omitted", "path": "/z" }
+      ]
+    }
+  },
+  {
+    "version": 1,
     "name": "default-deny",
     "description": "No satisfied permit produces Cedar's default deny.",
     "policies": [

--- a/internal/cedareval/testdata/portable/v1/authorization-v1.json
+++ b/internal/cedareval/testdata/portable/v1/authorization-v1.json
@@ -254,5 +254,30 @@
       "determiningPolicyIds": [],
       "contextDiagnostics": []
     }
+  },
+  {
+    "version": 1,
+    "name": "binary64-json-number-semantics",
+    "description": "Long-tail and exponent JSON spellings are interpreted as binary64 values before portable Cedar decimal conversion.",
+    "policies": [
+      "@id(\"binary64_numbers\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource == Kontext::Tool::\"NumericTool\") when { context has longTail && context.longTail == decimal(\"0.0001\") && context has exponent && context.exponent == decimal(\"0.0001\") };"
+    ],
+    "request": {
+      "evaluationPrincipal": {
+        "entityType": "Kontext::User",
+        "entityId": "alice@example.com"
+      },
+      "toolName": "NumericTool",
+      "toolInput": {
+        "longTail": 0.00010000000000000001,
+        "exponent": 1e-4
+      }
+    },
+    "expected": {
+      "decision": "allow",
+      "ask": false,
+      "determiningPolicyIds": ["binary64_numbers"],
+      "contextDiagnostics": []
+    }
   }
 ]

--- a/internal/cedareval/testdata/portable/v1/context-errors-v1.json
+++ b/internal/cedareval/testdata/portable/v1/context-errors-v1.json
@@ -1,0 +1,55 @@
+[
+  {
+    "version": 1,
+    "name": "null-inside-set",
+    "toolInput": { "values": ["one", null] },
+    "expectedCode": "null_in_set",
+    "expectedPath": "/values/1"
+  },
+  {
+    "version": 1,
+    "name": "unsafe-integer",
+    "toolInput": { "value": 9007199254740992 },
+    "expectedCode": "unsafe_integer",
+    "expectedPath": "/value"
+  },
+  {
+    "version": 1,
+    "name": "too-many-decimal-places",
+    "toolInput": { "value": 1.23456 },
+    "expectedCode": "unsupported_decimal",
+    "expectedPath": "/value"
+  },
+  {
+    "version": 1,
+    "name": "reserved-entity-escape",
+    "toolInput": {
+      "value": { "__entity": { "type": "Kontext::User", "id": "mallory" } }
+    },
+    "expectedCode": "reserved_cedar_escape",
+    "expectedPath": "/value"
+  },
+  {
+    "version": 1,
+    "name": "reserved-extension-escape",
+    "toolInput": {
+      "value": { "__extn": { "fn": "decimal", "arg": "1.0" } }
+    },
+    "expectedCode": "reserved_cedar_escape",
+    "expectedPath": "/value"
+  },
+  {
+    "version": 1,
+    "name": "maximum-depth-exceeded",
+    "inputGenerator": { "kind": "nested-record", "depth": 33 },
+    "expectedCode": "maximum_depth_exceeded",
+    "expectedPath": "/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value"
+  },
+  {
+    "version": 1,
+    "name": "maximum-values-exceeded",
+    "inputGenerator": { "kind": "wide-array", "length": 10000 },
+    "expectedCode": "maximum_values_exceeded",
+    "expectedPath": "/values/9998"
+  }
+]

--- a/internal/cedareval/testdata/portable/v1/context-errors-v1.json
+++ b/internal/cedareval/testdata/portable/v1/context-errors-v1.json
@@ -2,21 +2,36 @@
   {
     "version": 1,
     "name": "null-inside-set",
-    "toolInput": { "values": ["one", null] },
+    "toolInput": {
+      "values": ["one", null]
+    },
     "expectedCode": "null_in_set",
     "expectedPath": "/values/1"
   },
   {
     "version": 1,
     "name": "unsafe-integer",
-    "toolInput": { "value": 9007199254740992 },
+    "toolInput": {
+      "value": 9007199254740992
+    },
     "expectedCode": "unsafe_integer",
     "expectedPath": "/value"
   },
   {
     "version": 1,
     "name": "too-many-decimal-places",
-    "toolInput": { "value": 1.23456 },
+    "toolInput": {
+      "value": 1.23456
+    },
+    "expectedCode": "unsupported_decimal",
+    "expectedPath": "/value"
+  },
+  {
+    "version": 1,
+    "name": "decimal-out-of-range",
+    "toolInput": {
+      "value": 922337203685477.9
+    },
     "expectedCode": "unsupported_decimal",
     "expectedPath": "/value"
   },
@@ -24,7 +39,12 @@
     "version": 1,
     "name": "reserved-entity-escape",
     "toolInput": {
-      "value": { "__entity": { "type": "Kontext::User", "id": "mallory" } }
+      "value": {
+        "__entity": {
+          "type": "Kontext::User",
+          "id": "mallory"
+        }
+      }
     },
     "expectedCode": "reserved_cedar_escape",
     "expectedPath": "/value"
@@ -33,7 +53,12 @@
     "version": 1,
     "name": "reserved-extension-escape",
     "toolInput": {
-      "value": { "__extn": { "fn": "decimal", "arg": "1.0" } }
+      "value": {
+        "__extn": {
+          "fn": "decimal",
+          "arg": "1.0"
+        }
+      }
     },
     "expectedCode": "reserved_cedar_escape",
     "expectedPath": "/value"
@@ -41,14 +66,20 @@
   {
     "version": 1,
     "name": "maximum-depth-exceeded",
-    "inputGenerator": { "kind": "nested-record", "depth": 33 },
+    "inputGenerator": {
+      "kind": "nested-record",
+      "depth": 33
+    },
     "expectedCode": "maximum_depth_exceeded",
     "expectedPath": "/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value/value"
   },
   {
     "version": 1,
     "name": "maximum-values-exceeded",
-    "inputGenerator": { "kind": "wide-array", "length": 10000 },
+    "inputGenerator": {
+      "kind": "wide-array",
+      "length": 10000
+    },
     "expectedCode": "maximum_values_exceeded",
     "expectedPath": "/values/9998"
   }

--- a/internal/cedareval/testdata/portable/v1/evaluation-errors-v1.json
+++ b/internal/cedareval/testdata/portable/v1/evaluation-errors-v1.json
@@ -1,0 +1,26 @@
+[
+  {
+    "version": 1,
+    "name": "guarded-context-type-error",
+    "description": "A present context field with the wrong Cedar type produces an engine diagnostic without relying on error text.",
+    "policies": [
+      "@id(\"command_pattern\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource) when { context has command && context.command like \"git*\" };"
+    ],
+    "request": {
+      "evaluationPrincipal": {
+        "entityType": "Kontext::User",
+        "entityId": "alice@example.com"
+      },
+      "toolName": "Bash",
+      "toolInput": {
+        "command": 1
+      }
+    },
+    "expected": {
+      "decision": "deny",
+      "engineErrorCount": 1,
+      "determiningPolicyIds": [],
+      "contextDiagnostics": []
+    }
+  }
+]

--- a/internal/cedareval/testdata/portable/v1/hashing-v1.json
+++ b/internal/cedareval/testdata/portable/v1/hashing-v1.json
@@ -1,0 +1,16 @@
+[
+  {
+    "version": 1,
+    "name": "observe-policy-for-alice",
+    "policyText": "@id(\"allow_read\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource == Kontext::Tool::\"Read\");",
+    "revision": "rev_01",
+    "rolloutMode": "observe",
+    "evaluationPrincipal": {
+      "entityType": "Kontext::User",
+      "entityId": "alice@example.com"
+    },
+    "expectedPolicyHash": "8a7304637341166679a0a61d629afd6d565b64372548092784157da3ae3a38ca",
+    "expectedDeploymentPreimage": "[\"kontext:cedar-deployment:v1\",1,1,\"rev_01\",\"8a7304637341166679a0a61d629afd6d565b64372548092784157da3ae3a38ca\",\"observe\",\"Kontext::User\",\"alice@example.com\"]",
+    "expectedDeploymentIdentity": "e0df4ce03c17760128b4e2e99e34fcd1986d2f61a63a86a3a4fa5855b1be31c1"
+  }
+]

--- a/internal/cedareval/testdata/portable/v1/hashing-v1.json
+++ b/internal/cedareval/testdata/portable/v1/hashing-v1.json
@@ -3,14 +3,26 @@
     "version": 1,
     "name": "observe-policy-for-alice",
     "policyText": "@id(\"allow_read\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource == Kontext::Tool::\"Read\");",
-    "revision": "rev_01",
     "rolloutMode": "observe",
     "evaluationPrincipal": {
       "entityType": "Kontext::User",
       "entityId": "alice@example.com"
     },
     "expectedPolicyHash": "8a7304637341166679a0a61d629afd6d565b64372548092784157da3ae3a38ca",
-    "expectedDeploymentPreimage": "[\"kontext:cedar-deployment:v1\",1,1,\"rev_01\",\"8a7304637341166679a0a61d629afd6d565b64372548092784157da3ae3a38ca\",\"observe\",\"Kontext::User\",\"alice@example.com\"]",
-    "expectedDeploymentIdentity": "e0df4ce03c17760128b4e2e99e34fcd1986d2f61a63a86a3a4fa5855b1be31c1"
+    "expectedDeploymentPreimage": "[\"kontext:cedar-deployment:v2\",1,1,\"8a7304637341166679a0a61d629afd6d565b64372548092784157da3ae3a38ca\",\"observe\",\"Kontext::User\",\"alice@example.com\"]",
+    "expectedDeploymentIdentity": "b9c31bdf2805ca4fd89e6109684831646c7f83d75a5165f015e367243b7fee4b"
+  },
+  {
+    "version": 1,
+    "name": "unicode-and-json-sensitive-principal",
+    "policyText": "@id(\"allow_read\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource == Kontext::Tool::\"Read\");",
+    "rolloutMode": "enforce",
+    "evaluationPrincipal": {
+      "entityType": "Kontext::User",
+      "entityId": "Jöhn<>&\"\\\u2028\u2029@例え.テスト"
+    },
+    "expectedPolicyHash": "8a7304637341166679a0a61d629afd6d565b64372548092784157da3ae3a38ca",
+    "expectedDeploymentPreimage": "[\"kontext:cedar-deployment:v2\",1,1,\"8a7304637341166679a0a61d629afd6d565b64372548092784157da3ae3a38ca\",\"enforce\",\"Kontext::User\",\"Jöhn<>&\\\"\\\\\u2028\u2029@例え.テスト\"]",
+    "expectedDeploymentIdentity": "434b7cde3aadd03fc086f3079df82881eead2c3f7d876db495f6e9a09a5606ec"
   }
 ]

--- a/internal/hookruntime/claude.go
+++ b/internal/hookruntime/claude.go
@@ -46,7 +46,7 @@ type claudeHookSpecificOutput struct {
 
 func DecodeClaudeEvent(input []byte, agentName string) (hook.Event, error) {
 	var h claudeHookInput
-	if err := json.Unmarshal(input, &h); err != nil {
+	if err := decodeUseNumber(input, &h); err != nil {
 		return hook.Event{}, fmt.Errorf("claude: decode hook input: %w", err)
 	}
 	hookName := firstString(h.HookEventName, h.HookEventNameAlt, h.HookEventLegacy)

--- a/internal/hookruntime/claude.go
+++ b/internal/hookruntime/claude.go
@@ -3,7 +3,9 @@ package hookruntime
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/kontext-security/kontext-cli/internal/hook"
@@ -114,7 +116,16 @@ func normalizeToolResponse(values ...json.RawMessage) map[string]any {
 func decodeUseNumber(data []byte, dst any) error {
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.UseNumber()
-	return decoder.Decode(dst)
+	if err := decoder.Decode(dst); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("unexpected trailing JSON value")
+		}
+		return fmt.Errorf("decode trailing JSON: %w", err)
+	}
+	return nil
 }
 
 func EncodeClaudeResult(hookEventName string, result hook.Result) ([]byte, error) {

--- a/internal/hookruntime/claude_test.go
+++ b/internal/hookruntime/claude_test.go
@@ -78,6 +78,15 @@ func TestDecodeClaudeEventToolInputPreservesNumbers(t *testing.T) {
 	}
 }
 
+func TestDecodeClaudeEventRejectsTrailingJSON(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`{"hook_event_name":"PreToolUse","tool_name":"Bash"} {}`)
+	if _, err := DecodeClaudeEvent(input, "claude"); err == nil {
+		t.Fatal("DecodeClaudeEvent() error = nil, want trailing JSON rejection")
+	}
+}
+
 func TestDecodeClaudeEventToolResponseAbsent(t *testing.T) {
 	t.Parallel()
 

--- a/internal/hookruntime/claude_test.go
+++ b/internal/hookruntime/claude_test.go
@@ -62,6 +62,22 @@ func TestDecodeClaudeEventToolResponsePreservesLargeNumbers(t *testing.T) {
 	}
 }
 
+func TestDecodeClaudeEventToolInputPreservesNumbers(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`{"hook_event_name":"PreToolUse","tool_name":"CustomTool","tool_input":{"risk":1.25,"id":9007199254740993}}`)
+	event, err := DecodeClaudeEvent(input, "claude")
+	if err != nil {
+		t.Fatalf("DecodeClaudeEvent() error = %v", err)
+	}
+	if number, ok := event.ToolInput["risk"].(json.Number); !ok || number.String() != "1.25" {
+		t.Fatalf("ToolInput[risk] = %v (%T), want json.Number 1.25", event.ToolInput["risk"], event.ToolInput["risk"])
+	}
+	if number, ok := event.ToolInput["id"].(json.Number); !ok || number.String() != "9007199254740993" {
+		t.Fatalf("ToolInput[id] = %v (%T), want exact json.Number", event.ToolInput["id"], event.ToolInput["id"])
+	}
+}
+
 func TestDecodeClaudeEventToolResponseAbsent(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Why

The endpoint needs a deterministic local Cedar boundary before policy retrieval or production wiring is introduced.

## What

- parses policy once and validates unique non-empty `@id` plus supported `@ask` metadata at load time
- implements the User / ToolUse / exact tool / complete JSON-input request contract
- defines binary64 JSON-number semantics and bounded JSON-to-Cedar conversion
- pins hashing, ASK behavior, and portable fixtures shared byte-for-byte with TypeScript
- verifies every supported hook adapter preserves the required input

## Verification

- full `go test -race ./...`
- `go vet ./...`
- byte-identical cross-runtime fixture comparison

## Change size

13 files, +1,689/-2 — evaluator, conversion, hashing, hook conformance, fixtures, and tests.

Tracks ENG-531.
