### PR TITLE
feat(policy): gate Cedar enforcement cutover

### DIFF
--- a/internal/cedareval/fixtures_test.go
+++ b/internal/cedareval/fixtures_test.go
@@ -28,7 +28,7 @@ var fixtureDigests = map[string]string{
 	"context-errors-v1.json":    "945e6be23af02aa4d0c7bd382f5963b6342f46a02602bfbc8f134ae283b6773e",
 	"decision-contract-v1.json": "8d33cd7924de64b9000c18fdc3cb532250653f768e2a65c7acb001c26376a3c4",
 	"decision-mapping-v1.json":  "7a0ba0b761b13759ef1a5ffefb155c7a066412b0115227f928529546a337e0b2",
-	"evaluation-errors-v1.json": "8318efcd613fd56645fac3bf49939d6b70f41af102a1f06df2a6cc9da75d8415",
+	"evaluation-errors-v1.json": "aef0f751ebf54625b4f516f67f37b58a59042a03fd684614172736a91c07a763",
 	"hashing-v1.json":           "5179f41ae61872ee9f6a048cba4592dc12c0267fc8c8699a0c2afa886da62775",
 }
 
@@ -66,10 +66,13 @@ type evaluationErrorFixture struct {
 	Policies    []string               `json:"policies"`
 	Request     cedareval.ToolUseInput `json:"request"`
 	Expected    struct {
-		Decision             cedareval.Decision            `json:"decision"`
-		EngineErrorCount     int                           `json:"engineErrorCount"`
-		DeterminingPolicyIDs []string                      `json:"determiningPolicyIds"`
-		ContextDiagnostics   []cedareval.ContextDiagnostic `json:"contextDiagnostics"`
+		Decision                      cedareval.Decision                 `json:"decision"`
+		EngineErrorCount              int                                `json:"engineErrorCount"`
+		DeterminingPolicyIDs          []string                           `json:"determiningPolicyIds"`
+		ContextDiagnostics            []cedareval.ContextDiagnostic      `json:"contextDiagnostics"`
+		ObserveCurrentAuthorityAction cedareval.EffectiveExecutionAction `json:"observeCurrentAuthorityAction"`
+		Observe                       cedareval.DecisionMapping          `json:"observe"`
+		Enforce                       cedareval.DecisionMapping          `json:"enforce"`
 	} `json:"expected"`
 }
 
@@ -211,6 +214,37 @@ func TestPortableEvaluationErrorFixtures(t *testing.T) {
 			}
 			if !reflect.DeepEqual(result.ContextDiagnostics, fixture.Expected.ContextDiagnostics) {
 				t.Errorf("ContextDiagnostics = %v, want %v", result.ContextDiagnostics, fixture.Expected.ContextDiagnostics)
+			}
+
+			principal := fixture.Request.EvaluationPrincipal
+			evaluation := cedareval.EvaluationOutcome{
+				State:  cedareval.EvaluationStateFailed,
+				Reason: cedareval.ReasonEngineError,
+			}
+			observe, err := cedareval.MapDecision(cedareval.DecisionMappingInput{
+				RolloutMode:            cedareval.RolloutModeObserve,
+				CurrentAuthorityAction: fixture.Expected.ObserveCurrentAuthorityAction,
+				EvaluationPrincipal:    &principal,
+				Evaluation:             evaluation,
+			})
+			if err != nil {
+				t.Fatalf("MapDecision(observe) error = %v", err)
+			}
+			if !reflect.DeepEqual(observe, fixture.Expected.Observe) {
+				t.Errorf("MapDecision(observe) = %#v, want %#v", observe, fixture.Expected.Observe)
+			}
+
+			enforce, err := cedareval.MapDecision(cedareval.DecisionMappingInput{
+				RolloutMode:         cedareval.RolloutModeEnforce,
+				EnforcementReady:    true,
+				EvaluationPrincipal: &principal,
+				Evaluation:          evaluation,
+			})
+			if err != nil {
+				t.Fatalf("MapDecision(enforce) error = %v", err)
+			}
+			if !reflect.DeepEqual(enforce, fixture.Expected.Enforce) {
+				t.Errorf("MapDecision(enforce) = %#v, want %#v", enforce, fixture.Expected.Enforce)
 			}
 		})
 	}

--- a/internal/cedareval/testdata/portable/v1/evaluation-errors-v1.json
+++ b/internal/cedareval/testdata/portable/v1/evaluation-errors-v1.json
@@ -1,10 +1,11 @@
 [
   {
     "version": 1,
-    "name": "guarded-context-type-error",
-    "description": "A present context field with the wrong Cedar type produces an engine diagnostic without relying on error text.",
+    "name": "erroring-forbid-cannot-authorize",
+    "description": "A matching permit plus a forbid evaluation error returns a raw Cedar allow, but the application classifies the evaluation as failed before rollout mapping.",
     "policies": [
-      "@id(\"command_pattern\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource) when { context has command && context.command like \"git*\" };"
+      "@id(\"allow\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource);",
+      "@id(\"erroring_forbid\")\nforbid(principal, action == Kontext::Action::\"ToolUse\", resource) when { !(context has command) || (context has command && context.command like \"git*\") };"
     ],
     "request": {
       "evaluationPrincipal": {
@@ -17,10 +18,33 @@
       }
     },
     "expected": {
-      "decision": "deny",
+      "decision": "allow",
       "engineErrorCount": 1,
-      "determiningPolicyIds": [],
-      "contextDiagnostics": []
+      "determiningPolicyIds": ["allow"],
+      "contextDiagnostics": [],
+      "observeCurrentAuthorityAction": "allow",
+      "observe": {
+        "evaluationState": "failed",
+        "evaluationPrincipal": {
+          "entityType": "Kontext::User",
+          "entityId": "alice@example.com"
+        },
+        "effectiveExecutionAction": "allow",
+        "evaluationReasonCode": "engine_error",
+        "effectiveReasonCode": "observe_non_authoritative",
+        "determiningPolicyIds": []
+      },
+      "enforce": {
+        "evaluationState": "failed",
+        "evaluationPrincipal": {
+          "entityType": "Kontext::User",
+          "entityId": "alice@example.com"
+        },
+        "effectiveExecutionAction": "deny",
+        "evaluationReasonCode": "engine_error",
+        "effectiveReasonCode": "engine_error",
+        "determiningPolicyIds": []
+      }
     }
   }
 ]

--- a/internal/cedarpolicy/cache.go
+++ b/internal/cedarpolicy/cache.go
@@ -209,6 +209,9 @@ func (c *Cache) MarkFailed(err error, attemptedAt time.Time) {
 	c.mu.Unlock()
 }
 
