### PR TITLE
feat(policy): observe local Cedar decisions

### DIFF
--- a/internal/guard/app/server/cedar.go
+++ b/internal/guard/app/server/cedar.go
@@ -1,0 +1,148 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/kontext-security/kontext-cli/internal/cedareval"
+	"github.com/kontext-security/kontext-cli/internal/cedarpolicy"
+	"github.com/kontext-security/kontext-cli/internal/guard/risk"
+	"github.com/kontext-security/kontext-cli/internal/hook"
+)
+
+const cedarEvaluatorVersion = "cedar-go/v1.8.0"
+
+type cedarPolicyProvider struct {
+	current   PolicyProvider
+	snapshots cedarpolicy.SnapshotProvider
+
+	mu        sync.Mutex
+	identity  string
+	evaluator *cedareval.Evaluator
+	parseErr  error
+}
+
+func newCedarPolicyProvider(current PolicyProvider, snapshots cedarpolicy.SnapshotProvider) PolicyProvider {
+	if snapshots == nil {
+		return current
+	}
+	return &cedarPolicyProvider{current: current, snapshots: snapshots}
+}
+
+func (p *cedarPolicyProvider) DecideHook(ctx context.Context, event risk.HookEvent) (risk.RiskDecision, error) {
+	decision, err := p.current.DecideHook(ctx, event)
+	if err != nil || event.HookEventName != hook.HookPreToolUse.String() {
+		return decision, err
+	}
+
+	snapshot := p.snapshots.Current()
+	evidence := p.evaluate(snapshot, event, executionAction(decision.Decision))
+	decision.Cedar = &evidence
+	return decision, nil
+}
+
+func (p *cedarPolicyProvider) evaluate(snapshot cedarpolicy.Snapshot, event risk.HookEvent, current cedareval.EffectiveExecutionAction) risk.CedarEvidence {
+	evidence := risk.CedarEvidence{
+		AppliedRolloutMode: cedareval.RolloutModeObserve,
+		CacheFetchedAt:     snapshot.Status.FetchedAt,
+		CacheStale:         snapshot.Status.Stale,
+		EvaluatorVersion:   cedarEvaluatorVersion,
+		ContextDiagnostics: []cedareval.ContextDiagnostic{},
+	}
+	outcome := cedareval.EvaluationOutcome{State: cedareval.EvaluationStateFailed, Reason: cedareval.ReasonPolicyMissing}
+	var principal *cedareval.EvaluationPrincipal
+
+	if deployment := snapshot.Deployment; deployment != nil {
+		evidence.ResponseVersion = deployment.ResponseVersion
+		evidence.RequestContractVersion = deployment.RequestContractVersion
+		evidence.PolicyHash = deployment.PolicyHash
+		evidence.DeploymentIdentity = deployment.DeploymentIdentity
+		evidence.ConfiguredRolloutMode = deployment.RolloutMode
+		principalValue := deployment.EvaluationPrincipal
+		principal = &principalValue
+
+		evaluator, parseErr := p.evaluatorFor(deployment)
+		if parseErr != nil {
+			outcome.Reason = cedareval.ReasonInvalidCachedPolicy
+			evidence.EngineErrorCount = 1
+		} else {
+			input, inputErr := cedareval.InputFromEvent(principalValue, hookEvent(event))
+			if inputErr != nil {
+				outcome.Reason = cedareval.ReasonRequestConversionFailed
+			} else if result, evaluateErr := evaluator.Evaluate(input); evaluateErr != nil {
+				var conversionErr *cedareval.ConversionError
+				if errors.As(evaluateErr, &conversionErr) {
+					outcome.Reason = cedareval.ReasonRequestConversionFailed
+				} else {
+					outcome.Reason = cedareval.ReasonEngineError
+				}
+				evidence.EngineErrorCount = 1
+			} else {
+				outcome = cedareval.EvaluationOutcome{
+					State:                cedareval.EvaluationStateEvaluated,
+					Decision:             result.Decision,
+					Ask:                  result.Ask,
+					DeterminingPolicyIDs: result.DeterminingPolicyIDs,
+				}
+				evidence.ContextDiagnostics = result.ContextDiagnostics
+				evidence.EngineErrorCount = len(result.EngineDiagnostics.Errors)
+			}
+		}
+	} else if isPrincipalState(snapshot.State) {
+		outcome = cedareval.EvaluationOutcome{State: cedareval.EvaluationStatePrincipalUnresolved, Reason: cedareval.ReasonPrincipalUnresolved}
+	} else if snapshot.Status.Stale {
+		outcome.Reason = cedareval.ReasonStaleCachedPolicy
+	}
+
+	evidence.AppliedRolloutMode = cedareval.RolloutModeObserve
+	mapping, err := cedareval.MapDecision(cedareval.DecisionMappingInput{
+		RolloutMode:            cedareval.RolloutModeObserve,
+		CurrentAuthorityAction: current,
+		EvaluationPrincipal:    principal,
+		Evaluation:             outcome,
+	})
+	if err != nil {
+		fallback, _ := cedareval.MapDecision(cedareval.DecisionMappingInput{
+			RolloutMode:            cedareval.RolloutModeObserve,
+			CurrentAuthorityAction: current,
+			Evaluation:             cedareval.EvaluationOutcome{State: cedareval.EvaluationStateFailed, Reason: cedareval.ReasonEngineError},
+		})
+		evidence.Mapping = fallback
+		evidence.AppliedRolloutMode = cedareval.RolloutModeObserve
+		evidence.EngineErrorCount++
+		return evidence
+	}
+	evidence.Mapping = mapping
+	return evidence
+}
+
+func (p *cedarPolicyProvider) evaluatorFor(deployment *cedarpolicy.Deployment) (*cedareval.Evaluator, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.identity != deployment.DeploymentIdentity {
+		p.identity = deployment.DeploymentIdentity
+		p.evaluator, p.parseErr = cedareval.New(deployment.PolicyText)
+	}
+	return p.evaluator, p.parseErr
+}
+
+func executionAction(decision risk.Decision) cedareval.EffectiveExecutionAction {
+	if decision == risk.DecisionDeny {
+		return cedareval.EffectiveExecutionActionDeny
+	}
+	return cedareval.EffectiveExecutionActionAllow
+}
+
+func hookEvent(event risk.HookEvent) hook.Event {
+	return hook.Event{SessionID: event.SessionID, Agent: event.Agent, HookName: hook.HookName(event.HookEventName), ToolName: event.ToolName, ToolInput: event.ToolInput, ToolResponse: event.ToolResponse, ToolUseID: event.ToolUseID, CWD: event.CWD}
+}
+
+func isPrincipalState(state cedarpolicy.State) bool {
+	switch state {
+	case cedarpolicy.StatePrincipalUnavailable:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/guard/app/server/cedar_test.go
+++ b/internal/guard/app/server/cedar_test.go
@@ -1,0 +1,84 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/cedareval"
+	"github.com/kontext-security/kontext-cli/internal/cedarpolicy"
+	"github.com/kontext-security/kontext-cli/internal/guard/risk"
+)
+
+type staticCedarSnapshots struct{ snapshot cedarpolicy.Snapshot }
+
+func (s staticCedarSnapshots) Current() cedarpolicy.Snapshot { return s.snapshot }
+
+type staticHookPolicy struct{ decision risk.RiskDecision }
+
+func (p staticHookPolicy) DecideHook(context.Context, risk.HookEvent) (risk.RiskDecision, error) {
+	return p.decision, nil
+}
+
+func TestCedarObservePreservesCurrentAuthorityAndRecordsDecision(t *testing.T) {
+	deployment := cedarTestDeployment(t, cedareval.RolloutModeEnforce, `@id("permit-read") permit(principal, action, resource == Kontext::Tool::"Read");`)
+	current := staticHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionDeny, Reason: "current deny", ReasonCode: "current_deny", RiskEvent: risk.RiskEvent{Decision: risk.DecisionDeny}}}
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, State: cedarpolicy.StateSuccess, Status: cedarpolicy.CacheStatus{FetchedAt: time.Now()}}})
+
+	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Decision != risk.DecisionDeny || decision.ReasonCode != "current_deny" {
+		t.Fatalf("effective decision = %#v, want unchanged current authority", decision)
+	}
+	if decision.Cedar == nil || decision.Cedar.AppliedRolloutMode != cedareval.RolloutModeObserve {
+		t.Fatalf("Cedar evidence = %#v, want observe", decision.Cedar)
+	}
+	if decision.Cedar.Mapping.DerivedCedarAction != cedareval.DerivedCedarActionAllow {
+		t.Fatalf("derived action = %q, want allow", decision.Cedar.Mapping.DerivedCedarAction)
+	}
+	if decision.Cedar.Mapping.EffectiveExecutionAction != cedareval.EffectiveExecutionActionDeny {
+		t.Fatalf("effective Cedar mapping = %q, want current deny", decision.Cedar.Mapping.EffectiveExecutionAction)
+	}
+}
+
+func TestCedarObserveClassifiesContextConversionFailure(t *testing.T) {
+	deployment := cedarTestDeployment(t, cedareval.RolloutModeObserve, `@id("permit") permit(principal, action, resource);`)
+	current := staticHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow, RiskEvent: risk.RiskEvent{Decision: risk.DecisionAllow}}}
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, State: cedarpolicy.StateSuccess}})
+
+	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{"bad": make(chan struct{})}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Cedar.Mapping.EvaluationReasonCode != cedareval.ReasonRequestConversionFailed {
+		t.Fatalf("evaluation reason = %q, want conversion failure", decision.Cedar.Mapping.EvaluationReasonCode)
+	}
+	if decision.Decision != risk.DecisionAllow {
+		t.Fatal("observe failure changed current authority")
+	}
+}
+
+func TestCedarObserveRecordsUnresolvedPrincipal(t *testing.T) {
+	current := staticHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow, RiskEvent: risk.RiskEvent{Decision: risk.DecisionAllow}}}
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{State: cedarpolicy.StatePrincipalUnavailable}})
+	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Cedar.Mapping.EvaluationState != cedareval.EvaluationStatePrincipalUnresolved || decision.Cedar.Mapping.EvaluationPrincipal != nil {
+		t.Fatalf("mapping = %#v, want unresolved principal without identity", decision.Cedar.Mapping)
+	}
+}
+
+func cedarTestDeployment(t *testing.T, mode cedareval.RolloutMode, policy string) cedarpolicy.Deployment {
+	t.Helper()
+	principal := cedareval.EvaluationPrincipal{EntityType: cedareval.PrincipalEntityType, EntityID: "user@example.com"}
+	hash := cedareval.ComputePolicyHash(policy)
+	identity, err := cedareval.ComputeDeploymentIdentity(cedareval.DeploymentIdentityInput{ResponseVersion: 1, RequestContractVersion: 1, PolicyHash: hash, RolloutMode: string(mode), EvaluationPrincipal: principal})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cedarpolicy.Deployment{ResponseVersion: 1, RequestContractVersion: 1, PolicyHash: hash, RolloutMode: mode, EvaluationPrincipal: principal, PolicyText: policy, DeploymentIdentity: identity}
+}

