### PR TITLE
feat(policy): cache native Cedar deployments

### DIFF
--- a/internal/cedarpolicy/cache.go
+++ b/internal/cedarpolicy/cache.go
@@ -353,7 +353,11 @@ func (r *Refresher) Refresh(ctx context.Context) error {
 		r.recordFailure(err)
 		return err
 	}
-	return r.Cache.Apply(result, r.now())
+	if err := r.Cache.Apply(result, r.now()); err != nil {
+		r.recordFailure(err)
+		return err
+	}
+	return nil
 }
 
 func (r *Refresher) Run(ctx context.Context) {

--- a/internal/cedarpolicy/cache.go
+++ b/internal/cedarpolicy/cache.go
@@ -1,0 +1,402 @@
+package cedarpolicy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	DefaultRefreshInterval = time.Minute
+	DefaultMaxAge          = 15 * time.Minute
+)
+
+type CacheStatus struct {
+	State         State
+	FetchedAt     time.Time
+	LastAttemptAt time.Time
+	Stale         bool
+	Expired       bool
+	LastError     string
+	Invalid       bool
+}
+
+type Snapshot struct {
+	Deployment    *Deployment
+	LastKnownGood *Deployment
+	State         State
+	Status        CacheStatus
+}
+
+// SnapshotProvider exposes validated in-memory policy state to the hook path.
+// Current never performs filesystem or network I/O.
+type SnapshotProvider interface {
+	Current() Snapshot
+}
+
+type cacheFile struct {
+	Version    int         `json:"version"`
+	State      State       `json:"state"`
+	FetchedAt  string      `json:"fetchedAt"`
+	Deployment *Deployment `json:"deployment,omitempty"`
+	LastGood   *Deployment `json:"lastGood,omitempty"`
+}
+
+type Cache struct {
+	path   string
+	maxAge time.Duration
+	now    func() time.Time
+
+	mu       sync.RWMutex
+	state    State
+	fetched  time.Time
+	active   *Deployment
+	lastGood *Deployment
+	status   CacheStatus
+}
+
+func NewCache(path string, maxAge time.Duration) *Cache {
+	if maxAge <= 0 {
+		maxAge = DefaultMaxAge
+	}
+	return &Cache{path: path, maxAge: maxAge, now: time.Now}
+}
+
+func DefaultCachePathForDB(dbPath string) string {
+	return filepath.Join(filepath.Dir(dbPath), "cedar-policy.json")
+}
+
+func (c *Cache) Load() error {
+	if c.path == "" {
+		return nil
+	}
+	data, err := os.ReadFile(c.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("cedar policy cache: read: %w", err)
+	}
+	var file cacheFile
+	if err := decodeStrict(strings.NewReader(string(data)), &file); err != nil {
+		return fmt.Errorf("cedar policy cache: %w", err)
+	}
+	if file.Version != 1 {
+		return fmt.Errorf("cedar policy cache: unsupported version %d", file.Version)
+	}
+	if file.Deployment != nil {
+		if err := file.Deployment.Validate(); err != nil {
+			return fmt.Errorf("cedar policy cache: invalid deployment: %w", err)
+		}
+	}
+	if file.LastGood != nil {
+		if err := file.LastGood.Validate(); err != nil {
+			return fmt.Errorf("cedar policy cache: invalid last-known-good deployment: %w", err)
+		}
+	}
+	if file.State == StateSuccess && file.Deployment == nil && file.LastGood == nil {
+		return errors.New("cedar policy cache: success state has no deployment")
+	}
+	fetchedAt, err := time.Parse(time.RFC3339Nano, file.FetchedAt)
+	if err != nil {
+		return fmt.Errorf("cedar policy cache: invalid fetchedAt: %w", err)
+	}
+
+	c.mu.Lock()
+	c.state = file.State
+	c.fetched = fetchedAt
+	c.active = cloneDeployment(file.Deployment)
+	c.lastGood = cloneDeployment(file.LastGood)
+	if c.lastGood == nil && file.Deployment != nil {
+		c.lastGood = cloneDeployment(file.Deployment)
+	}
+	c.status = CacheStatus{
+		State:     file.State,
+		FetchedAt: fetchedAt,
+		Stale:     true,
+		LastError: "persisted deployment not yet confirmed",
+	}
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *Cache) Apply(result FetchResult, fetchedAt time.Time) error {
+	if fetchedAt.IsZero() {
+		fetchedAt = c.now().UTC()
+	}
+	c.mu.RLock()
+	file := cacheFile{
+		Version:    1,
+		State:      c.state,
+		FetchedAt:  fetchedAt.UTC().Format(time.RFC3339Nano),
+		Deployment: cloneDeployment(c.active),
+		LastGood:   cloneDeployment(c.lastGood),
+	}
+	c.mu.RUnlock()
+
+	switch result.State {
+	case StateSuccess:
+		if result.Deployment == nil {
+			return errors.New("cedar policy cache: success result has no deployment")
+		}
+		if err := result.Deployment.Validate(); err != nil {
+			return err
+		}
+		file.State = StateSuccess
+		file.Deployment = cloneDeployment(result.Deployment)
+		file.LastGood = nil
+	case StateNotModified:
+		if file.LastGood == nil || result.ETag == "" || result.ETag != file.LastGood.DeploymentIdentity {
+			return errors.New("cedar policy cache: not-modified result does not match last-known-good deployment")
+		}
+		file.State = StateSuccess
+		file.Deployment = cloneDeployment(file.LastGood)
+		file.LastGood = nil
+	case StateDisabled, StateNoActivePolicy, StatePrincipalUnavailable, StateUnauthorized,
+		StateUnsupportedVersion:
+		if result.Response == nil || result.Response.State != result.State {
+			return errors.New("cedar policy cache: state result is missing its response")
+		}
+		if err := result.Response.Validate(); err != nil {
+			return err
+		}
+		file.State = result.State
+		file.Deployment = nil
+	case StateUnavailable:
+		return errors.New("cedar policy cache: unavailable result must be recorded as a failed refresh")
+	default:
+		return fmt.Errorf("cedar policy cache: unsupported result state %q", result.State)
+	}
+
+	if err := c.persist(file); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	c.state = file.State
+	c.fetched = fetchedAt
+	c.active = cloneDeployment(file.Deployment)
+	c.lastGood = cloneDeployment(file.LastGood)
+	if c.lastGood == nil && file.Deployment != nil {
+		c.lastGood = cloneDeployment(file.Deployment)
+	}
+	c.status = CacheStatus{
+		State:         file.State,
+		FetchedAt:     fetchedAt,
+		LastAttemptAt: fetchedAt,
+	}
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *Cache) MarkFailed(err error, attemptedAt time.Time) {
+	if attemptedAt.IsZero() {
+		attemptedAt = c.now().UTC()
+	}
+	c.mu.Lock()
+	c.status.State = c.state
+	c.status.FetchedAt = c.fetched
+	c.status.LastAttemptAt = attemptedAt
+	c.status.Stale = true
+	if err != nil {
+		c.status.LastError = err.Error()
+	}
+	c.mu.Unlock()
+}
+
+func (c *Cache) MarkInvalid(err error) {
+	c.mu.Lock()
+	c.status.Invalid = true
+	c.status.Stale = true
+	c.status.Expired = true
+	if err != nil {
+		c.status.LastError = err.Error()
+	}
+	c.mu.Unlock()
+}
+
+func (c *Cache) Current() Snapshot {
+	c.mu.RLock()
+	now := c.now()
+	state := c.state
+	fetched := c.fetched
+	active := cloneDeployment(c.active)
+	lastGood := cloneDeployment(c.lastGood)
+	status := c.status
+	c.mu.RUnlock()
+
+	if active == nil && state == StateSuccess {
+		active = lastGood
+	}
+	if !fetched.IsZero() && now.Sub(fetched) > c.maxAge {
+		status.Stale = true
+		status.Expired = true
+		if state == StateSuccess {
+			active = nil
+		}
+	}
+	return Snapshot{
+		Deployment:    active,
+		LastKnownGood: lastGood,
+		State:         state,
+		Status:        status,
+	}
+}
+
+func (c *Cache) ConditionalIdentity() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.lastGood == nil {
+		return ""
+	}
+	return c.lastGood.DeploymentIdentity
+}
+
+func (c *Cache) persist(file cacheFile) error {
+	if c.path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(c.path), 0o700); err != nil {
+		return fmt.Errorf("cedar policy cache: create directory: %w", err)
+	}
+	data, err := json.MarshalIndent(file, "", "  ")
+	if err != nil {
+		return fmt.Errorf("cedar policy cache: encode: %w", err)
+	}
+	data = append(data, '\n')
+	temp, err := os.CreateTemp(filepath.Dir(c.path), ".cedar-policy-*.tmp")
+	if err != nil {
+		return fmt.Errorf("cedar policy cache: create temporary file: %w", err)
+	}
+	tempPath := temp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tempPath)
+		}
+	}()
+	if err := temp.Chmod(0o600); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("cedar policy cache: set permissions: %w", err)
+	}
+	if _, err := temp.Write(data); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("cedar policy cache: write: %w", err)
+	}
+	if err := temp.Sync(); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("cedar policy cache: sync: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("cedar policy cache: close: %w", err)
+	}
+	if err := os.Rename(tempPath, c.path); err != nil {
+		return fmt.Errorf("cedar policy cache: replace: %w", err)
+	}
+	cleanup = false
+	directory, err := os.Open(filepath.Dir(c.path))
+	if err != nil {
+		return fmt.Errorf("cedar policy cache: open directory: %w", err)
+	}
+	defer directory.Close()
+	if err := directory.Sync(); err != nil {
+		return fmt.Errorf("cedar policy cache: sync directory: %w", err)
+	}
+	return nil
+}
+
+func cloneDeployment(input *Deployment) *Deployment {
+	if input == nil {
+		return nil
+	}
+	clone := *input
+	return &clone
+}
+
+type TokenSource func(context.Context) (string, error)
+
+type Refresher struct {
+	Client         *Client
+	Cache          *Cache
+	TokenSource    TokenSource
+	InstallationID string
+	Interval       time.Duration
+	MaxBackoff     time.Duration
+	Now            func() time.Time
+}
+
+func (r *Refresher) Refresh(ctx context.Context) error {
+	if r.Client == nil || r.Cache == nil || r.TokenSource == nil {
+		err := errors.New("cedar policy refresher is not configured")
+		if r.Cache != nil {
+			r.recordFailure(err)
+		}
+		return err
+	}
+	token, err := r.TokenSource(ctx)
+	if err != nil {
+		r.recordFailure(err)
+		return err
+	}
+	result, err := r.Client.Fetch(ctx, token, r.InstallationID, r.Cache.ConditionalIdentity())
+	if err != nil {
+		r.recordFailure(err)
+		return err
+	}
+	if result.State == StateUnavailable {
+		err = errors.New("cedar policy is temporarily unavailable")
+		r.recordFailure(err)
+		return err
+	}
+	return r.Cache.Apply(result, r.now())
+}
+
+func (r *Refresher) Run(ctx context.Context) {
+	interval := r.Interval
+	if interval <= 0 {
+		interval = DefaultRefreshInterval
+	}
+	maxBackoff := r.MaxBackoff
+	if maxBackoff < interval {
+		maxBackoff = 10 * interval
+	}
+	delay := interval
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		if err := r.Refresh(ctx); err == nil {
+			delay = interval
+		} else if delay < maxBackoff {
+			delay *= 2
+			if delay > maxBackoff {
+				delay = maxBackoff
+			}
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return
+		case <-timer.C:
+		}
+	}
+}
+
+func (r *Refresher) recordFailure(err error) {
+	r.Cache.MarkFailed(err, r.now())
+}
+
+func (r *Refresher) now() time.Time {
+	if r.Now != nil {
+		return r.Now().UTC()
+	}
+	return time.Now().UTC()
+}