+// MarkInvalid records that a cache file existed but could not be validated.
+// Enforcement uses this signal to fail closed instead of treating corruption
+// like a first installation with no cached policy.
 func (c *Cache) MarkInvalid(err error) {
 	c.mu.Lock()
 	c.status.Invalid = true

--- a/internal/guard/app/server/cedar.go
+++ b/internal/guard/app/server/cedar.go
@@ -129,14 +129,21 @@ func (p *cedarPolicyProvider) evaluate(snapshot cedarpolicy.Snapshot, event risk
 				}
 				evidence.EngineErrorCount = 1
 			} else {
-				outcome = cedareval.EvaluationOutcome{
-					State:                cedareval.EvaluationStateEvaluated,
-					Decision:             result.Decision,
-					Ask:                  result.Ask,
-					DeterminingPolicyIDs: result.DeterminingPolicyIDs,
-				}
 				evidence.ContextDiagnostics = result.ContextDiagnostics
 				evidence.EngineErrorCount = len(result.EngineDiagnostics.Errors)
+				if evidence.EngineErrorCount > 0 {
+					outcome = cedareval.EvaluationOutcome{
+						State:  cedareval.EvaluationStateFailed,
+						Reason: cedareval.ReasonEngineError,
+					}
+				} else {
+					outcome = cedareval.EvaluationOutcome{
+						State:                cedareval.EvaluationStateEvaluated,
+						Decision:             result.Decision,
+						Ask:                  result.Ask,
+						DeterminingPolicyIDs: result.DeterminingPolicyIDs,
+					}
+				}
 			}
 		}
 	} else if snapshot.Status.Invalid {

--- a/internal/guard/app/server/cedar.go
+++ b/internal/guard/app/server/cedar.go
@@ -14,8 +14,9 @@ import (
 const cedarEvaluatorVersion = "cedar-go/v1.8.0"
 
 type cedarPolicyProvider struct {
-	current   PolicyProvider
-	snapshots cedarpolicy.SnapshotProvider
+	current            PolicyProvider
+	snapshots          cedarpolicy.SnapshotProvider
+	enforcementEnabled bool
 
 	mu        sync.Mutex
 	identity  string
@@ -23,37 +24,85 @@ type cedarPolicyProvider struct {
 	parseErr  error
 }
 
-func newCedarPolicyProvider(current PolicyProvider, snapshots cedarpolicy.SnapshotProvider) PolicyProvider {
+func newCedarPolicyProvider(current PolicyProvider, snapshots cedarpolicy.SnapshotProvider, enforcementEnabled bool) PolicyProvider {
 	if snapshots == nil {
 		return current
 	}
-	return &cedarPolicyProvider{current: current, snapshots: snapshots}
+	return &cedarPolicyProvider{current: current, snapshots: snapshots, enforcementEnabled: enforcementEnabled}
 }
 
 func (p *cedarPolicyProvider) DecideHook(ctx context.Context, event risk.HookEvent) (risk.RiskDecision, error) {
-	decision, err := p.current.DecideHook(ctx, event)
-	if err != nil || event.HookEventName != hook.HookPreToolUse.String() {
-		return decision, err
+	if event.HookEventName != hook.HookPreToolUse.String() {
+		return p.current.DecideHook(ctx, event)
 	}
 
 	snapshot := p.snapshots.Current()
-	evidence := p.evaluate(snapshot, event, executionAction(decision.Decision))
+	claimsAuthority := p.claimsAuthority(snapshot)
+	decision := risk.RiskDecision{}
+	currentAction := cedareval.EffectiveExecutionActionAllow
+	if claimsAuthority {
+		riskEvent := risk.NormalizeHookEvent(event)
+		riskEvent.Decision = risk.DecisionDeny
+		decision = risk.RiskDecision{Decision: risk.DecisionDeny, Reason: "Cedar enforcement is not ready", ReasonCode: string(cedareval.ReasonEnforcementNotReady), RiskEvent: riskEvent}
+	} else {
+		var err error
+		decision, err = p.current.DecideHook(ctx, event)
+		if err != nil {
+			return risk.RiskDecision{}, err
+		}
+		currentAction = executionAction(decision.Decision)
+	}
+	evidence := p.evaluate(snapshot, event, currentAction, claimsAuthority)
 	decision.Cedar = &evidence
+	if claimsAuthority {
+		applyCedarDecision(&decision, evidence.Mapping)
+	}
 	return decision, nil
 }
 
-func (p *cedarPolicyProvider) evaluate(snapshot cedarpolicy.Snapshot, event risk.HookEvent, current cedareval.EffectiveExecutionAction) risk.CedarEvidence {
+func (p *cedarPolicyProvider) claimsAuthority(snapshot cedarpolicy.Snapshot) bool {
+	if !p.enforcementEnabled {
+		return false
+	}
+	if snapshot.State == cedarpolicy.StateDisabled || snapshot.State == cedarpolicy.StateNoActivePolicy {
+		return false
+	}
+	if snapshot.Status.Invalid {
+		return true
+	}
+	deployment := snapshot.Deployment
+	if deployment == nil {
+		deployment = snapshot.LastKnownGood
+	}
+	if deployment == nil {
+		// Once the local cutover gate is enabled, absence and untrusted response
+		// states cannot silently restore the previous evaluator. Only explicit
+		// disabled/no-active-policy states relinquish Cedar authority.
+		return true
+	}
+	return deployment.RolloutMode == cedareval.RolloutModeEnforce
+}
+
+func (p *cedarPolicyProvider) evaluate(snapshot cedarpolicy.Snapshot, event risk.HookEvent, current cedareval.EffectiveExecutionAction, claimsAuthority bool) risk.CedarEvidence {
 	evidence := risk.CedarEvidence{
 		AppliedRolloutMode: cedareval.RolloutModeObserve,
 		CacheFetchedAt:     snapshot.Status.FetchedAt,
+		DistributionState:  string(snapshot.State),
 		CacheStale:         snapshot.Status.Stale,
+		CacheExpired:       snapshot.Status.Expired,
+		CacheInvalid:       snapshot.Status.Invalid,
 		EvaluatorVersion:   cedarEvaluatorVersion,
 		ContextDiagnostics: []cedareval.ContextDiagnostic{},
 	}
 	outcome := cedareval.EvaluationOutcome{State: cedareval.EvaluationStateFailed, Reason: cedareval.ReasonPolicyMissing}
 	var principal *cedareval.EvaluationPrincipal
 
-	if deployment := snapshot.Deployment; deployment != nil {
+	metadata := snapshot.Deployment
+	if metadata == nil {
+		metadata = snapshot.LastKnownGood
+	}
+	if metadata != nil {
+		deployment := metadata
 		evidence.ResponseVersion = deployment.ResponseVersion
 		evidence.RequestContractVersion = deployment.RequestContractVersion
 		evidence.PolicyHash = deployment.PolicyHash
@@ -62,8 +111,9 @@ func (p *cedarPolicyProvider) evaluate(snapshot cedarpolicy.Snapshot, event risk
 		principalValue := deployment.EvaluationPrincipal
 		principal = &principalValue
 
-		evaluator, parseErr := p.evaluatorFor(deployment)
-		if parseErr != nil {
+		if snapshot.Deployment == nil {
+			outcome.Reason = cedareval.ReasonStaleCachedPolicy
+		} else if evaluator, parseErr := p.evaluatorFor(deployment); parseErr != nil {
 			outcome.Reason = cedareval.ReasonInvalidCachedPolicy
 			evidence.EngineErrorCount = 1
 		} else {
@@ -89,20 +139,63 @@ func (p *cedarPolicyProvider) evaluate(snapshot cedarpolicy.Snapshot, event risk
 				evidence.EngineErrorCount = len(result.EngineDiagnostics.Errors)
 			}
 		}
-	} else if isPrincipalState(snapshot.State) {
-		outcome = cedareval.EvaluationOutcome{State: cedareval.EvaluationStatePrincipalUnresolved, Reason: cedareval.ReasonPrincipalUnresolved}
+	} else if snapshot.Status.Invalid {
+		outcome.Reason = cedareval.ReasonInvalidCachedPolicy
 	} else if snapshot.Status.Stale {
 		outcome.Reason = cedareval.ReasonStaleCachedPolicy
 	}
+	if isPrincipalState(snapshot.State) {
+		principal = nil
+		outcome = cedareval.EvaluationOutcome{State: cedareval.EvaluationStatePrincipalUnresolved, Reason: cedareval.ReasonPrincipalUnresolved}
+	}
 
-	evidence.AppliedRolloutMode = cedareval.RolloutModeObserve
+	appliedMode := cedareval.RolloutModeObserve
+	enforcementReady := false
+	currentAuthority := current
+	if claimsAuthority {
+		appliedMode = cedareval.RolloutModeEnforce
+		enforcementReady = snapshot.Deployment != nil && !snapshot.Status.Expired && !snapshot.Status.Invalid
+		currentAuthority = ""
+		if !enforcementReady {
+			outcome = cedareval.EvaluationOutcome{State: cedareval.EvaluationStateNotEvaluated, Reason: cedareval.ReasonEnforcementNotReady}
+		}
+	}
+	evidence.AppliedRolloutMode = appliedMode
 	mapping, err := cedareval.MapDecision(cedareval.DecisionMappingInput{
-		RolloutMode:            cedareval.RolloutModeObserve,
-		CurrentAuthorityAction: current,
+		RolloutMode:            appliedMode,
+		CurrentAuthorityAction: currentAuthority,
+		EnforcementReady:       enforcementReady,
 		EvaluationPrincipal:    principal,
 		Evaluation:             outcome,
 	})
 	if err != nil {
+		if claimsAuthority {
+			// Fail closed: a ready-but-failed evaluation is the valid enforce
+			// input and maps to a deny with the engine-error reason. Passing
+			// EnforcementReady:false alongside a failed evaluation is the
+			// contradictory input the mapper rejects, which would leave a
+			// zero-value mapping that applyCedarDecision reads as allow. Never
+			// discard the mapping error; if it somehow does not map, deny
+			// explicitly.
+			fallback, ferr := cedareval.MapDecision(cedareval.DecisionMappingInput{
+				RolloutMode:      cedareval.RolloutModeEnforce,
+				EnforcementReady: true,
+				Evaluation:       cedareval.EvaluationOutcome{State: cedareval.EvaluationStateFailed, Reason: cedareval.ReasonEngineError},
+			})
+			if ferr != nil {
+				fallback = cedareval.DecisionMapping{
+					EvaluationState:          cedareval.EvaluationStateFailed,
+					EffectiveExecutionAction: cedareval.EffectiveExecutionActionDeny,
+					EvaluationReasonCode:     cedareval.ReasonEngineError,
+					EffectiveReasonCode:      cedareval.ReasonEngineError,
+					DeterminingPolicyIDs:     []string{},
+				}
+			}
+			evidence.Mapping = fallback
+			evidence.AppliedRolloutMode = cedareval.RolloutModeEnforce
+			evidence.EngineErrorCount++
+			return evidence
+		}
 		fallback, _ := cedareval.MapDecision(cedareval.DecisionMappingInput{
 			RolloutMode:            cedareval.RolloutModeObserve,
 			CurrentAuthorityAction: current,
@@ -145,4 +238,18 @@ func isPrincipalState(state cedarpolicy.State) bool {
 	default:
 		return false
 	}
+}
+
+func applyCedarDecision(decision *risk.RiskDecision, mapping cedareval.DecisionMapping) {
+	decision.ReasonCode = string(mapping.EffectiveReasonCode)
+	decision.Reason = "local Cedar policy decision"
+	decision.RiskEvent.ReasonCode = decision.ReasonCode
+	decision.RiskEvent.DecisionStage = "cedar_policy"
+	if mapping.EffectiveExecutionAction == cedareval.EffectiveExecutionActionDeny {
+		decision.Decision = risk.DecisionDeny
+		decision.RiskEvent.Decision = risk.DecisionDeny
+		return
+	}
+	decision.Decision = risk.DecisionAllow
+	decision.RiskEvent.Decision = risk.DecisionAllow
 }

--- a/internal/guard/app/server/cedar_test.go
+++ b/internal/guard/app/server/cedar_test.go
@@ -70,6 +70,29 @@ func TestCedarObserveClassifiesContextConversionFailure(t *testing.T) {
 	}
 }
 
+func TestCedarObserveClassifiesEngineDiagnosticsAsFailure(t *testing.T) {
+	deployment := cedarTestDeployment(t, cedareval.RolloutModeObserve, `@id("unguarded") permit(principal, action, resource) when { context.command == "git status" };`)
+	current := &countingHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow, ReasonCode: "current_allow", RiskEvent: risk.RiskEvent{Decision: risk.DecisionAllow}}}
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, State: cedarpolicy.StateSuccess}}, false)
+
+	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Bash", ToolInput: map[string]any{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.calls != 1 || decision.Decision != risk.DecisionAllow {
+		t.Fatalf("calls = %d decision = %#v, want preserved current authority", current.calls, decision)
+	}
+	if decision.Cedar == nil || decision.Cedar.EngineErrorCount != 1 {
+		t.Fatalf("Cedar evidence = %#v, want one engine error", decision.Cedar)
+	}
+	if decision.Cedar.Mapping.EvaluationState != cedareval.EvaluationStateFailed || decision.Cedar.Mapping.EvaluationReasonCode != cedareval.ReasonEngineError {
+		t.Fatalf("mapping = %#v, want failed/engine_error", decision.Cedar.Mapping)
+	}
+	if len(decision.Cedar.Mapping.DeterminingPolicyIDs) != 0 {
+		t.Fatalf("determining policy ids = %v, want none for failed evaluation", decision.Cedar.Mapping.DeterminingPolicyIDs)
+	}
+}
+
 func TestCedarObserveRecordsUnresolvedPrincipal(t *testing.T) {
 	current := staticHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow, RiskEvent: risk.RiskEvent{Decision: risk.DecisionAllow}}}
 	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{State: cedarpolicy.StatePrincipalUnavailable}}, false)
@@ -109,6 +132,29 @@ func TestCedarEnforceDeniesAskWithoutApprovalChannel(t *testing.T) {
 	}
 	if decision.Decision != risk.DecisionDeny || decision.ReasonCode != string(cedareval.ReasonAskUnavailable) {
 		t.Fatalf("decision = %#v, want ask fail-closed", decision)
+	}
+}
+
+func TestCedarEnforceFailsClosedOnEngineDiagnostics(t *testing.T) {
+	deployment := cedarTestDeployment(t, cedareval.RolloutModeEnforce, `@id("unguarded") permit(principal, action, resource) when { context.command == "git status" };`)
+	current := &countingHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow}}
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, LastKnownGood: &deployment, State: cedarpolicy.StateSuccess}}, true)
+
+	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Bash", ToolInput: map[string]any{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.calls != 0 {
+		t.Fatalf("previous evaluator calls = %d, want zero after cutover", current.calls)
+	}
+	if decision.Decision != risk.DecisionDeny || decision.ReasonCode != string(cedareval.ReasonEngineError) {
+		t.Fatalf("decision = %#v, want fail-closed engine_error deny", decision)
+	}
+	if decision.Cedar == nil || decision.Cedar.EngineErrorCount != 1 || decision.Cedar.Mapping.EvaluationState != cedareval.EvaluationStateFailed {
+		t.Fatalf("Cedar evidence = %#v, want failed evaluation with one engine error", decision.Cedar)
+	}
+	if len(decision.Cedar.Mapping.DeterminingPolicyIDs) != 0 {
+		t.Fatalf("determining policy ids = %v, want none for failed evaluation", decision.Cedar.Mapping.DeterminingPolicyIDs)
 	}
 }
 