--- a/internal/guard/app/server/server.go
+++ b/internal/guard/app/server/server.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kontext-security/kontext-cli/internal/cedarpolicy"
 	"github.com/kontext-security/kontext-cli/internal/guard/judge"
 	"github.com/kontext-security/kontext-cli/internal/guard/policy"
 	"github.com/kontext-security/kontext-cli/internal/guard/policyconfig"
@@ -52,6 +53,7 @@ type Options struct {
 	PolicyConfigProvider PolicyConfigProvider
 	ProviderPolicies     []ProviderPolicyBinding
 	EndpointID           string
+	CedarPolicies        cedarpolicy.SnapshotProvider
 	CurrentSessionID     string
 	Mode                 string
 }
@@ -133,6 +135,7 @@ func NewServerWithPolicyConfigAndOptions(store *sqlite.Store, policy PolicyProvi
 			PolicyConfigProvider: policyStoreConfigProvider{store: policyStore},
 		})
 	}
+	policy = newCedarPolicyProvider(policy, opts.CedarPolicies)
 	currentSessionID := strings.TrimSpace(opts.CurrentSessionID)
 	mode := strings.TrimSpace(opts.Mode)
 	if currentSessionID != "" && mode == "" {

--- a/internal/guard/risk/types.go
+++ b/internal/guard/risk/types.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/kontext-security/kontext-cli/internal/cedareval"
 	"github.com/kontext-security/kontext-cli/internal/guard/decision"
 	"github.com/kontext-security/kontext-cli/internal/providerpolicy"
 )
