### PR TITLE
feat(policy): add Go Cedar decision conformance

### DIFF
--- a/internal/cedareval/decision.go
+++ b/internal/cedareval/decision.go
@@ -3,6 +3,7 @@ package cedareval
 import (
 	"fmt"
 	"sort"
+	"unicode/utf8"
 )
 
 const DecisionContractVersion = 1
@@ -304,8 +305,8 @@ func validateEvaluatedOutcome(evaluation EvaluationOutcome) error {
 		return fmt.Errorf("cedareval: a Cedar allow requires a determining permit")
 	}
 	for _, policyID := range evaluation.DeterminingPolicyIDs {
-		if policyID == "" {
-			return fmt.Errorf("cedareval: determining policy id cannot be empty")
+		if policyID == "" || !utf8.ValidString(policyID) {
+			return fmt.Errorf("cedareval: determining policy id must be non-empty valid UTF-8")
 		}
 	}
 	return nil

--- a/internal/cedareval/decision.go
+++ b/internal/cedareval/decision.go
@@ -1,0 +1,398 @@
+package cedareval
+
+import (
+	"fmt"
+	"sort"
+)
+
+const DecisionContractVersion = 1
+
+type EvaluationState string
+
+const (
+	EvaluationStateNotEvaluated        EvaluationState = "not_evaluated"
+	EvaluationStateEvaluated           EvaluationState = "evaluated"
+	EvaluationStateFailed              EvaluationState = "failed"
+	EvaluationStatePrincipalUnresolved EvaluationState = "principal_unresolved"
+)
+
+type DerivedCedarAction string
+
+const (
+	DerivedCedarActionAllow DerivedCedarAction = "allow"
+	DerivedCedarActionDeny  DerivedCedarAction = "deny"
+	DerivedCedarActionAsk   DerivedCedarAction = "ask"
+)
+
+type EffectiveExecutionAction string
+
+const (
+	EffectiveExecutionActionAllow EffectiveExecutionAction = "allow"
+	EffectiveExecutionActionDeny  EffectiveExecutionAction = "deny"
+)
+
+type RolloutMode string
+
+const (
+	RolloutModeDisabled RolloutMode = "disabled"
+	RolloutModeObserve  RolloutMode = "observe"
+	RolloutModeEnforce  RolloutMode = "enforce"
+)
+
+type EvaluationProvider string
+
+const (
+	EvaluationProviderLocal  EvaluationProvider = "local"
+	EvaluationProviderRemote EvaluationProvider = "remote"
+)
+
+type ReasonCode string
+
+const (
+	ReasonPolicyDisabled                    ReasonCode = "policy_disabled"
+	ReasonPolicyEvaluated                   ReasonCode = "policy_evaluated"
+	ReasonDefaultDeny                       ReasonCode = "default_deny"
+	ReasonExplicitForbid                    ReasonCode = "explicit_forbid"
+	ReasonPermit                            ReasonCode = "permit"
+	ReasonAskDerived                        ReasonCode = "ask_derived"
+	ReasonAskUnavailable                    ReasonCode = "ask_unavailable"
+	ReasonPrincipalUnresolved               ReasonCode = "principal_unresolved"
+	ReasonRequestConversionFailed           ReasonCode = "request_conversion_failed"
+	ReasonPolicyMissing                     ReasonCode = "policy_missing"
+	ReasonUnsupportedResponseVersion        ReasonCode = "unsupported_response_version"
+	ReasonUnsupportedRequestContractVersion ReasonCode = "unsupported_request_contract_version"
+	ReasonInvalidCachedPolicy               ReasonCode = "invalid_cached_policy"
+	ReasonStaleCachedPolicy                 ReasonCode = "stale_cached_policy"
+	ReasonEngineError                       ReasonCode = "engine_error"
+	ReasonRemoteTimeout                     ReasonCode = "remote_timeout"
+	ReasonObserveNonAuthoritative           ReasonCode = "observe_non_authoritative"
+	ReasonEnforcementNotReady               ReasonCode = "enforcement_not_ready"
+	ReasonRemoteDelegated                   ReasonCode = "remote_delegated"
+)
+
+type EvaluationOutcome struct {
+	State                EvaluationState `json:"state"`
+	Reason               ReasonCode      `json:"reason,omitempty"`
+	Decision             Decision        `json:"decision,omitempty"`
+	Ask                  bool            `json:"ask,omitempty"`
+	DeterminingPolicyIDs []string        `json:"determiningPolicyIds,omitempty"`
+}
+
+type DecisionMappingInput struct {
+	RolloutMode            RolloutMode              `json:"rolloutMode"`
+	CurrentAuthorityAction EffectiveExecutionAction `json:"currentAuthorityAction,omitempty"`
+	EnforcementReady       bool                     `json:"enforcementReady,omitempty"`
+	EvaluationPrincipal    *EvaluationPrincipal     `json:"evaluationPrincipal,omitempty"`
+	Evaluation             EvaluationOutcome        `json:"evaluation"`
+}
+
+type DecisionMapping struct {
+	EvaluationState          EvaluationState          `json:"evaluationState"`
+	EvaluationPrincipal      *EvaluationPrincipal     `json:"evaluationPrincipal,omitempty"`
+	CedarDecision            Decision                 `json:"cedarDecision,omitempty"`
+	DerivedCedarAction       DerivedCedarAction       `json:"derivedCedarAction,omitempty"`
+	EffectiveExecutionAction EffectiveExecutionAction `json:"effectiveExecutionAction"`
+	EvaluationReasonCode     ReasonCode               `json:"evaluationReasonCode"`
+	DecisionReasonCode       ReasonCode               `json:"decisionReasonCode,omitempty"`
+	EffectiveReasonCode      ReasonCode               `json:"effectiveReasonCode"`
+	DeterminingPolicyIDs     []string                 `json:"determiningPolicyIds"`
+}
+
+func MapDecision(input DecisionMappingInput) (DecisionMapping, error) {
+	if err := validateDecisionMappingInput(input); err != nil {
+		return DecisionMapping{}, err
+	}
+
+	principal := cloneEvaluationPrincipal(input.EvaluationPrincipal)
+	if input.RolloutMode == RolloutModeDisabled {
+		return DecisionMapping{
+			EvaluationState:          EvaluationStateNotEvaluated,
+			EvaluationPrincipal:      principal,
+			EffectiveExecutionAction: input.CurrentAuthorityAction,
+			EvaluationReasonCode:     ReasonPolicyDisabled,
+			EffectiveReasonCode:      ReasonPolicyDisabled,
+			DeterminingPolicyIDs:     []string{},
+		}, nil
+	}
+
+	if input.RolloutMode == RolloutModeObserve {
+		return mapObserveDecision(input, principal), nil
+	}
+
+	return mapEnforceDecision(input, principal), nil
+}
+
+func mapObserveDecision(
+	input DecisionMappingInput,
+	principal *EvaluationPrincipal,
+) DecisionMapping {
+	if input.Evaluation.State != EvaluationStateEvaluated {
+		return DecisionMapping{
+			EvaluationState:          input.Evaluation.State,
+			EvaluationPrincipal:      principal,
+			EffectiveExecutionAction: input.CurrentAuthorityAction,
+			EvaluationReasonCode:     input.Evaluation.Reason,
+			EffectiveReasonCode:      ReasonObserveNonAuthoritative,
+			DeterminingPolicyIDs:     []string{},
+		}
+	}
+
+	decision := mapEvaluatedDecision(input.Evaluation)
+	decision.EvaluationPrincipal = principal
+	decision.EffectiveExecutionAction = input.CurrentAuthorityAction
+	decision.EffectiveReasonCode = ReasonObserveNonAuthoritative
+	return decision
+}
+
+func mapEnforceDecision(
+	input DecisionMappingInput,
+	principal *EvaluationPrincipal,
+) DecisionMapping {
+	if !input.EnforcementReady {
+		return DecisionMapping{
+			EvaluationState:          EvaluationStateNotEvaluated,
+			EvaluationPrincipal:      principal,
+			EffectiveExecutionAction: EffectiveExecutionActionDeny,
+			EvaluationReasonCode:     ReasonEnforcementNotReady,
+			EffectiveReasonCode:      ReasonEnforcementNotReady,
+			DeterminingPolicyIDs:     []string{},
+		}
+	}
+
+	if input.Evaluation.State != EvaluationStateEvaluated {
+		return DecisionMapping{
+			EvaluationState:          input.Evaluation.State,
+			EvaluationPrincipal:      principal,
+			EffectiveExecutionAction: EffectiveExecutionActionDeny,
+			EvaluationReasonCode:     input.Evaluation.Reason,
+			EffectiveReasonCode:      input.Evaluation.Reason,
+			DeterminingPolicyIDs:     []string{},
+		}
+	}
+
+	decision := mapEvaluatedDecision(input.Evaluation)
+	decision.EvaluationPrincipal = principal
+	switch decision.DerivedCedarAction {
+	case DerivedCedarActionAllow:
+		decision.EffectiveExecutionAction = EffectiveExecutionActionAllow
+		decision.EffectiveReasonCode = decision.DecisionReasonCode
+	case DerivedCedarActionAsk:
+		decision.EffectiveExecutionAction = EffectiveExecutionActionDeny
+		decision.EffectiveReasonCode = ReasonAskUnavailable
+	default:
+		decision.EffectiveExecutionAction = EffectiveExecutionActionDeny
+		decision.EffectiveReasonCode = decision.DecisionReasonCode
+	}
+	return decision
+}
+
+func mapEvaluatedDecision(evaluation EvaluationOutcome) DecisionMapping {
+	policyIDs := canonicalPolicyIDs(evaluation.DeterminingPolicyIDs)
+	result := DecisionMapping{
+		EvaluationState:      EvaluationStateEvaluated,
+		CedarDecision:        evaluation.Decision,
+		EvaluationReasonCode: ReasonPolicyEvaluated,
+		DeterminingPolicyIDs: policyIDs,
+	}
+
+	if evaluation.Decision == DecisionAllow {
+		if evaluation.Ask {
+			result.DerivedCedarAction = DerivedCedarActionAsk
+			result.DecisionReasonCode = ReasonAskDerived
+			return result
+		}
+		result.DerivedCedarAction = DerivedCedarActionAllow
+		result.DecisionReasonCode = ReasonPermit
+		return result
+	}
+
+	result.DerivedCedarAction = DerivedCedarActionDeny
+	result.DecisionReasonCode = ReasonExplicitForbid
+	if len(policyIDs) == 0 {
+		result.DecisionReasonCode = ReasonDefaultDeny
+	}
+	return result
+}
+
+func validateDecisionMappingInput(input DecisionMappingInput) error {
+	if err := validateMappingPrincipal(input); err != nil {
+		return err
+	}
+	if err := validateEvaluationOutcome(input.Evaluation); err != nil {
+		return err
+	}
+
+	switch input.RolloutMode {
+	case RolloutModeDisabled:
+		return validateDisabledMappingInput(input)
+	case RolloutModeObserve:
+		return validateObserveMappingInput(input)
+	case RolloutModeEnforce:
+		return validateEnforceMappingInput(input)
+	default:
+		return fmt.Errorf("cedareval: unsupported rollout mode %q", input.RolloutMode)
+	}
+}
+
+func validateMappingPrincipal(input DecisionMappingInput) error {
+	if input.Evaluation.State == EvaluationStatePrincipalUnresolved {
+		if input.EvaluationPrincipal != nil {
+			return fmt.Errorf("cedareval: unresolved principal cannot emit principal evidence")
+		}
+		return nil
+	}
+	if input.EvaluationPrincipal == nil {
+		return nil
+	}
+	if input.EvaluationPrincipal.EntityType != PrincipalEntityType {
+		return fmt.Errorf(
+			"cedareval: unsupported principal entity type %q for decision contract v%d",
+			input.EvaluationPrincipal.EntityType,
+			DecisionContractVersion,
+		)
+	}
+	entityIDLength := stringLength(input.EvaluationPrincipal.EntityID)
+	if entityIDLength == 0 || entityIDLength > 1024 {
+		return fmt.Errorf("cedareval: principal entity id must contain 1 to 1024 characters")
+	}
+	return nil
+}
+
+func validateEvaluationOutcome(evaluation EvaluationOutcome) error {
+	switch evaluation.State {
+	case EvaluationStateNotEvaluated:
+		if evaluation.Reason != ReasonPolicyDisabled && evaluation.Reason != ReasonEnforcementNotReady {
+			return fmt.Errorf("cedareval: invalid not-evaluated reason %q", evaluation.Reason)
+		}
+		return validateEmptyEngineResult(evaluation)
+	case EvaluationStatePrincipalUnresolved:
+		if evaluation.Reason != ReasonPrincipalUnresolved {
+			return fmt.Errorf("cedareval: invalid principal-unresolved reason %q", evaluation.Reason)
+		}
+		return validateEmptyEngineResult(evaluation)
+	case EvaluationStateFailed:
+		if !isEvaluationFailureReason(evaluation.Reason) {
+			return fmt.Errorf("cedareval: invalid evaluation-failure reason %q", evaluation.Reason)
+		}
+		return validateEmptyEngineResult(evaluation)
+	case EvaluationStateEvaluated:
+		return validateEvaluatedOutcome(evaluation)
+	default:
+		return fmt.Errorf("cedareval: unsupported evaluation state %q", evaluation.State)
+	}
+}
+
+func validateEmptyEngineResult(evaluation EvaluationOutcome) error {
+	hasEngineResult := evaluation.Decision != "" || evaluation.Ask || len(evaluation.DeterminingPolicyIDs) != 0
+	if hasEngineResult {
+		return fmt.Errorf("cedareval: evaluation state %q cannot include a Cedar result", evaluation.State)
+	}
+	return nil
+}
+
+func validateEvaluatedOutcome(evaluation EvaluationOutcome) error {
+	if evaluation.Reason != "" {
+		return fmt.Errorf("cedareval: evaluated outcome cannot include failure reason %q", evaluation.Reason)
+	}
+	if evaluation.Decision != DecisionAllow && evaluation.Decision != DecisionDeny {
+		return fmt.Errorf("cedareval: unsupported Cedar decision %q", evaluation.Decision)
+	}
+	if evaluation.Decision == DecisionDeny && evaluation.Ask {
+		return fmt.Errorf("cedareval: a Cedar deny cannot derive ask")
+	}
+	if evaluation.Decision == DecisionAllow && len(evaluation.DeterminingPolicyIDs) == 0 {
+		return fmt.Errorf("cedareval: a Cedar allow requires a determining permit")
+	}
+	for _, policyID := range evaluation.DeterminingPolicyIDs {
+		if policyID == "" {
+			return fmt.Errorf("cedareval: determining policy id cannot be empty")
+		}
+	}
+	return nil
+}
+
+func validateDisabledMappingInput(input DecisionMappingInput) error {
+	if !isExecutionAction(input.CurrentAuthorityAction) {
+		return fmt.Errorf("cedareval: disabled mode requires the current authority action")
+	}
+	isDisabledOutcome := input.Evaluation.State == EvaluationStateNotEvaluated &&
+		input.Evaluation.Reason == ReasonPolicyDisabled
+	if !isDisabledOutcome {
+		return fmt.Errorf("cedareval: disabled mode must be not evaluated with policy-disabled reason")
+	}
+	if input.EnforcementReady {
+		return fmt.Errorf("cedareval: disabled mode cannot be enforcement ready")
+	}
+	return nil
+}
+
+func validateObserveMappingInput(input DecisionMappingInput) error {
+	if !isExecutionAction(input.CurrentAuthorityAction) {
+		return fmt.Errorf("cedareval: observe mode requires the current authority action")
+	}
+	if input.Evaluation.State == EvaluationStateNotEvaluated {
+		return fmt.Errorf("cedareval: observe mode requires an evaluation attempt")
+	}
+	if input.EnforcementReady {
+		return fmt.Errorf("cedareval: observe mode cannot be enforcement ready")
+	}
+	return nil
+}
+
+func validateEnforceMappingInput(input DecisionMappingInput) error {
+	if input.CurrentAuthorityAction != "" {
+		return fmt.Errorf("cedareval: enforce mode cannot use a migration authority action")
+	}
+	if input.Evaluation.State == EvaluationStateNotEvaluated &&
+		input.Evaluation.Reason == ReasonPolicyDisabled {
+		return fmt.Errorf("cedareval: enforce mode cannot carry a disabled-policy reason")
+	}
+	isReadinessOutcome := input.Evaluation.State == EvaluationStateNotEvaluated &&
+		input.Evaluation.Reason == ReasonEnforcementNotReady
+	if input.EnforcementReady == isReadinessOutcome {
+		return fmt.Errorf("cedareval: enforce mode must evaluate exactly when enforcement is ready")
+	}
+	return nil
+}
+
+func isExecutionAction(action EffectiveExecutionAction) bool {
+	return action == EffectiveExecutionActionAllow || action == EffectiveExecutionActionDeny
+}
+
+func isEvaluationFailureReason(reason ReasonCode) bool {
+	switch reason {
+	case ReasonRequestConversionFailed,
+		ReasonPolicyMissing,
+		ReasonUnsupportedResponseVersion,
+		ReasonUnsupportedRequestContractVersion,
+		ReasonInvalidCachedPolicy,
+		ReasonStaleCachedPolicy,
+		ReasonEngineError,
+		ReasonRemoteTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
+func canonicalPolicyIDs(policyIDs []string) []string {
+	unique := make(map[string]struct{}, len(policyIDs))
+	for _, policyID := range policyIDs {
+		unique[policyID] = struct{}{}
+	}
+
+	result := make([]string, 0, len(unique))
+	for policyID := range unique {
+		result = append(result, policyID)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func cloneEvaluationPrincipal(principal *EvaluationPrincipal) *EvaluationPrincipal {
+	if principal == nil {
+		return nil
+	}
+	clone := *principal
+	return &clone
+}

--- a/internal/cedareval/decision_fixtures_test.go
+++ b/internal/cedareval/decision_fixtures_test.go
@@ -1,0 +1,169 @@
+package cedareval_test
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/cedareval"
+)
+
+type decisionContractFixture struct {
+	Version                   int                                  `json:"version"`
+	EvaluationStates          []cedareval.EvaluationState          `json:"evaluationStates"`
+	DerivedCedarActions       []cedareval.DerivedCedarAction       `json:"derivedCedarActions"`
+	EffectiveExecutionActions []cedareval.EffectiveExecutionAction `json:"effectiveExecutionActions"`
+	RolloutModes              []cedareval.RolloutMode              `json:"rolloutModes"`
+	EvaluationProviders       []cedareval.EvaluationProvider       `json:"evaluationProviders"`
+	ReasonCodes               []cedareval.ReasonCode               `json:"reasonCodes"`
+}
+
+type decisionMappingFixture struct {
+	Version     int                            `json:"version"`
+	Name        string                         `json:"name"`
+	Description string                         `json:"description"`
+	Input       cedareval.DecisionMappingInput `json:"input"`
+	Expected    cedareval.DecisionMapping      `json:"expected"`
+}
+
+func TestPortableDecisionContractFixture(t *testing.T) {
+	t.Parallel()
+
+	var fixture decisionContractFixture
+	readFixture(t, "decision-contract-v1.json", &fixture)
+
+	expected := decisionContractFixture{
+		Version: cedareval.DecisionContractVersion,
+		EvaluationStates: []cedareval.EvaluationState{
+			cedareval.EvaluationStateNotEvaluated,
+			cedareval.EvaluationStateEvaluated,
+			cedareval.EvaluationStateFailed,
+			cedareval.EvaluationStatePrincipalUnresolved,
+		},
+		DerivedCedarActions: []cedareval.DerivedCedarAction{
+			cedareval.DerivedCedarActionAllow,
+			cedareval.DerivedCedarActionDeny,
+			cedareval.DerivedCedarActionAsk,
+		},
+		EffectiveExecutionActions: []cedareval.EffectiveExecutionAction{
+			cedareval.EffectiveExecutionActionAllow,
+			cedareval.EffectiveExecutionActionDeny,
+		},
+		RolloutModes: []cedareval.RolloutMode{
+			cedareval.RolloutModeDisabled,
+			cedareval.RolloutModeObserve,
+			cedareval.RolloutModeEnforce,
+		},
+		EvaluationProviders: []cedareval.EvaluationProvider{
+			cedareval.EvaluationProviderLocal,
+			cedareval.EvaluationProviderRemote,
+		},
+		ReasonCodes: []cedareval.ReasonCode{
+			cedareval.ReasonPolicyDisabled,
+			cedareval.ReasonPolicyEvaluated,
+			cedareval.ReasonDefaultDeny,
+			cedareval.ReasonExplicitForbid,
+			cedareval.ReasonPermit,
+			cedareval.ReasonAskDerived,
+			cedareval.ReasonAskUnavailable,
+			cedareval.ReasonPrincipalUnresolved,
+			cedareval.ReasonRequestConversionFailed,
+			cedareval.ReasonPolicyMissing,
+			cedareval.ReasonUnsupportedResponseVersion,
+			cedareval.ReasonUnsupportedRequestContractVersion,
+			cedareval.ReasonInvalidCachedPolicy,
+			cedareval.ReasonStaleCachedPolicy,
+			cedareval.ReasonEngineError,
+			cedareval.ReasonRemoteTimeout,
+			cedareval.ReasonObserveNonAuthoritative,
+			cedareval.ReasonEnforcementNotReady,
+			cedareval.ReasonRemoteDelegated,
+		},
+	}
+	if !reflect.DeepEqual(fixture, expected) {
+		t.Fatalf("decision contract fixture = %#v, want %#v", fixture, expected)
+	}
+}
+
+func TestPortableDecisionMappingFixtures(t *testing.T) {
+	var fixtures []decisionMappingFixture
+	readFixture(t, "decision-mapping-v1.json", &fixtures)
+
+	for _, fixture := range fixtures {
+		fixture := fixture
+		t.Run(fixture.Name, func(t *testing.T) {
+			t.Parallel()
+			if fixture.Version != cedareval.DecisionContractVersion {
+				t.Fatalf(
+					"fixture version = %d, want decision contract version %d",
+					fixture.Version,
+					cedareval.DecisionContractVersion,
+				)
+			}
+			result, err := cedareval.MapDecision(fixture.Input)
+			if err != nil {
+				t.Fatalf("MapDecision() error = %v", err)
+			}
+			if !reflect.DeepEqual(result, fixture.Expected) {
+				t.Fatalf("MapDecision() = %#v, want %#v", result, fixture.Expected)
+			}
+		})
+	}
+}
+
+func TestMapDecisionIsConcurrentAndDoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+
+	principal := &cedareval.EvaluationPrincipal{
+		EntityType: cedareval.PrincipalEntityType,
+		EntityID:   "alice@example.com",
+	}
+	input := cedareval.DecisionMappingInput{
+		RolloutMode:         "enforce",
+		EnforcementReady:    true,
+		EvaluationPrincipal: principal,
+		Evaluation: cedareval.EvaluationOutcome{
+			State:                cedareval.EvaluationStateEvaluated,
+			Decision:             cedareval.DecisionAllow,
+			DeterminingPolicyIDs: []string{"z", "a", "z"},
+		},
+	}
+
+	const workers = 32
+	errorsChannel := make(chan error, workers)
+	results := make(chan cedareval.DecisionMapping, workers)
+	var waitGroup sync.WaitGroup
+	for range workers {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			result, err := cedareval.MapDecision(input)
+			if err != nil {
+				errorsChannel <- err
+				return
+			}
+			results <- result
+		}()
+	}
+	waitGroup.Wait()
+	close(errorsChannel)
+	close(results)
+
+	for err := range errorsChannel {
+		t.Errorf("MapDecision() error = %v", err)
+	}
+	for result := range results {
+		if !reflect.DeepEqual(result.DeterminingPolicyIDs, []string{"a", "z"}) {
+			t.Errorf("DeterminingPolicyIDs = %v, want [a z]", result.DeterminingPolicyIDs)
+		}
+		result.DeterminingPolicyIDs[0] = "mutated"
+		result.EvaluationPrincipal.EntityID = "mutated@example.com"
+	}
+
+	if !reflect.DeepEqual(input.Evaluation.DeterminingPolicyIDs, []string{"z", "a", "z"}) {
+		t.Fatalf("MapDecision() mutated policy ids: %v", input.Evaluation.DeterminingPolicyIDs)
+	}
+	if input.EvaluationPrincipal.EntityID != "alice@example.com" {
+		t.Fatalf("MapDecision() mutated principal: %q", input.EvaluationPrincipal.EntityID)
+	}
+}

--- a/internal/cedareval/decision_test.go
+++ b/internal/cedareval/decision_test.go
@@ -1,0 +1,151 @@
+package cedareval
+
+import "testing"
+
+func TestMapDecisionRejectsInvalidStates(t *testing.T) {
+	t.Parallel()
+
+	principal := &EvaluationPrincipal{
+		EntityType: PrincipalEntityType,
+		EntityID:   "alice@example.com",
+	}
+	tests := []struct {
+		name  string
+		input DecisionMappingInput
+	}{
+		{
+			name: "unsupported rollout mode",
+			input: DecisionMappingInput{
+				RolloutMode: RolloutMode("invalid"),
+				Evaluation: EvaluationOutcome{
+					State:  EvaluationStateFailed,
+					Reason: ReasonEngineError,
+				},
+			},
+		},
+		{
+			name: "disabled mode evaluates",
+			input: DecisionMappingInput{
+				RolloutMode:            RolloutModeDisabled,
+				CurrentAuthorityAction: EffectiveExecutionActionAllow,
+				Evaluation: EvaluationOutcome{
+					State:                EvaluationStateEvaluated,
+					Decision:             DecisionAllow,
+					DeterminingPolicyIDs: []string{"permit"},
+				},
+			},
+		},
+		{
+			name: "observe mode is not evaluated",
+			input: DecisionMappingInput{
+				RolloutMode:            RolloutModeObserve,
+				CurrentAuthorityAction: EffectiveExecutionActionAllow,
+				Evaluation: EvaluationOutcome{
+					State:  EvaluationStateNotEvaluated,
+					Reason: ReasonEnforcementNotReady,
+				},
+			},
+		},
+		{
+			name: "enforce readiness contradicts evaluation",
+			input: DecisionMappingInput{
+				RolloutMode:      RolloutModeEnforce,
+				EnforcementReady: true,
+				Evaluation: EvaluationOutcome{
+					State:  EvaluationStateNotEvaluated,
+					Reason: ReasonEnforcementNotReady,
+				},
+			},
+		},
+		{
+			name: "enforce carries disabled-policy reason",
+			input: DecisionMappingInput{
+				RolloutMode:      RolloutModeEnforce,
+				EnforcementReady: true,
+				Evaluation: EvaluationOutcome{
+					State:  EvaluationStateNotEvaluated,
+					Reason: ReasonPolicyDisabled,
+				},
+			},
+		},
+		{
+			name: "enforce without readiness evaluates",
+			input: DecisionMappingInput{
+				RolloutMode: RolloutModeEnforce,
+				Evaluation: EvaluationOutcome{
+					State:  EvaluationStateFailed,
+					Reason: ReasonEngineError,
+				},
+			},
+		},
+		{
+			name: "deny derives ask",
+			input: DecisionMappingInput{
+				RolloutMode:      RolloutModeEnforce,
+				EnforcementReady: true,
+				Evaluation: EvaluationOutcome{
+					State:    EvaluationStateEvaluated,
+					Decision: DecisionDeny,
+					Ask:      true,
+				},
+			},
+		},
+		{
+			name: "allow has no determining permit",
+			input: DecisionMappingInput{
+				RolloutMode:      RolloutModeEnforce,
+				EnforcementReady: true,
+				Evaluation: EvaluationOutcome{
+					State:    EvaluationStateEvaluated,
+					Decision: DecisionAllow,
+				},
+			},
+		},
+		{
+			name: "unresolved principal includes fallback",
+			input: DecisionMappingInput{
+				RolloutMode:            RolloutModeObserve,
+				CurrentAuthorityAction: EffectiveExecutionActionAllow,
+				EvaluationPrincipal:    principal,
+				Evaluation: EvaluationOutcome{
+					State:  EvaluationStatePrincipalUnresolved,
+					Reason: ReasonPrincipalUnresolved,
+				},
+			},
+		},
+		{
+			name: "failed evaluation includes Cedar decision",
+			input: DecisionMappingInput{
+				RolloutMode:            RolloutModeObserve,
+				CurrentAuthorityAction: EffectiveExecutionActionAllow,
+				Evaluation: EvaluationOutcome{
+					State:    EvaluationStateFailed,
+					Reason:   ReasonEngineError,
+					Decision: DecisionDeny,
+				},
+			},
+		},
+		{
+			name: "enforce uses migration authority",
+			input: DecisionMappingInput{
+				RolloutMode:            RolloutModeEnforce,
+				CurrentAuthorityAction: EffectiveExecutionActionAllow,
+				EnforcementReady:       true,
+				Evaluation: EvaluationOutcome{
+					State:  EvaluationStateFailed,
+					Reason: ReasonEngineError,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := MapDecision(test.input); err == nil {
+				t.Fatal("MapDecision() error = nil, want invalid-state rejection")
+			}
+		})
+	}
+}

--- a/internal/cedareval/decision_test.go
+++ b/internal/cedareval/decision_test.go
@@ -102,6 +102,18 @@ func TestMapDecisionRejectsInvalidStates(t *testing.T) {
 			},
 		},
 		{
+			name: "invalid UTF-8 determining policy id",
+			input: DecisionMappingInput{
+				RolloutMode:      RolloutModeEnforce,
+				EnforcementReady: true,
+				Evaluation: EvaluationOutcome{
+					State:                EvaluationStateEvaluated,
+					Decision:             DecisionAllow,
+					DeterminingPolicyIDs: []string{"\xff"},
+				},
+			},
+		},
+		{
 			name: "unresolved principal includes fallback",
 			input: DecisionMappingInput{
 				RolloutMode:            RolloutModeObserve,

--- a/internal/cedareval/fixtures_test.go
+++ b/internal/cedareval/fixtures_test.go
@@ -26,6 +26,8 @@ const portableFixtureContractVersion = 1
 var fixtureDigests = map[string]string{
 	"authorization-v1.json":     "c7f8aaf5da2acbf9a5d832ebf2bcf3ca531a617cdea3a6aed1b6b1840c4735b5",
 	"context-errors-v1.json":    "945e6be23af02aa4d0c7bd382f5963b6342f46a02602bfbc8f134ae283b6773e",
+	"decision-contract-v1.json": "8d33cd7924de64b9000c18fdc3cb532250653f768e2a65c7acb001c26376a3c4",
+	"decision-mapping-v1.json":  "7a0ba0b761b13759ef1a5ffefb155c7a066412b0115227f928529546a337e0b2",
 	"evaluation-errors-v1.json": "8318efcd613fd56645fac3bf49939d6b70f41af102a1f06df2a6cc9da75d8415",
 	"hashing-v1.json":           "5179f41ae61872ee9f6a048cba4592dc12c0267fc8c8699a0c2afa886da62775",
 }

--- a/internal/cedareval/testdata/portable/v1/README.md
+++ b/internal/cedareval/testdata/portable/v1/README.md
@@ -17,6 +17,11 @@ The hashing corpus pins the semantic seven-term
 `kontext:cedar-deployment:v2` identity. It contains no storage revision or
 endpoint operational configuration.
 
+The decision-contract and decision-mapping files additionally pin
+decision-contract v1. They are copied byte-for-byte from the shared contract
+and cover only the pure rollout state machine; they do not enable production
+authorization behavior.
+
 `TestPortableFixtureProvenance` pins the contract version and SHA-256 digest of
 every portable JSON file. Update the version and digests only when intentionally
 adopting a reviewed contract revision.

--- a/internal/cedareval/testdata/portable/v1/decision-contract-v1.json
+++ b/internal/cedareval/testdata/portable/v1/decision-contract-v1.json
@@ -1,0 +1,34 @@
+{
+  "version": 1,
+  "evaluationStates": [
+    "not_evaluated",
+    "evaluated",
+    "failed",
+    "principal_unresolved"
+  ],
+  "derivedCedarActions": ["allow", "deny", "ask"],
+  "effectiveExecutionActions": ["allow", "deny"],
+  "rolloutModes": ["disabled", "observe", "enforce"],
+  "evaluationProviders": ["local", "remote"],
+  "reasonCodes": [
+    "policy_disabled",
+    "policy_evaluated",
+    "default_deny",
+    "explicit_forbid",
+    "permit",
+    "ask_derived",
+    "ask_unavailable",
+    "principal_unresolved",
+    "request_conversion_failed",
+    "policy_missing",
+    "unsupported_response_version",
+    "unsupported_request_contract_version",
+    "invalid_cached_policy",
+    "stale_cached_policy",
+    "engine_error",
+    "remote_timeout",
+    "observe_non_authoritative",
+    "enforcement_not_ready",
+    "remote_delegated"
+  ]
+}

--- a/internal/cedareval/testdata/portable/v1/decision-mapping-v1.json
+++ b/internal/cedareval/testdata/portable/v1/decision-mapping-v1.json
@@ -1,0 +1,464 @@
+[
+  {
+    "version": 1,
+    "name": "disabled-preserves-current-allow",
+    "description": "Disabled mode does not evaluate Cedar and preserves an allowing migration authority.",
+    "input": {
+      "rolloutMode": "disabled",
+      "currentAuthorityAction": "allow",
+      "evaluation": { "state": "not_evaluated", "reason": "policy_disabled" }
+    },
+    "expected": {
+      "evaluationState": "not_evaluated",
+      "effectiveExecutionAction": "allow",
+      "evaluationReasonCode": "policy_disabled",
+      "effectiveReasonCode": "policy_disabled",
+      "determiningPolicyIds": []
+    }
+  },
+  {
+    "version": 1,
+    "name": "disabled-preserves-current-deny",
+    "description": "Disabled mode preserves a denying migration authority without manufacturing a Cedar decision.",
+    "input": {
+      "rolloutMode": "disabled",
+      "currentAuthorityAction": "deny",
+      "evaluation": { "state": "not_evaluated", "reason": "policy_disabled" }
+    },
+    "expected": {
+      "evaluationState": "not_evaluated",
+      "effectiveExecutionAction": "deny",
+      "evaluationReasonCode": "policy_disabled",
+      "effectiveReasonCode": "policy_disabled",
+      "determiningPolicyIds": []
+    }
+  },
+  {
+    "version": 1,
+    "name": "observe-records-permit-but-preserves-deny",
+    "description": "Observe mode records a Cedar permit but keeps the current denying authority effective.",
+    "input": {
+      "rolloutMode": "observe",
+      "currentAuthorityAction": "deny",
+      "evaluationPrincipal": {
+        "entityType": "Kontext::User",
+        "entityId": "alice@example.com"
+      },
+      "evaluation": {
+        "state": "evaluated",
+        "decision": "allow",
+        "ask": false,
+        "determiningPolicyIds": ["permit-z", "permit-a", "permit-z"]
+      }
+    },
+    "expected": {
+      "evaluationState": "evaluated",
+      "evaluationPrincipal": {
+        "entityType": "Kontext::User",
+        "entityId": "alice@example.com"
+      },
+      "cedarDecision": "allow",
+      "derivedCedarAction": "allow",
+      "effectiveExecutionAction": "deny",
+      "evaluationReasonCode": "policy_evaluated",
+      "decisionReasonCode": "permit",
+      "effectiveReasonCode": "observe_non_authoritative",
+      "determiningPolicyIds": ["permit-a", "permit-z"]
+    }
+  },
+  {
+    "version": 1,
+    "name": "utf8-policy-id-ordering",
+    "description": "Determining policy evidence is deduplicated and ordered by UTF-8 bytes across runtimes.",
+    "input": {
+      "rolloutMode": "observe",
+      "currentAuthorityAction": "allow",
+      "evaluation": {
+        "state": "evaluated",
+        "decision": "allow",
+        "ask": false,
+        "determiningPolicyIds": ["permit-\ud800\udc00", "permit-\ue000", "permit-\ud800\udc00"]
+      }
+    },
+    "expected": {
+      "evaluationState": "evaluated",
+      "cedarDecision": "allow",
+      "derivedCedarAction": "allow",
+      "effectiveExecutionAction": "allow",
+      "evaluationReasonCode": "policy_evaluated",
+      "decisionReasonCode": "permit",
+      "effectiveReasonCode": "observe_non_authoritative",
+      "determiningPolicyIds": ["permit-\ue000", "permit-\ud800\udc00"]
+    }
+  },
+
+  {
+    "version": 1,
+    "name": "observe-records-explicit-forbid-but-preserves-allow",
+    "description": "Observe mode records a determining forbid while current authority still allows execution.",
+    "input": {
+      "rolloutMode": "observe",
+      "currentAuthorityAction": "allow",
+      "evaluation": {
+        "state": "evaluated",
+        "decision": "deny",
+        "ask": false,
+        "determiningPolicyIds": ["forbid-delete"]
+      }
+    },
+    "expected": {
+      "evaluationState": "evaluated",
+      "cedarDecision": "deny",
+      "derivedCedarAction": "deny",
+      "effectiveExecutionAction": "allow",
+      "evaluationReasonCode": "policy_evaluated",
+      "decisionReasonCode": "explicit_forbid",
+      "effectiveReasonCode": "observe_non_authoritative",
+      "determiningPolicyIds": ["forbid-delete"]
+    }
+  },
+  {
+    "version": 1,
+    "name": "observe-records-ask-without-prompting",
+    "description": "Observe mode records ask derivation and does not invoke an approval flow.",
+    "input": {
+      "rolloutMode": "observe",
+      "currentAuthorityAction": "allow",
+      "evaluation": {
+        "state": "evaluated",
+        "decision": "allow",
+        "ask": true,
+        "determiningPolicyIds": ["ask-shell"]
+      }
+    },
+    "expected": {
+      "evaluationState": "evaluated",
+      "cedarDecision": "allow",
+      "derivedCedarAction": "ask",
+      "effectiveExecutionAction": "allow",
+      "evaluationReasonCode": "policy_evaluated",
+      "decisionReasonCode": "ask_derived",
+      "effectiveReasonCode": "observe_non_authoritative",
+      "determiningPolicyIds": ["ask-shell"]
+    }
+  },
+  {
+    "version": 1,
+    "name": "observe-preserves-authority-when-principal-unresolved",
+    "description": "An unresolved principal is evidence, not a synthetic Cedar deny, during observe rollout.",
+    "input": {
+      "rolloutMode": "observe",
+      "currentAuthorityAction": "allow",
+      "evaluation": {
+        "state": "principal_unresolved",
+        "reason": "principal_unresolved"
+      }
+    },
+    "expected": {
+      "evaluationState": "principal_unresolved",
+      "effectiveExecutionAction": "allow",
+      "evaluationReasonCode": "principal_unresolved",
+      "effectiveReasonCode": "observe_non_authoritative",
+      "determiningPolicyIds": []
+    }
+  },
+  {
+    "version": 1,
+    "name": "observe-preserves-authority-on-engine-error",
+    "description": "An engine failure does not become a new blocker in observe mode.",
+    "input": {
+      "rolloutMode": "observe",
+      "currentAuthorityAction": "deny",
+      "evaluation": { "state": "failed", "reason": "engine_error" }
+    },
+    "expected": {
+      "evaluationState": "failed",
+      "effectiveExecutionAction": "deny",
+      "evaluationReasonCode": "engine_error",
+      "effectiveReasonCode": "observe_non_authoritative",
+      "determiningPolicyIds": []
+    }
+  },
+  {
+    "version": 1,
+    "name": "enforce-allows-permit",
+    "description": "A normal Cedar permit is authoritative in ready enforce mode.",
+    "input": {
+      "rolloutMode": "enforce",
+      "enforcementReady": true,
+      "evaluation": {
+        "state": "evaluated",
+        "decision": "allow",
+        "ask": false,
+        "determiningPolicyIds": ["permit-read"]
+      }
+    },
+    "expected": {
+      "evaluationState": "evaluated",
+      "cedarDecision": "allow",
+      "derivedCedarAction": "allow",
+      "effectiveExecutionAction": "allow",
+      "evaluationReasonCode": "policy_evaluated",
+      "decisionReasonCode": "permit",
+      "effectiveReasonCode": "permit",
+      "determiningPolicyIds": ["permit-read"]
+    }
+  },
+  {
+    "version": 1,
+    "name": "enforce-denies-default-deny",
+    "description": "A Cedar deny without determining policies is classified as default deny.",
+    "input": {
+      "rolloutMode": "enforce",
+      "enforcementReady": true,
+      "evaluation": {
+        "state": "evaluated",
+        "decision": "deny",
+        "ask": false,
+        "determiningPolicyIds": []
+      }
+    },
+    "expected": {
+      "evaluationState": "evaluated",
+      "cedarDecision": "deny",
+      "derivedCedarAction": "deny",
+      "effectiveExecutionAction": "deny",
+      "evaluationReasonCode": "policy_evaluated",
+      "decisionReasonCode": "default_deny",
+      "effectiveReasonCode": "default_deny",
+      "determiningPolicyIds": []
+    }
+  },
+  {
+    "version": 1,
+    "name": "enforce-denies-explicit-forbid",
+    "description": "A Cedar deny with determining policies is classified as explicit forbid.",
+    "input": {
+      "rolloutMode": "enforce",
+      "enforcementReady": true,
+      "evaluation": {
+        "state": "evaluated",
+        "decision": "deny",
+        "ask": false,
+        "determiningPolicyIds": ["forbid-force-push"]
+      }
+    },
+    "expected": {
+      "evaluationState": "evaluated",
+      "cedarDecision": "deny",
+      "derivedCedarAction": "deny",
+      "effectiveExecutionAction": "deny",
+      "evaluationReasonCode": "policy_evaluated",
+      "decisionReasonCode": "explicit_forbid",
+      "effectiveReasonCode": "explicit_forbid",
+      "determiningPolicyIds": ["forbid-force-push"]
+    }
+  },
+  {
+    "version": 1,
+    "name": "enforce-denies-ask-when-approval-is-unavailable",
+    "description": "Ask remains derived evidence, while v1 enforce mode fails closed without an approval channel.",
+    "input": {
+      "rolloutMode": "enforce",
+      "enforcementReady": true,
+      "evaluation": {
+        "state": "evaluated",
+        "decision": "allow",
+        "ask": true,
+        "determiningPolicyIds": ["ask-write"]
+      }
+    },
+    "expected": {
+      "evaluationState": "evaluated",
+      "cedarDecision": "allow",
+      "derivedCedarAction": "ask",
+      "effectiveExecutionAction": "deny",
+      "evaluationReasonCode": "policy_evaluated",
+      "decisionReasonCode": "ask_derived",
+      "effectiveReasonCode": "ask_unavailable",
+      "determiningPolicyIds": ["ask-write"]
+    }
+  },
+  {
+    "version": 1,
+    "name": "enforce-denies-unresolved-principal",
+    "description": "Enforce mode fails closed without manufacturing a Cedar decision for an unresolved principal.",
+    "input": {
+      "rolloutMode": "enforce",
+      "enforcementReady": true,
+      "evaluation": {
+        "state": "principal_unresolved",
+        "reason": "principal_unresolved"
+      }
+    },
+    "expected": {
+      "evaluationState": "principal_unresolved",
+      "effectiveExecutionAction": "deny",
+      "evaluationReasonCode": "principal_unresolved",
+      "effectiveReasonCode": "principal_unresolved",
+      "determiningPolicyIds": []
+    }
+  },
+  {
+    "version": 1,
+    "name": "enforce-denies-request-conversion-failure",
+    "description": "Request conversion failure is explicit and fail closed in enforce mode.",
+    "input": {
+      "rolloutMode": "enforce",
+      "enforcementReady": true,
+      "evaluation": { "state": "failed", "reason": "request_conversion_failed" }
+    },
+    "expected": {
+      "evaluationState": "failed",
+      "effectiveExecutionAction": "deny",
+      "evaluationReasonCode": "request_conversion_failed",
+      "effectiveReasonCode": "request_conversion_failed",
+      "determiningPolicyIds": []
+    }
+  },
+  {
+    "version": 1,
+    "name": "enforce-denies-stale-policy",
+    "description": "A stale cached policy is explicit and fail closed in enforce mode.",
+    "input": {
+      "rolloutMode": "enforce",
+      "enforcementReady": true,
+      "evaluation": { "state": "failed", "reason": "stale_cached_policy" }
+    },
+    "expected": {
+      "evaluationState": "failed",
+      "effectiveExecutionAction": "deny",
+      "evaluationReasonCode": "stale_cached_policy",
+      "effectiveReasonCode": "stale_cached_policy",
+      "determiningPolicyIds": []
+    }
+  },
+  {
+    "version": 1,
+    "name": "enforce-denies-when-readiness-fails",
+    "description": "Enforce mode is fail closed and does not evaluate when readiness is false.",
+    "input": {
+      "rolloutMode": "enforce",
+      "enforcementReady": false,
+      "evaluation": {
+        "state": "not_evaluated",
+        "reason": "enforcement_not_ready"
+      }
+    },
+    "expected": {
+      "evaluationState": "not_evaluated",
+      "effectiveExecutionAction": "deny",
+      "evaluationReasonCode": "enforcement_not_ready",
+      "effectiveReasonCode": "enforcement_not_ready",
+      "determiningPolicyIds": []
+    }
+  },
+  {
+    "version": 1,
+    "name": "enforce-denies-missing-policy",
+    "description": "A missing usable policy is explicit and fail closed in enforce mode.",
+    "input": {
+      "rolloutMode": "enforce",
+      "enforcementReady": true,
+      "evaluation": { "state": "failed", "reason": "policy_missing" }
+    },
+    "expected": {
+      "evaluationState": "failed",
+      "effectiveExecutionAction": "deny",
+      "evaluationReasonCode": "policy_missing",
+      "effectiveReasonCode": "policy_missing",
+      "determiningPolicyIds": []
+    }
+  },
+  {
+    "version": 1,
+    "name": "enforce-denies-unsupported-response-version",
+    "description": "An unsupported policy response version is explicit and fail closed in enforce mode.",
+    "input": {
+      "rolloutMode": "enforce",
+      "enforcementReady": true,
+      "evaluation": {
+        "state": "failed",
+        "reason": "unsupported_response_version"
+      }
+    },
+    "expected": {
+      "evaluationState": "failed",
+      "effectiveExecutionAction": "deny",
+      "evaluationReasonCode": "unsupported_response_version",
+      "effectiveReasonCode": "unsupported_response_version",
+      "determiningPolicyIds": []
+    }
+  },
+  {
+    "version": 1,
+    "name": "enforce-denies-unsupported-request-contract-version",
+    "description": "An unsupported request-contract version is explicit and fail closed in enforce mode.",
+    "input": {
+      "rolloutMode": "enforce",
+      "enforcementReady": true,
+      "evaluation": {
+        "state": "failed",
+        "reason": "unsupported_request_contract_version"
+      }
+    },
+    "expected": {
+      "evaluationState": "failed",
+      "effectiveExecutionAction": "deny",
+      "evaluationReasonCode": "unsupported_request_contract_version",
+      "effectiveReasonCode": "unsupported_request_contract_version",
+      "determiningPolicyIds": []
+    }
+  },
+  {
+    "version": 1,
+    "name": "enforce-denies-invalid-cached-policy",
+    "description": "An invalid cached policy is explicit and fail closed in enforce mode.",
+    "input": {
+      "rolloutMode": "enforce",
+      "enforcementReady": true,
+      "evaluation": { "state": "failed", "reason": "invalid_cached_policy" }
+    },
+    "expected": {
+      "evaluationState": "failed",
+      "effectiveExecutionAction": "deny",
+      "evaluationReasonCode": "invalid_cached_policy",
+      "effectiveReasonCode": "invalid_cached_policy",
+      "determiningPolicyIds": []
+    }
+  },
+  {
+    "version": 1,
+    "name": "enforce-denies-engine-error",
+    "description": "A Cedar engine error is explicit and fail closed in enforce mode.",
+    "input": {
+      "rolloutMode": "enforce",
+      "enforcementReady": true,
+      "evaluation": { "state": "failed", "reason": "engine_error" }
+    },
+    "expected": {
+      "evaluationState": "failed",
+      "effectiveExecutionAction": "deny",
+      "evaluationReasonCode": "engine_error",
+      "effectiveReasonCode": "engine_error",
+      "determiningPolicyIds": []
+    }
+  },
+  {
+    "version": 1,
+    "name": "enforce-denies-reserved-remote-timeout",
+    "description": "The reserved remote timeout state uses the same fail-closed vocabulary.",
+    "input": {
+      "rolloutMode": "enforce",
+      "enforcementReady": true,
+      "evaluation": { "state": "failed", "reason": "remote_timeout" }
+    },
+    "expected": {
+      "evaluationState": "failed",
+      "effectiveExecutionAction": "deny",
+      "evaluationReasonCode": "remote_timeout",
+      "effectiveReasonCode": "remote_timeout",
+      "determiningPolicyIds": []
+    }
+  }
+]


### PR DESCRIPTION
## Why

Observe and enforce modes need the same deterministic decision state machine and evidence vocabulary on the endpoint and server.

## What

- mirrors the versioned rollout mapper and reason-code contract in Go
- preserves existing authority in observe mode and fails closed in enforce mode
- rejects contradictory enforce/disabled states
- deduplicates and orders policy evidence by UTF-8 bytes
- pins BMP/non-BMP ordering and all rollout outcomes in portable fixtures

## Verification

- full `go test -race ./...`
- `go vet ./...`
- byte-identical cross-runtime fixture comparison

## Change size

7 files, +1,223/-3 — decision mapper, validation, portable fixtures, and tests.

Tracks ENG-536.