--- a/internal/guard/app/server/cedar_test.go
+++ b/internal/guard/app/server/cedar_test.go
@@ -25,6 +25,9 @@ type countingHookPolicy struct {
 	calls    int
 }
 
+const portableEngineErrorPolicy = `@id("command_pattern")
+permit(principal, action == Kontext::Action::"ToolUse", resource) when { context has command && context.command like "git*" };`
+
 func (p *countingHookPolicy) DecideHook(context.Context, risk.HookEvent) (risk.RiskDecision, error) {
 	p.calls++
 	return p.decision, nil
@@ -71,11 +74,11 @@ func TestCedarObserveClassifiesContextConversionFailure(t *testing.T) {
 }
 
 func TestCedarObserveClassifiesEngineDiagnosticsAsFailure(t *testing.T) {
-	deployment := cedarTestDeployment(t, cedareval.RolloutModeObserve, `@id("unguarded") permit(principal, action, resource) when { context.command == "git status" };`)
+	deployment := cedarTestDeployment(t, cedareval.RolloutModeObserve, portableEngineErrorPolicy)
 	current := &countingHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow, ReasonCode: "current_allow", RiskEvent: risk.RiskEvent{Decision: risk.DecisionAllow}}}
 	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, State: cedarpolicy.StateSuccess}}, false)
 