@@ -107,6 +108,25 @@ type RiskDecision struct {
 	// event, grouped per provider; each evaluation is recorded as a separate
 	// request.decided ledger row.
 	ProviderPolicy []ProviderPolicyEvaluations `json:"provider_policy,omitempty"`
+	Cedar          *CedarEvidence              `json:"cedar,omitempty"`
+}
+
+// CedarEvidence is the local evaluator's decision evidence. It is separate
+// from the effective hook decision so observe mode cannot become authority by
+// accident.
+type CedarEvidence struct {
+	ResponseVersion        int                           `json:"responseVersion,omitempty"`
+	RequestContractVersion int                           `json:"requestContractVersion,omitempty"`
+	PolicyHash             string                        `json:"policyHash,omitempty"`
+	DeploymentIdentity     string                        `json:"deploymentIdentity,omitempty"`
+	ConfiguredRolloutMode  cedareval.RolloutMode         `json:"configuredRolloutMode,omitempty"`
+	AppliedRolloutMode     cedareval.RolloutMode         `json:"appliedRolloutMode"`
+	Mapping                cedareval.DecisionMapping     `json:"mapping"`
+	ContextDiagnostics     []cedareval.ContextDiagnostic `json:"contextDiagnostics"`
+	EngineErrorCount       int                           `json:"engineErrorCount"`
+	CacheFetchedAt         time.Time                     `json:"cacheFetchedAt,omitempty"`
+	CacheStale             bool                          `json:"cacheStale"`
+	EvaluatorVersion       string                        `json:"evaluatorVersion"`
 }
 
 // ProviderPolicyEvaluations groups one provider's synced-policy evaluations

