### PR TITLE
feat(config): sync endpoint configuration independently

### DIFF
--- a/internal/endpointconfig/cache.go
+++ b/internal/endpointconfig/cache.go
@@ -1,0 +1,375 @@
+package endpointconfig
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/payloadcapture"
+)
+
+const (
+	DefaultRefreshInterval = time.Minute
+	DefaultMaxBackoff      = 10 * time.Minute
+)
+
+var defaultConfig = Config{PayloadCaptureMode: payloadcapture.ModeSummary}
+
+type Status struct {
+	FetchedAt     time.Time
+	LastAttemptAt time.Time
+	Stale         bool
+	LastError     string
+	Invalid       bool
+}
+
+type Snapshot struct {
+	Config         Config
+	Configured     Config
+	ConfigIdentity string
+	Confirmed      bool
+	FallbackReason string
+	LastKnownGood  *Response
+	Status         Status
+}
+
+type cacheFile struct {
+	Version   int       `json:"version"`
+	FetchedAt string    `json:"fetchedAt"`
+	Response  *Response `json:"response"`
+}
+
+type Cache struct {
+	path string
+	now  func() time.Time
+
+	mu       sync.RWMutex
+	fetched  time.Time
+	active   *Response
+	lastGood *Response
+	status   Status
+}
+
+func NewCache(path string) *Cache {
+	return &Cache{path: path, now: time.Now}
+}
+
+func DefaultCachePathForDB(dbPath string) string {
+	return filepath.Join(filepath.Dir(dbPath), "endpoint-config.json")
+}
+
+// Load restores only the conditional value. The effective configuration stays
+// at the privacy-safe default until the server confirms it with 200 or 304.
+func (c *Cache) Load() error {
+	if c.path == "" {
+		return nil
+	}
+	data, err := os.ReadFile(c.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("endpoint configuration cache: read: %w", err)
+	}
+	var file cacheFile
+	if err := decodeStrict(strings.NewReader(string(data)), &file); err != nil {
+		return fmt.Errorf("endpoint configuration cache: %w", err)
+	}
+	if file.Version != 1 || file.Response == nil {
+		return errors.New("endpoint configuration cache: invalid cache shape")
+	}
+	if err := file.Response.Validate(); err != nil {
+		return fmt.Errorf("endpoint configuration cache: %w", err)
+	}
+	fetchedAt, err := time.Parse(time.RFC3339Nano, file.FetchedAt)
+	if err != nil {
+		return fmt.Errorf("endpoint configuration cache: invalid fetchedAt: %w", err)
+	}
+	c.mu.Lock()
+	c.fetched = fetchedAt
+	c.active = nil
+	c.lastGood = cloneResponse(file.Response)
+	c.status = Status{FetchedAt: fetchedAt, Stale: true, LastError: "persisted configuration not yet confirmed"}
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *Cache) Apply(result FetchResult, fetchedAt time.Time) error {
+	if fetchedAt.IsZero() {
+		fetchedAt = c.now().UTC()
+	}
+	c.mu.RLock()
+	lastGood := cloneResponse(c.lastGood)
+	c.mu.RUnlock()
+	var confirmed *Response
+	switch {
+	case result.NotModified:
+		if lastGood == nil || result.ETag == "" || result.ETag != lastGood.ConfigIdentity {
+			return errors.New("endpoint configuration cache: not-modified result does not match last-known-good config")
+		}
+		confirmed = lastGood
+	case result.Response != nil:
+		if err := result.Response.Validate(); err != nil {
+			return err
+		}
+		confirmed = cloneResponse(result.Response)
+	default:
+		return errors.New("endpoint configuration cache: result has no configuration")
+	}
+	file := cacheFile{
+		Version:   1,
+		FetchedAt: fetchedAt.UTC().Format(time.RFC3339Nano),
+		Response:  cloneResponse(confirmed),
+	}
+	if err := c.persist(file); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	c.fetched = fetchedAt
+	c.active = cloneResponse(confirmed)
+	c.lastGood = cloneResponse(confirmed)
+	c.status = Status{FetchedAt: fetchedAt, LastAttemptAt: fetchedAt}
+	c.mu.Unlock()
+	return nil
+}
+
+// MarkFailed immediately returns the effective config to summary while
+// retaining the validated value solely for conditional revalidation.
+func (c *Cache) MarkFailed(err error, attemptedAt time.Time) {
+	if attemptedAt.IsZero() {
+		attemptedAt = c.now().UTC()
+	}
+	c.mu.Lock()
+	c.active = nil
+	c.status.FetchedAt = c.fetched
+	c.status.LastAttemptAt = attemptedAt
+	c.status.Stale = true
+	if err != nil {
+		c.status.LastError = err.Error()
+	}
+	c.mu.Unlock()
+}
+
+func (c *Cache) MarkInvalid(err error) {
+	c.MarkFailed(err, c.now().UTC())
+	c.mu.Lock()
+	c.status.Invalid = true
+	c.mu.Unlock()
+}
+
+func (c *Cache) Current() Snapshot {
+	c.mu.RLock()
+	active := cloneResponse(c.active)
+	lastGood := cloneResponse(c.lastGood)
+	status := c.status
+	c.mu.RUnlock()
+	if active == nil {
+		configured := defaultConfig
+		identity := ""
+		fallbackReason := "no_confirmed_config"
+		if lastGood != nil {
+			configured = lastGood.Config
+			identity = lastGood.ConfigIdentity
+			fallbackReason = "awaiting_confirmation"
+		}
+		if !status.LastAttemptAt.IsZero() && status.Stale {
+			fallbackReason = "refresh_failed"
+		}
+		if status.Invalid {
+			fallbackReason = "invalid_cache"
+		}
+		return Snapshot{
+			Config:         defaultConfig,
+			Configured:     configured,
+			ConfigIdentity: identity,
+			FallbackReason: fallbackReason,
+			LastKnownGood:  lastGood,
+			Status:         status,
+		}
+	}
+	return Snapshot{
+		Config:         active.Config,
+		Configured:     active.Config,
+		ConfigIdentity: active.ConfigIdentity,
+		Confirmed:      true,
+		LastKnownGood:  lastGood,
+		Status:         status,
+	}
+}
+
+func (c *Cache) ConditionalIdentity() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.lastGood == nil {
+		return ""
+	}
+	return c.lastGood.ConfigIdentity
+}
+
+func (c *Cache) persist(file cacheFile) error {
+	if c.path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(c.path), 0o700); err != nil {
+		return fmt.Errorf("endpoint configuration cache: create directory: %w", err)
+	}
+	data, err := json.MarshalIndent(file, "", "  ")
+	if err != nil {
+		return fmt.Errorf("endpoint configuration cache: encode: %w", err)
+	}
+	data = append(data, '\n')
+	temporary, err := os.CreateTemp(filepath.Dir(c.path), ".endpoint-config-*.tmp")
+	if err != nil {
+		return fmt.Errorf("endpoint configuration cache: create temporary file: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+	if err := temporary.Chmod(0o600); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("endpoint configuration cache: set permissions: %w", err)
+	}
+	if _, err := temporary.Write(data); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("endpoint configuration cache: write: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("endpoint configuration cache: sync: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("endpoint configuration cache: close: %w", err)
+	}
+	if err := os.Rename(temporaryPath, c.path); err != nil {
+		return fmt.Errorf("endpoint configuration cache: replace: %w", err)
+	}
+	cleanup = false
+	directory, err := os.Open(filepath.Dir(c.path))
+	if err != nil {
+		return fmt.Errorf("endpoint configuration cache: open directory: %w", err)
+	}
+	defer directory.Close()
+	if err := directory.Sync(); err != nil {
+		return fmt.Errorf("endpoint configuration cache: sync directory: %w", err)
+	}
+	return nil
+}
+
+func cloneResponse(input *Response) *Response {
+	if input == nil {
+		return nil
+	}
+	clone := *input
+	return &clone
+}
+
+type TokenSource func(context.Context) (string, error)
+
+type Refresher struct {
+	Client         *Client
+	Cache          *Cache
+	TokenSource    TokenSource
+	InstallationID string
+	Interval       time.Duration
+	MaxBackoff     time.Duration
+	Now            func() time.Time
+	Jitter         func(time.Duration) time.Duration
+	OnChanged      func(Snapshot)
+}
+
+func (r *Refresher) Refresh(ctx context.Context) error {
+	if r.Client == nil || r.Cache == nil || r.TokenSource == nil {
+		return r.fail(errors.New("endpoint configuration refresher is not configured"))
+	}
+	token, err := r.TokenSource(ctx)
+	if err != nil {
+		return r.fail(err)
+	}
+	result, err := r.Client.Fetch(ctx, token, r.InstallationID, r.Cache.ConditionalIdentity())
+	if err != nil {
+		return r.fail(err)
+	}
+	if err := r.Cache.Apply(result, r.now()); err != nil {
+		return r.fail(err)
+	}
+	r.notify()
+	return nil
+}
+
+func (r *Refresher) Run(ctx context.Context) {
+	interval := r.Interval
+	if interval <= 0 {
+		interval = DefaultRefreshInterval
+	}
+	maxBackoff := r.MaxBackoff
+	if maxBackoff < interval {
+		maxBackoff = DefaultMaxBackoff
+		if maxBackoff < interval {
+			maxBackoff = 10 * interval
+		}
+	}
+	delay := interval
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		if err := r.Refresh(ctx); err == nil {
+			delay = interval
+		} else if delay < maxBackoff {
+			delay *= 2
+			if delay > maxBackoff {
+				delay = maxBackoff
+			}
+		}
+		timer := time.NewTimer(r.jitter(delay))
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return
+		case <-timer.C:
+		}
+	}
+}
+
+func (r *Refresher) fail(err error) error {
+	if r.Cache != nil {
+		r.Cache.MarkFailed(err, r.now())
+		r.notify()
+	}
+	return err
+}
+
+func (r *Refresher) notify() {
+	if r.OnChanged != nil && r.Cache != nil {
+		r.OnChanged(r.Cache.Current())
+	}
+}
+
+func (r *Refresher) now() time.Time {
+	if r.Now != nil {
+		return r.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func (r *Refresher) jitter(delay time.Duration) time.Duration {
+	if r.Jitter != nil {
+		return r.Jitter(delay)
+	}
+	// Spread retry traffic over [75%, 125%] without changing the configured
+	// steady-state interval or the bounded exponential backoff.
+	return delay*3/4 + time.Duration(rand.Int64N(int64(delay/2)+1))
+}

--- a/internal/endpointconfig/cache.go
+++ b/internal/endpointconfig/cache.go
@@ -147,6 +147,11 @@ func (c *Cache) MarkFailed(err error, attemptedAt time.Time) {
 		attemptedAt = c.now().UTC()
 	}
 	c.mu.Lock()
+	c.markFailedLocked(err, attemptedAt)
+	c.mu.Unlock()
+}
+
+func (c *Cache) markFailedLocked(err error, attemptedAt time.Time) {
 	c.active = nil
 	c.status.FetchedAt = c.fetched
 	c.status.LastAttemptAt = attemptedAt
@@ -154,12 +159,12 @@ func (c *Cache) MarkFailed(err error, attemptedAt time.Time) {
 	if err != nil {
 		c.status.LastError = err.Error()
 	}
-	c.mu.Unlock()
 }
 
 func (c *Cache) MarkInvalid(err error) {
-	c.MarkFailed(err, c.now().UTC())
+	attemptedAt := c.now().UTC()
 	c.mu.Lock()
+	c.markFailedLocked(err, attemptedAt)
 	c.status.Invalid = true
 	c.mu.Unlock()
 }
@@ -255,6 +260,10 @@ func (c *Cache) persist(file cacheFile) error {
 		return fmt.Errorf("endpoint configuration cache: replace: %w", err)
 	}
 	cleanup = false
+	// A successful rename makes the new file visible, but the replacement is
+	// not crash-durable until the containing directory is synced. If that sync
+	// fails, Apply deliberately leaves the in-memory value unconfirmed and the
+	// next refresh heals the cache (possibly after one extra 200 response).
 	directory, err := os.Open(filepath.Dir(c.path))
 	if err != nil {
 		return fmt.Errorf("endpoint configuration cache: open directory: %w", err)

--- a/internal/endpointconfig/cache_test.go
+++ b/internal/endpointconfig/cache_test.go
@@ -1,0 +1,94 @@
+package endpointconfig
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/payloadcapture"
+)
+
+func TestCacheRestartRequiresServerConfirmation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state", "endpoint-configuration.json")
+	now := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	full := testResponse(t, payloadcapture.ModeFull)
+	cache := NewCache(path)
+	if err := cache.Apply(FetchResult{Response: &full}, now); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("cache mode = %o", info.Mode().Perm())
+	}
+
+	restored := NewCache(path)
+	if err := restored.Load(); err != nil {
+		t.Fatal(err)
+	}
+	if snapshot := restored.Current(); snapshot.Config.PayloadCaptureMode != payloadcapture.ModeSummary || snapshot.LastKnownGood == nil || !snapshot.Status.Stale {
+		t.Fatalf("unconfirmed snapshot = %#v", snapshot)
+	}
+	if err := restored.Apply(FetchResult{NotModified: true, ETag: full.ConfigIdentity}, now.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if snapshot := restored.Current(); snapshot.Config.PayloadCaptureMode != payloadcapture.ModeFull || snapshot.ConfigIdentity != full.ConfigIdentity {
+		t.Fatalf("confirmed snapshot = %#v", snapshot)
+	}
+}
+
+func TestCacheFailureFallsBackWithoutDiscardingConditionalValue(t *testing.T) {
+	cache := NewCache(filepath.Join(t.TempDir(), "endpoint-config.json"))
+	full := testResponse(t, payloadcapture.ModeFull)
+	if err := cache.Apply(FetchResult{Response: &full}, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	cache.MarkFailed(errors.New("offline"), time.Now().UTC())
+	snapshot := cache.Current()
+	if snapshot.Config.PayloadCaptureMode != payloadcapture.ModeSummary || snapshot.ConfigIdentity != full.ConfigIdentity || snapshot.LastKnownGood == nil || !snapshot.Status.Stale || snapshot.FallbackReason != "refresh_failed" {
+		t.Fatalf("failed snapshot = %#v", snapshot)
+	}
+	if cache.ConditionalIdentity() != full.ConfigIdentity {
+		t.Fatalf("ConditionalIdentity() = %q", cache.ConditionalIdentity())
+	}
+}
+
+func TestCacheRejectsMismatchedNotModified(t *testing.T) {
+	cache := NewCache("")
+	if err := cache.Apply(FetchResult{NotModified: true, ETag: strings.Repeat("a", 64)}, time.Now().UTC()); err == nil {
+		t.Fatal("Apply() error = nil")
+	}
+}
+
+func TestRefresherFailureNotifiesSafeDefault(t *testing.T) {
+	cache := NewCache("")
+	full := testResponse(t, payloadcapture.ModeFull)
+	if err := cache.Apply(FetchResult{Response: &full}, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	changed := make(chan Snapshot, 1)
+	refresher := Refresher{
+		Cache: cache,
+		TokenSource: func(context.Context) (string, error) {
+			return "", errors.New("token unavailable")
+		},
+		OnChanged: func(snapshot Snapshot) { changed <- snapshot },
+	}
+	if err := refresher.Refresh(context.Background()); err == nil {
+		t.Fatal("Refresh() error = nil")
+	}
+	select {
+	case snapshot := <-changed:
+		if snapshot.Config.PayloadCaptureMode != payloadcapture.ModeSummary {
+			t.Fatalf("notified config = %#v", snapshot.Config)
+		}
+	default:
+		t.Fatal("OnChanged was not called")
+	}
+}

--- a/internal/endpointconfig/cache_test.go
+++ b/internal/endpointconfig/cache_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -63,6 +64,70 @@ func TestCacheRejectsMismatchedNotModified(t *testing.T) {
 	cache := NewCache("")
 	if err := cache.Apply(FetchResult{NotModified: true, ETag: strings.Repeat("a", 64)}, time.Now().UTC()); err == nil {
 		t.Fatal("Apply() error = nil")
+	}
+}
+
+func TestCacheConcurrentApplyAndMarkInvalidPreserveSnapshotInvariant(t *testing.T) {
+	cache := NewCache("")
+	full := testResponse(t, payloadcapture.ModeFull)
+	if err := cache.Apply(FetchResult{Response: &full}, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+
+	const iterations = 500
+	applyErrors := make(chan error, iterations)
+	violations := make(chan Snapshot, 1)
+	stopReading := make(chan struct{})
+	var readers sync.WaitGroup
+	readers.Add(1)
+	go func() {
+		defer readers.Done()
+		for {
+			select {
+			case <-stopReading:
+				return
+			default:
+				snapshot := cache.Current()
+				if snapshot.Confirmed == snapshot.Status.Invalid {
+					select {
+					case violations <- snapshot:
+					default:
+					}
+					return
+				}
+			}
+		}
+	}()
+
+	var writers sync.WaitGroup
+	for range iterations {
+		writers.Add(2)
+		go func() {
+			defer writers.Done()
+			if err := cache.Apply(FetchResult{Response: &full}, time.Now().UTC()); err != nil {
+				applyErrors <- err
+			}
+		}()
+		go func() {
+			defer writers.Done()
+			cache.MarkInvalid(errors.New("invalid cache"))
+		}()
+	}
+	writers.Wait()
+	close(stopReading)
+	readers.Wait()
+	close(applyErrors)
+
+	for err := range applyErrors {
+		t.Errorf("Apply() error = %v", err)
+	}
+	select {
+	case snapshot := <-violations:
+		t.Fatalf("observed contradictory snapshot = %#v", snapshot)
+	default:
+	}
+	if snapshot := cache.Current(); snapshot.Confirmed == snapshot.Status.Invalid {
+		t.Fatalf("final contradictory snapshot = %#v", snapshot)
 	}
 }
 

--- a/internal/endpointconfig/client.go
+++ b/internal/endpointconfig/client.go
@@ -1,0 +1,111 @@
+package endpointconfig
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var installationIDPattern = regexp.MustCompile(`^ins_[A-Za-z0-9_-]{32}$`)
+
+type FetchResult struct {
+	NotModified bool
+	Response    *Response
+	ETag        string
+}
+
+type Client struct {
+	baseURL string
+	http    *http.Client
+}
+
+func NewClient(baseURL string, httpClient *http.Client) (*Client, error) {
+	parsed, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return nil, errors.New("endpoint configuration: invalid base URL")
+	}
+	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && isLoopbackHost(parsed.Hostname())) {
+		return nil, errors.New("endpoint configuration: base URL must use HTTPS or loopback HTTP")
+	}
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 10 * time.Second}
+	}
+	return &Client{baseURL: strings.TrimRight(parsed.String(), "/"), http: httpClient}, nil
+}
+
+func (c *Client) Fetch(ctx context.Context, installToken, installationID, configIdentity string) (FetchResult, error) {
+	if !installationIDPattern.MatchString(installationID) {
+		return FetchResult{}, errors.New("endpoint configuration: invalid installation ID")
+	}
+	if strings.TrimSpace(installToken) == "" {
+		return FetchResult{}, errors.New("endpoint configuration: install token is required")
+	}
+	endpoint, err := url.Parse(c.baseURL + "/api/v1/installations/" + installationID + "/configuration")
+	if err != nil {
+		return FetchResult{}, err
+	}
+	query := endpoint.Query()
+	query.Set("response_version", "1")
+	endpoint.RawQuery = query.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return FetchResult{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(installToken))
+	if configIdentity != "" {
+		if !sha256HexPattern.MatchString(configIdentity) {
+			return FetchResult{}, errors.New("endpoint configuration: invalid conditional identity")
+		}
+		req.Header.Set("If-None-Match", `"`+configIdentity+`"`)
+	}
+	response, err := c.http.Do(req)
+	if err != nil {
+		return FetchResult{}, fmt.Errorf("endpoint configuration fetch: %w", err)
+	}
+	defer response.Body.Close()
+	etag := parseETag(response.Header.Get("ETag"))
+	if response.StatusCode == http.StatusNotModified {
+		if configIdentity == "" || etag != configIdentity {
+			return FetchResult{}, errors.New("endpoint configuration: invalid not-modified ETag")
+		}
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 1))
+		return FetchResult{NotModified: true, ETag: etag}, nil
+	}
+	if response.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, MaxResponseBytes+1))
+		return FetchResult{}, fmt.Errorf("endpoint configuration fetch: unexpected status %d", response.StatusCode)
+	}
+	var decoded Response
+	if err := decodeStrict(response.Body, &decoded); err != nil {
+		return FetchResult{}, fmt.Errorf("endpoint configuration: decode response: %w", err)
+	}
+	if err := decoded.Validate(); err != nil {
+		return FetchResult{}, err
+	}
+	if etag == "" || etag != decoded.ConfigIdentity {
+		return FetchResult{}, errors.New("endpoint configuration: ETag does not match config identity")
+	}
+	return FetchResult{Response: &decoded, ETag: etag}, nil
+}
+
+func parseETag(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) != 66 || value[0] != '"' || value[len(value)-1] != '"' {
+		return ""
+	}
+	identity := value[1 : len(value)-1]
+	if !sha256HexPattern.MatchString(identity) {
+		return ""
+	}
+	return identity
+}
+
+func isLoopbackHost(host string) bool {
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}