-	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Bash", ToolInput: map[string]any{}})
+	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Bash", ToolInput: map[string]any{"command": 1}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,11 +139,11 @@ func TestCedarEnforceDeniesAskWithoutApprovalChannel(t *testing.T) {
 }
 
 func TestCedarEnforceFailsClosedOnEngineDiagnostics(t *testing.T) {
-	deployment := cedarTestDeployment(t, cedareval.RolloutModeEnforce, `@id("unguarded") permit(principal, action, resource) when { context.command == "git status" };`)
+	deployment := cedarTestDeployment(t, cedareval.RolloutModeEnforce, portableEngineErrorPolicy)
 	current := &countingHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow}}
 	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, LastKnownGood: &deployment, State: cedarpolicy.StateSuccess}}, true)
 
-	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Bash", ToolInput: map[string]any{}})
+	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Bash", ToolInput: map[string]any{"command": 1}})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/guard/app/server/cedar_test.go
+++ b/internal/guard/app/server/cedar_test.go
@@ -25,8 +25,11 @@ type countingHookPolicy struct {
 	calls    int
 }
 
-const portableEngineErrorPolicy = `@id("command_pattern")
-permit(principal, action == Kontext::Action::"ToolUse", resource) when { context has command && context.command like "git*" };`
+const portableEngineErrorPolicy = `@id("allow")
+permit(principal, action == Kontext::Action::"ToolUse", resource);
+
+@id("erroring_forbid")
+forbid(principal, action == Kontext::Action::"ToolUse", resource) when { !(context has command) || (context has command && context.command like "git*") };`
 
 func (p *countingHookPolicy) DecideHook(context.Context, risk.HookEvent) (risk.RiskDecision, error) {
 	p.calls++

--- a/internal/guard/app/server/cedar_test.go
+++ b/internal/guard/app/server/cedar_test.go
@@ -20,10 +20,20 @@ func (p staticHookPolicy) DecideHook(context.Context, risk.HookEvent) (risk.Risk
 	return p.decision, nil
 }
 
+type countingHookPolicy struct {
+	decision risk.RiskDecision
+	calls    int
+}
+
+func (p *countingHookPolicy) DecideHook(context.Context, risk.HookEvent) (risk.RiskDecision, error) {
+	p.calls++
+	return p.decision, nil
+}
+
 func TestCedarObservePreservesCurrentAuthorityAndRecordsDecision(t *testing.T) {
 	deployment := cedarTestDeployment(t, cedareval.RolloutModeEnforce, `@id("permit-read") permit(principal, action, resource == Kontext::Tool::"Read");`)
 	current := staticHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionDeny, Reason: "current deny", ReasonCode: "current_deny", RiskEvent: risk.RiskEvent{Decision: risk.DecisionDeny}}}