--- a/internal/guard/store/sqlite/cedar.go
+++ b/internal/guard/store/sqlite/cedar.go
@@ -1,0 +1,94 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kontext-security/kontext-cli/internal/cedareval"
+	"github.com/kontext-security/kontext-cli/internal/guard/risk"
+)
+
+func (s *Store) insertCedarDecisionAction(ctx context.Context, tx *sql.Tx, sessionID string, event risk.HookEvent, decision risk.RiskDecision, now time.Time) error {
+	if decision.Cedar == nil {
+		return nil
+	}
+	action := cedarDecisionActionValues("act_"+uuid.NewString(), sessionID, event, *decision.Cedar, now)
+	return s.insertActionRecord(ctx, tx, action, "decision", now)
+}
+
+func cedarDecisionActionValues(actionID, sessionID string, event risk.HookEvent, evidence risk.CedarEvidence, now time.Time) map[string]any {
+	principal := map[string]any{}
+	if evidence.Mapping.EvaluationPrincipal != nil {
+		principal["entity_type"] = evidence.Mapping.EvaluationPrincipal.EntityType
+		principal["entity_id"] = evidence.Mapping.EvaluationPrincipal.EntityID
+	}
+	identityJSON, identityHash := mustHashJSON(principal)
+	parametersJSON, parametersHash := mustHashJSON(map[string]any{})
+	contextJSON, contextHash := mustHashJSON(map[string]any{
+		"configured_rollout_mode":  evidence.ConfiguredRolloutMode,
+		"applied_rollout_mode":     evidence.AppliedRolloutMode,
+		"deployment_identity":      evidence.DeploymentIdentity,
+		"response_version":         evidence.ResponseVersion,
+		"request_contract_version": evidence.RequestContractVersion,
+		"cache_fetched_at":         evidence.CacheFetchedAt,
+		"cache_stale":              evidence.CacheStale,
+		"evaluator_version":        evidence.EvaluatorVersion,
+		"evaluation_state":         evidence.Mapping.EvaluationState,
+		"derived_action":           evidence.Mapping.DerivedCedarAction,
+		"evaluation_reason_code":   evidence.Mapping.EvaluationReasonCode,
+		"decision_reason_code":     evidence.Mapping.DecisionReasonCode,
+		"effective_reason_code":    evidence.Mapping.EffectiveReasonCode,
+		"context_diagnostics":      evidence.ContextDiagnostics,
+		"engine_error_count":       evidence.EngineErrorCount,
+	})
+
+	decisionResult := cedarLedgerDecisionResult(evidence.Mapping.DerivedCedarAction)
+	policyID := ""
+	if len(evidence.Mapping.DeterminingPolicyIDs) == 1 {
+		policyID = evidence.Mapping.DeterminingPolicyIDs[0]
+	}
+	timestamp := now.Format(time.RFC3339Nano)
+	return map[string]any{
+		"id": actionID, "session_id": sessionID, "tool_use_id": event.ToolUseID,
+		"canonical_event_type": canonicalEventRequestDecided, "adapter_event_name": event.HookEventName,
+		"correlation_key": correlationKey(event), "tool_name": event.ToolName,
+		"provider": "cedar", "operation": "ToolUse", "operation_class": "tool_use",
+		"resource_class": "tool", "resource_id": nullIfEmpty(event.ToolName),
+		"parameters_redacted_json": parametersJSON, "parameters_hash": parametersHash,
+		"identity_context_json": identityJSON, "identity_hash": identityHash,
+		"context_json": contextJSON, "context_hash": contextHash,
+		"policy_id": policyID, "policy_version": "", "policy_hash": evidence.PolicyHash,
+		"default_posture": "", "decision_result": decisionResult, "decision_category": cedarDecisionCategory(evidence),
+		"adapter_decision": "", "reason_code": string(evidence.Mapping.EffectiveReasonCode), "reason": "local Cedar policy evaluation",
+		"risk_level": "", "risk_score": nil, "risk_threshold": nil, "model_version": evidence.EvaluatorVersion,
+		"confidence": 0.0, "matched_rules_json": mustJSONText(evidence.Mapping.DeterminingPolicyIDs),
+		"risk_signals_json": "[]", "risk_event_json": "{}", "modifications_json": "{}",
+		"approval_context_json": "{}", "approval_channel": "", "approval_request_id": "", "deferral_context_json": "{}",
+		"status": "evaluated", "outcome": "", "output_summary": "", "output_hash": "", "error_redacted": "",
+		"tool_input_captured_json": nil, "tool_output_captured_json": nil,
+		"proposed_at": nil, "decision_at": timestamp, "completed_at": nil,
+		"created_at": timestamp, "updated_at": timestamp, "updated_at_cursor_key": ledgerTimestampCursorKeyFromValues(timestamp),
+	}
+}
+
+func cedarDecisionCategory(evidence risk.CedarEvidence) string {
+	return "dry_run"
+}
+
+// cedarLedgerDecisionResult projects a Cedar verdict onto the ledger's
+// decision_result contract, which the ingest boundary accepts as exactly the
+// lowercase set {"allow", "deny"}. An ask verdict has no approval channel in
+// v1, so it collapses to a fail-closed "deny" here; the three-valued Cedar
+// verdict is preserved verbatim in context_json.derived_action, and the ask
+// nature is carried by the reason codes. This mirrors the legacy
+// canonicalDecisionResult projection (deny is the default) so Cedar and legacy
+// rows share one decision_result vocabulary.
+func cedarLedgerDecisionResult(action cedareval.DerivedCedarAction) string {
+	if action == cedareval.DerivedCedarActionAllow {
+		return string(cedareval.EffectiveExecutionActionAllow)
+	}
+	return string(cedareval.EffectiveExecutionActionDeny)
+}

