### PR TITLE
test(policy): pin the validation-diagnostics conformance corpus

### DIFF
--- a/internal/cedareval/fixtures_test.go
+++ b/internal/cedareval/fixtures_test.go
@@ -24,12 +24,13 @@ import (
 const portableFixtureContractVersion = 1
 
 var fixtureDigests = map[string]string{
-	"authorization-v1.json":     "c7f8aaf5da2acbf9a5d832ebf2bcf3ca531a617cdea3a6aed1b6b1840c4735b5",
-	"context-errors-v1.json":    "945e6be23af02aa4d0c7bd382f5963b6342f46a02602bfbc8f134ae283b6773e",
-	"decision-contract-v1.json": "8d33cd7924de64b9000c18fdc3cb532250653f768e2a65c7acb001c26376a3c4",
-	"decision-mapping-v1.json":  "7a0ba0b761b13759ef1a5ffefb155c7a066412b0115227f928529546a337e0b2",
-	"evaluation-errors-v1.json": "aef0f751ebf54625b4f516f67f37b58a59042a03fd684614172736a91c07a763",
-	"hashing-v1.json":           "5179f41ae61872ee9f6a048cba4592dc12c0267fc8c8699a0c2afa886da62775",
+	"authorization-v1.json":          "c7f8aaf5da2acbf9a5d832ebf2bcf3ca531a617cdea3a6aed1b6b1840c4735b5",
+	"context-errors-v1.json":         "945e6be23af02aa4d0c7bd382f5963b6342f46a02602bfbc8f134ae283b6773e",
+	"decision-contract-v1.json":      "8d33cd7924de64b9000c18fdc3cb532250653f768e2a65c7acb001c26376a3c4",
+	"decision-mapping-v1.json":       "7a0ba0b761b13759ef1a5ffefb155c7a066412b0115227f928529546a337e0b2",
+	"evaluation-errors-v1.json":      "aef0f751ebf54625b4f516f67f37b58a59042a03fd684614172736a91c07a763",
+	"hashing-v1.json":                "5179f41ae61872ee9f6a048cba4592dc12c0267fc8c8699a0c2afa886da62775",
+	"validation-diagnostics-v1.json": "81c0bbc5adf24937f2c0ff95e270c05928ba08f9b83313841a89196f10b7dbff",
 }
 
 type authorizationFixture struct {

--- a/internal/cedareval/testdata/portable/v1/validation-diagnostics-v1.json
+++ b/internal/cedareval/testdata/portable/v1/validation-diagnostics-v1.json
@@ -1,0 +1,239 @@
+{
+  "version": 1,
+  "smokeRequests": [
+    {
+      "evaluationPrincipal": {
+        "entityType": "Kontext::User",
+        "entityId": "validation@example.invalid"
+      },
+      "toolName": "Read",
+      "toolInput": {}
+    },
+    {
+      "evaluationPrincipal": {
+        "entityType": "Kontext::User",
+        "entityId": "validation@example.invalid"
+      },
+      "toolName": "Bash",
+      "toolInput": { "command": "pwd" }
+    }
+  ],
+  "fixtures": [
+    {
+      "version": 1,
+      "name": "permit-any-tool",
+      "description": "A minimal permit over every tool is the smallest valid request-contract v1 policy.",
+      "policyText": "@id(\"permit-any-tool\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource);",
+      "expected": { "valid": true, "diagnosticCodes": [] }
+    },
+    {
+      "version": 1,
+      "name": "permit-exact-tool",
+      "description": "Resource scope may name one exact runtime tool.",
+      "policyText": "@id(\"permit-read\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource == Kontext::Tool::\"Read\");",
+      "expected": { "valid": true, "diagnosticCodes": [] }
+    },
+    {
+      "version": 1,
+      "name": "ask-annotated-permit",
+      "description": "ASK and description annotations are valid on permit policies.",
+      "policyText": "@id(\"ask-bash\")\n@ask(\"prompt\")\n@description(\"ask before Bash runs\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource == Kontext::Tool::\"Bash\");",
+      "expected": { "valid": true, "diagnosticCodes": [] }
+    },
+    {
+      "version": 1,
+      "name": "guarded-optional-context",
+      "description": "Optional context access is valid when a has-guard dominates every evaluation path.",
+      "policyText": "@id(\"guarded-git\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource == Kontext::Tool::\"Bash\") when { context has command && context.command like \"git*\" };",
+      "expected": { "valid": true, "diagnosticCodes": [] }
+    },
+    {
+      "version": 1,
+      "name": "nested-context-guard",
+      "description": "Path-aware guards support nested context records.",
+      "policyText": "@id(\"nested-guard\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource) when { context has repository && context.repository has owner && context.repository.owner == \"kontext-security\" };",
+      "expected": { "valid": true, "diagnosticCodes": [] }
+    },
+    {
+      "version": 1,
+      "name": "fail-closed-forbid",
+      "description": "A forbid reading optional context is valid when it explicitly matches the absent case.",
+      "policyText": "@id(\"forbid-curl\")\nforbid(principal, action == Kontext::Action::\"ToolUse\", resource == Kontext::Tool::\"Bash\") when { !(context has command) || (context has command && context.command like \"curl*\") };",
+      "expected": { "valid": true, "diagnosticCodes": [] }
+    },
+    {
+      "version": 1,
+      "name": "multi-policy-set",
+      "description": "A set combining permit and fail-closed forbid policies with distinct ids is valid.",
+      "policyText": "@id(\"allow-tools\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource);\n@id(\"forbid-rm\")\nforbid(principal, action == Kontext::Action::\"ToolUse\", resource == Kontext::Tool::\"Bash\") when { !(context has command) || (context has command && context.command == \"rm -rf /\") };",
+      "expected": { "valid": true, "diagnosticCodes": [] }
+    },
+    {
+      "version": 1,
+      "name": "invalid-utf8",
+      "description": "Policy text containing an unpaired UTF-16 surrogate is rejected before parsing.",
+      "policyText": "@id(\"lonely\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource);\n\ud800",
+      "expected": { "valid": false, "diagnosticCodes": ["invalid_utf8"] }
+    },
+    {
+      "version": 1,
+      "name": "policy-too-large",
+      "description": "Policy text above the byte ceiling is rejected before parsing.",
+      "policyTextGenerator": {
+        "kind": "repeated-text",
+        "text": " ",
+        "count": 1048577
+      },
+      "expected": { "valid": false, "diagnosticCodes": ["policy_too_large"] }
+    },
+    {
+      "version": 1,
+      "name": "parse-error",
+      "description": "Text that is not a Cedar policy set is rejected.",
+      "policyText": "@id(\"broken\")\npermit(principal,",
+      "expected": { "valid": false, "diagnosticCodes": ["parse_error"] }
+    },
+    {
+      "version": 1,
+      "name": "too-many-policies",
+      "description": "A policy set above the policy-count ceiling is rejected before per-policy analysis.",
+      "policyTextGenerator": { "kind": "repeated-policies", "count": 1001 },
+      "expected": { "valid": false, "diagnosticCodes": ["too_many_policies"] }
+    },
+    {
+      "version": 1,
+      "name": "policy-too-complex",
+      "description": "A policy above the AST node or depth ceiling is rejected before recursive analysis.",
+      "policyTextGenerator": { "kind": "repeated-conjunction", "count": 1100 },
+      "expected": { "valid": false, "diagnosticCodes": ["policy_too_complex"] }
+    },
+    {
+      "version": 1,
+      "name": "templates-unsupported",
+      "description": "Policy templates and slots are outside request-contract v1.",
+      "policyText": "@id(\"template\")\npermit(principal == ?principal, action, resource);",
+      "expected": {
+        "valid": false,
+        "diagnosticCodes": ["templates_unsupported"]
+      }
+    },
+    {
+      "version": 1,
+      "name": "missing-policy-id",
+      "description": "Every policy requires a stable @id annotation.",
+      "policyText": "permit(principal, action == Kontext::Action::\"ToolUse\", resource);",
+      "expected": { "valid": false, "diagnosticCodes": ["missing_policy_id"] }
+    },
+    {
+      "version": 1,
+      "name": "invalid-policy-id",
+      "description": "Policy ids must be 1-128 portable identifier characters starting alphanumerically.",
+      "policyText": "@id(\"-invalid\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource);",
+      "expected": { "valid": false, "diagnosticCodes": ["invalid_policy_id"] }
+    },
+    {
+      "version": 1,
+      "name": "duplicate-policy-id",
+      "description": "Policy ids must be unique across the set.",
+      "policyText": "@id(\"same\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource);\n@id(\"same\")\nforbid(principal, action == Kontext::Action::\"ToolUse\", resource);",
+      "expected": { "valid": false, "diagnosticCodes": ["duplicate_policy_id"] }
+    },
+    {
+      "version": 1,
+      "name": "unsupported-annotation",
+      "description": "Annotations outside the id/description/ask vocabulary are rejected.",
+      "policyText": "@id(\"annotated\")\n@owner(\"security-team\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource);",
+      "expected": {
+        "valid": false,
+        "diagnosticCodes": ["unsupported_annotation"]
+      }
+    },
+    {
+      "version": 1,
+      "name": "unsupported-ask-value",
+      "description": "The ask annotation accepts only the literal prompt value.",
+      "policyText": "@id(\"ask-value\")\n@ask(\"always\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource);",
+      "expected": {
+        "valid": false,
+        "diagnosticCodes": ["unsupported_ask_value"]
+      }
+    },
+    {
+      "version": 1,
+      "name": "ask-on-forbid",
+      "description": "ASK annotations are valid only on permit policies.",
+      "policyText": "@id(\"ask-forbid\")\n@ask(\"prompt\")\nforbid(principal, action == Kontext::Action::\"ToolUse\", resource);",
+      "expected": { "valid": false, "diagnosticCodes": ["ask_on_forbid"] }
+    },
+    {
+      "version": 1,
+      "name": "unsupported-entity-scope",
+      "description": "Entity types outside the request-contract v1 vocabulary are rejected.",
+      "policyText": "@id(\"foreign-entity\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource == Files::Doc::\"readme\");",
+      "expected": {
+        "valid": false,
+        "diagnosticCodes": ["unsupported_entity_scope"]
+      }
+    },
+    {
+      "version": 1,
+      "name": "unsupported-action-scope",
+      "description": "The only action in request-contract v1 is ToolUse.",
+      "policyText": "@id(\"foreign-action\")\npermit(principal, action == Kontext::Action::\"Delete\", resource);",
+      "expected": {
+        "valid": false,
+        "diagnosticCodes": ["unsupported_action_scope"]
+      }
+    },
+    {
+      "version": 1,
+      "name": "principal-policy-scope",
+      "description": "Principal-bound scopes are rejected while identity is descriptive.",
+      "policyText": "@id(\"bound-principal\")\npermit(principal == Kontext::User::\"alice@example.com\", action == Kontext::Action::\"ToolUse\", resource);",
+      "expected": {
+        "valid": false,
+        "diagnosticCodes": ["principal_policy_unsupported"]
+      }
+    },
+    {
+      "version": 1,
+      "name": "principal-policy-condition",
+      "description": "Principal references in conditions are rejected while identity is descriptive.",
+      "policyText": "@id(\"principal-attr\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource) when { principal.department == \"engineering\" };",
+      "expected": {
+        "valid": false,
+        "diagnosticCodes": ["principal_policy_unsupported"]
+      }
+    },
+    {
+      "version": 1,
+      "name": "unguarded-optional-context",
+      "description": "Optional context access without a dominating has-guard is rejected.",
+      "policyText": "@id(\"unguarded\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource) when { context.command == \"pwd\" };",
+      "expected": {
+        "valid": false,
+        "diagnosticCodes": ["unguarded_optional_context"]
+      }
+    },
+    {
+      "version": 1,
+      "name": "forbid-may-fail-open",
+      "description": "A forbid reading optional context without matching its absence can fail open and is rejected.",
+      "policyText": "@id(\"fail-open\")\nforbid(principal, action == Kontext::Action::\"ToolUse\", resource) when { context has command && context.command == \"rm -rf /\" };",
+      "expected": {
+        "valid": false,
+        "diagnosticCodes": ["forbid_may_fail_open"]
+      }
+    },
+    {
+      "version": 1,
+      "name": "corpus-evaluation-error",
+      "description": "A policy that errors against the smoke request corpus is rejected.",
+      "policyText": "@id(\"type-confused\")\npermit(principal, action == Kontext::Action::\"ToolUse\", resource) when { context has command && context.command > 5 };",
+      "expected": {
+        "valid": false,
+        "diagnosticCodes": ["validation_corpus_error"]
+      }
+    }
+  ]
+}

--- a/internal/cedareval/validation_diagnostics_fixtures_test.go
+++ b/internal/cedareval/validation_diagnostics_fixtures_test.go
@@ -1,0 +1,95 @@
+package cedareval_test
+
+import (
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/cedareval"
+)
+
+// The validation-diagnostics corpus pins the portable policy dialect: entries
+// the management plane accepts must construct and evaluate in this engine
+// without engine errors, and rejected entries never reach an endpoint.
+type validationDiagnosticsCorpus struct {
+	Version       int                            `json:"version"`
+	SmokeRequests []cedareval.ToolUseInput       `json:"smokeRequests"`
+	Fixtures      []validationDiagnosticsFixture `json:"fixtures"`
+}
+
+type validationDiagnosticsFixture struct {
+	Version             int     `json:"version"`
+	Name                string  `json:"name"`
+	Description         string  `json:"description"`
+	PolicyText          *string `json:"policyText"`
+	PolicyTextGenerator *struct {
+		Kind  string `json:"kind"`
+		Text  string `json:"text"`
+		Count int    `json:"count"`
+	} `json:"policyTextGenerator"`
+	Expected struct {
+		Valid           bool     `json:"valid"`
+		DiagnosticCodes []string `json:"diagnosticCodes"`
+	} `json:"expected"`
+}
+
+const validationDiagnosticsCorpusVersion = 1
+
+func TestPortableValidationDiagnosticsFixtures(t *testing.T) {
+	var corpus validationDiagnosticsCorpus
+	readFixture(t, "validation-diagnostics-v1.json", &corpus)
+
+	if corpus.Version != validationDiagnosticsCorpusVersion {
+		t.Fatalf("corpus version = %d, want %d", corpus.Version, validationDiagnosticsCorpusVersion)
+	}
+	if len(corpus.SmokeRequests) == 0 {
+		t.Fatal("corpus carries no smoke requests")
+	}
+	accepted := 0
+	for _, fixture := range corpus.Fixtures {
+		if fixture.Expected.Valid {
+			accepted++
+		}
+	}
+	if accepted == 0 {
+		t.Fatal("corpus carries no accepted-dialect fixtures")
+	}
+
+	for _, fixture := range corpus.Fixtures {
+		fixture := fixture
+		t.Run(fixture.Name, func(t *testing.T) {
+			t.Parallel()
+			if fixture.Version != validationDiagnosticsCorpusVersion {
+				t.Fatalf("fixture version = %d, want %d", fixture.Version, validationDiagnosticsCorpusVersion)
+			}
+			if !fixture.Expected.Valid {
+				if len(fixture.Expected.DiagnosticCodes) == 0 {
+					t.Fatal("rejected fixture lists no diagnostic codes")
+				}
+				return
+			}
+			if len(fixture.Expected.DiagnosticCodes) != 0 {
+				t.Fatal("accepted fixture lists diagnostic codes")
+			}
+			if fixture.PolicyText == nil {
+				t.Fatal("accepted fixture carries no inline policy text")
+			}
+
+			evaluator, err := cedareval.New(*fixture.PolicyText)
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			for _, request := range corpus.SmokeRequests {
+				result, err := evaluator.Evaluate(request)
+				if err != nil {
+					t.Fatalf("Evaluate(%s) error = %v", request.ToolName, err)
+				}
+				if len(result.EngineDiagnostics.Errors) != 0 {
+					t.Errorf(
+						"Evaluate(%s) EngineDiagnostics.Errors = %v, want none",
+						request.ToolName,
+						result.EngineDiagnostics.Errors,
+					)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Mirrors the portable `validation-diagnostics-v1.json` fixture byte-identically (digest-pinned alongside the other portable corpora) and adds the conformance test proving the policy-dialect boundary from this runtime's side:

- every corpus entry the management plane **accepts** must construct via `cedareval.New` and evaluate against the shared smoke requests without engine errors;
- **rejected** entries carry at least one diagnostic code and are never distributed to endpoints, so this runtime only documents them.

This closes the drift surface between what policy validation accepts and what this engine evaluates: any dialect change now has to land as a reviewed, digest-pinned fixture change in both runtimes.

## Verification

- `go test ./internal/cedareval/...` (including `-race`)
- `go vet ./internal/cedareval/`
- `TestPortableFixtureProvenance` pins the new fixture digest; `TestPortableValidationDiagnosticsFixtures` runs all 26 corpus entries.

ENG-600

🤖 Generated with [Claude Code](https://claude.com/claude-code)