-	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, State: cedarpolicy.StateSuccess, Status: cedarpolicy.CacheStatus{FetchedAt: time.Now()}}})
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, State: cedarpolicy.StateSuccess, Status: cedarpolicy.CacheStatus{FetchedAt: time.Now()}}}, false)
 
 	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{}})
 	if err != nil {
@@ -46,7 +56,7 @@ func TestCedarObservePreservesCurrentAuthorityAndRecordsDecision(t *testing.T) {
 func TestCedarObserveClassifiesContextConversionFailure(t *testing.T) {
 	deployment := cedarTestDeployment(t, cedareval.RolloutModeObserve, `@id("permit") permit(principal, action, resource);`)
 	current := staticHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow, RiskEvent: risk.RiskEvent{Decision: risk.DecisionAllow}}}
-	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, State: cedarpolicy.StateSuccess}})
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, State: cedarpolicy.StateSuccess}}, false)
 
 	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{"bad": make(chan struct{})}})
 	if err != nil {
@@ -62,13 +72,174 @@ func TestCedarObserveClassifiesContextConversionFailure(t *testing.T) {
 
 func TestCedarObserveRecordsUnresolvedPrincipal(t *testing.T) {
 	current := staticHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow, RiskEvent: risk.RiskEvent{Decision: risk.DecisionAllow}}}
-	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{State: cedarpolicy.StatePrincipalUnavailable}})
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{State: cedarpolicy.StatePrincipalUnavailable}}, false)
 	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{}})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if decision.Cedar.Mapping.EvaluationState != cedareval.EvaluationStatePrincipalUnresolved || decision.Cedar.Mapping.EvaluationPrincipal != nil {
 		t.Fatalf("mapping = %#v, want unresolved principal without identity", decision.Cedar.Mapping)
+	}
+}
+
+func TestCedarEnforceIsSingularAuthority(t *testing.T) {
+	deployment := cedarTestDeployment(t, cedareval.RolloutModeEnforce, `@id("permit-read") permit(principal, action, resource == Kontext::Tool::"Read");`)
+	current := &countingHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionDeny, ReasonCode: "legacy_deny"}}
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, LastKnownGood: &deployment, State: cedarpolicy.StateSuccess, Status: cedarpolicy.CacheStatus{FetchedAt: time.Now()}}}, true)
+
+	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.calls != 0 {
+		t.Fatalf("previous evaluator calls = %d, want zero after cutover", current.calls)
+	}
+	if decision.Decision != risk.DecisionAllow || decision.ReasonCode != string(cedareval.ReasonPermit) {
+		t.Fatalf("decision = %#v, want Cedar allow", decision)
+	}
+}
+
+func TestCedarEnforceDeniesAskWithoutApprovalChannel(t *testing.T) {
+	deployment := cedarTestDeployment(t, cedareval.RolloutModeEnforce, `@id("ask-write") @ask("prompt") permit(principal, action, resource == Kontext::Tool::"Write");`)
+	current := &countingHookPolicy{}
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, LastKnownGood: &deployment, State: cedarpolicy.StateSuccess}}, true)
+	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Write", ToolInput: map[string]any{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Decision != risk.DecisionDeny || decision.ReasonCode != string(cedareval.ReasonAskUnavailable) {
+		t.Fatalf("decision = %#v, want ask fail-closed", decision)
+	}
+}
+
+func TestCedarEnforceFailsClosedWithoutFallback(t *testing.T) {
+	deployment := cedarTestDeployment(t, cedareval.RolloutModeEnforce, `@id("permit") permit(principal, action, resource);`)
+	tests := []struct {
+		name     string
+		snapshot cedarpolicy.Snapshot
+	}{
+		{name: "expired cache", snapshot: cedarpolicy.Snapshot{LastKnownGood: &deployment, State: cedarpolicy.StateSuccess, Status: cedarpolicy.CacheStatus{Stale: true, Expired: true}}},
+		{name: "invalid cache", snapshot: cedarpolicy.Snapshot{Status: cedarpolicy.CacheStatus{Invalid: true, Stale: true, Expired: true}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			current := &countingHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow}}
+			provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: tt.snapshot}, true)
+			decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if current.calls != 0 || decision.Decision != risk.DecisionDeny || decision.ReasonCode != string(cedareval.ReasonEnforcementNotReady) {
+				t.Fatalf("calls = %d decision = %#v, want no fallback and deny", current.calls, decision)
+			}
+		})
+	}
+}
+
+func TestCedarExplicitDisableReturnsAuthorityToCurrentEvaluator(t *testing.T) {
+	current := &countingHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow, ReasonCode: "current_allow", RiskEvent: risk.RiskEvent{Decision: risk.DecisionAllow}}}
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{State: cedarpolicy.StateDisabled}}, true)
+	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.calls != 1 || decision.Decision != risk.DecisionAllow || decision.Cedar.AppliedRolloutMode != cedareval.RolloutModeObserve {
+		t.Fatalf("calls = %d decision = %#v, want explicit rollback", current.calls, decision)
+	}
+}
+
+func TestCedarEnforceDoesNotFallbackOnNonRollbackResponseStates(t *testing.T) {
+	deployment := cedarTestDeployment(t, cedareval.RolloutModeEnforce, `@id("permit") permit(principal, action, resource);`)
+	states := []cedarpolicy.State{
+		cedarpolicy.StatePrincipalUnavailable,
+		cedarpolicy.StateUnsupportedVersion,
+		cedarpolicy.StateUnauthorized,
+	}
+	for _, state := range states {
+		t.Run(string(state), func(t *testing.T) {
+			current := &countingHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow}}
+			provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{
+				LastKnownGood: &deployment,
+				State:         state,
+			}}, true)
+			decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if current.calls != 0 || decision.Decision != risk.DecisionDeny {
+				t.Fatalf("calls = %d decision = %#v, want retained Cedar authority and deny", current.calls, decision)
+			}
+		})
+	}
+}
+
+func TestCedarEnforceFailsClosedWithoutLastKnownGood(t *testing.T) {
+	states := []cedarpolicy.State{
+		"",
+		cedarpolicy.StatePrincipalUnavailable,
+		cedarpolicy.StateUnsupportedVersion,
+		cedarpolicy.StateUnauthorized,
+	}
+	for _, state := range states {
+		name := string(state)
+		if name == "" {
+			name = "missing"
+		}
+		t.Run(name, func(t *testing.T) {
+			current := &countingHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow}}
+			provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{State: state}}, true)
+			decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if current.calls != 0 || decision.Decision != risk.DecisionDeny || decision.ReasonCode != string(cedareval.ReasonEnforcementNotReady) {
+				t.Fatalf("calls = %d decision = %#v, want fail-closed Cedar authority", current.calls, decision)
+			}
+		})
+	}
+}
+
+func TestCedarConfiguredObserveKeepsCurrentAuthority(t *testing.T) {
+	deployment := cedarTestDeployment(t, cedareval.RolloutModeObserve, `@id("forbid-all") forbid(principal, action, resource);`)
+	current := &countingHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow, ReasonCode: "current_allow", RiskEvent: risk.RiskEvent{Decision: risk.DecisionAllow}}}
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, LastKnownGood: &deployment, State: cedarpolicy.StateSuccess}}, true)
+	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.calls != 1 || decision.Decision != risk.DecisionAllow || decision.Cedar.AppliedRolloutMode != cedareval.RolloutModeObserve {
+		t.Fatalf("calls = %d decision = %#v, want current observe authority", current.calls, decision)
+	}
+}
+
+func TestCedarNoActivePolicyIsExplicitRollback(t *testing.T) {
+	deployment := cedarTestDeployment(t, cedareval.RolloutModeEnforce, `@id("permit") permit(principal, action, resource);`)
+	current := &countingHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow, RiskEvent: risk.RiskEvent{Decision: risk.DecisionAllow}}}
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{LastKnownGood: &deployment, State: cedarpolicy.StateNoActivePolicy}}, true)
+	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.calls != 1 || decision.Decision != risk.DecisionAllow {
+		t.Fatalf("calls = %d decision = %#v, want explicit no-policy rollback", current.calls, decision)
+	}
+}
+
+func TestCedarEnforceUsesAgeValidLastKnownGoodAfterRefreshFailure(t *testing.T) {
+	deployment := cedarTestDeployment(t, cedareval.RolloutModeEnforce, `@id("permit") permit(principal, action, resource);`)
+	current := &countingHookPolicy{}
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{
+		Deployment:    &deployment,
+		LastKnownGood: &deployment,
+		State:         cedarpolicy.StateSuccess,
+		Status:        cedarpolicy.CacheStatus{Stale: true},
+	}}, true)
+	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.calls != 0 || decision.Decision != risk.DecisionAllow {
+		t.Fatalf("calls = %d decision = %#v, want age-valid LKG authority", current.calls, decision)
 	}
 }
 

--- a/internal/guard/app/server/server.go
+++ b/internal/guard/app/server/server.go
@@ -54,6 +54,7 @@ type Options struct {
 	ProviderPolicies     []ProviderPolicyBinding
 	EndpointID           string
 	CedarPolicies        cedarpolicy.SnapshotProvider
+	CedarEnforcement     bool
 	CurrentSessionID     string
 	Mode                 string
 }
@@ -135,7 +136,7 @@ func NewServerWithPolicyConfigAndOptions(store *sqlite.Store, policy PolicyProvi
 			PolicyConfigProvider: policyStoreConfigProvider{store: policyStore},
 		})
 	}
-	policy = newCedarPolicyProvider(policy, opts.CedarPolicies)
+	policy = newCedarPolicyProvider(policy, opts.CedarPolicies, opts.CedarEnforcement)
 	currentSessionID := strings.TrimSpace(opts.CurrentSessionID)
 	mode := strings.TrimSpace(opts.Mode)
 	if currentSessionID != "" && mode == "" {

--- a/internal/guard/risk/types.go
+++ b/internal/guard/risk/types.go
@@ -125,7 +125,10 @@ type CedarEvidence struct {
 	ContextDiagnostics     []cedareval.ContextDiagnostic `json:"contextDiagnostics"`
 	EngineErrorCount       int                           `json:"engineErrorCount"`
 	CacheFetchedAt         time.Time                     `json:"cacheFetchedAt,omitempty"`
+	DistributionState      string                        `json:"distributionState,omitempty"`
 	CacheStale             bool                          `json:"cacheStale"`
+	CacheExpired           bool                          `json:"cacheExpired"`
+	CacheInvalid           bool                          `json:"cacheInvalid"`
 	EvaluatorVersion       string                        `json:"evaluatorVersion"`
 }
 

--- a/internal/guard/store/sqlite/cedar.go
+++ b/internal/guard/store/sqlite/cedar.go
@@ -77,15 +77,12 @@ func cedarDecisionActionValues(actionID, sessionID string, event risk.HookEvent,
 	}
 }
 