--- a/internal/cedarpolicy/cache_test.go
+++ b/internal/cedarpolicy/cache_test.go
@@ -1,0 +1,190 @@
+package cedarpolicy
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/cedareval"
+)
+
+func TestCachePersistsDeploymentAndRestoresStale(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state", "cedar-policy.json")
+	now := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
+	deployment := testDeployment(t, cedareval.RolloutModeObserve)
+	cache := NewCache(path, time.Hour)
+	cache.now = func() time.Time { return now }
+	if err := cache.Apply(FetchResult{State: StateSuccess, Deployment: &deployment, ETag: deployment.DeploymentIdentity}, now); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("cache mode = %o", info.Mode().Perm())
+	}
+
+	restored := NewCache(path, time.Hour)
+	restored.now = func() time.Time { return now.Add(time.Minute) }
+	if err := restored.Load(); err != nil {
+		t.Fatal(err)
+	}
+	snapshot := restored.Current()
+	if snapshot.Deployment == nil || snapshot.LastKnownGood == nil || !snapshot.Status.Stale {
+		t.Fatalf("restored snapshot = %#v", snapshot)
+	}
+}
+
+func TestCacheRejectsInvalidReplacementWithoutMutatingKnownGood(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cedar-policy.json")
+	now := time.Now().UTC()
+	cache := NewCache(path, time.Hour)
+	good := testDeployment(t, cedareval.RolloutModeObserve)
+	if err := cache.Apply(FetchResult{State: StateSuccess, Deployment: &good}, now); err != nil {
+		t.Fatal(err)
+	}
+	bad := good
+	bad.PolicyHash = "invalid"
+	if err := cache.Apply(FetchResult{State: StateSuccess, Deployment: &bad}, now.Add(time.Minute)); err == nil {
+		t.Fatal("Apply() error = nil")
+	}
+	if got := cache.Current().Deployment; got == nil || got.DeploymentIdentity != good.DeploymentIdentity {
+		t.Fatalf("known good changed: %#v", got)
+	}
+}
+
+func TestCacheExplicitStateThenMatchingNotModifiedRestoresPolicy(t *testing.T) {
+	tests := []struct {
+		name     string
+		response StateResponse
+	}{
+		{name: "disabled", response: StateResponse{ResponseVersion: 1, RequestContractVersion: 1, State: StateDisabled, RolloutMode: "disabled"}},
+		{name: "no active policy", response: StateResponse{ResponseVersion: 1, RequestContractVersion: 1, State: StateNoActivePolicy}},
+		{name: "principal unavailable", response: StateResponse{ResponseVersion: 1, RequestContractVersion: 1, State: StatePrincipalUnavailable}},
+		{name: "unauthorized", response: StateResponse{ResponseVersion: 1, RequestContractVersion: 1, State: StateUnauthorized}},
+		{name: "unsupported version", response: StateResponse{
+			ResponseVersion:                  1,
+			RequestContractVersion:           1,
+			State:                            StateUnsupportedVersion,
+			SupportedResponseVersions:        []int{1},
+			SupportedRequestContractVersions: []int{1},
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			now := time.Now().UTC()
+			cache := NewCache(filepath.Join(t.TempDir(), "cache.json"), time.Hour)
+			good := testDeployment(t, cedareval.RolloutModeObserve)
+			if err := cache.Apply(FetchResult{State: StateSuccess, Deployment: &good}, now); err != nil {
+				t.Fatal(err)
+			}
+			if err := cache.Apply(FetchResult{State: test.response.State, Response: &test.response}, now.Add(time.Minute)); err != nil {
+				t.Fatal(err)
+			}
+			if got := cache.Current(); got.Deployment != nil || got.LastKnownGood == nil || got.State != test.response.State {
+				t.Fatalf("non-ready snapshot = %#v", got)
+			}
+			if err := cache.Apply(FetchResult{State: StateNotModified, ETag: good.DeploymentIdentity}, now.Add(2*time.Minute)); err != nil {
+				t.Fatal(err)
+			}
+			if got := cache.Current(); got.Deployment == nil || got.State != StateSuccess || got.Deployment.DeploymentIdentity != good.DeploymentIdentity {
+				t.Fatalf("restored snapshot = %#v", got)
+			}
+		})
+	}
+}
+
+func TestCacheUnavailableThenMatchingNotModifiedKeepsPolicy(t *testing.T) {
+	now := time.Now().UTC()
+	cache := NewCache(filepath.Join(t.TempDir(), "cache.json"), time.Hour)
+	good := testDeployment(t, cedareval.RolloutModeObserve)
+	if err := cache.Apply(FetchResult{State: StateSuccess, Deployment: &good}, now); err != nil {
+		t.Fatal(err)
+	}
+	cache.MarkFailed(errors.New("temporarily unavailable"), now.Add(time.Minute))
+	if err := cache.Apply(FetchResult{State: StateNotModified, ETag: good.DeploymentIdentity}, now.Add(2*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if got := cache.Current(); got.Deployment == nil || got.State != StateSuccess || got.Status.Stale {
+		t.Fatalf("restored snapshot = %#v", got)
+	}
+}
+
+func TestCacheExpiresActivePolicyButRetainsLastKnownGood(t *testing.T) {
+	now := time.Now().UTC()
+	cache := NewCache(filepath.Join(t.TempDir(), "cache.json"), 10*time.Minute)
+	cache.now = func() time.Time { return now }
+	good := testDeployment(t, cedareval.RolloutModeEnforce)
+	if err := cache.Apply(FetchResult{State: StateSuccess, Deployment: &good}, now); err != nil {
+		t.Fatal(err)
+	}
+	cache.now = func() time.Time { return now.Add(11 * time.Minute) }
+	snapshot := cache.Current()
+	if snapshot.Deployment != nil || snapshot.LastKnownGood == nil || !snapshot.Status.Stale || !snapshot.Status.Expired {
+		t.Fatalf("expired snapshot = %#v", snapshot)
+	}
+}
+
+func TestCacheCorruptPersistedFileDoesNotLoad(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cache.json")
+	if err := os.WriteFile(path, []byte(`{"version":1,"state":"success"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cache := NewCache(path, time.Hour)
+	if err := cache.Load(); err == nil {
+		t.Fatal("Load() error = nil")
+	} else {
+		cache.MarkInvalid(err)
+	}
+	if snapshot := cache.Current(); snapshot.Deployment != nil || !snapshot.Status.Invalid {
+		t.Fatalf("corrupt cache snapshot = %#v", snapshot)
+	}
+}
+
+func TestRefresherMarksFailureWithoutDroppingKnownGood(t *testing.T) {
+	now := time.Now().UTC()
+	cache := NewCache(filepath.Join(t.TempDir(), "cache.json"), time.Hour)
+	good := testDeployment(t, cedareval.RolloutModeObserve)
+	if err := cache.Apply(FetchResult{State: StateSuccess, Deployment: &good}, now); err != nil {
+		t.Fatal(err)
+	}
+	refresher := Refresher{
+		Cache: cache,
+		TokenSource: func(context.Context) (string, error) {
+			return "", errors.New("token unavailable")
+		},
+	}
+	if err := refresher.Refresh(context.Background()); err == nil {
+		t.Fatal("Refresh() error = nil")
+	}
+	if snapshot := cache.Current(); snapshot.Deployment == nil || !snapshot.Status.Stale {
+		t.Fatalf("failed refresh discarded known good: %#v", snapshot)
+	}
+}
+
+func TestRefresherRunStopsOnCancellation(t *testing.T) {
+	cache := NewCache("", time.Hour)
+	refresher := Refresher{
+		Cache:    cache,
+		Interval: time.Hour,
+		TokenSource: func(context.Context) (string, error) {
+			return "", errors.New("token unavailable")
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		refresher.Run(ctx)
+	}()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run() did not stop after cancellation")
+	}
+}

--- a/internal/cedarpolicy/cache_test.go
+++ b/internal/cedarpolicy/cache_test.go
@@ -2,7 +2,10 @@ package cedarpolicy
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -163,6 +166,45 @@ func TestRefresherMarksFailureWithoutDroppingKnownGood(t *testing.T) {
 	}
 	if snapshot := cache.Current(); snapshot.Deployment == nil || !snapshot.Status.Stale {
 		t.Fatalf("failed refresh discarded known good: %#v", snapshot)
+	}
+}
+
+func TestRefresherRecordsCacheApplyFailure(t *testing.T) {
+	now := time.Now().UTC()
+	notDirectory := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(notDirectory, []byte("occupied"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cache := NewCache(filepath.Join(notDirectory, "cache.json"), time.Hour)
+	state := StateResponse{
+		ResponseVersion:        1,
+		RequestContractVersion: 1,
+		State:                  StateDisabled,
+		RolloutMode:            "disabled",
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(state)
+	}))
+	defer server.Close()
+	client, err := NewClient(server.URL, server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	refresher := Refresher{
+		Client:         client,
+		Cache:          cache,
+		InstallationID: testInstallationID,
+		Now:            func() time.Time { return now },
+		TokenSource: func(context.Context) (string, error) {
+			return "token", nil
+		},
+	}
+	if err := refresher.Refresh(context.Background()); err == nil {
+		t.Fatal("Refresh() error = nil, want cache persistence failure")
+	}
+	snapshot := cache.Current()
+	if !snapshot.Status.Stale || snapshot.Status.LastError == "" || !snapshot.Status.LastAttemptAt.Equal(now) {
+		t.Fatalf("failed apply status = %#v", snapshot.Status)
 	}
 }
 

--- a/internal/cedarpolicy/client.go
+++ b/internal/cedarpolicy/client.go
@@ -1,0 +1,154 @@
+package cedarpolicy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var installationIDPattern = regexp.MustCompile(`^ins_[A-Za-z0-9_-]{32}$`)
+
+type FetchResult struct {
+	State      State
+	Deployment *Deployment
+	Response   *StateResponse
+	ETag       string
+}
+
+type Client struct {
+	baseURL string
+	http    *http.Client
+}
+
+func NewClient(baseURL string, httpClient *http.Client) (*Client, error) {
+	parsed, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return nil, errors.New("cedar policy: invalid base URL")
+	}
+	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && isLoopbackHost(parsed.Hostname())) {
+		return nil, errors.New("cedar policy: base URL must use HTTPS or loopback HTTP")
+	}
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 10 * time.Second}
+	}
+	return &Client{baseURL: strings.TrimRight(parsed.String(), "/"), http: httpClient}, nil
+}
+
+func (c *Client) Fetch(ctx context.Context, installToken, installationID, deploymentIdentity string) (FetchResult, error) {
+	if !installationIDPattern.MatchString(installationID) {
+		return FetchResult{}, errors.New("cedar policy: invalid installation ID")
+	}
+	if strings.TrimSpace(installToken) == "" {
+		return FetchResult{}, errors.New("cedar policy: install token is required")
+	}
+	endpoint, err := url.Parse(c.baseURL + "/api/v1/installations/" + installationID + "/policy")
+	if err != nil {
+		return FetchResult{}, err
+	}
+	query := endpoint.Query()
+	query.Set("response_version", "1")
+	query.Set("request_contract_version", "1")
+	endpoint.RawQuery = query.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return FetchResult{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(installToken))
+	if deploymentIdentity != "" {
+		if !sha256HexPattern.MatchString(deploymentIdentity) {
+			return FetchResult{}, errors.New("cedar policy: invalid conditional deployment identity")
+		}
+		req.Header.Set("If-None-Match", `"`+deploymentIdentity+`"`)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return FetchResult{}, fmt.Errorf("cedar policy fetch: %w", err)
+	}
+	defer resp.Body.Close()
+	etag := parseETag(resp.Header.Get("ETag"))
+	if resp.StatusCode == http.StatusNotModified {
+		if deploymentIdentity == "" || etag != deploymentIdentity {
+			return FetchResult{}, errors.New("cedar policy: invalid not-modified ETag")
+		}
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1))
+		return FetchResult{State: StateNotModified, ETag: etag}, nil
+	}
+
+	if resp.StatusCode == http.StatusOK {
+		var probe struct {
+			State State `json:"state"`
+		}
+		body, err := io.ReadAll(io.LimitReader(resp.Body, MaxResponseBytes+1))
+		if err != nil {
+			return FetchResult{}, err
+		}
+		if len(body) > MaxResponseBytes {
+			return FetchResult{}, fmt.Errorf("cedar policy: response exceeds %d bytes", MaxResponseBytes)
+		}
+		if err := json.Unmarshal(body, &probe); err != nil {
+			return FetchResult{}, fmt.Errorf("cedar policy: decode response: %w", err)
+		}
+		if probe.State == "" {
+			var deployment Deployment
+			if err := decodeStrict(strings.NewReader(string(body)), &deployment); err != nil {
+				return FetchResult{}, fmt.Errorf("cedar policy: decode deployment: %w", err)
+			}
+			if err := deployment.Validate(); err != nil {
+				return FetchResult{}, err
+			}
+			if etag == "" || etag != deployment.DeploymentIdentity {
+				return FetchResult{}, errors.New("cedar policy: ETag does not match deployment identity")
+			}
+			return FetchResult{State: StateSuccess, Deployment: &deployment, ETag: etag}, nil
+		}
+		return decodeStateResult(body, etag)
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusNotAcceptable || resp.StatusCode == http.StatusServiceUnavailable {
+		body, err := io.ReadAll(io.LimitReader(resp.Body, MaxResponseBytes+1))
+		if err != nil {
+			return FetchResult{}, err
+		}
+		if len(body) > MaxResponseBytes {
+			return FetchResult{}, fmt.Errorf("cedar policy: response exceeds %d bytes", MaxResponseBytes)
+		}
+		return decodeStateResult(body, etag)
+	}
+	return FetchResult{}, fmt.Errorf("cedar policy fetch: unexpected status %d", resp.StatusCode)
+}
+
+func decodeStateResult(body []byte, etag string) (FetchResult, error) {
+	var state StateResponse
+	if err := decodeStrict(strings.NewReader(string(body)), &state); err != nil {
+		return FetchResult{}, fmt.Errorf("cedar policy: decode state: %w", err)
+	}
+	if err := state.Validate(); err != nil {
+		return FetchResult{}, err
+	}
+	return FetchResult{State: state.State, Response: &state, ETag: etag}, nil
+}
+
+func parseETag(value string) string {
+	value = strings.TrimSpace(value)
+	value = strings.TrimPrefix(value, "W/")
+	if len(value) != 66 || value[0] != '"' || value[len(value)-1] != '"' {
+		return ""
+	}
+	identity := value[1 : len(value)-1]
+	if !sha256HexPattern.MatchString(identity) {
+		return ""
+	}
+	return identity
+}
+
+func isLoopbackHost(host string) bool {
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}

--- a/internal/cedarpolicy/client.go
+++ b/internal/cedarpolicy/client.go
@@ -109,7 +109,13 @@ func (c *Client) Fetch(ctx context.Context, installToken, installationID, deploy
 			}
 			return FetchResult{State: StateSuccess, Deployment: &deployment, ETag: etag}, nil
 		}
-		return decodeStateResult(body, etag)
+		return decodeStateResult(
+			body,
+			etag,
+			StateDisabled,
+			StateNoActivePolicy,
+			StatePrincipalUnavailable,
+		)
 	}
 
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusNotAcceptable || resp.StatusCode == http.StatusServiceUnavailable {
@@ -120,12 +126,18 @@ func (c *Client) Fetch(ctx context.Context, installToken, installationID, deploy
 		if len(body) > MaxResponseBytes {
 			return FetchResult{}, fmt.Errorf("cedar policy: response exceeds %d bytes", MaxResponseBytes)
 		}
-		return decodeStateResult(body, etag)
+		expectedState := StateUnauthorized
+		if resp.StatusCode == http.StatusNotAcceptable {
+			expectedState = StateUnsupportedVersion
+		} else if resp.StatusCode == http.StatusServiceUnavailable {
+			expectedState = StateUnavailable
+		}
+		return decodeStateResult(body, etag, expectedState)
 	}
 	return FetchResult{}, fmt.Errorf("cedar policy fetch: unexpected status %d", resp.StatusCode)
 }
 
-func decodeStateResult(body []byte, etag string) (FetchResult, error) {
+func decodeStateResult(body []byte, etag string, allowedStates ...State) (FetchResult, error) {
 	var state StateResponse
 	if err := decodeStrict(strings.NewReader(string(body)), &state); err != nil {
 		return FetchResult{}, fmt.Errorf("cedar policy: decode state: %w", err)
@@ -133,7 +145,12 @@ func decodeStateResult(body []byte, etag string) (FetchResult, error) {
 	if err := state.Validate(); err != nil {
 		return FetchResult{}, err
 	}
-	return FetchResult{State: state.State, Response: &state, ETag: etag}, nil
+	for _, allowed := range allowedStates {
+		if state.State == allowed {
+			return FetchResult{State: state.State, Response: &state, ETag: etag}, nil
+		}
+	}
+	return FetchResult{}, fmt.Errorf("cedar policy: response state %q does not match HTTP status", state.State)
 }
 
 func parseETag(value string) string {

--- a/internal/cedarpolicy/client_test.go
+++ b/internal/cedarpolicy/client_test.go
@@ -68,6 +68,7 @@ func TestClientFetchStateResponses(t *testing.T) {
 	}{
 		{name: "disabled", status: http.StatusOK, body: StateResponse{ResponseVersion: 1, RequestContractVersion: 1, State: StateDisabled, RolloutMode: "disabled"}},
 		{name: "no active policy", status: http.StatusOK, body: StateResponse{ResponseVersion: 1, RequestContractVersion: 1, State: StateNoActivePolicy}},
+		{name: "principal unavailable", status: http.StatusOK, body: StateResponse{ResponseVersion: 1, RequestContractVersion: 1, State: StatePrincipalUnavailable}},
 		{name: "unauthorized", status: http.StatusUnauthorized, body: StateResponse{ResponseVersion: 1, RequestContractVersion: 1, State: StateUnauthorized}},
 		{name: "unsupported", status: http.StatusNotAcceptable, body: StateResponse{ResponseVersion: 1, RequestContractVersion: 1, State: StateUnsupportedVersion, SupportedResponseVersions: []int{1}, SupportedRequestContractVersions: []int{1}}},
 		{name: "unavailable", status: http.StatusServiceUnavailable, body: StateResponse{ResponseVersion: 1, RequestContractVersion: 1, State: StateUnavailable, Retryable: true}},
@@ -89,6 +90,38 @@ func TestClientFetchStateResponses(t *testing.T) {
 			}
 			if result.State != test.body.State {
 				t.Fatalf("Fetch().State = %q, want %q", result.State, test.body.State)
+			}
+		})
+	}
+}
+
+func TestClientRejectsStateThatDoesNotMatchHTTPStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   StateResponse
+	}{
+		{name: "success with unavailable", status: http.StatusOK, body: StateResponse{ResponseVersion: 1, RequestContractVersion: 1, State: StateUnavailable, Retryable: true}},
+		{name: "unauthorized with disabled", status: http.StatusUnauthorized, body: StateResponse{ResponseVersion: 1, RequestContractVersion: 1, State: StateDisabled, RolloutMode: "disabled"}},
+		{name: "not acceptable with unauthorized", status: http.StatusNotAcceptable, body: StateResponse{ResponseVersion: 1, RequestContractVersion: 1, State: StateUnauthorized}},
+		{name: "unavailable with disabled", status: http.StatusServiceUnavailable, body: StateResponse{ResponseVersion: 1, RequestContractVersion: 1, State: StateDisabled, RolloutMode: "disabled"}},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(test.status)
+				_ = json.NewEncoder(w).Encode(test.body)
+			}))
+			defer server.Close()
+			client, err := NewClient(server.URL, server.Client())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := client.Fetch(context.Background(), "token", testInstallationID, ""); err == nil {
+				t.Fatal("Fetch() error = nil, want HTTP status/state mismatch")
 			}
 		})
 	}

--- a/internal/cedarpolicy/client_test.go
+++ b/internal/cedarpolicy/client_test.go
@@ -1,0 +1,175 @@
+package cedarpolicy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/cedareval"
+)
+
+const testInstallationID = "ins_0123456789abcdefghijklmnopqrstuv"
+
+func TestClientFetchDeploymentAndConditionalRefresh(t *testing.T) {
+	deployment := testDeployment(t, cedareval.RolloutModeObserve)
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.URL.Path != "/api/v1/installations/"+testInstallationID+"/policy" {
+			t.Fatalf("request path = %q", r.URL.Path)
+		}
+		query := r.URL.Query()
+		if len(query) != 2 || query.Get("response_version") != "1" || query.Get("request_contract_version") != "1" {
+			t.Fatalf("request query = %v", query)
+		}
+		if r.Header.Get("Authorization") != "Bearer token" {
+			t.Fatalf("authorization = %q", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("ETag", `"`+deployment.DeploymentIdentity+`"`)
+		if got := r.Header.Get("If-None-Match"); got != "" {
+			if got != `"`+deployment.DeploymentIdentity+`"` {
+				t.Fatalf("If-None-Match = %q", got)
+			}
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(deployment)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL, server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := client.Fetch(context.Background(), "token", testInstallationID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.State != StateSuccess || result.Deployment == nil {
+		t.Fatalf("Fetch() = %#v", result)
+	}
+	result, err = client.Fetch(context.Background(), "token", testInstallationID, deployment.DeploymentIdentity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.State != StateNotModified || result.ETag != deployment.DeploymentIdentity || requests != 2 {
+		t.Fatalf("conditional Fetch() = %#v, requests = %d", result, requests)
+	}
+}
+
+func TestClientFetchStateResponses(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   StateResponse
+	}{
+		{name: "disabled", status: http.StatusOK, body: StateResponse{ResponseVersion: 1, RequestContractVersion: 1, State: StateDisabled, RolloutMode: "disabled"}},
+		{name: "no active policy", status: http.StatusOK, body: StateResponse{ResponseVersion: 1, RequestContractVersion: 1, State: StateNoActivePolicy}},
+		{name: "unauthorized", status: http.StatusUnauthorized, body: StateResponse{ResponseVersion: 1, RequestContractVersion: 1, State: StateUnauthorized}},
+		{name: "unsupported", status: http.StatusNotAcceptable, body: StateResponse{ResponseVersion: 1, RequestContractVersion: 1, State: StateUnsupportedVersion, SupportedResponseVersions: []int{1}, SupportedRequestContractVersions: []int{1}}},
+		{name: "unavailable", status: http.StatusServiceUnavailable, body: StateResponse{ResponseVersion: 1, RequestContractVersion: 1, State: StateUnavailable, Retryable: true}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(test.status)
+				_ = json.NewEncoder(w).Encode(test.body)
+			}))
+			defer server.Close()
+			client, err := NewClient(server.URL, server.Client())
+			if err != nil {
+				t.Fatal(err)
+			}
+			result, err := client.Fetch(context.Background(), "token", testInstallationID, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.State != test.body.State {
+				t.Fatalf("Fetch().State = %q, want %q", result.State, test.body.State)
+			}
+		})
+	}
+}
+
+func TestClientRejectsUntrustedResponses(t *testing.T) {
+	tests := []struct {
+		name string
+		body func(*Deployment) string
+		etag string
+	}{
+		{name: "unknown deployment field", body: func(d *Deployment) string {
+			data, _ := json.Marshal(d)
+			return strings.TrimSuffix(string(data), "}") + `,"endpointConfig":{}}`
+		}, etag: "valid"},
+		{name: "known state field on wrong state", body: func(*Deployment) string {
+			return `{"responseVersion":1,"requestContractVersion":1,"state":"no_active_policy","retryable":true}`
+		}},
+		{name: "missing etag", body: marshalDeployment},
+		{name: "wrong etag", body: marshalDeployment, etag: strings.Repeat("f", 64)},
+		{name: "trailing json", body: func(d *Deployment) string { return marshalDeployment(d) + `{}` }, etag: "valid"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			deployment := testDeployment(t, cedareval.RolloutModeObserve)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if test.etag == "valid" {
+					w.Header().Set("ETag", `"`+deployment.DeploymentIdentity+`"`)
+				} else if test.etag != "" {
+					w.Header().Set("ETag", `"`+test.etag+`"`)
+				}
+				_, _ = w.Write([]byte(test.body(&deployment)))
+			}))
+			defer server.Close()
+			client, err := NewClient(server.URL, server.Client())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := client.Fetch(context.Background(), "token", testInstallationID, ""); err == nil {
+				t.Fatal("Fetch() error = nil")
+			}
+		})
+	}
+}
+
+func TestClientAcceptsMaximumDecodedPolicyDespiteJSONEscaping(t *testing.T) {
+	deployment := testDeployment(t, cedareval.RolloutModeObserve)
+	deployment.PolicyText = strings.Repeat(`"`, cedareval.PolicyMaxBytes)
+	deployment.PolicyHash = cedareval.ComputePolicyHash(deployment.PolicyText)
+	identity, err := cedareval.ComputeDeploymentIdentity(cedareval.DeploymentIdentityInput{
+		ResponseVersion:        deployment.ResponseVersion,
+		RequestContractVersion: deployment.RequestContractVersion,
+		PolicyHash:             deployment.PolicyHash,
+		RolloutMode:            string(deployment.RolloutMode),
+		EvaluationPrincipal:    deployment.EvaluationPrincipal,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	deployment.DeploymentIdentity = identity
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("ETag", `"`+deployment.DeploymentIdentity+`"`)
+		_ = json.NewEncoder(w).Encode(deployment)
+	}))
+	defer server.Close()
+	client, err := NewClient(server.URL, server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Fetch(context.Background(), "token", testInstallationID, ""); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNewClientRejectsPlaintextRemoteURL(t *testing.T) {
+	if _, err := NewClient("http://example.com", nil); err == nil {
+		t.Fatal("NewClient() error = nil")
+	}
+}
+
+func marshalDeployment(deployment *Deployment) string {
+	data, _ := json.Marshal(deployment)
+	return string(data)
+}

--- a/internal/cedarpolicy/contract.go
+++ b/internal/cedarpolicy/contract.go
@@ -1,0 +1,209 @@
+package cedarpolicy
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"unicode/utf16"
+
+	"github.com/kontext-security/kontext-cli/internal/cedareval"
+)
+
+const (
+	ResponseVersion        = 1
+	RequestContractVersion = 1
+	// A valid 1 MiB UTF-8 policy can expand to six bytes per input byte when
+	// represented with JSON Unicode escapes. Bound the wire independently from
+	// the decoded policy contract so valid responses are never truncated.
+	MaxResponseBytes = 6*cedareval.PolicyMaxBytes + 64*1024
+)
+
+var sha256HexPattern = regexp.MustCompile(`^[a-f0-9]{64}$`)
+
+type Deployment struct {
+	ResponseVersion        int                           `json:"responseVersion"`
+	RequestContractVersion int                           `json:"requestContractVersion"`
+	PolicyHash             string                        `json:"policyHash"`
+	RolloutMode            cedareval.RolloutMode         `json:"rolloutMode"`
+	EvaluationPrincipal    cedareval.EvaluationPrincipal `json:"evaluationPrincipal"`
+	PolicyText             string                        `json:"policyText"`
+	Signature              string                        `json:"signature,omitempty"`
+	DeploymentIdentity     string                        `json:"deploymentIdentity"`
+}
+
+func (d Deployment) Validate() error {
+	if d.ResponseVersion != ResponseVersion {
+		return fmt.Errorf("cedar policy: unsupported response version %d", d.ResponseVersion)
+	}
+	if d.RequestContractVersion != RequestContractVersion {
+		return fmt.Errorf("cedar policy: unsupported request contract version %d", d.RequestContractVersion)
+	}
+	if len([]byte(d.PolicyText)) > cedareval.PolicyMaxBytes {
+		return fmt.Errorf("cedar policy: policy text exceeds %d bytes", cedareval.PolicyMaxBytes)
+	}
+	if d.RolloutMode != cedareval.RolloutModeObserve && d.RolloutMode != cedareval.RolloutModeEnforce {
+		return fmt.Errorf("cedar policy: unsupported rollout mode %q", d.RolloutMode)
+	}
+	principalLength := utf16Length(d.EvaluationPrincipal.EntityID)
+	if d.EvaluationPrincipal.EntityType != cedareval.PrincipalEntityType || principalLength == 0 || principalLength > 1024 {
+		return errors.New("cedar policy: invalid evaluation principal")
+	}
+	if d.Signature != "" {
+		signatureLength := utf16Length(d.Signature)
+		if signatureLength == 0 || signatureLength > 8192 {
+			return errors.New("cedar policy: invalid signature")
+		}
+	}
+	if !sha256HexPattern.MatchString(d.PolicyHash) || !sha256HexPattern.MatchString(d.DeploymentIdentity) {
+		return errors.New("cedar policy: invalid hash encoding")
+	}
+	expectedPolicyHash := cedareval.ComputePolicyHash(d.PolicyText)
+	if d.PolicyHash != expectedPolicyHash {
+		return errors.New("cedar policy: policy hash does not match policy text")
+	}
+	expectedDeploymentIdentity, err := cedareval.ComputeDeploymentIdentity(cedareval.DeploymentIdentityInput{
+		ResponseVersion:        d.ResponseVersion,
+		RequestContractVersion: d.RequestContractVersion,
+		PolicyHash:             d.PolicyHash,
+		RolloutMode:            string(d.RolloutMode),
+		EvaluationPrincipal:    d.EvaluationPrincipal,
+	})
+	if err != nil {
+		return err
+	}
+	if d.DeploymentIdentity != expectedDeploymentIdentity {
+		return errors.New("cedar policy: deployment identity does not match response metadata")
+	}
+	return nil
+}
+
+type State string
+
+const (
+	StateSuccess              State = "success"
+	StateNotModified          State = "not_modified"
+	StateDisabled             State = "disabled"
+	StateNoActivePolicy       State = "no_active_policy"
+	StatePrincipalUnavailable State = "principal_unavailable"
+	StateUnsupportedVersion   State = "unsupported_version"
+	StateUnauthorized         State = "unauthorized"
+	StateUnavailable          State = "unavailable"
+)
+
+type StateResponse struct {
+	ResponseVersion                  int    `json:"responseVersion"`
+	RequestContractVersion           int    `json:"requestContractVersion"`
+	State                            State  `json:"state"`
+	DeploymentIdentity               string `json:"deploymentIdentity,omitempty"`
+	RolloutMode                      string `json:"rolloutMode,omitempty"`
+	SupportedResponseVersions        []int  `json:"supportedResponseVersions,omitempty"`
+	SupportedRequestContractVersions []int  `json:"supportedRequestContractVersions,omitempty"`
+	Retryable                        bool   `json:"retryable,omitempty"`
+}
+
+func (s *StateResponse) UnmarshalJSON(data []byte) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	var probe struct {
+		State State `json:"state"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return err
+	}
+	allowed := []string{"responseVersion", "requestContractVersion", "state"}
+	switch probe.State {
+	case StateNotModified:
+		allowed = append(allowed, "deploymentIdentity")
+	case StateDisabled:
+		allowed = append(allowed, "rolloutMode")
+	case StateNoActivePolicy, StatePrincipalUnavailable, StateUnauthorized:
+	case StateUnsupportedVersion:
+		allowed = append(allowed, "supportedResponseVersions", "supportedRequestContractVersions")
+	case StateUnavailable:
+		allowed = append(allowed, "retryable")
+	default:
+		return fmt.Errorf("cedar policy: unknown response state %q", probe.State)
+	}
+	if err := requireExactFields(fields, allowed); err != nil {
+		return err
+	}
+	type wireState StateResponse
+	var decoded wireState
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&decoded); err != nil {
+		return err
+	}
+	*s = StateResponse(decoded)
+	return s.Validate()
+}
+
+func (s StateResponse) Validate() error {
+	if s.ResponseVersion != ResponseVersion || s.RequestContractVersion != RequestContractVersion {
+		return errors.New("cedar policy: state response uses unsupported contract versions")
+	}
+	switch s.State {
+	case StateNotModified:
+		if !sha256HexPattern.MatchString(s.DeploymentIdentity) {
+			return errors.New("cedar policy: not-modified response has invalid deployment identity")
+		}
+	case StateDisabled:
+		if s.RolloutMode != string(cedareval.RolloutModeDisabled) {
+			return errors.New("cedar policy: disabled response must declare disabled rollout mode")
+		}
+	case StateNoActivePolicy, StatePrincipalUnavailable, StateUnauthorized:
+	case StateUnsupportedVersion:
+		if len(s.SupportedResponseVersions) != 1 || s.SupportedResponseVersions[0] != ResponseVersion ||
+			len(s.SupportedRequestContractVersions) != 1 || s.SupportedRequestContractVersions[0] != RequestContractVersion {
+			return errors.New("cedar policy: unsupported-version response has invalid supported versions")
+		}
+	case StateUnavailable:
+		if !s.Retryable {
+			return errors.New("cedar policy: unavailable response must be retryable")
+		}
+	default:
+		return fmt.Errorf("cedar policy: unknown response state %q", s.State)
+	}
+	return nil
+}
+
+func requireExactFields(fields map[string]json.RawMessage, allowed []string) error {
+	if len(fields) != len(allowed) {
+		return errors.New("cedar policy: state response has missing or unexpected fields")
+	}
+	for _, field := range allowed {
+		if _, ok := fields[field]; !ok {
+			return fmt.Errorf("cedar policy: state response is missing field %q", field)
+		}
+	}
+	return nil
+}
+
+func decodeStrict[T any](reader io.Reader, target *T) error {
+	limited := io.LimitReader(reader, MaxResponseBytes+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return err
+	}
+	if len(data) > MaxResponseBytes {
+		return fmt.Errorf("cedar policy: response exceeds %d bytes", MaxResponseBytes)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return errors.New("cedar policy: unexpected trailing json value")
+	}
+	return nil
+}
+
+func utf16Length(value string) int {
+	return len(utf16.Encode([]rune(value)))
+}

--- a/internal/cedarpolicy/contract_test.go
+++ b/internal/cedarpolicy/contract_test.go
@@ -1,0 +1,106 @@
+package cedarpolicy
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/cedareval"
+)
+
+func TestDeploymentValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*Deployment)
+		wantErr string
+	}{
+		{name: "valid response"},
+		{
+			name: "policy hash mismatch",
+			mutate: func(d *Deployment) {
+				d.PolicyHash = strings.Repeat("a", 64)
+			},
+			wantErr: "policy hash",
+		},
+		{
+			name: "deployment identity mismatch",
+			mutate: func(d *Deployment) {
+				d.DeploymentIdentity = strings.Repeat("b", 64)
+			},
+			wantErr: "deployment identity",
+		},
+		{
+			name: "unsupported mode",
+			mutate: func(d *Deployment) {
+				d.RolloutMode = "future"
+			},
+			wantErr: "rollout mode",
+		},
+		{
+			name: "oversized signature",
+			mutate: func(d *Deployment) {
+				d.Signature = strings.Repeat("x", 8193)
+			},
+			wantErr: "signature",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			deployment := testDeployment(t, cedareval.RolloutModeObserve)
+			if test.mutate != nil {
+				test.mutate(&deployment)
+			}
+			err := deployment.Validate()
+			if test.wantErr == "" && err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+			if test.wantErr != "" && (err == nil || !strings.Contains(err.Error(), test.wantErr)) {
+				t.Fatalf("Validate() error = %v, want containing %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestStateResponseRejectsWrongShape(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "unknown field",
+			body: `{"responseVersion":1,"requestContractVersion":1,"state":"no_active_policy","extra":true}`,
+		},
+		{
+			name: "known field on wrong state",
+			body: `{"responseVersion":1,"requestContractVersion":1,"state":"no_active_policy","retryable":true}`,
+		},
+		{
+			name: "missing disabled mode",
+			body: `{"responseVersion":1,"requestContractVersion":1,"state":"disabled"}`,
+		},
+		{
+			name: "unsupported versions not exact",
+			body: `{"responseVersion":1,"requestContractVersion":1,"state":"unsupported_version","supportedResponseVersions":[1,2],"supportedRequestContractVersions":[1]}`,
+		},
+		{
+			name: "retired principal detail state",
+			body: `{"responseVersion":1,"requestContractVersion":1,"state":"principal_unmatched"}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var response StateResponse
+			if err := json.Unmarshal([]byte(test.body), &response); err == nil {
+				t.Fatal("Unmarshal() error = nil")
+			}
+		})
+	}
+}
+
+func TestDecodeStrictRejectsTrailingData(t *testing.T) {
+	body := `{"responseVersion":1,"requestContractVersion":1,"state":"no_active_policy"}{}`
+	var response StateResponse
+	if err := decodeStrict(strings.NewReader(body), &response); err == nil {
+		t.Fatal("decodeStrict() error = nil")
+	}
+}