--- a/internal/guard/store/sqlite/cedar_test.go
+++ b/internal/guard/store/sqlite/cedar_test.go
@@ -1,0 +1,39 @@
+package sqlite
+
+import (
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/cedareval"
+)
+
+// ledgerAcceptedDecisionResults is the set the authorization-ledger upload
+// contract accepts for decision_result on a decided action ({allow, deny},
+// the same values the non-Cedar path emits). Emitting anything else is
+// rejected on upload. This test pins the projection so it cannot drift back to
+// uppercase or a third value.
+var ledgerAcceptedDecisionResults = map[string]struct{}{
+	"allow": {},
+	"deny":  {},
+}
+
+func TestCedarLedgerDecisionResultMatchesIngestContract(t *testing.T) {
+	cases := []struct {
+		action cedareval.DerivedCedarAction
+		want   string
+	}{
+		{cedareval.DerivedCedarActionAllow, "allow"},
+		{cedareval.DerivedCedarActionDeny, "deny"},
+		// No approval channel in v1: an ask collapses to a fail-closed deny.
+		{cedareval.DerivedCedarActionAsk, "deny"},
+	}
+
+	for _, tc := range cases {
+		got := cedarLedgerDecisionResult(tc.action)
+		if got != tc.want {
+			t.Errorf("cedarLedgerDecisionResult(%q) = %q, want %q", tc.action, got, tc.want)
+		}
+		if _, ok := ledgerAcceptedDecisionResults[got]; !ok {
+			t.Errorf("cedarLedgerDecisionResult(%q) = %q, which the ingest boundary rejects", tc.action, got)
+		}
+	}
+}