-// cedarDecisionCategory marks whether a Cedar row is an authoritative decision
-// or an observe-mode shadow. In enforce mode Cedar is the authority, so the row
-// is a real policy decision ("cedar_policy", matching the DecisionStage stamped
-// by applyCedarDecision); otherwise it is a dry-run shadow the dashboard filters
-// out of authoritative views.
-func cedarDecisionCategory(evidence risk.CedarEvidence) string {
-	if evidence.AppliedRolloutMode == cedareval.RolloutModeEnforce {
-		return "cedar_policy"
-	}
+// The dedicated Cedar row preserves evaluator evidence but is never the
+// authoritative request decision. SaveDecision's primary request.decided row
+// carries the applied outcome (including the cedar_policy decision stage in
+// enforce mode), so this auxiliary row must remain excluded from decision
+// totals in every rollout mode.
+func cedarDecisionCategory(_ risk.CedarEvidence) string {
 	return "dry_run"
 }
 

--- a/internal/guard/store/sqlite/cedar.go
+++ b/internal/guard/store/sqlite/cedar.go
@@ -34,7 +34,10 @@ func cedarDecisionActionValues(actionID, sessionID string, event risk.HookEvent,
 		"response_version":         evidence.ResponseVersion,
 		"request_contract_version": evidence.RequestContractVersion,
 		"cache_fetched_at":         evidence.CacheFetchedAt,
+		"distribution_state":       evidence.DistributionState,
 		"cache_stale":              evidence.CacheStale,
+		"cache_expired":            evidence.CacheExpired,
+		"cache_invalid":            evidence.CacheInvalid,
 		"evaluator_version":        evidence.EvaluatorVersion,
 		"evaluation_state":         evidence.Mapping.EvaluationState,
 		"derived_action":           evidence.Mapping.DerivedCedarAction,
@@ -74,7 +77,15 @@ func cedarDecisionActionValues(actionID, sessionID string, event risk.HookEvent,
 	}
 }
 
+// cedarDecisionCategory marks whether a Cedar row is an authoritative decision
+// or an observe-mode shadow. In enforce mode Cedar is the authority, so the row
+// is a real policy decision ("cedar_policy", matching the DecisionStage stamped
+// by applyCedarDecision); otherwise it is a dry-run shadow the dashboard filters
+// out of authoritative views.
 func cedarDecisionCategory(evidence risk.CedarEvidence) string {
+	if evidence.AppliedRolloutMode == cedareval.RolloutModeEnforce {
+		return "cedar_policy"
+	}
 	return "dry_run"
 }
 

--- a/internal/guard/store/sqlite/cedar_category_test.go
+++ b/internal/guard/store/sqlite/cedar_category_test.go
@@ -1,21 +1,20 @@
 package sqlite
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	"github.com/kontext-security/kontext-cli/internal/cedareval"
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
 )
 
-// A Cedar row is a dry-run shadow in observe mode and an authoritative decision
-// in enforce mode; the category must distinguish them so authoritative denials
-// are not filtered out as shadows.
-func TestCedarDecisionCategoryReflectsAppliedMode(t *testing.T) {
+func TestCedarDecisionEvidenceCategoryIsNeverAuthoritative(t *testing.T) {
 	cases := []struct {
 		mode cedareval.RolloutMode
 		want string
 	}{
-		{cedareval.RolloutModeEnforce, "cedar_policy"},
+		{cedareval.RolloutModeEnforce, "dry_run"},
 		{cedareval.RolloutModeObserve, "dry_run"},
 		{cedareval.RolloutModeDisabled, "dry_run"},
 	}
@@ -24,5 +23,54 @@ func TestCedarDecisionCategoryReflectsAppliedMode(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("cedarDecisionCategory(mode=%q) = %q, want %q", tc.mode, got, tc.want)
 		}
+	}
+}
+
+func TestSaveDecisionWritesOneAuthoritativeEnforceDecision(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	decision := risk.RiskDecision{
+		Decision:   risk.DecisionDeny,
+		Reason:     "local Cedar policy decision",
+		ReasonCode: string(cedareval.ReasonExplicitForbid),
+		RiskEvent: risk.RiskEvent{
+			Decision:      risk.DecisionDeny,
+			DecisionStage: "cedar_policy",
+		},
+		Cedar: &risk.CedarEvidence{
+			PolicyHash:         strings.Repeat("a", 64),
+			AppliedRolloutMode: cedareval.RolloutModeEnforce,
+			Mapping: cedareval.DecisionMapping{
+				DerivedCedarAction:  cedareval.DerivedCedarActionDeny,
+				EffectiveReasonCode: cedareval.ReasonExplicitForbid,
+			},
+		},
+	}
+	if _, err := store.SaveDecision(context.Background(), risk.HookEvent{
+		SessionID:     "session-1",
+		HookEventName: "PreToolUse",
+		ToolName:      "Bash",
+		ToolUseID:     "tool-1",
+	}, decision); err != nil {
+		t.Fatal(err)
+	}
+
+	var authoritative, evidence int
+	err = store.db.QueryRowContext(context.Background(), `
+select
+  count(*) filter (where coalesce(decision_category, '') <> 'dry_run'),
+  count(*) filter (where provider = 'cedar' and decision_category = 'dry_run')
+from authorization_actions
+where canonical_event_type = 'request.decided'
+	`).Scan(&authoritative, &evidence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if authoritative != 1 || evidence != 1 {
+		t.Fatalf("decision rows = authoritative %d evidence %d, want 1 and 1", authoritative, evidence)
 	}
 }

--- a/internal/guard/store/sqlite/cedar_category_test.go
+++ b/internal/guard/store/sqlite/cedar_category_test.go
@@ -1,0 +1,28 @@
+package sqlite
+
+import (
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/cedareval"
+	"github.com/kontext-security/kontext-cli/internal/guard/risk"
+)
+
+// A Cedar row is a dry-run shadow in observe mode and an authoritative decision
+// in enforce mode; the category must distinguish them so authoritative denials
+// are not filtered out as shadows.
+func TestCedarDecisionCategoryReflectsAppliedMode(t *testing.T) {
+	cases := []struct {
+		mode cedareval.RolloutMode
+		want string
+	}{
+		{cedareval.RolloutModeEnforce, "cedar_policy"},
+		{cedareval.RolloutModeObserve, "dry_run"},
+		{cedareval.RolloutModeDisabled, "dry_run"},
+	}
+	for _, tc := range cases {
+		got := cedarDecisionCategory(risk.CedarEvidence{AppliedRolloutMode: tc.mode})
+		if got != tc.want {
+			t.Errorf("cedarDecisionCategory(mode=%q) = %q, want %q", tc.mode, got, tc.want)
+		}
+	}
+}

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -171,6 +171,7 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 		},
 		EndpointID:         installationState.InstallationID,
 		CedarPolicies:      cedarCache,
+		CedarEnforcement:   mode == guardhookruntime.ModeEnforce,
 		Mode:               mode,
 		Diagnostic:         opts.Diagnostic,
 		SkipInitialSession: true,