--- a/internal/endpointconfig/client_test.go
+++ b/internal/endpointconfig/client_test.go
@@ -1,0 +1,106 @@
+package endpointconfig
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/payloadcapture"
+)
+
+const testInstallationID = "ins_0123456789abcdefghijklmnopqrstuv"
+
+func TestClientFetchAndConditionalRefresh(t *testing.T) {
+	configuration := testResponse(t, payloadcapture.ModeFull)
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		requests++
+		if request.URL.Path != "/api/v1/installations/"+testInstallationID+"/configuration" {
+			t.Fatalf("path = %q", request.URL.Path)
+		}
+		query := request.URL.Query()
+		if len(query) != 1 || query.Get("response_version") != "1" {
+			t.Fatalf("query = %v", query)
+		}
+		if request.Header.Get("Authorization") != "Bearer token" {
+			t.Fatalf("Authorization = %q", request.Header.Get("Authorization"))
+		}
+		w.Header().Set("ETag", `"`+configuration.ConfigIdentity+`"`)
+		if got := request.Header.Get("If-None-Match"); got != "" {
+			if got != `"`+configuration.ConfigIdentity+`"` {
+				t.Fatalf("If-None-Match = %q", got)
+			}
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(configuration)
+	}))
+	defer server.Close()
+	client, err := NewClient(server.URL, server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := client.Fetch(context.Background(), "token", testInstallationID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Response == nil || result.Response.Config.PayloadCaptureMode != payloadcapture.ModeFull {
+		t.Fatalf("Fetch() = %#v", result)
+	}
+	result, err = client.Fetch(context.Background(), "token", testInstallationID, configuration.ConfigIdentity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.NotModified || result.ETag != configuration.ConfigIdentity || requests != 2 {
+		t.Fatalf("conditional Fetch() = %#v, requests = %d", result, requests)
+	}
+}
+
+func TestClientRejectsUntrustedResponses(t *testing.T) {
+	tests := []struct {
+		name string
+		body func(Response) string
+		etag string
+	}{
+		{name: "unknown field", body: func(response Response) string {
+			data, _ := json.Marshal(response)
+			return strings.TrimSuffix(string(data), "}") + `,"policyText":"permit();"}`
+		}, etag: "valid"},
+		{name: "wrong identity", body: func(response Response) string {
+			response.ConfigIdentity = strings.Repeat("f", 64)
+			data, _ := json.Marshal(response)
+			return string(data)
+		}, etag: strings.Repeat("f", 64)},
+		{name: "missing etag", body: marshalResponse},
+		{name: "wrong etag", body: marshalResponse, etag: strings.Repeat("f", 64)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			configuration := testResponse(t, payloadcapture.ModeFull)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if test.etag == "valid" {
+					w.Header().Set("ETag", `"`+configuration.ConfigIdentity+`"`)
+				} else if test.etag != "" {
+					w.Header().Set("ETag", `"`+test.etag+`"`)
+				}
+				_, _ = w.Write([]byte(test.body(configuration)))
+			}))
+			defer server.Close()
+			client, err := NewClient(server.URL, server.Client())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := client.Fetch(context.Background(), "token", testInstallationID, ""); err == nil {
+				t.Fatal("Fetch() error = nil")
+			}
+		})
+	}
+}
+
+func marshalResponse(response Response) string {
+	data, _ := json.Marshal(response)
+	return string(data)
+}

