### PR TITLE
fix(managedstream): drain past wide receipt ranges, restore batch limit after reductions

### DIFF
--- a/internal/guard/store/sqlite/ledger.go
+++ b/internal/guard/store/sqlite/ledger.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 )
@@ -15,6 +17,7 @@ type LedgerExportOptions struct {
 	UpdatedAfter   *time.Time
 	UpdatedAfterID string
 	Limit          int
+	ReceiptLimit   int
 }
 
 type LedgerBatch struct {
@@ -37,9 +40,12 @@ type LedgerCursor struct {
 const (
 	ledgerCursorUpdatedAtKeyColumn = "__cursor_updated_at_key"
 	ledgerTimestampCursorKeyLayout = "2006-01-02T15:04:05.000000000Z07:00"
+	maxSQLQueryParams              = 500
 )
 
 var ledgerFallbackTimestamp = time.Unix(0, 0).UTC()
+
+var ErrLedgerReceiptRangeTooLarge = errors.New("ledger receipt range exceeds limit")
 
 const authorizationActionsSelect = `
 select id, session_id, turn_id, tool_use_id, trace_id, span_id, parent_span_id,
@@ -71,8 +77,16 @@ func (s *Store) LedgerBatch(ctx context.Context, opts LedgerExportOptions) (Ledg
 	if err != nil {
 		return LedgerBatch{}, err
 	}
-	receipts, err := s.authorizationReceiptRangeForActions(ctx, recordIDs(actions))
+	receipts, err := s.authorizationReceiptRangeForActions(ctx, recordIDs(actions), opts.ReceiptLimit)
 	if err != nil {
+		if errors.Is(err, ErrLedgerReceiptRangeTooLarge) {
+			return LedgerBatch{
+				Sessions: []LedgerRecord{},
+				Actions:  actions,
+				Receipts: []LedgerRecord{},
+				Cursor:   cursor,
+			}, err
+		}
 		return LedgerBatch{}, err
 	}
 	actions, err = s.authorizationActionsByIDs(ctx, appendMissingIDs(recordIDs(actions), recordStrings(receipts, "action_id")))
@@ -114,23 +128,41 @@ func receiptChainAnchor(receipts []LedgerRecord) *LedgerReceiptChainAnchor {
 }
 
 func (s *Store) AgentSessions(ctx context.Context, ids []string) ([]LedgerRecord, error) {
+	ids = uniqueStrings(ids)
 	if len(ids) == 0 {
 		return []LedgerRecord{}, nil
 	}
-	placeholders := strings.TrimRight(strings.Repeat("?,", len(ids)), ",")
-	args := make([]any, 0, len(ids))
-	for _, id := range ids {
-		args = append(args, id)
-	}
-	return queryLedgerRecords(ctx, s.db, fmt.Sprintf(`
+	records := []LedgerRecord{}
+	for _, chunk := range stringChunks(ids) {
+		placeholders := strings.TrimRight(strings.Repeat("?,", len(chunk)), ",")
+		args := make([]any, 0, len(chunk))
+		for _, id := range chunk {
+			args = append(args, id)
+		}
+		chunkRecords, err := queryLedgerRecords(ctx, s.db, fmt.Sprintf(`
 select id, runtime_kind, runtime_instance_id, adapter_kind, adapter_version, agent_provider, agent,
   conversation_id, trace_id, principal_id, identity_context_json, identity_hash,
   policy_version, policy_hash, cwd, source, status, external_id, closed_at,
   mode, created_at, updated_at
 from agent_sessions
 where id in (%s)
-order by created_at, id
 	`, placeholders), args...)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, chunkRecords...)
+	}
+	sort.Slice(records, func(i, j int) bool {
+		createdI, _ := records[i]["created_at"].(string)
+		createdJ, _ := records[j]["created_at"].(string)
+		if createdI != createdJ {
+			return createdI < createdJ
+		}
+		idI, _ := records[i]["id"].(string)
+		idJ, _ := records[j]["id"].(string)
+		return idI < idJ
+	})
+	return records, nil
 }
 
 func (s *Store) AuthorizationActions(ctx context.Context, opts LedgerExportOptions) ([]LedgerRecord, error) {
@@ -192,12 +224,31 @@ func (s *Store) authorizationActionsByIDs(ctx context.Context, ids []string) ([]
 	if len(ids) == 0 {
 		return []LedgerRecord{}, nil
 	}
-	placeholders := strings.TrimRight(strings.Repeat("?,", len(ids)), ",")
-	args := make([]any, 0, len(ids))
-	for _, id := range ids {
-		args = append(args, id)
+	records := []LedgerRecord{}
+	for _, chunk := range stringChunks(ids) {
+		placeholders := strings.TrimRight(strings.Repeat("?,", len(chunk)), ",")
+		args := make([]any, 0, len(chunk))
+		for _, id := range chunk {
+			args = append(args, id)
+		}
+		chunkRecords, err := queryLedgerRecords(ctx, s.db, fmt.Sprintf("%s\nwhere id in (%s)", authorizationActionsSelectWithCursorKey(), placeholders), args...)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, chunkRecords...)
 	}
-	return queryLedgerRecords(ctx, s.db, fmt.Sprintf("%s\nwhere id in (%s)\norder by updated_at_cursor_key, id", authorizationActionsSelect, placeholders), args...)
+	sort.Slice(records, func(i, j int) bool {
+		updatedI, _ := records[i][ledgerCursorUpdatedAtKeyColumn].(string)
+		updatedJ, _ := records[j][ledgerCursorUpdatedAtKeyColumn].(string)
+		if updatedI != updatedJ {
+			return updatedI < updatedJ
+		}
+		idI, _ := records[i]["id"].(string)
+		idJ, _ := records[j]["id"].(string)
+		return idI < idJ
+	})
+	stripLedgerCursorColumns(records)
+	return records, nil
 }
 
 func (s *Store) AuthorizationReceipts(ctx context.Context, opts LedgerExportOptions) ([]LedgerRecord, error) {
@@ -215,30 +266,56 @@ func (s *Store) AuthorizationReceipts(ctx context.Context, opts LedgerExportOpti
 	return queryLedgerRecords(ctx, s.db, query, args...)
 }
 
-func (s *Store) authorizationReceiptRangeForActions(ctx context.Context, actionIDs []string) ([]LedgerRecord, error) {
+func (s *Store) authorizationReceiptRangeForActions(ctx context.Context, actionIDs []string, limit int) ([]LedgerRecord, error) {
 	actionIDs = uniqueStrings(actionIDs)
 	if len(actionIDs) == 0 {
 		return []LedgerRecord{}, nil
 	}
-	placeholders := strings.TrimRight(strings.Repeat("?,", len(actionIDs)), ",")
-	args := make([]any, 0, len(actionIDs))
-	for _, id := range actionIDs {
-		args = append(args, id)
+	var startRowID, endRowID sql.NullInt64
+	for _, chunk := range stringChunks(actionIDs) {
+		placeholders := strings.TrimRight(strings.Repeat("?,", len(chunk)), ",")
+		args := make([]any, 0, len(chunk))
+		for _, id := range chunk {
+			args = append(args, id)
+		}
+		var chunkStart, chunkEnd sql.NullInt64
+		if err := s.db.QueryRowContext(ctx, fmt.Sprintf(`
+select min(rowid), max(rowid)
+from authorization_receipts
+where action_id in (%s)
+		`, placeholders), args...).Scan(&chunkStart, &chunkEnd); err != nil {
+			return nil, err
+		}
+		if chunkStart.Valid && (!startRowID.Valid || chunkStart.Int64 < startRowID.Int64) {
+			startRowID = chunkStart
+		}
+		if chunkEnd.Valid && (!endRowID.Valid || chunkEnd.Int64 > endRowID.Int64) {
+			endRowID = chunkEnd
+		}
 	}
-	return queryLedgerRecords(ctx, s.db, fmt.Sprintf(`
-with selected_receipts as (
-  select rowid
-  from authorization_receipts
-  where action_id in (%s)
-),
-receipt_bounds as (
-  select min(rowid) as start_rowid, max(rowid) as end_rowid
-  from selected_receipts
-)
-%s, receipt_bounds
-where authorization_receipts.rowid between receipt_bounds.start_rowid and receipt_bounds.end_rowid
-order by authorization_receipts.rowid
-	`, placeholders, authorizationReceiptsSelect), args...)
+	if !startRowID.Valid || !endRowID.Valid {
+		return []LedgerRecord{}, nil
+	}
+	// Interleaved sessions make action update order diverge from receipt insert
+	// order, so reject a wide rowid range before reading and decoding its payloads.
+	// Receipts are append-only, and concurrent inserts get rowids above endRowID,
+	// so they cannot enter this range between the count and fetch. This guard only
+	// avoids decoding cost; the caller still rejects oversized materialized payloads.
+	var count int
+	if err := s.db.QueryRowContext(ctx, `
+select count(*)
+from authorization_receipts
+where rowid between ? and ?
+	`, startRowID.Int64, endRowID.Int64).Scan(&count); err != nil {
+		return nil, err
+	}
+	if limit > 0 && count > limit {
+		return nil, fmt.Errorf("%w: count %d exceeds limit %d", ErrLedgerReceiptRangeTooLarge, count, limit)
+	}
+	return queryLedgerRecords(ctx, s.db, authorizationReceiptsSelect+`
+where rowid between ? and ?
+order by rowid
+	`, startRowID.Int64, endRowID.Int64)
 }
 
 func queryLedgerRecords(ctx context.Context, db *sql.DB, query string, args ...any) ([]LedgerRecord, error) {
@@ -449,4 +526,16 @@ func uniqueStrings(values []string) []string {
 		out = append(out, value)
 	}
 	return out
+}
+
+func stringChunks(values []string) [][]string {
+	// modernc.org/sqlite caps one statement at 32,766 variables; keep every
+	// unbounded IN query comfortably below that limit.
+	chunks := make([][]string, 0, (len(values)+maxSQLQueryParams-1)/maxSQLQueryParams)
+	for len(values) > 0 {
+		size := min(len(values), maxSQLQueryParams)
+		chunks = append(chunks, values[:size])
+		values = values[size:]
+	}
+	return chunks
 }

--- a/internal/guard/store/sqlite/ledger_test.go
+++ b/internal/guard/store/sqlite/ledger_test.go
@@ -1,0 +1,149 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func TestAuthorizationActionsByIDsChunksBeyondSQLiteVariableLimit(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	base := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	tx, err := store.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	insertLedgerTestAction(t, tx, "act_32999", base)
+	insertLedgerTestAction(t, tx, "act_00020", base.Add(time.Second))
+	insertLedgerTestAction(t, tx, "act_16000", base.Add(2*time.Second))
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	ids := make([]string, 33_000)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("act_%05d", i)
+	}
+	records, err := store.authorizationActionsByIDs(context.Background(), ids)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"act_32999", "act_00020", "act_16000"}
+	if len(records) != len(want) {
+		t.Fatalf("records = %d, want %d", len(records), len(want))
+	}
+	for i, record := range records {
+		if record["id"] != want[i] {
+			t.Fatalf("record %d id = %v, want %s", i, record["id"], want[i])
+		}
+		if _, ok := record[ledgerCursorUpdatedAtKeyColumn]; ok {
+			t.Fatalf("record %d leaked cursor key", i)
+		}
+	}
+}
+
+func TestAuthorizationActionsByIDsOrdersMergedChunks(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	const total = 1_100
+	base := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	order := rand.New(rand.NewSource(1)).Perm(total)
+	ids := make([]string, 0, total)
+	tx, err := store.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, i := range order {
+		id := fmt.Sprintf("act_%04d", i)
+		insertLedgerTestAction(t, tx, id, base.Add(time.Duration(i)*time.Second))
+		ids = append(ids, id)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	records, err := store.authorizationActionsByIDs(context.Background(), ids)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != total {
+		t.Fatalf("records = %d, want %d", len(records), total)
+	}
+	for i, record := range records {
+		want := fmt.Sprintf("act_%04d", i)
+		if record["id"] != want {
+			t.Fatalf("record %d id = %v, want %s", i, record["id"], want)
+		}
+	}
+}
+
+func TestLedgerBatchReturnsCursorWhenReceiptRangeExceedsLimit(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	base := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	tx, err := store.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	insertLedgerTestAction(t, tx, "act_selected_1", base)
+	insertLedgerTestAction(t, tx, "act_selected_2", base.Add(time.Second))
+	insertLedgerTestAction(t, tx, "act_foreign", base.Add(2*time.Second))
+	insertLedgerTestReceipt(t, tx, "rcpt_selected_1", "act_selected_1", base)
+	insertLedgerTestReceipt(t, tx, "rcpt_foreign_1", "act_foreign", base.Add(time.Second))
+	insertLedgerTestReceipt(t, tx, "rcpt_foreign_2", "act_foreign", base.Add(2*time.Second))
+	insertLedgerTestReceipt(t, tx, "rcpt_selected_2", "act_selected_2", base.Add(3*time.Second))
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	batch, err := store.LedgerBatch(context.Background(), LedgerExportOptions{Limit: 2, ReceiptLimit: 3})
+	if !errors.Is(err, ErrLedgerReceiptRangeTooLarge) {
+		t.Fatalf("LedgerBatch() error = %v, want ErrLedgerReceiptRangeTooLarge", err)
+	}
+	if batch.Cursor == nil {
+		t.Fatal("LedgerBatch() cursor = nil")
+	}
+	if len(batch.Actions) != 2 || len(batch.Sessions) != 0 || len(batch.Receipts) != 0 {
+		t.Fatalf("batch sizes = actions %d sessions %d receipts %d", len(batch.Actions), len(batch.Sessions), len(batch.Receipts))
+	}
+}
+
+func insertLedgerTestAction(t *testing.T, tx *sql.Tx, id string, updatedAt time.Time) {
+	t.Helper()
+	timestamp := updatedAt.Format(time.RFC3339Nano)
+	if _, err := tx.ExecContext(context.Background(), `
+insert into authorization_actions(
+  id, session_id, canonical_event_type, status, created_at, updated_at, updated_at_cursor_key
+) values(?, 'session-1', 'request.observed', 'completed', ?, ?, ?)
+	`, id, timestamp, timestamp, ledgerTimestampCursorKeyFromTime(updatedAt)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func insertLedgerTestReceipt(t *testing.T, tx *sql.Tx, id, actionID string, createdAt time.Time) {
+	t.Helper()
+	if _, err := tx.ExecContext(context.Background(), `
+insert into authorization_receipts(
+  id, action_id, session_id, receipt_type, receipt_payload_json, receipt_hash, created_at
+) values(?, ?, 'session-1', 'observed', '{}', ?, ?)
+	`, id, actionID, "hash_"+id, createdAt.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/managedstream/replay_live_test.go
+++ b/internal/managedstream/replay_live_test.go
@@ -1,0 +1,80 @@
+package managedstream
+
+// Throwaway replay harness: drains a copy of a real wedged guard.db against a
+// fake ingest server. Run manually:
+//   KONTEXT_REPLAY_DB=/path/guard-copy.db KONTEXT_REPLAY_CURSOR=2026-07-12T10:04:31.732097Z \
+//   KONTEXT_REPLAY_ACTION_ID=act_9d3adf32-230e-471a-85f9-31f74a8bbb39 \
+//   go test ./internal/managedstream -run TestReplayLiveDB -v -timeout 30m
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/diagnostic"
+)
+
+func TestReplayLiveDB(t *testing.T) {
+	dbPath := os.Getenv("KONTEXT_REPLAY_DB")
+	if dbPath == "" {
+		t.Skip("KONTEXT_REPLAY_DB not set")
+	}
+	var batches, actions, receipts, sessions int
+	var bytesTotal int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		bytesTotal += int64(len(body))
+		var p Payload
+		if err := json.Unmarshal(body, &p); err != nil {
+			t.Errorf("bad payload: %v", err)
+		}
+		batches++
+		actions += len(p.Actions)
+		receipts += len(p.Receipts)
+		sessions += len(p.Sessions)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	statePath := filepath.Join(t.TempDir(), "stream-state.json")
+	cursor, err := time.Parse(time.RFC3339Nano, os.Getenv("KONTEXT_REPLAY_CURSOR"))
+	if err != nil {
+		t.Fatalf("parse cursor: %v", err)
+	}
+	if err := SaveState(statePath, State{UpdatedAfter: &cursor, ActionID: os.Getenv("KONTEXT_REPLAY_ACTION_ID")}); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	flushErr := Flush(context.Background(), Options{
+		DBPath:         dbPath,
+		StatePath:      statePath,
+		CloudURL:       server.URL,
+		InstallationID: "replay-install",
+		InstallToken:   "replay-token",
+		Diagnostic:     diagnostic.New(os.Stderr, true),
+	})
+	elapsed := time.Since(start)
+
+	state, err := LoadState(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("flush err: %v", flushErr)
+	t.Logf("elapsed: %s, batches: %d, actions: %d, receipts: %d, sessions: %d, bytes: %.1f MB",
+		elapsed, batches, actions, receipts, sessions, float64(bytesTotal)/1024/1024)
+	if state.UpdatedAfter != nil {
+		t.Logf("final cursor: %s (id %s)", state.UpdatedAfter.Format(time.RFC3339Nano), state.ActionID)
+	} else {
+		t.Log("final cursor: nil")
+	}
+	if state.UpdatedAfter == nil || !state.UpdatedAfter.After(cursor) {
+		t.Fatal("cursor did not advance past the wedged position")
+	}
+}

--- a/internal/managedstream/stream.go
+++ b/internal/managedstream/stream.go
@@ -158,6 +158,7 @@ func Flush(ctx context.Context, opts Options) error {
 	}
 
 	limit := batchLimit(opts.BatchLimit)
+	maxLimit := limit
 	// Pagination within this call uses the true batch cursor so the drain
 	// makes forward progress; only the PERSISTED cursor is held back by
 	// cursorSafetyLag (see clampCursor).
@@ -171,8 +172,22 @@ func Flush(ctx context.Context, opts Options) error {
 			UpdatedAfter:   pageUpdatedAfter,
 			UpdatedAfterID: pageActionID,
 			Limit:          limit,
+			ReceiptLimit:   maxPayloadReceipts,
 		})
 		if err != nil {
+			if errors.Is(err, sqlite.ErrLedgerReceiptRangeTooLarge) {
+				if limit == 1 {
+					return advancePastMinimumBatch(statePath, batch, state, "receipt range too large", err)
+				}
+				nextLimit := reducedBatchLimit(limit)
+				opts.Diagnostic.Printf(
+					"managed stream receipt range exceeds hosted limit; reducing batch limit from %d to %d\n",
+					limit,
+					nextLimit,
+				)
+				limit = nextLimit
+				continue
+			}
 			return err
 		}
 		if len(batch.Actions) == 0 {
@@ -223,6 +238,13 @@ func Flush(ctx context.Context, opts Options) error {
 		// credential works, which is what breadcrumb-clearing needs.
 		if opts.OnFlushSuccess != nil {
 			opts.OnFlushSuccess()
+		}
+
+		// Reductions are multiplicative and per-region; recovery is additive
+		// (AIMD, like TCP), so a drain neither stays pinned at tiny batches nor
+		// oscillates against the same wide receipt range it just backed off from.
+		if limit < maxLimit {
+			limit++
 		}
 
 		if batch.Cursor == nil {

--- a/internal/managedstream/stream_test.go
+++ b/internal/managedstream/stream_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -409,22 +410,29 @@ func TestFlushRetriesWithSmallerBatchWhenHostedBackendRejectsSize(t *testing.T) 
 		t.Fatalf("Flush() error = %v", err)
 	}
 
-	// The first post is rejected (413) and retried at half size; the same
-	// call then drains the remaining backlog at the reduced size.
-	if len(actionCounts) != 5 {
-		t.Fatalf("request count = %d, want 5 (1 rejected + 4 reduced batches)", len(actionCounts))
+	// The first post is rejected (413) and retried at half size; after an
+	// accepted retry, later batches grow again while draining the full backlog.
+	if len(actionCounts) < 3 {
+		t.Fatalf("action counts = %v, want rejected post, smaller retry, and recovered batch", actionCounts)
 	}
 	if actionCounts[0] <= actionCounts[1] {
 		t.Fatalf("action counts = %v, want retry with a smaller batch", actionCounts)
 	}
 	accepted := 0
+	recovered := false
 	for _, count := range actionCounts[1:] {
 		accepted += count
+		if count > actionCounts[1] {
+			recovered = true
+		}
 	}
 	// Pages can overlap via receipt-chain continuity, so require at least
 	// full coverage of the 8-action backlog.
 	if accepted < 8 {
 		t.Fatalf("accepted %d actions, want at least the whole backlog (8)", accepted)
+	}
+	if !recovered {
+		t.Fatalf("action counts = %v, want batch limit to recover after smaller retry", actionCounts)
 	}
 	state, err := LoadState(statePath)
 	if err != nil {
@@ -631,6 +639,90 @@ func TestFlushAdvancesCursorPastOversizedMinimumBatch(t *testing.T) {
 	if state.UpdatedAfter == nil || state.ActionID == "" {
 		t.Fatalf("state = %+v, want cursor advanced", state)
 	}
+}
+
+func TestFlushAdvancesCursorPastMinimumBatchWithWideReceiptRange(t *testing.T) {
+	store, dbPath := testStore(t)
+	saveTestDecision(t, store, "session-1", "toolu_1")
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var poisonActionID string
+	if err := db.QueryRow(`
+select id
+from authorization_actions
+order by updated_at_cursor_key, id
+limit 1
+	`).Scan(&poisonActionID); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < maxPayloadReceipts; i++ {
+		if _, err := tx.Exec(`
+insert into authorization_receipts(
+  id, action_id, session_id, receipt_type, receipt_payload_json, receipt_hash, created_at
+) values(?, 'act_foreign', 'session-foreign', 'observed', '{}', ?, ?)
+		`, fmt.Sprintf("rcpt_foreign_%04d", i), fmt.Sprintf("hash_%04d", i), time.Now().UTC().Format(time.RFC3339Nano)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := tx.Exec(`
+insert into authorization_receipts(
+  id, action_id, session_id, receipt_type, receipt_payload_json, receipt_hash, created_at
+) values('rcpt_poison_tail', ?, 'session-1', 'observed', '{}', 'hash_poison_tail', ?)
+	`, poisonActionID, time.Now().UTC().Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	called := false
+	client := &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		called = true
+		return &http.Response{StatusCode: http.StatusAccepted, Body: io.NopCloser(strings.NewReader(""))}, nil
+	})}
+
+	statePath := filepath.Join(t.TempDir(), "stream-state.json")
+	err = Flush(context.Background(), Options{
+		DBPath:         dbPath,
+		StatePath:      statePath,
+		CloudURL:       "https://example.test",
+		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
+		InstallToken:   "test-install-token",
+		BatchLimit:     8,
+		HTTPClient:     client,
+	})
+	if err == nil || !strings.Contains(err.Error(), "receipt range too large") {
+		t.Fatalf("Flush() error = %v, want receipt range diagnostic", err)
+	}
+	if !errors.Is(err, sqlite.ErrLedgerReceiptRangeTooLarge) {
+		t.Fatalf("Flush() error = %v, want ErrLedgerReceiptRangeTooLarge", err)
+	}
+	if called {
+		t.Fatal("server was called despite wide receipt range")
+	}
+	state, err := LoadState(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.UpdatedAfter == nil || state.ActionID != poisonActionID {
+		t.Fatalf("state = %+v, want cursor advanced past %s", state, poisonActionID)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }
 
 func TestFlushPreservesHeartbeatStatePastOversizedMinimumBatch(t *testing.T) {
@@ -988,5 +1080,57 @@ func saveLargeTestDecision(t *testing.T, store *sqlite.Store, sessionID, toolUse
 	})
 	if err != nil {
 		t.Fatalf("SaveDecision() error = %v", err)
+	}
+}
+
+func TestFlushRestoresBatchLimitAfterReduction(t *testing.T) {
+	store, dbPath := testStore(t)
+	for i := 0; i < 25; i++ {
+		saveTestDecision(t, store, "session-1", fmt.Sprintf("toolu_%02d", i))
+	}
+
+	var batchSizes []int
+	requests := 0
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var payload Payload
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatal(err)
+		}
+		if requests == 1 {
+			return &http.Response{StatusCode: http.StatusRequestEntityTooLarge, Body: io.NopCloser(strings.NewReader(""))}, nil
+		}
+		batchSizes = append(batchSizes, len(payload.Actions))
+		return &http.Response{StatusCode: http.StatusAccepted, Body: io.NopCloser(strings.NewReader(""))}, nil
+	})}
+
+	statePath := filepath.Join(t.TempDir(), "stream-state.json")
+	if err := Flush(context.Background(), Options{
+		DBPath:         dbPath,
+		StatePath:      statePath,
+		CloudURL:       "https://example.test",
+		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
+		InstallToken:   "test-install-token",
+		BatchLimit:     8,
+		HTTPClient:     client,
+	}); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+
+	// The first post is rejected with 413 → the page limit halves to 4; each
+	// accepted post then increments it by one toward the cap. Payload action counts
+	// exceed the page size (the receipt rowid range pulls in neighbors), so
+	// assert recovery via the essential property: without it every remaining
+	// page stays at 4 and no accepted payload ever reaches the original cap.
+	maxSize := 0
+	for _, size := range batchSizes {
+		maxSize = max(maxSize, size)
+	}
+	if maxSize < 8 {
+		t.Fatalf("accepted batch sizes = %v, want at least one >= 8 (limit recovered)", batchSizes)
 	}
 }


### PR DESCRIPTION
## Summary

Wires the store-level receipt-range guard (previous PR) into the flush drain and fixes the drain's degenerate batching:

- Pass `ReceiptLimit` (`maxPayloadReceipts`) to `LedgerBatch`; on `ErrLedgerReceiptRangeTooLarge` halve the batch limit, and at the minimum batch advance the cursor past the poison action instead of retrying it forever.
- Restore the batch limit **additively** (+1 per accepted post, AIMD): reductions are per-region, and replaying the real wedged guard.db showed a 73,111-action backlog shipping as **73,111 single-action HTTP posts** because one early reduction pinned the drain at limit 1 — the request pattern behind ENG-546. Multiplicative recovery was tried first and oscillated against the same wide receipt range it had just backed off from, running ~3x slower than no recovery at all.
- Add an env-gated replay harness (`TestReplayLiveDB`) that drains a copy of a real guard.db against a fake ingest server.

## Verification

- [x] `go test ./...`
- [x] Replayed the full 8-day production backlog (73k actions, ~480 MB) from this branch: drains clean end to end, `Flush` returns nil, cursor advances July 12 → July 20, including resume after a mid-drain interruption
- [x] 413-retry and limit-recovery behavior covered by unit tests

## Release notes

- [x] conventional commit title matches semver intent (fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