--- a/internal/managedobserve/lifecycle.go
+++ b/internal/managedobserve/lifecycle.go
@@ -31,6 +31,10 @@ type Lifecycle struct {
 	Label      string
 	Kickstart  func(context.Context, string) error
 	Diagnostic diagnostic.Logger
+	// Mode is the managed rollout posture ("observe" or "enforce"). Empty is
+	// treated as observe. In enforce the daemon's decision is authoritative and
+	// passes through unchanged; in observe the hook can never block.
+	Mode string
 }
 
 func NewLifecycle() Lifecycle {
@@ -38,7 +42,27 @@ func NewLifecycle() Lifecycle {
 		SocketPath: DefaultSocketPath(),
 		Label:      DefaultLabel(),
 		Kickstart:  KickstartLaunchd,
+		Mode:       loadManagedMode(),
 	}
+}
+
+// loadManagedMode reads the managed rollout posture from the installed managed
+// config, defaulting to observe when the config is absent or unreadable (the
+// caller only reaches here when Active() already succeeded, so this is a
+// defensive fallback).
+func loadManagedMode() string {
+	cfg, err := managedconfig.Load()
+	if err != nil {
+		return managedconfig.Mode
+	}
+	if cfg.Config.Mode == managedconfig.ModeEnforce {
+		return managedconfig.ModeEnforce
+	}
+	return managedconfig.Mode
+}
+
+func (l Lifecycle) enforcing() bool {
+	return l.Mode == managedconfig.ModeEnforce
 }
 
 func Active() bool {
@@ -81,18 +105,54 @@ func (l Lifecycle) processWithKickstart(ctx context.Context, event hook.Event, b
 		launchdMu.Unlock()
 	}
 	if l.waitForProbe(ctx) {
-		return observeResult(event, l.call(ctx, event))
+		return l.finalize(event, l.call(ctx, event))
 	}
-	return observeResult(event, hook.Result{Decision: hook.DecisionAllow, Reason: "managed observe daemon unavailable"})
+	return l.daemonUnavailable(event)
 }
 
 func (l Lifecycle) processIfAvailable(ctx context.Context, event hook.Event, budget time.Duration) hook.Result {
 	ctx, cancel := context.WithTimeout(ctx, budget)
 	defer cancel()
 	if !l.probe(ctx) {
-		return observeResult(event, hook.Result{Decision: hook.DecisionAllow, Reason: "managed observe daemon unavailable"})
+		return l.daemonUnavailable(event)
 	}
-	return observeResult(event, l.call(ctx, event))
+	return l.finalize(event, l.call(ctx, event))
+}
+
+// finalize applies the client-side posture to a daemon result. In enforce the
+// daemon already produced the authoritative decision (the guard server does not
+// observe-transform in enforce), so it passes through unchanged — only
+// normalized. In observe the hook must never block, so the decision is forced
+// to allow with a "would" note. This is the boundary that must not silently
+// downgrade an enforce deny to allow.
+func (l Lifecycle) finalize(event hook.Event, result hook.Result) hook.Result {
+	if l.enforcing() {
+		if result.Decision == "" {
+			result.Decision = hook.DecisionAllow
+		}
+		if result.Mode == "" {
+			result.Mode = managedconfig.ModeEnforce
+		}
+		return result
+	}
+	return observeResult(event, result)
+}
+
+// daemonUnavailable is the fail path when the managed daemon cannot be reached.
+// Observe fails open (it never blocks). Enforce fails closed: enforcement
+// requires an authoritative decision and an unreachable daemon cannot provide
+// one, so the tool call is denied rather than silently allowed. This means an
+// enforce endpoint with no reachable daemon blocks blocking hooks until the
+// daemon is back — the deliberate fail-closed posture for enforcement.
+func (l Lifecycle) daemonUnavailable(event hook.Event) hook.Result {
+	if l.enforcing() {
+		return hook.Result{
+			Decision: hook.DecisionDeny,
+			Mode:     managedconfig.ModeEnforce,
+			Reason:   "Kontext enforce: managed policy daemon unavailable",
+		}
+	}
+	return observeResult(event, hook.Result{Decision: hook.DecisionAllow, Reason: "managed observe daemon unavailable"})
 }
 
 func (l Lifecycle) probe(ctx context.Context) bool {

--- a/internal/managedobserve/lifecycle.go
+++ b/internal/managedobserve/lifecycle.go
@@ -105,7 +105,11 @@ func (l Lifecycle) processWithKickstart(ctx context.Context, event hook.Event, b
 		launchdMu.Unlock()
 	}
 	if l.waitForProbe(ctx) {
-		return l.finalize(event, l.call(ctx, event))
+		result, err := l.call(ctx, event)
+		if err != nil {
+			return l.daemonUnavailable(event)
+		}
+		return l.finalize(event, result)
 	}
 	return l.daemonUnavailable(event)
 }
@@ -116,22 +120,26 @@ func (l Lifecycle) processIfAvailable(ctx context.Context, event hook.Event, bud
 	if !l.probe(ctx) {
 		return l.daemonUnavailable(event)
 	}
-	return l.finalize(event, l.call(ctx, event))
+	result, err := l.call(ctx, event)
+	if err != nil {
+		return l.daemonUnavailable(event)
+	}
+	return l.finalize(event, result)
 }
 