--- a/internal/cedarpolicy/fixture_test.go
+++ b/internal/cedarpolicy/fixture_test.go
@@ -1,0 +1,47 @@
+package cedarpolicy
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"reflect"
+	"testing"
+)
+
+const getPolicyStateFixturePath = "testdata/portable/v1/get-policy-states-v1.json"
+const getPolicyStateFixtureSHA256 = "eaa1c01f0ab6f54db822894dc8038a5608ae0001aa0396b5402d2d3cc67caf26"
+
+func TestPortableGetPolicyStateFixture(t *testing.T) {
+	data, err := os.ReadFile(getPolicyStateFixturePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256(data)
+	if got := hex.EncodeToString(digest[:]); got != getPolicyStateFixtureSHA256 {
+		t.Fatalf("fixture SHA-256 = %s, want %s", got, getPolicyStateFixtureSHA256)
+	}
+	var responses []StateResponse
+	if err := json.Unmarshal(data, &responses); err != nil {
+		t.Fatal(err)
+	}
+	got := make([]State, 0, len(responses))
+	for _, response := range responses {
+		if err := response.Validate(); err != nil {
+			t.Fatalf("Validate(%q) error = %v", response.State, err)
+		}
+		got = append(got, response.State)
+	}
+	want := []State{
+		StateNotModified,
+		StateDisabled,
+		StateNoActivePolicy,
+		StatePrincipalUnavailable,
+		StateUnsupportedVersion,
+		StateUnauthorized,
+		StateUnavailable,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("fixture states = %v, want %v", got, want)
+	}
+}

--- a/internal/cedarpolicy/test_helpers_test.go
+++ b/internal/cedarpolicy/test_helpers_test.go
@@ -1,0 +1,42 @@
+package cedarpolicy
+
+import (
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/cedareval"
+)
+
+const testPolicy = `@id("permit-read")
+permit (
+  principal,
+  action == Kontext::Action::"ToolUse",
+  resource == Kontext::Tool::"Read"
+);`
+
+func testDeployment(t *testing.T, mode cedareval.RolloutMode) Deployment {
+	t.Helper()
+	principal := cedareval.EvaluationPrincipal{
+		EntityType: cedareval.PrincipalEntityType,
+		EntityID:   "user@example.com",
+	}
+	policyHash := cedareval.ComputePolicyHash(testPolicy)
+	identity, err := cedareval.ComputeDeploymentIdentity(cedareval.DeploymentIdentityInput{
+		ResponseVersion:        ResponseVersion,
+		RequestContractVersion: RequestContractVersion,
+		PolicyHash:             policyHash,
+		RolloutMode:            string(mode),
+		EvaluationPrincipal:    principal,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return Deployment{
+		ResponseVersion:        ResponseVersion,
+		RequestContractVersion: RequestContractVersion,
+		PolicyHash:             policyHash,
+		RolloutMode:            mode,
+		EvaluationPrincipal:    principal,
+		PolicyText:             testPolicy,
+		DeploymentIdentity:     identity,
+	}
+}

--- a/internal/cedarpolicy/testdata/portable/v1/README.md
+++ b/internal/cedarpolicy/testdata/portable/v1/README.md
@@ -1,0 +1,5 @@
+# GetPolicy state fixture v1
+
+`get-policy-states-v1.json` is copied byte-for-byte from the shared GetPolicy
+contract. Consumers must copy these bytes and pin the file digest rather than
+maintaining independently equivalent state examples.

--- a/internal/cedarpolicy/testdata/portable/v1/get-policy-states-v1.json
+++ b/internal/cedarpolicy/testdata/portable/v1/get-policy-states-v1.json
@@ -1,0 +1,42 @@
+[
+  {
+    "responseVersion": 1,
+    "requestContractVersion": 1,
+    "state": "not_modified",
+    "deploymentIdentity": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+  },
+  {
+    "responseVersion": 1,
+    "requestContractVersion": 1,
+    "state": "disabled",
+    "rolloutMode": "disabled"
+  },
+  {
+    "responseVersion": 1,
+    "requestContractVersion": 1,
+    "state": "no_active_policy"
+  },
+  {
+    "responseVersion": 1,
+    "requestContractVersion": 1,
+    "state": "principal_unavailable"
+  },
+  {
+    "responseVersion": 1,
+    "requestContractVersion": 1,
+    "state": "unsupported_version",
+    "supportedResponseVersions": [1],
+    "supportedRequestContractVersions": [1]
+  },
+  {
+    "responseVersion": 1,
+    "requestContractVersion": 1,
+    "state": "unauthorized"
+  },
+  {
+    "responseVersion": 1,
+    "requestContractVersion": 1,
+    "state": "unavailable",
+    "retryable": true
+  }
+]

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kontext-security/kontext-cli/internal/cedarpolicy"
 	"github.com/kontext-security/kontext-cli/internal/claudemanaged"
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 	"github.com/kontext-security/kontext-cli/internal/githubpolicy"
@@ -33,6 +34,7 @@ type DaemonOptions struct {
 	StreamHTTPClient       *http.Client
 	GithubPolicyCachePath  string
 	HubspotPolicyCachePath string
+	CedarPolicyCachePath   string
 	// PolicyRefreshInterval and PolicyHTTPClient apply to every provider's
 	// snapshot refresh loop (test knobs; zero values use defaults).
 	PolicyRefreshInterval time.Duration
@@ -128,6 +130,19 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 
 	githubCache := newProviderPolicyCache(opts.GithubPolicyCachePath, dbPath, githubpolicy.Config, opts.Diagnostic)
 	hubspotCache := newProviderPolicyCache(opts.HubspotPolicyCachePath, dbPath, hubspotpolicy.Config, opts.Diagnostic)
+	cedarCachePath := opts.CedarPolicyCachePath
+	if cedarCachePath == "" {
+		cedarCachePath = cedarpolicy.DefaultCachePathForDB(dbPath)
+	}
+	cedarCache := cedarpolicy.NewCache(cedarCachePath, 0)
+	if err := cedarCache.Load(); err != nil {
+		cedarCache.MarkInvalid(err)
+		opts.Diagnostic.Printf("cedar policy cache load: %v\n", err)
+	}
+	cedarClient, err := cedarpolicy.NewClient(loadedConfig.Config.CloudURL, opts.PolicyHTTPClient)
+	if err != nil {
+		return fmt.Errorf("configure cedar policy client: %w", err)
+	}
 
 	host, err := runtimehost.Start(ctx, runtimehost.Options{
 		AgentName:  managedconfig.Agent,
@@ -170,6 +185,20 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 	// other providers' refreshers pass nil and never touch the gate.
 	go runProviderPolicy(policyCtx, opts, githubpolicy.Config, githubCache, installationState.InstallationID, host.SetPayloadCaptureMode)
 	go runProviderPolicy(policyCtx, opts, hubspotpolicy.Config, hubspotCache, installationState.InstallationID, nil)
+	cedarRefresher := cedarpolicy.Refresher{
+		Client: cedarClient,
+		Cache:  cedarCache,
+		TokenSource: func(refreshCtx context.Context) (string, error) {
+			loaded, err := managedconfig.Load()
+			if err != nil {
+				return "", err
+			}
+			return managedconfig.ResolveInstallToken(refreshCtx, loaded.Config.Credentials.InstallTokenRef)
+		},
+		InstallationID: installationState.InstallationID,
+		Interval:       opts.PolicyRefreshInterval,
+	}
+	go cedarRefresher.Run(policyCtx)
 
 	streamCtx, stopStream := context.WithCancel(ctx)
 	defer stopStream()

--- a/internal/managedobserve/daemon_test.go
+++ b/internal/managedobserve/daemon_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/managedconfig"
 )
 
+const testRuntimeTimeout = 5 * time.Second
+
 func TestDaemonPreservesHookSessionIDs(t *testing.T) {
 	socketPath, dbPath, stop := startTestDaemon(t)
 	if status := LoadDaemonStatus(dbPath); status == nil || status.PID == 0 {
@@ -28,7 +30,7 @@ func TestDaemonPreservesHookSessionIDs(t *testing.T) {
 	}
 
 	client := localruntime.NewClient(socketPath)
-	client.Timeout = time.Second
+	client.Timeout = testRuntimeTimeout
 	for _, sessionID := range []string{"claude-session-one", "claude-session-two"} {
 		result, err := client.Process(context.Background(), hook.Event{
 			SessionID: sessionID,
@@ -60,7 +62,7 @@ func TestDaemonSessionEndClosesHookSessionID(t *testing.T) {
 	socketPath, dbPath, stop := startTestDaemon(t)
 
 	client := localruntime.NewClient(socketPath)
-	client.Timeout = time.Second
+	client.Timeout = testRuntimeTimeout
 	result, err := client.Process(context.Background(), hook.Event{
 		SessionID: "claude-session-end",
 		Agent:     "claude",
@@ -163,7 +165,7 @@ func TestDaemonStreamsLedgerBatches(t *testing.T) {
 	waitForSocket(t, socketPath, errCh)
 
 	client := localruntime.NewClient(socketPath)
-	client.Timeout = time.Second
+	client.Timeout = testRuntimeTimeout
 	if _, err := client.Process(context.Background(), hook.Event{
 		SessionID: "claude-stream-session",
 		Agent:     "claude",
@@ -267,7 +269,7 @@ func TestDaemonRefreshesStreamInstallToken(t *testing.T) {
 	t.Setenv("KONTEXT_INSTALL_TOKEN", "refreshed-install-token")
 
 	client := localruntime.NewClient(socketPath)
-	client.Timeout = time.Second
+	client.Timeout = testRuntimeTimeout
 	if _, err := client.Process(context.Background(), hook.Event{
 		SessionID: "claude-stream-token-session",
 		Agent:     "claude",
@@ -344,7 +346,7 @@ func TestDaemonWritesAuthErrorAfterConsecutiveStreamAuthFailures(t *testing.T) {
 	waitForSocket(t, socketPath, errCh)
 
 	client := localruntime.NewClient(socketPath)
-	client.Timeout = time.Second
+	client.Timeout = testRuntimeTimeout
 	if _, err := client.Process(context.Background(), hook.Event{
 		SessionID: "claude-auth-error-session",
 		Agent:     "claude",
@@ -402,6 +404,12 @@ func TestDaemonRefreshesGithubPolicyInstallToken(t *testing.T) {
 			// 404 — so the daemon treats this as quietly-not-configured
 			// (keep any cache, mark stale, back off polling), not a failure.
 			w.WriteHeader(http.StatusNotFound)
+		case "/api/v1/installations/ins_0123456789abcdefghijklmnopqrstuv/policy":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"responseVersion":        1,
+				"requestContractVersion": 1,
+				"state":                  "no_active_policy",
+			})
 		case "/api/v1/authorization-ledger/batches":
 			w.WriteHeader(http.StatusAccepted)
 		default:
@@ -470,8 +478,19 @@ func TestDaemonRefreshesGithubPolicyInstallToken(t *testing.T) {
 }
 
 func TestRunDaemonExitsCleanlyAfterHomebrewUpgradeSignal(t *testing.T) {
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusAccepted)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v1/installations/ins_0123456789abcdefghijklmnopqrstuv/policy":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"responseVersion":        1,
+				"requestContractVersion": 1,
+				"state":                  "no_active_policy",
+			})
+		case "/api/v1/policy/github/snapshot", "/api/v1/policy/hubspot/snapshot":
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			w.WriteHeader(http.StatusAccepted)
+		}
 	}))
 	t.Cleanup(server.Close)
 
@@ -719,13 +738,16 @@ func startTestDaemon(t *testing.T) (string, string, func()) {
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- RunDaemon(ctx, DaemonOptions{
-			SocketPath:       socketPath,
-			DBPath:           dbPath,
-			IdleTimeout:      time.Hour,
-			StreamHTTPClient: server.Client(),
+			SocketPath:            socketPath,
+			DBPath:                dbPath,
+			IdleTimeout:           time.Hour,
+			StreamHTTPClient:      server.Client(),
+			PolicyRefreshInterval: time.Hour,
+			PolicyHTTPClient:      server.Client(),
 		})
 	}()
 	waitForSocket(t, socketPath, errCh)
+	waitForDaemonStatus(t, dbPath, errCh)
 	stopped := false
 	stop := func() {
 		if stopped {
@@ -763,6 +785,23 @@ func waitForSocket(t *testing.T, socketPath string, errCh <-chan error) {
 		time.Sleep(20 * time.Millisecond)
 	}
 	t.Fatalf("managed observe daemon socket %s did not become ready", socketPath)
+}
+
+func waitForDaemonStatus(t *testing.T, dbPath string, errCh <-chan error) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-errCh:
+			t.Fatalf("RunDaemon exited before status was ready: %v", err)
+		default:
+		}
+		if status := LoadDaemonStatus(dbPath); status != nil && status.PID != 0 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("managed observe daemon status did not become ready")
 }
 
 func writeTestManagedConfig(t *testing.T, path string) {


### PR DESCRIPTION
## Why

Local Cedar evaluation needs a validated policy mirror that refreshes outside the hook path and remains usable through bounded network failure.

## What

- fetches GET /api/v1/installations/:id/policy with version negotiation and conditional ETags
- accepts a policy-only ready response and strict reduced-v1 states, including principal_unavailable
- validates policy hash, principal, rollout mode, and the seven-term semantic deployment identity
- copies and digest-pins the canonical GetPolicy state fixture
- atomically persists a private last-known-good cache
- restores every retained non-ready state after a matching 304 and expires policy by age
- starts immediate and periodic refresh under daemon lifecycle cancellation

## Scope

Policy retrieval and caching only. No endpoint configuration fields and no hook-decision changes.

Depends on #383. Tracks ENG-533.

## Verification

- go test ./...
- focused go test -race across Cedar policy and daemon packages
- go vet ./...

Change size: 12 files, +1,451/-11 — GetPolicy contract/client/cache, daemon lifecycle, portable fixture, and tests.