--- a/internal/guard/store/sqlite/store.go
+++ b/internal/guard/store/sqlite/store.go
@@ -777,6 +777,9 @@ on conflict(id) do update set
 		if err := s.insertProviderDryRunActions(ctx, tx, sessionID, event, decision, now.Add(2*time.Millisecond)); err != nil {
 			return DecisionRecord{}, err
 		}
+		if err := s.insertCedarDecisionAction(ctx, tx, sessionID, event, decision, now.Add(3*time.Millisecond)); err != nil {
+			return DecisionRecord{}, err
+		}
 	} else {
 		if err := s.insertAction(ctx, tx, actionID, sessionID, event, decision, canonicalEventType(event.HookEventName), "outcome", captureConfig, now); err != nil {
 			return DecisionRecord{}, err

--- a/internal/guard/store/sqlite/store_test.go
+++ b/internal/guard/store/sqlite/store_test.go
@@ -9,8 +9,50 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kontext-security/kontext-cli/internal/cedareval"
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
 )
+
+func TestSaveDecisionStoresCedarEvidenceWithoutPayload(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	principal := &cedareval.EvaluationPrincipal{EntityType: cedareval.PrincipalEntityType, EntityID: "user@example.com"}
+	_, err = store.SaveDecision(context.Background(), risk.HookEvent{SessionID: "s1", HookEventName: "PreToolUse", ToolName: "Read", ToolUseID: "tool-1", ToolInput: map[string]any{"secret": "must-not-duplicate"}}, risk.RiskDecision{
+		Decision:   risk.DecisionAllow,
+		Reason:     "current allow",
+		ReasonCode: "current_allow",
+		RiskEvent:  risk.RiskEvent{Decision: risk.DecisionAllow},
+		Cedar:      &risk.CedarEvidence{PolicyHash: strings.Repeat("a", 64), DeploymentIdentity: strings.Repeat("b", 64), AppliedRolloutMode: cedareval.RolloutModeObserve, EvaluatorVersion: "cedar-go/test", Mapping: cedareval.DecisionMapping{EvaluationState: cedareval.EvaluationStateEvaluated, EvaluationPrincipal: principal, CedarDecision: cedareval.DecisionAllow, DerivedCedarAction: cedareval.DerivedCedarActionAllow, EffectiveExecutionAction: cedareval.EffectiveExecutionActionAllow, EvaluationReasonCode: cedareval.ReasonPolicyEvaluated, DecisionReasonCode: cedareval.ReasonPermit, EffectiveReasonCode: cedareval.ReasonObserveNonAuthoritative, DeterminingPolicyIDs: []string{"permit-read"}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var category, result, reasonCode, contextJSON string
+	var captured any
+	err = store.db.QueryRowContext(context.Background(), `select decision_category, decision_result, reason_code, context_json, tool_input_captured_json from authorization_actions where provider = 'cedar'`).Scan(&category, &result, &reasonCode, &contextJSON, &captured)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if category != "dry_run" || result != "allow" || reasonCode != string(cedareval.ReasonObserveNonAuthoritative) || captured != nil {
+		t.Fatalf("Cedar row = category %q result %q reason %q captured %#v", category, result, reasonCode, captured)
+	}
+	var contextEvidence map[string]any
+	if err := json.Unmarshal([]byte(contextJSON), &contextEvidence); err != nil {
+		t.Fatal(err)
+	}
+	for field, want := range map[string]string{
+		"evaluation_reason_code": string(cedareval.ReasonPolicyEvaluated),
+		"decision_reason_code":   string(cedareval.ReasonPermit),
+		"effective_reason_code":  string(cedareval.ReasonObserveNonAuthoritative),
+	} {
+		if got := contextEvidence[field]; got != want {
+			t.Fatalf("context evidence %s = %#v, want %q", field, got, want)
+		}
+	}
+}
 
 func TestEmptyCollectionsEncodeAsJSONArray(t *testing.T) {
 	store, err := OpenStore(t.TempDir() + "/guard.db")

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -170,6 +170,7 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 			server.HubspotPolicyBinding(hubspotCache),
 		},
 		EndpointID:         installationState.InstallationID,
+		CedarPolicies:      cedarCache,
 		Mode:               mode,
 		Diagnostic:         opts.Diagnostic,
 		SkipInitialSession: true,

--- a/internal/runtimehost/host.go
+++ b/internal/runtimehost/host.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kontext-security/kontext-cli/internal/cedarpolicy"
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 	"github.com/kontext-security/kontext-cli/internal/guard/app/server"
 	guardhookruntime "github.com/kontext-security/kontext-cli/internal/guard/hookruntime"
@@ -39,6 +40,7 @@ type Options struct {
 	JudgeManagedDefault       bool
 	JudgeDownloadProgress     judge.DownloadProgressHandler
 	ProviderPolicies          []server.ProviderPolicyBinding
+	CedarPolicies             cedarpolicy.SnapshotProvider
 	EndpointID                string
 	Mode                      guardhookruntime.Mode
 	Diagnostic                diagnostic.Logger
@@ -116,6 +118,7 @@ func Start(ctx context.Context, opts Options) (*Host, error) {
 		Judge:            localJudge,
 		ProviderPolicies: opts.ProviderPolicies,
 		EndpointID:       opts.EndpointID,
+		CedarPolicies:    opts.CedarPolicies,
 		CurrentSessionID: serverSessionID,
 		Mode:             string(mode),
 	})


### PR DESCRIPTION
## Why

We need to evaluate native Cedar against real pre-use events and inspect canonical evidence before granting it authorization authority.

## What

- connects the validated policy cache to the shared pre-use path used by every supported adapter
- parses once per deployment identity and evaluates locally without hook-path network access
- always applies the observe mapper and preserves the existing effective decision
- records revision-free deployment, principal, diagnostics, and would-decision evidence as a separate ledger row
- projects evaluation, decision, and effective reason codes explicitly
- avoids duplicating captured tool payloads in Cedar evidence

## Scope

Observation only. This PR cannot change an effective hook decision.

Depends on #387. Tracks ENG-534.

## Verification

- go test ./...
- focused go test -race across evaluator, server, ledger, runtime, and daemon packages
- go vet ./...

Change size: 9 files, +391/-0 — observe-only runtime wiring, canonical ledger evidence, and tests.