-// finalize applies the client-side posture to a daemon result. In enforce the
-// daemon already produced the authoritative decision (the guard server does not
-// observe-transform in enforce), so it passes through unchanged — only
-// normalized. In observe the hook must never block, so the decision is forced
-// to allow with a "would" note. This is the boundary that must not silently
-// downgrade an enforce deny to allow.
+// finalize applies the client-side posture to a daemon result. Enforce accepts
+// only an explicit enforce-mode allow or deny; a stale daemon or malformed RPC
+// result is not authoritative. Non-blocking hooks are always normalized to
+// allow. In observe the hook can never block, so the decision is forced to
+// allow with a "would" note.
 func (l Lifecycle) finalize(event hook.Event, result hook.Result) hook.Result {
 	if l.enforcing() {
-		if result.Decision == "" {
-			result.Decision = hook.DecisionAllow
+		if result.Mode != managedconfig.ModeEnforce ||
+			(result.Decision != hook.DecisionAllow && result.Decision != hook.DecisionDeny) {
+			return l.daemonUnavailable(event)
 		}
-		if result.Mode == "" {
-			result.Mode = managedconfig.ModeEnforce
+		if !event.HookName.CanBlock() {
+			result.Decision = hook.DecisionAllow
 		}
 		return result
 	}
@@ -139,15 +147,17 @@ func (l Lifecycle) finalize(event hook.Event, result hook.Result) hook.Result {
 }
 
 // daemonUnavailable is the fail path when the managed daemon cannot be reached.
-// Observe fails open (it never blocks). Enforce fails closed: enforcement
-// requires an authoritative decision and an unreachable daemon cannot provide
-// one, so the tool call is denied rather than silently allowed. This means an
-// enforce endpoint with no reachable daemon blocks blocking hooks until the
-// daemon is back — the deliberate fail-closed posture for enforcement.
+// Observe fails open (it never blocks). Enforce fails closed for blocking
+// hooks: enforcement requires an authoritative decision and an unreachable
+// daemon cannot provide one. Non-blocking lifecycle hooks remain informational.
 func (l Lifecycle) daemonUnavailable(event hook.Event) hook.Result {
 	if l.enforcing() {
+		decision := hook.DecisionAllow
+		if event.HookName.CanBlock() {
+			decision = hook.DecisionDeny
+		}
 		return hook.Result{
-			Decision: hook.DecisionDeny,
+			Decision: decision,
 			Mode:     managedconfig.ModeEnforce,
 			Reason:   "Kontext enforce: managed policy daemon unavailable",
 		}
@@ -180,7 +190,7 @@ func (l Lifecycle) waitForProbe(ctx context.Context) bool {
 	}
 }
 
-func (l Lifecycle) call(ctx context.Context, event hook.Event) hook.Result {
+func (l Lifecycle) call(ctx context.Context, event hook.Event) (hook.Result, error) {
 	client := localruntime.NewClient(l.SocketPath)
 	client.Timeout = time.Until(deadlineOr(ctx, time.Now().Add(asyncHookWait)))
 	if client.Timeout <= 0 {
@@ -189,9 +199,9 @@ func (l Lifecycle) call(ctx context.Context, event hook.Event) hook.Result {
 	result, err := client.Process(ctx, event)
 	if err != nil {
 		l.Diagnostic.Printf("managed observe call: %v\n", err)
-		return hook.Result{Decision: hook.DecisionAllow, Reason: "managed observe daemon unavailable"}
+		return hook.Result{}, err
 	}
-	return result
+	return result, nil
 }
 
 func observeResult(event hook.Event, result hook.Result) hook.Result {

--- a/internal/managedobserve/lifecycle_test.go
+++ b/internal/managedobserve/lifecycle_test.go
@@ -187,6 +187,78 @@ func TestLifecycleHealthySocketDoesNotKickstart(t *testing.T) {
 	}
 }
 
+func TestLifecycleEnforcePassesDaemonDenyThroughToAgent(t *testing.T) {
+	socketPath := filepath.Join("/tmp", fmt.Sprintf("kontext-managedobserve-enforce-test-%d.sock", time.Now().UnixNano()))
+	t.Cleanup(func() { _ = os.Remove(socketPath) })
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Listen() error = %v", err)
+	}
+	defer ln.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 2; i++ {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		var req localruntime.EvaluateRequest
+		if err := localruntime.ReadMessage(conn, &req); err != nil {
+			return
+		}
+		// In enforce the guard server returns the authoritative decision
+		// without an observe transform; the wrapper must not downgrade it.
+		_ = localruntime.WriteMessage(conn, localruntime.EvaluateResult{
+			Decision: "deny",
+			Allowed:  false,
+			Reason:   "local Cedar policy decision",
+			Mode:     "enforce",
+		})
+	}()
+
+	lifecycle := Lifecycle{
+		SocketPath: socketPath,
+		Label:      DefaultLaunchdLabel,
+		Mode:       "enforce",
+		Kickstart: func(context.Context, string) error {
+			t.Fatal("kickstart should not be called")
+			return nil
+		},
+	}
+	result := lifecycle.Process(context.Background(), hook.Event{HookName: hook.HookPreToolUse})
+	if result.Decision != hook.DecisionDeny {
+		t.Fatalf("result = %+v, want enforce deny passed through", result)
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("server did not receive request")
+	}
+}
+
+func TestLifecycleEnforceFailsClosedWhenDaemonUnavailable(t *testing.T) {
+	socketPath := filepath.Join("/tmp", fmt.Sprintf("kontext-managedobserve-enforce-down-%d.sock", time.Now().UnixNano()))
+	lifecycle := Lifecycle{
+		SocketPath: socketPath,
+		Label:      DefaultLaunchdLabel,
+		Mode:       "enforce",
+		Kickstart:  func(context.Context, string) error { return nil },
+	}
+	result := lifecycle.Process(context.Background(), hook.Event{HookName: hook.HookPreToolUse})
+	if result.Decision != hook.DecisionDeny {
+		t.Fatalf("result = %+v, want enforce fail-closed deny when daemon unavailable", result)
+	}
+}
+
 func TestObserveResultFormatsBlockingPromptSubmit(t *testing.T) {
 	result := observeResult(hook.Event{HookName: hook.HookUserPromptSubmit}, hook.Result{
 		Decision: hook.DecisionDeny,

--- a/internal/managedobserve/lifecycle_test.go
+++ b/internal/managedobserve/lifecycle_test.go
@@ -259,6 +259,82 @@ func TestLifecycleEnforceFailsClosedWhenDaemonUnavailable(t *testing.T) {
 	}
 }
 
+func TestLifecycleEnforceFailsClosedWhenDaemonDropsRPC(t *testing.T) {
+	socketPath := filepath.Join("/tmp", fmt.Sprintf("kontext-managedobserve-enforce-rpc-%d.sock", time.Now().UnixNano()))
+	t.Cleanup(func() { _ = os.Remove(socketPath) })
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Listen() error = %v", err)
+	}
+	defer listener.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 3 {
+			connection, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			_ = connection.Close()
+		}
+	}()
+
+	lifecycle := Lifecycle{
+		SocketPath: socketPath,
+		Label:      DefaultLaunchdLabel,
+		Mode:       "enforce",
+		Kickstart: func(context.Context, string) error {
+			t.Fatal("kickstart should not be called")
+			return nil
+		},
+	}
+	result := lifecycle.Process(context.Background(), hook.Event{HookName: hook.HookPreToolUse})
+	if result.Decision != hook.DecisionDeny {
+		t.Fatalf("result = %+v, want enforce fail-closed deny after RPC failure", result)
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("server did not receive RPC")
+	}
+}
+
+func TestLifecycleEnforceRejectsNonAuthoritativeDaemonResult(t *testing.T) {
+	t.Parallel()
+
+	lifecycle := Lifecycle{Mode: "enforce"}
+	event := hook.Event{HookName: hook.HookPreToolUse}
+	tests := []struct {
+		name   string
+		result hook.Result
+	}{
+		{name: "missing decision", result: hook.Result{Mode: "enforce"}},
+		{name: "missing mode", result: hook.Result{Decision: hook.DecisionAllow}},
+		{name: "stale observe daemon", result: hook.Result{Decision: hook.DecisionAllow, Mode: "observe"}},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			result := lifecycle.finalize(event, test.result)
+			if result.Decision != hook.DecisionDeny || result.Mode != "enforce" {
+				t.Fatalf("finalize() = %+v, want enforce fail-closed deny", result)
+			}
+		})
+	}
+}
+
+func TestLifecycleEnforceUnavailableNonBlockingHookDoesNotDeny(t *testing.T) {
+	t.Parallel()
+
+	lifecycle := Lifecycle{Mode: "enforce"}
+	result := lifecycle.daemonUnavailable(hook.Event{HookName: hook.HookPostToolUse})
+	if result.Decision != hook.DecisionAllow || result.Mode != "enforce" {
+		t.Fatalf("daemonUnavailable() = %+v, want enforce allow for non-blocking hook", result)
+	}
+}
+
 func TestObserveResultFormatsBlockingPromptSubmit(t *testing.T) {
 	result := observeResult(hook.Event{HookName: hook.HookUserPromptSubmit}, hook.Result{
 		Decision: hook.DecisionDeny,

--- a/internal/runtimehost/host.go
+++ b/internal/runtimehost/host.go
@@ -41,6 +41,7 @@ type Options struct {
 	JudgeDownloadProgress     judge.DownloadProgressHandler
 	ProviderPolicies          []server.ProviderPolicyBinding
 	CedarPolicies             cedarpolicy.SnapshotProvider
+	CedarEnforcement          bool
 	EndpointID                string
 	Mode                      guardhookruntime.Mode
 	Diagnostic                diagnostic.Logger
@@ -119,6 +120,7 @@ func Start(ctx context.Context, opts Options) (*Host, error) {
 		ProviderPolicies: opts.ProviderPolicies,
 		EndpointID:       opts.EndpointID,
 		CedarPolicies:    opts.CedarPolicies,
+		CedarEnforcement: opts.CedarEnforcement,
 		CurrentSessionID: serverSessionID,
 		Mode:             string(mode),
 	})


### PR DESCRIPTION
## Why

Cedar enforcement needs a singular authority boundary with deterministic behavior during startup, refresh failure, expiration, identity failure, incompatibility, corruption, and explicit rollback.

## What

- grants Cedar authority only when the local cutover gate is enabled and the semantic deployment requests enforce
- stops calling the previous evaluator after cutover
- continues an age-valid last-known-good deployment through transient refresh failure
- denies when enforcement has no trusted ready deployment, including no-LKG, principal_unavailable, unauthorized, unsupported, expired, and invalid states
- returns authority only for configured observe, disabled, or no_active_policy
- maps ASK to deny until an approval channel exists
- records distribution state and cache readiness in decision evidence

## Scope

Authorization cutover only. Endpoint configuration remains independent and cannot grant or revoke policy authority.

Depends on #385. Tracks ENG-535.

## Verification

- go test ./...
- focused go test -race across policy, server, ledger, runtime, and daemon packages
- go vet ./...

Change size: 8 files, +296/-21 — authority/readiness gate, fail-closed evidence, and transition tests.