--- a/internal/endpointconfig/contract.go
+++ b/internal/endpointconfig/contract.go
@@ -1,0 +1,93 @@
+package endpointconfig
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+
+	"github.com/kontext-security/kontext-cli/internal/payloadcapture"
+)
+
+const (
+	ResponseVersion  = 1
+	identityDomain   = "kontext:endpoint-config:v1"
+	MaxResponseBytes = 64 * 1024
+)
+
+var sha256HexPattern = regexp.MustCompile(`^[a-f0-9]{64}$`)
+
+type Config struct {
+	PayloadCaptureMode payloadcapture.Mode `json:"payloadCaptureMode"`
+}
+
+func (c Config) Validate() error {
+	switch c.PayloadCaptureMode {
+	case payloadcapture.ModeOmitted, payloadcapture.ModeSummary, payloadcapture.ModeFull:
+		return nil
+	default:
+		return fmt.Errorf("endpoint configuration: unsupported payload capture mode %q", c.PayloadCaptureMode)
+	}
+}
+
+type Response struct {
+	ResponseVersion int    `json:"responseVersion"`
+	Config          Config `json:"config"`
+	ConfigIdentity  string `json:"configIdentity"`
+}
+
+func (r Response) Validate() error {
+	if r.ResponseVersion != ResponseVersion {
+		return fmt.Errorf("endpoint configuration: unsupported response version %d", r.ResponseVersion)
+	}
+	if err := r.Config.Validate(); err != nil {
+		return err
+	}
+	if !sha256HexPattern.MatchString(r.ConfigIdentity) {
+		return errors.New("endpoint configuration: invalid identity encoding")
+	}
+	identity, err := ComputeIdentity(r.Config)
+	if err != nil {
+		return err
+	}
+	if r.ConfigIdentity != identity {
+		return errors.New("endpoint configuration: identity does not match config")
+	}
+	return nil
+}
+
+func ComputeIdentity(config Config) (string, error) {
+	if err := config.Validate(); err != nil {
+		return "", err
+	}
+	preimage, err := json.Marshal([]any{identityDomain, ResponseVersion, string(config.PayloadCaptureMode)})
+	if err != nil {
+		return "", fmt.Errorf("endpoint configuration: encode identity preimage: %w", err)
+	}
+	digest := sha256.Sum256(preimage)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func decodeStrict[T any](reader io.Reader, target *T) error {
+	limited := io.LimitReader(reader, MaxResponseBytes+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return err
+	}
+	if len(data) > MaxResponseBytes {
+		return fmt.Errorf("endpoint configuration: response exceeds %d bytes", MaxResponseBytes)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return errors.New("endpoint configuration: unexpected trailing json value")
+	}
+	return nil
+}

--- a/internal/endpointconfig/contract_test.go
+++ b/internal/endpointconfig/contract_test.go
@@ -1,0 +1,50 @@
+package endpointconfig
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/payloadcapture"
+)
+
+func TestResponseValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*Response)
+		wantErr string
+	}{
+		{name: "valid"},
+		{name: "unsupported version", mutate: func(response *Response) { response.ResponseVersion = 2 }, wantErr: "version"},
+		{name: "unknown mode", mutate: func(response *Response) { response.Config.PayloadCaptureMode = "unknown" }, wantErr: "mode"},
+		{name: "identity mismatch", mutate: func(response *Response) { response.ConfigIdentity = strings.Repeat("f", 64) }, wantErr: "identity"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := testResponse(t, payloadcapture.ModeSummary)
+			if test.mutate != nil {
+				test.mutate(&response)
+			}
+			err := response.Validate()
+			if test.wantErr == "" && err != nil {
+				t.Fatal(err)
+			}
+			if test.wantErr != "" && (err == nil || !strings.Contains(err.Error(), test.wantErr)) {
+				t.Fatalf("Validate() error = %v, want containing %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestDecodeStrictRejectsUnknownAndTrailingFields(t *testing.T) {
+	response := testResponse(t, payloadcapture.ModeFull)
+	valid := `{"responseVersion":1,"config":{"payloadCaptureMode":"full"},"configIdentity":"` + response.ConfigIdentity + `"}`
+	for _, body := range []string{
+		strings.TrimSuffix(valid, "}") + `,"policyText":"permit();"}`,
+		valid + `{}`,
+	} {
+		var decoded Response
+		if err := decodeStrict(strings.NewReader(body), &decoded); err == nil {
+			t.Fatalf("decodeStrict(%q) error = nil", body)
+		}
+	}
+}

--- a/internal/endpointconfig/fixture_test.go
+++ b/internal/endpointconfig/fixture_test.go
@@ -1,0 +1,70 @@
+package endpointconfig
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+const identityFixturePath = "testdata/portable/v1/identity-v1.json"
+
+// Update only when deliberately revising the portable fixture bytes.
+const identityFixtureSHA256 = "c2f4f46040cf3dcbfa0599f33ad78874ebb675f76c2cb44c2fee3672bd0d4f5a"
+
+type identityFixture struct {
+	SchemaVersion  string                  `json:"schemaVersion"`
+	IdentityDomain string                  `json:"identityDomain"`
+	Vectors        []identityFixtureVector `json:"vectors"`
+}
+
+type identityFixtureVector struct {
+	Name            string `json:"name"`
+	ResponseVersion int    `json:"responseVersion"`
+	Config          Config `json:"config"`
+	Preimage        string `json:"preimage"`
+	ConfigIdentity  string `json:"configIdentity"`
+}
+
+func TestPortableIdentityFixture(t *testing.T) {
+	data, err := os.ReadFile(identityFixturePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256(data)
+	if got := hex.EncodeToString(digest[:]); got != identityFixtureSHA256 {
+		t.Fatalf("fixture SHA-256 = %s, want %s", got, identityFixtureSHA256)
+	}
+	var fixture identityFixture
+	if err := json.Unmarshal(data, &fixture); err != nil {
+		t.Fatal(err)
+	}
+	if fixture.SchemaVersion != "endpoint-config-identity-fixture-v1" || fixture.IdentityDomain != identityDomain {
+		t.Fatalf("fixture metadata = %#v", fixture)
+	}
+	if len(fixture.Vectors) != 3 {
+		t.Fatalf("fixture vector count = %d, want 3", len(fixture.Vectors))
+	}
+	for _, vector := range fixture.Vectors {
+		t.Run(vector.Name, func(t *testing.T) {
+			if vector.ResponseVersion != ResponseVersion {
+				t.Fatalf("responseVersion = %d", vector.ResponseVersion)
+			}
+			identity, err := ComputeIdentity(vector.Config)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if identity != vector.ConfigIdentity {
+				t.Fatalf("ComputeIdentity() = %s, want %s", identity, vector.ConfigIdentity)
+			}
+			preimage, err := json.Marshal([]any{identityDomain, ResponseVersion, string(vector.Config.PayloadCaptureMode)})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(preimage) != vector.Preimage {
+				t.Fatalf("preimage = %s, want %s", preimage, vector.Preimage)
+			}
+		})
+	}
+}

--- a/internal/endpointconfig/test_helpers_test.go
+++ b/internal/endpointconfig/test_helpers_test.go
@@ -1,0 +1,17 @@
+package endpointconfig
+
+import (
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/payloadcapture"
+)
+
+func testResponse(t *testing.T, mode payloadcapture.Mode) Response {
+	t.Helper()
+	config := Config{PayloadCaptureMode: mode}
+	identity, err := ComputeIdentity(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return Response{ResponseVersion: ResponseVersion, Config: config, ConfigIdentity: identity}
+}

--- a/internal/endpointconfig/testdata/portable/v1/README.md
+++ b/internal/endpointconfig/testdata/portable/v1/README.md
@@ -1,0 +1,9 @@
+# Endpoint configuration identity fixture v1
+
+`identity-v1.json` is the byte-canonical cross-runtime fixture for endpoint
+configuration identity. Copy this file byte-for-byte into every producer and
+consumer implementation; do not recreate equivalent vectors independently.
+
+The fixture pins the exact JSON preimage and SHA-256 result for each supported
+payload-capture mode. Its file digest is pinned by the Go test so whitespace,
+ordering, or vector changes require an explicit contract revision.

--- a/internal/endpointconfig/testdata/portable/v1/identity-v1.json
+++ b/internal/endpointconfig/testdata/portable/v1/identity-v1.json
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": "endpoint-config-identity-fixture-v1",
+  "identityDomain": "kontext:endpoint-config:v1",
+  "vectors": [
+    {
+      "name": "omitted",
+      "responseVersion": 1,
+      "config": {
+        "payloadCaptureMode": "omitted"
+      },
+      "preimage": "[\"kontext:endpoint-config:v1\",1,\"omitted\"]",
+      "configIdentity": "d2ed1e7314ee63c867a1904783e78d1bef52bd8249e5a1307b7705202ded2688"
+    },
+    {
+      "name": "summary",
+      "responseVersion": 1,
+      "config": {
+        "payloadCaptureMode": "summary"
+      },
+      "preimage": "[\"kontext:endpoint-config:v1\",1,\"summary\"]",
+      "configIdentity": "f66d28350c7a073a33d192cb90277397a81003eb1b8219b557244aeaf2a12390"
+    },
+    {
+      "name": "full",
+      "responseVersion": 1,
+      "config": {
+        "payloadCaptureMode": "full"
+      },
+      "preimage": "[\"kontext:endpoint-config:v1\",1,\"full\"]",
+      "configIdentity": "88b90b14eef977202aa7e45e464da92c2fdac29091e312bbf73ad0dfc921ef02"
+    }
+  ]
+}

--- a/internal/guard/app/server/server.go
+++ b/internal/guard/app/server/server.go
@@ -77,11 +77,15 @@ func NewServer(store *sqlite.Store) (*Server, error) {
 	return NewServerWithOptions(store, Options{})
 }
 
-// SetPayloadCaptureMode forwards the org's payload-capture directive to the
-// store, which reads it per recorded action. Called by the managed daemon's
-// policy refresh cycle whenever a snapshot is fetched or restored from disk.
+// SetPayloadCaptureMode is retained for local callers that configure only a
+// mode. Managed refresh uses SetPayloadCaptureConfiguration so evidence and
+// effective behavior are applied atomically.
 func (s *Server) SetPayloadCaptureMode(mode payloadcapture.Mode) {
 	s.store.SetPayloadCaptureMode(mode)
+}
+
+func (s *Server) SetPayloadCaptureConfiguration(config payloadcapture.RuntimeConfiguration) {
+	s.store.SetPayloadCaptureConfiguration(config)
 }
 
 func NewServerWithOptions(store *sqlite.Store, opts Options) (*Server, error) {

--- a/internal/guard/app/server/server.go
+++ b/internal/guard/app/server/server.go
@@ -77,13 +77,6 @@ func NewServer(store *sqlite.Store) (*Server, error) {
 	return NewServerWithOptions(store, Options{})
 }
 
-// SetPayloadCaptureMode is retained for local callers that configure only a
-// mode. Managed refresh uses SetPayloadCaptureConfiguration so evidence and
-// effective behavior are applied atomically.
-func (s *Server) SetPayloadCaptureMode(mode payloadcapture.Mode) {
-	s.store.SetPayloadCaptureMode(mode)
-}
-
 func (s *Server) SetPayloadCaptureConfiguration(config payloadcapture.RuntimeConfiguration) {
 	s.store.SetPayloadCaptureConfiguration(config)
 }

--- a/internal/guard/store/sqlite/store.go
+++ b/internal/guard/store/sqlite/store.go
@@ -31,20 +31,6 @@ type Store struct {
 	captureConfig payloadcapture.RuntimeConfiguration
 }
 
-// SetPayloadCaptureMode sets how tool payloads are captured on subsequently
-// recorded actions. The zero value keeps capture off ("summary" behavior):
-// unset or unrecognized modes never record payload content.
-func (s *Store) SetPayloadCaptureMode(mode payloadcapture.Mode) {
-	normalized := payloadcapture.NormalizeMode(string(mode))
-	s.captureMu.Lock()
-	defer s.captureMu.Unlock()
-	s.captureConfig = payloadcapture.RuntimeConfiguration{
-		ConfiguredMode: normalized,
-		EffectiveMode:  normalized,
-		FallbackReason: "legacy_mode",
-	}
-}
-
 func (s *Store) SetPayloadCaptureConfiguration(config payloadcapture.RuntimeConfiguration) {
 	s.captureMu.Lock()
 	defer s.captureMu.Unlock()

--- a/internal/guard/store/sqlite/store.go
+++ b/internal/guard/store/sqlite/store.go
@@ -25,29 +25,39 @@ type Store struct {
 	path   string
 	signer receiptSigner
 
-	// captureMode lives on Store (a mutable setter) rather than flowing
-	// through the policy-provider chain: what gets persisted is a storage
-	// concern, and the synced-policy layer only needs to flip it.
-	captureMu   sync.RWMutex
-	captureMode payloadcapture.Mode
+	// Capture configuration lives on Store so each persisted decision can
+	// snapshot behavior and evidence atomically.
+	captureMu     sync.RWMutex
+	captureConfig payloadcapture.RuntimeConfiguration
 }
 
 // SetPayloadCaptureMode sets how tool payloads are captured on subsequently
 // recorded actions. The zero value keeps capture off ("summary" behavior):
 // unset or unrecognized modes never record payload content.
 func (s *Store) SetPayloadCaptureMode(mode payloadcapture.Mode) {
+	normalized := payloadcapture.NormalizeMode(string(mode))
 	s.captureMu.Lock()
 	defer s.captureMu.Unlock()
-	s.captureMode = mode
+	s.captureConfig = payloadcapture.RuntimeConfiguration{
+		ConfiguredMode: normalized,
+		EffectiveMode:  normalized,
+		FallbackReason: "legacy_mode",
+	}
 }
 
-func (s *Store) payloadCaptureMode() payloadcapture.Mode {
+func (s *Store) SetPayloadCaptureConfiguration(config payloadcapture.RuntimeConfiguration) {
+	s.captureMu.Lock()
+	defer s.captureMu.Unlock()
+	s.captureConfig = payloadcapture.SafeRuntimeConfiguration(config)
+}
+
+func (s *Store) payloadCaptureConfiguration() payloadcapture.RuntimeConfiguration {
 	s.captureMu.RLock()
 	defer s.captureMu.RUnlock()
-	if s.captureMode == "" {
-		return payloadcapture.ModeSummary
+	if s.captureConfig.EffectiveMode == "" {
+		return payloadcapture.DefaultRuntimeConfiguration()
 	}
-	return s.captureMode
+	return s.captureConfig
 }
 
 type DecisionRecord struct {
@@ -767,22 +777,22 @@ on conflict(id) do update set
 
 	// Snapshot the mode once so every row of this decision is captured
 	// under the same policy, even if the mode flips concurrently.
-	captureMode := s.payloadCaptureMode()
+	captureConfig := s.payloadCaptureConfiguration()
 
 	actionID := "act_" + uuid.NewString()
 	if event.HookEventName == "PreToolUse" {
 		proposedID := "act_" + uuid.NewString()
-		if err := s.insertAction(ctx, tx, proposedID, sessionID, event, decision, canonicalEventRequestProposed, "event", captureMode, now); err != nil {
+		if err := s.insertAction(ctx, tx, proposedID, sessionID, event, decision, canonicalEventRequestProposed, "event", captureConfig, now); err != nil {
 			return DecisionRecord{}, err
 		}
-		if err := s.insertAction(ctx, tx, actionID, sessionID, event, decision, canonicalEventRequestDecided, "decision", captureMode, now.Add(time.Millisecond)); err != nil {
+		if err := s.insertAction(ctx, tx, actionID, sessionID, event, decision, canonicalEventRequestDecided, "decision", captureConfig, now.Add(time.Millisecond)); err != nil {
 			return DecisionRecord{}, err
 		}
 		if err := s.insertProviderDryRunActions(ctx, tx, sessionID, event, decision, now.Add(2*time.Millisecond)); err != nil {
 			return DecisionRecord{}, err
 		}
 	} else {
-		if err := s.insertAction(ctx, tx, actionID, sessionID, event, decision, canonicalEventType(event.HookEventName), "outcome", captureMode, now); err != nil {
+		if err := s.insertAction(ctx, tx, actionID, sessionID, event, decision, canonicalEventType(event.HookEventName), "outcome", captureConfig, now); err != nil {
 			return DecisionRecord{}, err
 		}
 	}
@@ -808,8 +818,8 @@ on conflict(id) do update set
 	}, nil
 }
 
-func (s *Store) insertAction(ctx context.Context, tx *sql.Tx, actionID, sessionID string, event risk.HookEvent, decision risk.RiskDecision, canonicalEvent, receiptType string, captureMode payloadcapture.Mode, now time.Time) error {
-	action, err := actionValues(actionID, sessionID, event, decision, canonicalEvent, captureMode, now)
+func (s *Store) insertAction(ctx context.Context, tx *sql.Tx, actionID, sessionID string, event risk.HookEvent, decision risk.RiskDecision, canonicalEvent, receiptType string, captureConfig payloadcapture.RuntimeConfiguration, now time.Time) error {
+	action, err := actionValues(actionID, sessionID, event, decision, canonicalEvent, captureConfig, now)
 	if err != nil {
 		return err
 	}
@@ -893,7 +903,7 @@ func capturedRecordJSON(payload map[string]any, mode payloadcapture.Mode) any {
 	return string(raw)
 }
 
-func actionValues(actionID, sessionID string, event risk.HookEvent, decision risk.RiskDecision, canonicalEvent string, captureMode payloadcapture.Mode, now time.Time) (map[string]any, error) {
+func actionValues(actionID, sessionID string, event risk.HookEvent, decision risk.RiskDecision, canonicalEvent string, captureConfig payloadcapture.RuntimeConfiguration, now time.Time) (map[string]any, error) {
 	riskEvent := decision.RiskEvent
 	if canonicalEvent != canonicalEventRequestDecided {
 		riskEvent.Decision = ""
@@ -928,6 +938,7 @@ func actionValues(actionID, sessionID string, event risk.HookEvent, decision ris
 	contextPayload := map[string]any{
 		"cwd":             event.CWD,
 		"hook_event_name": event.HookEventName,
+		"payload_capture": captureConfig,
 	}
 	if branch != "" {
 		contextPayload["github"] = map[string]any{"branch_or_ref": branch}
@@ -953,8 +964,8 @@ func actionValues(actionID, sessionID string, event risk.HookEvent, decision ris
 		decisionResult = canonicalDecisionResult(decision.Decision)
 	}
 	outcome, outputSummary, outputHash, errorRedacted := outcomeValues(event, decision)
-	toolInputCaptured := capturedInputJSON(event, canonicalEvent, captureMode)
-	toolOutputCaptured := capturedOutputJSON(event, canonicalEvent, captureMode)
+	toolInputCaptured := capturedInputJSON(event, canonicalEvent, captureConfig.EffectiveMode)
+	toolOutputCaptured := capturedOutputJSON(event, canonicalEvent, captureConfig.EffectiveMode)
 	proposedAt := ""
 	decisionAt := ""
 	completedAt := ""

--- a/internal/guard/store/sqlite/store_capture_test.go
+++ b/internal/guard/store/sqlite/store_capture_test.go
@@ -47,13 +47,22 @@ func capturedColumn(t *testing.T, store *Store, canonicalEvent, column string) s
 	return value
 }
 
+func setPayloadCaptureModeForTest(store *Store, mode payloadcapture.Mode) {
+	store.SetPayloadCaptureConfiguration(payloadcapture.RuntimeConfiguration{
+		ConfiguredMode: mode,
+		EffectiveMode:  mode,
+		ConfigIdentity: strings.Repeat("f", 64),
+		Confirmed:      true,
+	})
+}
+
 func TestSaveDecisionCapturesPayloadsInFullMode(t *testing.T) {
 	store, err := OpenStore(t.TempDir() + "/guard.db")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer store.Close()
-	store.SetPayloadCaptureMode(payloadcapture.ModeFull)
+	setPayloadCaptureModeForTest(store, payloadcapture.ModeFull)
 
 	saveCaptureFixtureDecision(t, store, "PreToolUse", map[string]any{
 		"command": "GITHUB_TOKEN=super-secret-raw-value gh api /user",
@@ -102,7 +111,7 @@ func TestSaveDecisionDefaultModeWritesNoCapturedPayloads(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer store.Close()
-	// No SetPayloadCaptureMode call: the default must be byte-identical to
+	// No capture configuration: the default must be byte-identical to
 	// the pre-capture behavior.
 
 	saveCaptureFixtureDecision(t, store, "PreToolUse", map[string]any{
@@ -156,7 +165,7 @@ func TestLedgerExportDecodesCapturedPayloadRecords(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer store.Close()
-	store.SetPayloadCaptureMode(payloadcapture.ModeFull)
+	setPayloadCaptureModeForTest(store, payloadcapture.ModeFull)
 
 	saveCaptureFixtureDecision(t, store, "PreToolUse", map[string]any{
 		"command": "curl https://example.test",
@@ -261,8 +270,8 @@ func TestCaptureFailedFallbackLiteralMatchesWireFormat(t *testing.T) {
 	}
 }
 
-// The managed daemon flips the capture mode via SetPayloadCaptureMode whenever
-// the policy snapshot refreshes (~60s). The store must read the CURRENT mode
+// The managed daemon applies a complete capture configuration whenever the
+// endpoint snapshot refreshes. The store must read the CURRENT configuration
 // per recorded event — no restart, no per-session pinning.
 func TestSaveDecisionModeChangeAppliesToNextEvent(t *testing.T) {
 	store, err := OpenStore(t.TempDir() + "/guard.db")
@@ -290,14 +299,14 @@ func TestSaveDecisionModeChangeAppliesToNextEvent(t *testing.T) {
 	}
 
 	// Snapshot flips to full: the very next event captures.
-	store.SetPayloadCaptureMode(payloadcapture.ModeFull)
+	setPayloadCaptureModeForTest(store, payloadcapture.ModeFull)
 	saveCaptureFixtureDecision(t, store, "PreToolUse", map[string]any{"command": "git diff"}, nil)
 	if got := capturedProposedRows(); got != 1 {
 		t.Fatalf("captured rows after flip to full = %d, want 1", got)
 	}
 
 	// Snapshot flips back to summary: capture stops again.
-	store.SetPayloadCaptureMode(payloadcapture.ModeSummary)
+	setPayloadCaptureModeForTest(store, payloadcapture.ModeSummary)
 	saveCaptureFixtureDecision(t, store, "PreToolUse", map[string]any{"command": "git log"}, nil)
 	if got := capturedProposedRows(); got != 1 {
 		t.Fatalf("captured rows after flip back to summary = %d, want 1", got)

--- a/internal/guard/store/sqlite/store_capture_test.go
+++ b/internal/guard/store/sqlite/store_capture_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
@@ -299,5 +301,110 @@ func TestSaveDecisionModeChangeAppliesToNextEvent(t *testing.T) {
 	saveCaptureFixtureDecision(t, store, "PreToolUse", map[string]any{"command": "git log"}, nil)
 	if got := capturedProposedRows(); got != 1 {
 		t.Fatalf("captured rows after flip back to summary = %d, want 1", got)
+	}
+}
+
+func TestSaveDecisionSnapshotsConcurrentCaptureConfiguration(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	full := payloadcapture.RuntimeConfiguration{
+		ConfiguredMode: payloadcapture.ModeFull,
+		EffectiveMode:  payloadcapture.ModeFull,
+		ConfigIdentity: strings.Repeat("a", 64),
+		Confirmed:      true,
+	}
+	summary := payloadcapture.RuntimeConfiguration{
+		ConfiguredMode: payloadcapture.ModeSummary,
+		EffectiveMode:  payloadcapture.ModeSummary,
+		ConfigIdentity: strings.Repeat("b", 64),
+		Confirmed:      true,
+	}
+	store.SetPayloadCaptureConfiguration(summary)
+	stop := make(chan struct{})
+	var flips sync.WaitGroup
+	flips.Add(1)
+	go func() {
+		defer flips.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				store.SetPayloadCaptureConfiguration(full)
+				store.SetPayloadCaptureConfiguration(summary)
+			}
+		}
+	}()
+	for index := range 40 {
+		_, err := store.SaveDecision(context.Background(), risk.HookEvent{
+			SessionID:     "s-capture-concurrent",
+			Agent:         "claude-code",
+			HookEventName: "PreToolUse",
+			ToolName:      "Bash",
+			ToolUseID:     fmt.Sprintf("tool-flip-%02d", index),
+			CWD:           "/tmp/project",
+			ToolInput:     map[string]any{"command": "git status"},
+		}, risk.RiskDecision{Decision: risk.DecisionAllow, Reason: "test", ReasonCode: "test"})
+		if err != nil {
+			close(stop)
+			flips.Wait()
+			t.Fatal(err)
+		}
+	}
+	close(stop)
+	flips.Wait()
+
+	rows, err := store.db.QueryContext(context.Background(), `
+select tool_use_id, canonical_event_type, context_json, tool_input_captured_json
+from authorization_actions
+where session_id = 's-capture-concurrent'
+order by tool_use_id, case canonical_event_type when 'request.proposed' then 0 else 1 end`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	type observed struct {
+		config   payloadcapture.RuntimeConfiguration
+		proposed bool
+	}
+	byToolUse := map[string]observed{}
+	for rows.Next() {
+		var toolUseID, eventType, contextJSON string
+		var captured sql.NullString
+		if err := rows.Scan(&toolUseID, &eventType, &contextJSON, &captured); err != nil {
+			t.Fatal(err)
+		}
+		var contextValue struct {
+			PayloadCapture payloadcapture.RuntimeConfiguration `json:"payload_capture"`
+		}
+		if err := json.Unmarshal([]byte(contextJSON), &contextValue); err != nil {
+			t.Fatal(err)
+		}
+		config := contextValue.PayloadCapture
+		if !config.Confirmed || config.ConfiguredMode != config.EffectiveMode ||
+			(config.ConfigIdentity != full.ConfigIdentity && config.ConfigIdentity != summary.ConfigIdentity) {
+			t.Fatalf("invalid capture evidence for %s: %#v", toolUseID, config)
+		}
+		if eventType == canonicalEventRequestProposed {
+			if captured.Valid != (config.EffectiveMode == payloadcapture.ModeFull) {
+				t.Fatalf("capture/evidence mismatch for %s: config=%#v captured=%t", toolUseID, config, captured.Valid)
+			}
+			byToolUse[toolUseID] = observed{config: config, proposed: true}
+			continue
+		}
+		proposed := byToolUse[toolUseID]
+		if !proposed.proposed || proposed.config != config {
+			t.Fatalf("decision %s mixed capture snapshots: proposed=%#v decided=%#v", toolUseID, proposed.config, config)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if len(byToolUse) != 40 {
+		t.Fatalf("observed decisions = %d, want 40", len(byToolUse))
 	}
 }

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/cedarpolicy"
 	"github.com/kontext-security/kontext-cli/internal/claudemanaged"
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
+	"github.com/kontext-security/kontext-cli/internal/endpointconfig"
 	"github.com/kontext-security/kontext-cli/internal/githubpolicy"
 	"github.com/kontext-security/kontext-cli/internal/guard/app/server"
 	guardhookruntime "github.com/kontext-security/kontext-cli/internal/guard/hookruntime"
@@ -26,20 +27,23 @@ import (
 )
 
 type DaemonOptions struct {
-	SocketPath             string
-	DBPath                 string
-	IdleTimeout            time.Duration
-	StreamStatePath        string
-	StreamInterval         time.Duration
-	StreamHTTPClient       *http.Client
-	GithubPolicyCachePath  string
-	HubspotPolicyCachePath string
-	CedarPolicyCachePath   string
+	SocketPath              string
+	DBPath                  string
+	IdleTimeout             time.Duration
+	StreamStatePath         string
+	StreamInterval          time.Duration
+	StreamHTTPClient        *http.Client
+	GithubPolicyCachePath   string
+	HubspotPolicyCachePath  string
+	CedarPolicyCachePath    string
+	EndpointConfigCachePath string
 	// PolicyRefreshInterval and PolicyHTTPClient apply to every provider's
 	// snapshot refresh loop (test knobs; zero values use defaults).
-	PolicyRefreshInterval time.Duration
-	PolicyHTTPClient      *http.Client
-	Diagnostic            diagnostic.Logger
+	PolicyRefreshInterval         time.Duration
+	PolicyHTTPClient              *http.Client
+	EndpointConfigRefreshInterval time.Duration
+	EndpointConfigHTTPClient      *http.Client
+	Diagnostic                    diagnostic.Logger
 	// BinaryVersion is the CLI binary version, for startup logging and future
 	// status reporting.
 	BinaryVersion string
@@ -143,6 +147,19 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 	if err != nil {
 		return fmt.Errorf("configure cedar policy client: %w", err)
 	}
+	endpointConfigCachePath := opts.EndpointConfigCachePath
+	if endpointConfigCachePath == "" {
+		endpointConfigCachePath = endpointconfig.DefaultCachePathForDB(dbPath)
+	}
+	endpointConfigCache := endpointconfig.NewCache(endpointConfigCachePath)
+	if err := endpointConfigCache.Load(); err != nil {
+		endpointConfigCache.MarkInvalid(err)
+		opts.Diagnostic.Printf("endpoint configuration cache load: %v\n", err)
+	}
+	endpointConfigClient, err := endpointconfig.NewClient(loadedConfig.Config.CloudURL, opts.EndpointConfigHTTPClient)
+	if err != nil {
+		return fmt.Errorf("configure endpoint configuration client: %w", err)
+	}
 
 	host, err := runtimehost.Start(ctx, runtimehost.Options{
 		AgentName:  managedconfig.Agent,
@@ -172,19 +189,15 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 		opts.Diagnostic.Printf("write daemon-status breadcrumb: %v\n", err)
 	}
 
-	// Restore the capture mode from the persisted snapshot before the first
-	// fetch completes, so an offline restart keeps the org's last-known
-	// directive instead of silently reverting to the "summary" default.
-	if snapshot, _, ok := githubCache.CurrentSnapshot(); ok {
-		host.SetPayloadCaptureMode(payloadcapture.NormalizeMode(snapshot.PayloadCaptureMode))
-	}
+	// Persisted endpoint configuration is conditional state only. Capture stays
+	// at the privacy-safe default until this process receives a confirming 200
+	// or matching 304 from the independent configuration endpoint.
+	host.SetPayloadCaptureConfiguration(captureConfiguration(endpointConfigCache.Current()))
 
 	policyCtx, stopPolicyRefresh := context.WithCancel(ctx)
 	defer stopPolicyRefresh()
-	// Capture mode rides the github snapshot only (the org-level directive);
-	// other providers' refreshers pass nil and never touch the gate.
-	go runProviderPolicy(policyCtx, opts, githubpolicy.Config, githubCache, installationState.InstallationID, host.SetPayloadCaptureMode)
-	go runProviderPolicy(policyCtx, opts, hubspotpolicy.Config, hubspotCache, installationState.InstallationID, nil)
+	go runProviderPolicy(policyCtx, opts, githubpolicy.Config, githubCache, installationState.InstallationID)
+	go runProviderPolicy(policyCtx, opts, hubspotpolicy.Config, hubspotCache, installationState.InstallationID)
 	cedarRefresher := cedarpolicy.Refresher{
 		Client: cedarClient,
 		Cache:  cedarCache,
@@ -199,6 +212,23 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 		Interval:       opts.PolicyRefreshInterval,
 	}
 	go cedarRefresher.Run(policyCtx)
+	endpointConfigRefresher := endpointconfig.Refresher{
+		Client: endpointConfigClient,
+		Cache:  endpointConfigCache,
+		TokenSource: func(refreshCtx context.Context) (string, error) {
+			loaded, err := managedconfig.Load()
+			if err != nil {
+				return "", err
+			}
+			return managedconfig.ResolveInstallToken(refreshCtx, loaded.Config.Credentials.InstallTokenRef)
+		},
+		InstallationID: installationState.InstallationID,
+		Interval:       opts.EndpointConfigRefreshInterval,
+		OnChanged: func(snapshot endpointconfig.Snapshot) {
+			host.SetPayloadCaptureConfiguration(captureConfiguration(snapshot))
+		},
+	}
+	go endpointConfigRefresher.Run(policyCtx)
 
 	streamCtx, stopStream := context.WithCancel(ctx)
 	defer stopStream()
@@ -252,6 +282,16 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 			}
 		}
 	}
+}
+
+func captureConfiguration(snapshot endpointconfig.Snapshot) payloadcapture.RuntimeConfiguration {
+	return payloadcapture.SafeRuntimeConfiguration(payloadcapture.RuntimeConfiguration{
+		ConfiguredMode: snapshot.Configured.PayloadCaptureMode,
+		EffectiveMode:  snapshot.Config.PayloadCaptureMode,
+		ConfigIdentity: snapshot.ConfigIdentity,
+		Confirmed:      snapshot.Confirmed,
+		FallbackReason: snapshot.FallbackReason,
+	})
 }
 
 func requireManagedHooksForLegacyCowork(cfg managedconfig.Config) error {
@@ -361,13 +401,13 @@ func newProviderPolicyCache(path, dbPath string, config providerpolicy.Config, d
 // route first ships is acceptable.
 const notConfiguredBackoffTicks = 10
 
-func runProviderPolicy(ctx context.Context, opts DaemonOptions, config providerpolicy.Config, cache *providerpolicy.Cache, installationID string, applyCaptureMode func(payloadcapture.Mode)) {
+func runProviderPolicy(ctx context.Context, opts DaemonOptions, config providerpolicy.Config, cache *providerpolicy.Cache, installationID string) {
 	interval := opts.PolicyRefreshInterval
 	if interval == 0 {
 		interval = providerpolicy.IntervalFromEnv(config)
 	}
 	skipTicks := 0
-	if refreshProviderPolicy(ctx, opts, config, cache, installationID, applyCaptureMode) {
+	if refreshProviderPolicy(ctx, opts, config, cache, installationID) {
 		skipTicks = notConfiguredBackoffTicks - 1
 	}
 	ticker := time.NewTicker(interval)
@@ -381,7 +421,7 @@ func runProviderPolicy(ctx context.Context, opts DaemonOptions, config providerp
 				skipTicks--
 				continue
 			}
-			if refreshProviderPolicy(ctx, opts, config, cache, installationID, applyCaptureMode) {
+			if refreshProviderPolicy(ctx, opts, config, cache, installationID) {
 				skipTicks = notConfiguredBackoffTicks - 1
 			}
 		}
@@ -390,7 +430,7 @@ func runProviderPolicy(ctx context.Context, opts DaemonOptions, config providerp
 
 // refreshProviderPolicy fetches and applies one snapshot; it reports whether
 // the cloud answered not-configured (the caller backs off polling then).
-func refreshProviderPolicy(ctx context.Context, opts DaemonOptions, config providerpolicy.Config, cache *providerpolicy.Cache, installationID string, applyCaptureMode func(payloadcapture.Mode)) bool {
+func refreshProviderPolicy(ctx context.Context, opts DaemonOptions, config providerpolicy.Config, cache *providerpolicy.Cache, installationID string) bool {
 	loadedConfig, installToken, err := loadManagedConfig(ctx)
 	if err != nil {
 		cache.MarkFetchFailed(err)
@@ -416,12 +456,6 @@ func refreshProviderPolicy(ctx context.Context, opts DaemonOptions, config provi
 	}
 	if err := cache.Apply(snapshot, time.Now().UTC()); err != nil {
 		opts.Diagnostic.Printf("%s policy persist: %v\n", config.ProviderKey, err)
-	}
-	// Applied from the freshly fetched snapshot, not re-read from the cache:
-	// payloadCaptureMode is excluded from the snapshot hash, so the fetched
-	// value must win regardless of any hash-based short-circuit.
-	if applyCaptureMode != nil {
-		applyCaptureMode(payloadcapture.NormalizeMode(snapshot.PayloadCaptureMode))
 	}
 	return false
 }

--- a/internal/managedobserve/daemon_test.go
+++ b/internal/managedobserve/daemon_test.go
@@ -410,6 +410,9 @@ func TestDaemonRefreshesGithubPolicyInstallToken(t *testing.T) {
 				"requestContractVersion": 1,
 				"state":                  "no_active_policy",
 			})
+		case "/api/v1/installations/ins_0123456789abcdefghijklmnopqrstuv/configuration":
+			// Configuration refresh is independent of provider-policy refresh.
+			w.WriteHeader(http.StatusServiceUnavailable)
 		case "/api/v1/authorization-ledger/batches":
 			w.WriteHeader(http.StatusAccepted)
 		default:
@@ -434,13 +437,15 @@ func TestDaemonRefreshesGithubPolicyInstallToken(t *testing.T) {
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- RunDaemon(ctx, DaemonOptions{
-			SocketPath:            socketPath,
-			DBPath:                dbPath,
-			IdleTimeout:           time.Hour,
-			StreamInterval:        time.Hour,
-			StreamHTTPClient:      server.Client(),
-			PolicyRefreshInterval: 20 * time.Millisecond,
-			PolicyHTTPClient:      server.Client(),
+			SocketPath:                    socketPath,
+			DBPath:                        dbPath,
+			IdleTimeout:                   time.Hour,
+			StreamInterval:                time.Hour,
+			StreamHTTPClient:              server.Client(),
+			PolicyRefreshInterval:         20 * time.Millisecond,
+			PolicyHTTPClient:              server.Client(),
+			EndpointConfigRefreshInterval: 20 * time.Millisecond,
+			EndpointConfigHTTPClient:      server.Client(),
 		})
 	}()
 	stopped := false
@@ -486,6 +491,8 @@ func TestRunDaemonExitsCleanlyAfterHomebrewUpgradeSignal(t *testing.T) {
 				"requestContractVersion": 1,
 				"state":                  "no_active_policy",
 			})
+		case "/api/v1/installations/ins_0123456789abcdefghijklmnopqrstuv/configuration":
+			w.WriteHeader(http.StatusServiceUnavailable)
 		case "/api/v1/policy/github/snapshot", "/api/v1/policy/hubspot/snapshot":
 			w.WriteHeader(http.StatusNotFound)
 		default:
@@ -738,12 +745,14 @@ func startTestDaemon(t *testing.T) (string, string, func()) {
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- RunDaemon(ctx, DaemonOptions{
-			SocketPath:            socketPath,
-			DBPath:                dbPath,
-			IdleTimeout:           time.Hour,
-			StreamHTTPClient:      server.Client(),
-			PolicyRefreshInterval: time.Hour,
-			PolicyHTTPClient:      server.Client(),
+			SocketPath:                    socketPath,
+			DBPath:                        dbPath,
+			IdleTimeout:                   time.Hour,
+			StreamHTTPClient:              server.Client(),
+			PolicyRefreshInterval:         time.Hour,
+			PolicyHTTPClient:              server.Client(),
+			EndpointConfigRefreshInterval: time.Hour,
+			EndpointConfigHTTPClient:      server.Client(),
 		})
 	}()
 	waitForSocket(t, socketPath, errCh)

--- a/internal/payloadcapture/capture.go
+++ b/internal/payloadcapture/capture.go
@@ -22,6 +22,44 @@ const (
 	ModeFull Mode = "full"
 )
 
+// RuntimeConfiguration is the atomic evidence snapshot applied to one
+// recorded decision. ConfiguredMode records the validated server directive;
+// EffectiveMode records the privacy-safe mode actually used for capture.
+type RuntimeConfiguration struct {
+	ConfiguredMode Mode   `json:"configured_mode"`
+	EffectiveMode  Mode   `json:"effective_mode"`
+	ConfigIdentity string `json:"config_identity,omitempty"`
+	Confirmed      bool   `json:"confirmed"`
+	FallbackReason string `json:"fallback_reason,omitempty"`
+}
+
+func DefaultRuntimeConfiguration() RuntimeConfiguration {
+	return RuntimeConfiguration{
+		ConfiguredMode: ModeSummary,
+		EffectiveMode:  ModeSummary,
+		FallbackReason: "no_confirmed_config",
+	}
+}
+
+// SafeRuntimeConfiguration prevents malformed or unconfirmed state from
+// enabling capture. It retains configured evidence while forcing effective
+// behavior to summary.
+func SafeRuntimeConfiguration(config RuntimeConfiguration) RuntimeConfiguration {
+	config.ConfiguredMode = NormalizeMode(string(config.ConfiguredMode))
+	config.EffectiveMode = NormalizeMode(string(config.EffectiveMode))
+	if !config.Confirmed || config.ConfigIdentity == "" {
+		config.Confirmed = false
+		config.EffectiveMode = ModeSummary
+		if config.FallbackReason == "" {
+			config.FallbackReason = "unconfirmed"
+		}
+	}
+	if config.Confirmed {
+		config.FallbackReason = ""
+	}
+	return config
+}
+
 // NormalizeMode maps an org-policy mode string to a Mode. Absent ("") or
 // unrecognized values normalize to ModeSummary: an unknown mode must never
 // mean "send content".

--- a/internal/runtimehost/host.go
+++ b/internal/runtimehost/host.go
@@ -246,6 +246,13 @@ func (h *Host) SetPayloadCaptureMode(mode payloadcapture.Mode) {
 	h.server.SetPayloadCaptureMode(mode)
 }
 
+func (h *Host) SetPayloadCaptureConfiguration(config payloadcapture.RuntimeConfiguration) {
+	if h == nil || h.server == nil {
+		return
+	}
+	h.server.SetPayloadCaptureConfiguration(config)
+}
+
 func (h *Host) Close(ctx context.Context) error {
 	var errs []error
 	if h == nil {

--- a/internal/runtimehost/host.go
+++ b/internal/runtimehost/host.go
@@ -237,15 +237,6 @@ func clientResultTransform(mode guardhookruntime.Mode) func(hook.Event, hook.Res
 	}
 }
 
-// SetPayloadCaptureMode forwards the org's payload-capture directive to the
-// guard server's store. Safe on a nil host (no-op).
-func (h *Host) SetPayloadCaptureMode(mode payloadcapture.Mode) {
-	if h == nil || h.server == nil {
-		return
-	}
-	h.server.SetPayloadCaptureMode(mode)
-}
-
 func (h *Host) SetPayloadCaptureConfiguration(config payloadcapture.RuntimeConfiguration) {
 	if h == nil || h.server == nil {
 		return


### PR DESCRIPTION
## Why

Payload capture is endpoint behavior, not policy deployment metadata. It needs an independent contract and failure posture so configuration availability cannot change policy authority.

## What

- fetches the versioned installation configuration endpoint with conditional ETags
- validates and digest-pins the portable configuration identity contract
- persists an independent private cache while keeping summary mode effective until a fresh 200 or matching 304 confirms it
- falls back to summary on refresh failure with independent bounded backoff and jitter
- removes payload-capture authority from provider-policy refresh
- snapshots configured mode, effective mode, identity, confirmation, and fallback reason atomically in decision evidence

## Scope

This PR changes endpoint payload-capture configuration only. It does not retrieve Cedar policy, evaluate policy, or change authorization authority.

Depends on #384. Tracks ENG-539.

## Verification

- go test ./...
- focused go test -race across endpoint configuration, policy, server, ledger, and daemon packages
- go vet ./...

Change size: 17 files, +1,235/-67 — configuration contract/client/cache, daemon application, atomic evidence, and tests.