### PR TITLE
feat(policy): resolve enforcement from remote rollout mode

### DIFF
--- a/internal/cedarpolicy/mode.go
+++ b/internal/cedarpolicy/mode.go
@@ -1,0 +1,23 @@
+package cedarpolicy
+
+import "github.com/kontext-security/kontext-cli/internal/cedareval"
+
+// DeploymentClaimsEnforce reports whether the cached policy distribution asks
+// this endpoint to enforce: an active (or last-known-good) deployment exists
+// and its rollout mode is enforce. This is the remote-managed counterpart of
+// the static cutover gate, with deliberately different unknown-state
+// semantics: a remote-managed endpoint without a trustworthy deployment stays
+// in observe, because the organization's intent is unknown until a deployment
+// has been fetched. Expiry and staleness do not relinquish enforcement — once
+// an enforce deployment is cached, only an explicit disabled/no-active-policy
+// state or an observe deployment hands authority back.
+func DeploymentClaimsEnforce(snapshot Snapshot) bool {
+	if snapshot.State == StateDisabled || snapshot.State == StateNoActivePolicy {
+		return false
+	}
+	deployment := snapshot.Deployment
+	if deployment == nil {
+		deployment = snapshot.LastKnownGood
+	}
+	return deployment != nil && deployment.RolloutMode == cedareval.RolloutModeEnforce
+}

--- a/internal/cedarpolicy/mode_test.go
+++ b/internal/cedarpolicy/mode_test.go
@@ -1,0 +1,33 @@
+package cedarpolicy
+
+import (
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/cedareval"
+)
+
+func TestDeploymentClaimsEnforce(t *testing.T) {
+	enforce := &Deployment{RolloutMode: cedareval.RolloutModeEnforce}
+	observe := &Deployment{RolloutMode: cedareval.RolloutModeObserve}
+
+	cases := map[string]struct {
+		snapshot Snapshot
+		want     bool
+	}{
+		"empty snapshot":              {Snapshot{}, false},
+		"active enforce":              {Snapshot{Deployment: enforce, State: StateSuccess}, true},
+		"active observe":              {Snapshot{Deployment: observe, State: StateSuccess}, false},
+		"last-known-good enforce":     {Snapshot{LastKnownGood: enforce, State: StateUnavailable}, true},
+		"expired enforce holds":       {Snapshot{Deployment: enforce, State: StateSuccess, Status: CacheStatus{Expired: true}}, true},
+		"disabled relinquishes":       {Snapshot{LastKnownGood: enforce, State: StateDisabled}, false},
+		"no active policy relinquish": {Snapshot{LastKnownGood: enforce, State: StateNoActivePolicy}, false},
+		"active observe over LKG":     {Snapshot{Deployment: observe, LastKnownGood: enforce, State: StateSuccess}, false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := DeploymentClaimsEnforce(tc.snapshot); got != tc.want {
+				t.Fatalf("DeploymentClaimsEnforce = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/guard/app/server/cedar.go
+++ b/internal/guard/app/server/cedar.go
@@ -13,10 +13,28 @@ import (
 
 const cedarEvaluatorVersion = "cedar-go/v1.8.0"
 
+// CedarEnforcementSource selects who decides whether Cedar decisions are
+// authoritative (real denies) or evidence-only (dry run).
+type CedarEnforcementSource string
+
+const (
+	// CedarEnforcementOff keeps Cedar evidence-only regardless of the
+	// deployment's rollout mode. This is the static observe posture.
+	CedarEnforcementOff CedarEnforcementSource = ""
+	// CedarEnforcementStatic makes Cedar authoritative whenever a policy is
+	// distributed, with fail-closed unknown-state semantics (the local
+	// cutover gate). This is the static enforce posture.
+	CedarEnforcementStatic CedarEnforcementSource = "static"
+	// CedarEnforcementRemote follows the fetched deployment's rollout mode:
+	// Cedar is authoritative exactly when the deployment says enforce, and
+	// evidence-only otherwise or while no deployment is cached.
+	CedarEnforcementRemote CedarEnforcementSource = "remote"
+)
+
 type cedarPolicyProvider struct {
-	current            PolicyProvider
-	snapshots          cedarpolicy.SnapshotProvider
-	enforcementEnabled bool
+	current     PolicyProvider
+	snapshots   cedarpolicy.SnapshotProvider
+	enforcement CedarEnforcementSource
 
 	mu        sync.Mutex
 	identity  string
@@ -24,11 +42,11 @@ type cedarPolicyProvider struct {
 	parseErr  error
 }
 
-func newCedarPolicyProvider(current PolicyProvider, snapshots cedarpolicy.SnapshotProvider, enforcementEnabled bool) PolicyProvider {
+func newCedarPolicyProvider(current PolicyProvider, snapshots cedarpolicy.SnapshotProvider, enforcement CedarEnforcementSource) PolicyProvider {
 	if snapshots == nil {
 		return current
 	}
-	return &cedarPolicyProvider{current: current, snapshots: snapshots, enforcementEnabled: enforcementEnabled}
+	return &cedarPolicyProvider{current: current, snapshots: snapshots, enforcement: enforcement}
 }
 
 func (p *cedarPolicyProvider) DecideHook(ctx context.Context, event risk.HookEvent) (risk.RiskDecision, error) {
@@ -61,26 +79,31 @@ func (p *cedarPolicyProvider) DecideHook(ctx context.Context, event risk.HookEve
 }
 
 func (p *cedarPolicyProvider) claimsAuthority(snapshot cedarpolicy.Snapshot) bool {
-	if !p.enforcementEnabled {
+	switch p.enforcement {
+	case CedarEnforcementStatic:
+		if snapshot.State == cedarpolicy.StateDisabled || snapshot.State == cedarpolicy.StateNoActivePolicy {
+			return false
+		}
+		if snapshot.Status.Invalid {
+			return true
+		}
+		deployment := snapshot.Deployment
+		if deployment == nil {
+			deployment = snapshot.LastKnownGood
+		}
+		if deployment == nil {
+			// Once the local cutover gate is enabled, absence and untrusted
+			// response states cannot silently restore the previous evaluator.
+			// Only explicit disabled/no-active-policy states relinquish Cedar
+			// authority.
+			return true
+		}
+		return deployment.RolloutMode == cedareval.RolloutModeEnforce
+	case CedarEnforcementRemote:
+		return cedarpolicy.DeploymentClaimsEnforce(snapshot)
+	default:
 		return false
 	}
-	if snapshot.State == cedarpolicy.StateDisabled || snapshot.State == cedarpolicy.StateNoActivePolicy {
-		return false
-	}
-	if snapshot.Status.Invalid {
-		return true
-	}
-	deployment := snapshot.Deployment
-	if deployment == nil {
-		deployment = snapshot.LastKnownGood
-	}
-	if deployment == nil {
-		// Once the local cutover gate is enabled, absence and untrusted response
-		// states cannot silently restore the previous evaluator. Only explicit
-		// disabled/no-active-policy states relinquish Cedar authority.
-		return true
-	}
-	return deployment.RolloutMode == cedareval.RolloutModeEnforce
 }
 
 func (p *cedarPolicyProvider) evaluate(snapshot cedarpolicy.Snapshot, event risk.HookEvent, current cedareval.EffectiveExecutionAction, claimsAuthority bool) risk.CedarEvidence {

--- a/internal/guard/app/server/cedar_test.go
+++ b/internal/guard/app/server/cedar_test.go
@@ -39,7 +39,7 @@ func (p *countingHookPolicy) DecideHook(context.Context, risk.HookEvent) (risk.R
 func TestCedarObservePreservesCurrentAuthorityAndRecordsDecision(t *testing.T) {
 	deployment := cedarTestDeployment(t, cedareval.RolloutModeEnforce, `@id("permit-read") permit(principal, action, resource == Kontext::Tool::"Read");`)
 	current := staticHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionDeny, Reason: "current deny", ReasonCode: "current_deny", RiskEvent: risk.RiskEvent{Decision: risk.DecisionDeny}}}
-	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, State: cedarpolicy.StateSuccess, Status: cedarpolicy.CacheStatus{FetchedAt: time.Now()}}}, false)
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, State: cedarpolicy.StateSuccess, Status: cedarpolicy.CacheStatus{FetchedAt: time.Now()}}}, CedarEnforcementOff)
 
 	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{}})
 	if err != nil {
@@ -62,7 +62,7 @@ func TestCedarObservePreservesCurrentAuthorityAndRecordsDecision(t *testing.T) {
 func TestCedarObserveClassifiesContextConversionFailure(t *testing.T) {
 	deployment := cedarTestDeployment(t, cedareval.RolloutModeObserve, `@id("permit") permit(principal, action, resource);`)
 	current := staticHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow, RiskEvent: risk.RiskEvent{Decision: risk.DecisionAllow}}}
-	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, State: cedarpolicy.StateSuccess}}, false)
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, State: cedarpolicy.StateSuccess}}, CedarEnforcementOff)
 
 	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{"bad": make(chan struct{})}})
 	if err != nil {
@@ -79,7 +79,7 @@ func TestCedarObserveClassifiesContextConversionFailure(t *testing.T) {
 func TestCedarObserveClassifiesEngineDiagnosticsAsFailure(t *testing.T) {
 	deployment := cedarTestDeployment(t, cedareval.RolloutModeObserve, portableEngineErrorPolicy)
 	current := &countingHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow, ReasonCode: "current_allow", RiskEvent: risk.RiskEvent{Decision: risk.DecisionAllow}}}
-	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, State: cedarpolicy.StateSuccess}}, false)
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, State: cedarpolicy.StateSuccess}}, CedarEnforcementOff)
 
 	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Bash", ToolInput: map[string]any{"command": 1}})
 	if err != nil {
@@ -101,7 +101,7 @@ func TestCedarObserveClassifiesEngineDiagnosticsAsFailure(t *testing.T) {
 
 func TestCedarObserveRecordsUnresolvedPrincipal(t *testing.T) {
 	current := staticHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow, RiskEvent: risk.RiskEvent{Decision: risk.DecisionAllow}}}
-	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{State: cedarpolicy.StatePrincipalUnavailable}}, false)
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{State: cedarpolicy.StatePrincipalUnavailable}}, CedarEnforcementOff)
 	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{}})
 	if err != nil {
 		t.Fatal(err)
@@ -114,7 +114,7 @@ func TestCedarObserveRecordsUnresolvedPrincipal(t *testing.T) {
 func TestCedarEnforceIsSingularAuthority(t *testing.T) {
 	deployment := cedarTestDeployment(t, cedareval.RolloutModeEnforce, `@id("permit-read") permit(principal, action, resource == Kontext::Tool::"Read");`)
 	current := &countingHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionDeny, ReasonCode: "legacy_deny"}}
-	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, LastKnownGood: &deployment, State: cedarpolicy.StateSuccess, Status: cedarpolicy.CacheStatus{FetchedAt: time.Now()}}}, true)
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, LastKnownGood: &deployment, State: cedarpolicy.StateSuccess, Status: cedarpolicy.CacheStatus{FetchedAt: time.Now()}}}, CedarEnforcementStatic)
 
 	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{}})
 	if err != nil {
@@ -131,7 +131,7 @@ func TestCedarEnforceIsSingularAuthority(t *testing.T) {
 func TestCedarEnforceDeniesAskWithoutApprovalChannel(t *testing.T) {
 	deployment := cedarTestDeployment(t, cedareval.RolloutModeEnforce, `@id("ask-write") @ask("prompt") permit(principal, action, resource == Kontext::Tool::"Write");`)
 	current := &countingHookPolicy{}
-	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, LastKnownGood: &deployment, State: cedarpolicy.StateSuccess}}, true)
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, LastKnownGood: &deployment, State: cedarpolicy.StateSuccess}}, CedarEnforcementStatic)
 	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Write", ToolInput: map[string]any{}})
 	if err != nil {
 		t.Fatal(err)
@@ -144,7 +144,7 @@ func TestCedarEnforceDeniesAskWithoutApprovalChannel(t *testing.T) {
 func TestCedarEnforceFailsClosedOnEngineDiagnostics(t *testing.T) {
 	deployment := cedarTestDeployment(t, cedareval.RolloutModeEnforce, portableEngineErrorPolicy)
 	current := &countingHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow}}
-	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, LastKnownGood: &deployment, State: cedarpolicy.StateSuccess}}, true)
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, LastKnownGood: &deployment, State: cedarpolicy.StateSuccess}}, CedarEnforcementStatic)
 
 	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Bash", ToolInput: map[string]any{"command": 1}})
 	if err != nil {
@@ -176,7 +176,7 @@ func TestCedarEnforceFailsClosedWithoutFallback(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			current := &countingHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow}}
-			provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: tt.snapshot}, true)
+			provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: tt.snapshot}, CedarEnforcementStatic)
 			decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{}})
 			if err != nil {
 				t.Fatal(err)
@@ -190,7 +190,7 @@ func TestCedarEnforceFailsClosedWithoutFallback(t *testing.T) {
 
 func TestCedarExplicitDisableReturnsAuthorityToCurrentEvaluator(t *testing.T) {
 	current := &countingHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow, ReasonCode: "current_allow", RiskEvent: risk.RiskEvent{Decision: risk.DecisionAllow}}}
-	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{State: cedarpolicy.StateDisabled}}, true)
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{State: cedarpolicy.StateDisabled}}, CedarEnforcementStatic)
 	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{}})
 	if err != nil {
 		t.Fatal(err)
@@ -213,7 +213,7 @@ func TestCedarEnforceDoesNotFallbackOnNonRollbackResponseStates(t *testing.T) {
 			provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{
 				LastKnownGood: &deployment,
 				State:         state,
-			}}, true)
+			}}, CedarEnforcementStatic)
 			decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{}})
 			if err != nil {
 				t.Fatal(err)
@@ -239,7 +239,7 @@ func TestCedarEnforceFailsClosedWithoutLastKnownGood(t *testing.T) {
 		}
 		t.Run(name, func(t *testing.T) {
 			current := &countingHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow}}
-			provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{State: state}}, true)
+			provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{State: state}}, CedarEnforcementStatic)
 			decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{}})
 			if err != nil {
 				t.Fatal(err)
@@ -254,7 +254,7 @@ func TestCedarEnforceFailsClosedWithoutLastKnownGood(t *testing.T) {
 func TestCedarConfiguredObserveKeepsCurrentAuthority(t *testing.T) {
 	deployment := cedarTestDeployment(t, cedareval.RolloutModeObserve, `@id("forbid-all") forbid(principal, action, resource);`)
 	current := &countingHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow, ReasonCode: "current_allow", RiskEvent: risk.RiskEvent{Decision: risk.DecisionAllow}}}
-	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, LastKnownGood: &deployment, State: cedarpolicy.StateSuccess}}, true)
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, LastKnownGood: &deployment, State: cedarpolicy.StateSuccess}}, CedarEnforcementStatic)
 	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{}})
 	if err != nil {
 		t.Fatal(err)
@@ -267,7 +267,7 @@ func TestCedarConfiguredObserveKeepsCurrentAuthority(t *testing.T) {
 func TestCedarNoActivePolicyIsExplicitRollback(t *testing.T) {
 	deployment := cedarTestDeployment(t, cedareval.RolloutModeEnforce, `@id("permit") permit(principal, action, resource);`)
 	current := &countingHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow, RiskEvent: risk.RiskEvent{Decision: risk.DecisionAllow}}}
-	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{LastKnownGood: &deployment, State: cedarpolicy.StateNoActivePolicy}}, true)
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{LastKnownGood: &deployment, State: cedarpolicy.StateNoActivePolicy}}, CedarEnforcementStatic)
 	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{}})
 	if err != nil {
 		t.Fatal(err)
@@ -285,7 +285,7 @@ func TestCedarEnforceUsesAgeValidLastKnownGoodAfterRefreshFailure(t *testing.T) 
 		LastKnownGood: &deployment,
 		State:         cedarpolicy.StateSuccess,
 		Status:        cedarpolicy.CacheStatus{Stale: true},
-	}}, true)
+	}}, CedarEnforcementStatic)
 	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{}})
 	if err != nil {
 		t.Fatal(err)
@@ -304,4 +304,88 @@ func cedarTestDeployment(t *testing.T, mode cedareval.RolloutMode, policy string
 		t.Fatal(err)
 	}
 	return cedarpolicy.Deployment{ResponseVersion: 1, RequestContractVersion: 1, PolicyHash: hash, RolloutMode: mode, EvaluationPrincipal: principal, PolicyText: policy, DeploymentIdentity: identity}
+}
+
+func TestCedarRemoteFollowsEnforceRollout(t *testing.T) {
+	deployment := cedarTestDeployment(t, cedareval.RolloutModeEnforce, `@id("permit-read") permit(principal, action, resource == Kontext::Tool::"Read");`)
+	current := &countingHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionDeny, ReasonCode: "legacy_deny"}}
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, LastKnownGood: &deployment, State: cedarpolicy.StateSuccess, Status: cedarpolicy.CacheStatus{FetchedAt: time.Now()}}}, CedarEnforcementRemote)
+
+	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.calls != 0 {
+		t.Fatalf("previous evaluator calls = %d, want zero under remote enforce rollout", current.calls)
+	}
+	if decision.Decision != risk.DecisionAllow || decision.ReasonCode != string(cedareval.ReasonPermit) {
+		t.Fatalf("decision = %#v, want Cedar allow", decision)
+	}
+	if decision.Cedar == nil || decision.Cedar.AppliedRolloutMode != cedareval.RolloutModeEnforce {
+		t.Fatalf("Cedar evidence = %#v, want applied enforce", decision.Cedar)
+	}
+}
+
+func TestCedarRemoteStaysObserveUnderObserveRollout(t *testing.T) {
+	deployment := cedarTestDeployment(t, cedareval.RolloutModeObserve, `@id("forbid-read") forbid(principal, action, resource == Kontext::Tool::"Read");`)
+	current := &countingHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow, ReasonCode: "current_allow", RiskEvent: risk.RiskEvent{Decision: risk.DecisionAllow}}}
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, LastKnownGood: &deployment, State: cedarpolicy.StateSuccess, Status: cedarpolicy.CacheStatus{FetchedAt: time.Now()}}}, CedarEnforcementRemote)
+
+	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.calls != 1 || decision.Decision != risk.DecisionAllow || decision.ReasonCode != "current_allow" {
+		t.Fatalf("calls = %d decision = %#v, want preserved current authority under observe rollout", current.calls, decision)
+	}
+	if decision.Cedar == nil || decision.Cedar.AppliedRolloutMode != cedareval.RolloutModeObserve {
+		t.Fatalf("Cedar evidence = %#v, want dry-run observe", decision.Cedar)
+	}
+}
+
+func TestCedarRemoteWithoutDeploymentStaysObserve(t *testing.T) {
+	current := &countingHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow, RiskEvent: risk.RiskEvent{Decision: risk.DecisionAllow}}}
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{State: cedarpolicy.StateUnavailable}}, CedarEnforcementRemote)
+
+	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.calls != 1 || decision.Decision != risk.DecisionAllow {
+		t.Fatalf("calls = %d decision = %#v, want fail-open observe before first deployment", current.calls, decision)
+	}
+}
+
+func TestCedarRemoteHoldsLastKnownGoodEnforce(t *testing.T) {
+	deployment := cedarTestDeployment(t, cedareval.RolloutModeEnforce, `@id("permit-read") permit(principal, action, resource == Kontext::Tool::"Read");`)
+	current := &countingHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow}}
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{
+		LastKnownGood: &deployment,
+		State:         cedarpolicy.StateUnavailable,
+	}}, CedarEnforcementRemote)
+
+	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.calls != 0 || decision.Decision != risk.DecisionDeny || decision.ReasonCode != string(cedareval.ReasonEnforcementNotReady) {
+		t.Fatalf("calls = %d decision = %#v, want fail-closed enforcement while only LKG enforce is cached", current.calls, decision)
+	}
+}
+
+func TestCedarRemoteDisabledStateRelinquishesAuthority(t *testing.T) {
+	deployment := cedarTestDeployment(t, cedareval.RolloutModeEnforce, `@id("permit-read") permit(principal, action, resource == Kontext::Tool::"Read");`)
+	current := &countingHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow, RiskEvent: risk.RiskEvent{Decision: risk.DecisionAllow}}}
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{
+		LastKnownGood: &deployment,
+		State:         cedarpolicy.StateDisabled,
+	}}, CedarEnforcementRemote)
+
+	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.calls != 1 || decision.Decision != risk.DecisionAllow {
+		t.Fatalf("calls = %d decision = %#v, want current authority after explicit disable", current.calls, decision)
+	}
 }

--- a/internal/guard/app/server/runtime.go
+++ b/internal/guard/app/server/runtime.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/kontext-security/kontext-cli/internal/cedareval"
+	guardhookruntime "github.com/kontext-security/kontext-cli/internal/guard/hookruntime"
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
 	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
 	"github.com/kontext-security/kontext-cli/internal/hook"
@@ -124,12 +126,20 @@ func hookEventFromRiskEvent(event risk.HookEvent) hook.Event {
 }
 
 func hookResultFromRiskDecision(decision risk.RiskDecision) hook.Result {
-	return hook.WithMetadata(hook.Result{
+	result := hook.Result{
 		Decision:   hook.Decision(decision.Decision),
 		Reason:     decision.Reason,
 		ReasonCode: decision.ReasonCode,
 		EventID:    decision.EventID,
-	}, decision)
+	}
+	// A Cedar decision applied under an enforce rollout is authoritative: mark
+	// the result so hook edges (which otherwise downgrade every decision to
+	// observe) pass the decision through. The client-side transform still owns
+	// the final posture per runtime mode.
+	if decision.Cedar != nil && decision.Cedar.AppliedRolloutMode == cedareval.RolloutModeEnforce {
+		result.Mode = string(guardhookruntime.ModeEnforce)
+	}
+	return hook.WithMetadata(result, decision)
 }
 
 func riskDecisionFromHookResult(result hook.Result) risk.RiskDecision {

--- a/internal/guard/app/server/runtime_test.go
+++ b/internal/guard/app/server/runtime_test.go
@@ -1,0 +1,36 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/cedareval"
+	"github.com/kontext-security/kontext-cli/internal/guard/risk"
+	"github.com/kontext-security/kontext-cli/internal/hook"
+)
+
+func TestHookResultStampsEnforceForAuthoritativeCedarDecision(t *testing.T) {
+	decision := risk.RiskDecision{
+		Decision: risk.DecisionDeny,
+		Cedar:    &risk.CedarEvidence{AppliedRolloutMode: cedareval.RolloutModeEnforce},
+	}
+	result := hookResultFromRiskDecision(decision)
+	if result.Mode != "enforce" {
+		t.Fatalf("result mode = %q, want enforce stamp for authoritative Cedar decision", result.Mode)
+	}
+	if result.Decision != hook.DecisionDeny {
+		t.Fatalf("result decision = %q, want deny", result.Decision)
+	}
+}
+
+func TestHookResultLeavesModeUnstampedWithoutCedarAuthority(t *testing.T) {
+	for name, decision := range map[string]risk.RiskDecision{
+		"no cedar evidence":  {Decision: risk.DecisionAllow},
+		"observe evaluation": {Decision: risk.DecisionAllow, Cedar: &risk.CedarEvidence{AppliedRolloutMode: cedareval.RolloutModeObserve}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if result := hookResultFromRiskDecision(decision); result.Mode != "" {
+				t.Fatalf("result mode = %q, want unstamped", result.Mode)
+			}
+		})
+	}
+}

--- a/internal/guard/app/server/server.go
+++ b/internal/guard/app/server/server.go
@@ -54,7 +54,7 @@ type Options struct {
 	ProviderPolicies     []ProviderPolicyBinding
 	EndpointID           string
 	CedarPolicies        cedarpolicy.SnapshotProvider
-	CedarEnforcement     bool
+	CedarEnforcement     CedarEnforcementSource
 	CurrentSessionID     string
 	Mode                 string
 }

--- a/internal/guard/hookruntime/posture.go
+++ b/internal/guard/hookruntime/posture.go
@@ -1,0 +1,49 @@
+package hookruntime
+
+import (
+	"github.com/kontext-security/kontext-cli/internal/hook"
+)
+
+// AuthoritativeEnforce reports whether a result carries the enforce stamp
+// with an actionable decision. Only such results may block a tool call; a
+// stamp without a real decision is never authoritative.
+func AuthoritativeEnforce(result hook.Result) bool {
+	return result.Mode == string(ModeEnforce) &&
+		(result.Decision == hook.DecisionAllow || result.Decision == hook.DecisionDeny)
+}
+
+// ObserveResult forces observe semantics: the hook never blocks, and a
+// decision that would have blocked is preserved as a would-note in the
+// reason. Observe is the default posture wherever a stronger one has not
+// been explicitly established.
+func ObserveResult(event hook.Event, result hook.Result) hook.Result {
+	result.Mode = string(ModeObserve)
+	if result.Decision == "" {
+		result.Decision = hook.DecisionAllow
+	}
+	if event.HookName.CanBlock() {
+		if result.Reason == "" {
+			result.Reason = "no reason provided"
+		}
+		if result.Decision != hook.DecisionAllow {
+			result.Reason = "Kontext observe mode: would " + string(result.Decision) + "; " + result.Reason
+		}
+	}
+	result.Decision = hook.DecisionAllow
+	return result
+}
+
+// ApplyRemote is the single implementation of the remote posture rule: a
+// result the policy distribution made authoritative (enforce-stamped, with a
+// real decision) passes through, normalized to allow on hooks that cannot
+// block; everything else defaults to observe. Every hook edge must call this
+// rather than reimplement the rule.
+func ApplyRemote(event hook.Event, result hook.Result) hook.Result {
+	if AuthoritativeEnforce(result) {
+		if !event.HookName.CanBlock() {
+			result.Decision = hook.DecisionAllow
+		}
+		return result
+	}
+	return ObserveResult(event, result)
+}

--- a/internal/guard/hookruntime/runtime.go
+++ b/internal/guard/hookruntime/runtime.go
@@ -86,15 +86,7 @@ func normalizeResult(result hook.Result) hook.Result {
 
 func effectiveResult(event hook.Event, result hook.Result, mode Mode) hook.Result {
 	if mode == ModeRemote {
-		// The runtime stamped enforce only on decisions the policy
-		// distribution made authoritative; everything else is observe.
-		if result.Mode == string(ModeEnforce) {
-			if !event.HookName.CanBlock() {
-				result.Decision = hook.DecisionAllow
-			}
-			return result
-		}
-		mode = ModeObserve
+		return ApplyRemote(event, result)
 	}
 	result.Mode = string(mode)
 	if mode == ModeObserve {

--- a/internal/guard/hookruntime/runtime.go
+++ b/internal/guard/hookruntime/runtime.go
@@ -14,6 +14,11 @@ type Mode string
 const (
 	ModeObserve Mode = "observe"
 	ModeEnforce Mode = "enforce"
+	// ModeRemote defers the posture to the policy distribution: a decision the
+	// runtime marked enforce (Mode on the result) passes through unchanged,
+	// everything else gets observe semantics. Neither the hook edge nor the
+	// daemon start-up pins the posture; the fetched deployment does.
+	ModeRemote Mode = "remote"
 )
 
 type Adapter interface {
@@ -64,8 +69,10 @@ func ParseMode(value string) (Mode, error) {
 		return ModeObserve, nil
 	case ModeEnforce:
 		return ModeEnforce, nil
+	case ModeRemote:
+		return ModeRemote, nil
 	default:
-		return "", fmt.Errorf("unknown hook mode %q; use observe or enforce", value)
+		return "", fmt.Errorf("unknown hook mode %q; use observe, enforce, or remote", value)
 	}
 }
 
@@ -78,6 +85,17 @@ func normalizeResult(result hook.Result) hook.Result {
 }
 
 func effectiveResult(event hook.Event, result hook.Result, mode Mode) hook.Result {
+	if mode == ModeRemote {
+		// The runtime stamped enforce only on decisions the policy
+		// distribution made authoritative; everything else is observe.
+		if result.Mode == string(ModeEnforce) {
+			if !event.HookName.CanBlock() {
+				result.Decision = hook.DecisionAllow
+			}
+			return result
+		}
+		mode = ModeObserve
+	}
 	result.Mode = string(mode)
 	if mode == ModeObserve {
 		result.Reason = formatObserveReason(result.Decision, result.Reason)

--- a/internal/guard/hookruntime/runtime_test.go
+++ b/internal/guard/hookruntime/runtime_test.go
@@ -154,3 +154,32 @@ func (a *stubAdapter) Encode(_ io.Writer, _ hook.Event, result hook.Result) erro
 func (a *stubAdapter) MalformedHookName() hook.HookName {
 	return hook.HookPreToolUse
 }
+
+func TestParseModeRemote(t *testing.T) {
+	mode, err := ParseMode(" Remote ")
+	if err != nil {
+		t.Fatalf("ParseMode() error = %v", err)
+	}
+	if mode != ModeRemote {
+		t.Fatalf("mode = %q, want remote", mode)
+	}
+}
+
+func TestEffectiveResultRemotePassesThroughEnforceStamp(t *testing.T) {
+	event := hook.Event{HookName: hook.HookPreToolUse}
+	result := effectiveResult(event, hook.Result{Decision: hook.DecisionDeny, Mode: string(ModeEnforce), Reason: "policy deny"}, ModeRemote)
+	if result.Decision != hook.DecisionDeny || result.Mode != string(ModeEnforce) {
+		t.Fatalf("result = %+v, want authoritative deny passed through", result)
+	}
+}
+
+func TestEffectiveResultRemoteDowngradesUnstampedToObserve(t *testing.T) {
+	event := hook.Event{HookName: hook.HookPreToolUse}
+	result := effectiveResult(event, hook.Result{Decision: hook.DecisionDeny, Reason: "would deny"}, ModeRemote)
+	if result.Decision != hook.DecisionAllow || result.Mode != string(ModeObserve) {
+		t.Fatalf("result = %+v, want observe downgrade", result)
+	}
+	if result.Reason != "Kontext observe mode: would deny; would deny" {
+		t.Fatalf("reason = %q, want observe would-note", result.Reason)
+	}
+}

--- a/internal/managedconfig/config.go
+++ b/internal/managedconfig/config.go
@@ -24,8 +24,13 @@ const (
 	Version = "managed-install-v1"
 	// Mode is the default posture; ModeEnforce turns daemon decisions into
 	// real denies at every hook edge (Claude Code and Cowork alike).
+	// ModeRemote delegates the posture to the fetched policy deployment's
+	// rollout mode: the endpoint observes until the deployment says enforce,
+	// with no local reinstall needed to flip. Observe and enforce remain
+	// static pins for deployments that must not change posture remotely.
 	Mode        = "observe"
 	ModeEnforce = "enforce"
+	ModeRemote  = "remote"
 	Agent       = "claude"
 
 	DefaultPath  = "/Library/Application Support/Kontext/managed.json"
@@ -282,8 +287,8 @@ func normalizeAndValidate(cfg Config) (Config, error) {
 	if err := validateCloudURL(cfg.CloudURL); err != nil {
 		return Config{}, err
 	}
-	if cfg.Mode != Mode && cfg.Mode != ModeEnforce {
-		return Config{}, fmt.Errorf("mode must be %q or %q", Mode, ModeEnforce)
+	if cfg.Mode != Mode && cfg.Mode != ModeEnforce && cfg.Mode != ModeRemote {
+		return Config{}, fmt.Errorf("mode must be %q, %q, or %q", Mode, ModeEnforce, ModeRemote)
 	}
 	if cfg.Agent != Agent {
 		return Config{}, fmt.Errorf("agent must be %q", Agent)

--- a/internal/managedconfig/config_test.go
+++ b/internal/managedconfig/config_test.go
@@ -294,3 +294,13 @@ func replacementFor(field string) string {
 		}[field] + `"`
 	}
 }
+
+func TestParseModeRemote(t *testing.T) {
+	cfg, err := Parse([]byte(strings.Replace(validConfigJSON(), `"mode": "observe"`, `"mode": "remote"`, 1)))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if cfg.Mode != ModeRemote {
+		t.Fatalf("Mode = %q, want %q", cfg.Mode, ModeRemote)
+	}
+}

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -126,10 +126,19 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 	}
 
 	// The deployment-level mode from managed.json drives every hook edge:
-	// observe records would-decisions, enforce returns real denies.
+	// observe records would-decisions, enforce returns real denies, remote
+	// defers to the fetched policy deployment's rollout mode so the posture
+	// can be flipped from the dashboard without touching the install.
 	mode, err := guardhookruntime.ParseMode(loadedConfig.Config.Mode)
 	if err != nil {
 		return fmt.Errorf("parse managed mode: %w", err)
+	}
+	cedarEnforcement := server.CedarEnforcementOff
+	switch mode {
+	case guardhookruntime.ModeEnforce:
+		cedarEnforcement = server.CedarEnforcementStatic
+	case guardhookruntime.ModeRemote:
+		cedarEnforcement = server.CedarEnforcementRemote
 	}
 
 	githubCache := newProviderPolicyCache(opts.GithubPolicyCachePath, dbPath, githubpolicy.Config, opts.Diagnostic)
@@ -171,7 +180,7 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 		},
 		EndpointID:         installationState.InstallationID,
 		CedarPolicies:      cedarCache,
-		CedarEnforcement:   mode == guardhookruntime.ModeEnforce,
+		CedarEnforcement:   cedarEnforcement,
 		Mode:               mode,
 		Diagnostic:         opts.Diagnostic,
 		SkipInitialSession: true,

--- a/internal/managedobserve/lifecycle.go
+++ b/internal/managedobserve/lifecycle.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kontext-security/kontext-cli/internal/cedarpolicy"
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 	guardhookruntime "github.com/kontext-security/kontext-cli/internal/guard/hookruntime"
 	"github.com/kontext-security/kontext-cli/internal/hook"
@@ -31,18 +32,28 @@ type Lifecycle struct {
 	Label      string
 	Kickstart  func(context.Context, string) error
 	Diagnostic diagnostic.Logger
-	// Mode is the managed rollout posture ("observe" or "enforce"). Empty is
-	// treated as observe. In enforce the daemon's decision is authoritative and
-	// passes through unchanged; in observe the hook can never block.
+	// Mode is the managed rollout posture ("observe", "enforce", or
+	// "remote"). Empty is treated as observe. In enforce the daemon's decision
+	// is authoritative and passes through unchanged; in observe the hook can
+	// never block. In remote the daemon's per-decision posture stamp decides:
+	// decisions the daemon marked enforce (the fetched policy deployment says
+	// enforce) pass through, everything else gets observe semantics.
 	Mode string
+	// RemoteEnforce reports whether the cached policy distribution currently
+	// claims enforcement. It is consulted only in remote mode when the daemon
+	// is unreachable, to pick between failing open (observe posture) and
+	// failing closed (enforce posture) — an unreachable daemon must not
+	// downgrade an enforcing endpoint to observe.
+	RemoteEnforce func() bool
 }
 
 func NewLifecycle() Lifecycle {
 	return Lifecycle{
-		SocketPath: DefaultSocketPath(),
-		Label:      DefaultLabel(),
-		Kickstart:  KickstartLaunchd,
-		Mode:       loadManagedMode(),
+		SocketPath:    DefaultSocketPath(),
+		Label:         DefaultLabel(),
+		Kickstart:     KickstartLaunchd,
+		Mode:          loadManagedMode(),
+		RemoteEnforce: remoteEnforceFromCache,
 	}
 }
 
@@ -55,14 +66,40 @@ func loadManagedMode() string {
 	if err != nil {
 		return managedconfig.Mode
 	}
-	if cfg.Config.Mode == managedconfig.ModeEnforce {
-		return managedconfig.ModeEnforce
+	switch cfg.Config.Mode {
+	case managedconfig.ModeEnforce, managedconfig.ModeRemote:
+		return cfg.Config.Mode
+	default:
+		return managedconfig.Mode
 	}
-	return managedconfig.Mode
+}
+
+// remoteEnforceFromCache reads the daemon's on-disk policy cache directly —
+// the daemon is unreachable when this is consulted. A missing or unreadable
+// cache reports no enforcement claim: with no trustworthy record of the
+// organization's intent, a self-serve endpoint fails open rather than
+// hard-blocking the agent.
+//
+// The cache location derives from DefaultDBPath(), the same env-overridable
+// default (KONTEXT_MANAGED_OBSERVE_DB) the daemon derives its cache path
+// from, mirroring how SocketPath resolution already keeps the two processes
+// aligned. The programmatic DaemonOptions path overrides are test seams; a
+// deployment that relocates the daemon state must export the env var to hook
+// processes too, or outage fallback will not see the enforcement claim.
+func remoteEnforceFromCache() bool {
+	cache := cedarpolicy.NewCache(cedarpolicy.DefaultCachePathForDB(DefaultDBPath()), 0)
+	if err := cache.Load(); err != nil {
+		return false
+	}
+	return cedarpolicy.DeploymentClaimsEnforce(cache.Current())
 }
 
 func (l Lifecycle) enforcing() bool {
 	return l.Mode == managedconfig.ModeEnforce
+}
+
+func (l Lifecycle) remote() bool {
+	return l.Mode == managedconfig.ModeRemote
 }
 
 func Active() bool {
@@ -131,13 +168,23 @@ func (l Lifecycle) processIfAvailable(ctx context.Context, event hook.Event, bud
 // only an explicit enforce-mode allow or deny; a stale daemon or malformed RPC
 // result is not authoritative. Non-blocking hooks are always normalized to
 // allow. In observe the hook can never block, so the decision is forced to
-// allow with a "would" note.
+// allow with a "would" note. Remote passes through only decisions the daemon
+// stamped enforce — the daemon stamps those exactly when the fetched policy
+// deployment claims enforcement — and treats everything else as observe.
 func (l Lifecycle) finalize(event hook.Event, result hook.Result) hook.Result {
 	if l.enforcing() {
 		if result.Mode != managedconfig.ModeEnforce ||
 			(result.Decision != hook.DecisionAllow && result.Decision != hook.DecisionDeny) {
 			return l.daemonUnavailable(event)
 		}
+		if !event.HookName.CanBlock() {
+			result.Decision = hook.DecisionAllow
+		}
+		return result
+	}
+	if l.remote() &&
+		result.Mode == managedconfig.ModeEnforce &&
+		(result.Decision == hook.DecisionAllow || result.Decision == hook.DecisionDeny) {
 		if !event.HookName.CanBlock() {
 			result.Decision = hook.DecisionAllow
 		}
@@ -150,7 +197,21 @@ func (l Lifecycle) finalize(event hook.Event, result hook.Result) hook.Result {
 // Observe fails open (it never blocks). Enforce fails closed for blocking
 // hooks: enforcement requires an authoritative decision and an unreachable
 // daemon cannot provide one. Non-blocking lifecycle hooks remain informational.
+// Remote fails closed only while the cached policy distribution claims
+// enforcement; otherwise it fails open like observe, so a fresh self-serve
+// install without an enforcing deployment never hard-blocks the agent.
 func (l Lifecycle) daemonUnavailable(event hook.Event) hook.Result {
+	if l.remote() && l.RemoteEnforce != nil && l.RemoteEnforce() {
+		decision := hook.DecisionAllow
+		if event.HookName.CanBlock() {
+			decision = hook.DecisionDeny
+		}
+		return hook.Result{
+			Decision: decision,
+			Mode:     managedconfig.ModeEnforce,
+			Reason:   "Kontext enforce: managed policy daemon unavailable",
+		}
+	}
 	if l.enforcing() {
 		decision := hook.DecisionAllow
 		if event.HookName.CanBlock() {

--- a/internal/managedobserve/lifecycle.go
+++ b/internal/managedobserve/lifecycle.go
@@ -173,8 +173,7 @@ func (l Lifecycle) processIfAvailable(ctx context.Context, event hook.Event, bud
 // deployment claims enforcement — and treats everything else as observe.
 func (l Lifecycle) finalize(event hook.Event, result hook.Result) hook.Result {
 	if l.enforcing() {
-		if result.Mode != managedconfig.ModeEnforce ||
-			(result.Decision != hook.DecisionAllow && result.Decision != hook.DecisionDeny) {
+		if !guardhookruntime.AuthoritativeEnforce(result) {
 			return l.daemonUnavailable(event)
 		}
 		if !event.HookName.CanBlock() {
@@ -182,15 +181,10 @@ func (l Lifecycle) finalize(event hook.Event, result hook.Result) hook.Result {
 		}
 		return result
 	}
-	if l.remote() &&
-		result.Mode == managedconfig.ModeEnforce &&
-		(result.Decision == hook.DecisionAllow || result.Decision == hook.DecisionDeny) {
-		if !event.HookName.CanBlock() {
-			result.Decision = hook.DecisionAllow
-		}
-		return result
+	if l.remote() {
+		return guardhookruntime.ApplyRemote(event, result)
 	}
-	return observeResult(event, result)
+	return guardhookruntime.ObserveResult(event, result)
 }
 
 // daemonUnavailable is the fail path when the managed daemon cannot be reached.
@@ -223,7 +217,7 @@ func (l Lifecycle) daemonUnavailable(event hook.Event) hook.Result {
 			Reason:   "Kontext enforce: managed policy daemon unavailable",
 		}
 	}
-	return observeResult(event, hook.Result{Decision: hook.DecisionAllow, Reason: "managed observe daemon unavailable"})
+	return guardhookruntime.ObserveResult(event, hook.Result{Decision: hook.DecisionAllow, Reason: "managed observe daemon unavailable"})
 }
 
 func (l Lifecycle) probe(ctx context.Context) bool {
@@ -263,26 +257,6 @@ func (l Lifecycle) call(ctx context.Context, event hook.Event) (hook.Result, err
 		return hook.Result{}, err
 	}
 	return result, nil
-}
-
-func observeResult(event hook.Event, result hook.Result) hook.Result {
-	result.Mode = string(guardhookruntime.ModeObserve)
-	if result.Decision == "" {
-		result.Decision = hook.DecisionAllow
-	}
-	if event.HookName.CanBlock() {
-		decision := result.Decision
-		if result.Reason == "" {
-			result.Reason = "no reason provided"
-		}
-		if decision != hook.DecisionAllow {
-			result.Reason = "Kontext observe mode: would " + string(decision) + "; " + result.Reason
-		}
-		result.Decision = hook.DecisionAllow
-		return result
-	}
-	result.Decision = hook.DecisionAllow
-	return result
 }
 
 func deadlineOr(ctx context.Context, fallback time.Time) time.Time {

--- a/internal/managedobserve/lifecycle_test.go
+++ b/internal/managedobserve/lifecycle_test.go
@@ -370,3 +370,88 @@ func TestActiveRequiresValidManagedConfig(t *testing.T) {
 		t.Fatal("Active() = false for valid config")
 	}
 }
+
+func TestLifecycleRemotePassesThroughEnforceStampedDecisions(t *testing.T) {
+	t.Parallel()
+
+	lifecycle := Lifecycle{Mode: "remote"}
+	event := hook.Event{HookName: hook.HookPreToolUse}
+
+	deny := lifecycle.finalize(event, hook.Result{Decision: hook.DecisionDeny, Mode: "enforce", Reason: "policy deny"})
+	if deny.Decision != hook.DecisionDeny || deny.Mode != "enforce" {
+		t.Fatalf("finalize(deny) = %+v, want authoritative deny passed through", deny)
+	}
+
+	allow := lifecycle.finalize(event, hook.Result{Decision: hook.DecisionAllow, Mode: "enforce"})
+	if allow.Decision != hook.DecisionAllow || allow.Mode != "enforce" {
+		t.Fatalf("finalize(allow) = %+v, want authoritative allow passed through", allow)
+	}
+}
+
+func TestLifecycleRemoteDowngradesUnstampedDecisionsToObserve(t *testing.T) {
+	t.Parallel()
+
+	lifecycle := Lifecycle{Mode: "remote"}
+	event := hook.Event{HookName: hook.HookPreToolUse}
+	tests := []struct {
+		name   string
+		result hook.Result
+	}{
+		{name: "unstamped deny", result: hook.Result{Decision: hook.DecisionDeny, Reason: "would deny"}},
+		{name: "observe stamped deny", result: hook.Result{Decision: hook.DecisionDeny, Mode: "observe", Reason: "would deny"}},
+		{name: "enforce stamp without decision", result: hook.Result{Mode: "enforce"}},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			result := lifecycle.finalize(event, test.result)
+			if result.Decision != hook.DecisionAllow || result.Mode != string(guardhookruntime.ModeObserve) {
+				t.Fatalf("finalize() = %+v, want observe allow", result)
+			}
+		})
+	}
+}
+
+func TestLifecycleRemoteNormalizesEnforceStampOnNonBlockingHook(t *testing.T) {
+	t.Parallel()
+
+	lifecycle := Lifecycle{Mode: "remote"}
+	result := lifecycle.finalize(hook.Event{HookName: hook.HookPostToolUse}, hook.Result{Decision: hook.DecisionDeny, Mode: "enforce"})
+	if result.Decision != hook.DecisionAllow || result.Mode != "enforce" {
+		t.Fatalf("finalize() = %+v, want allow for non-blocking hook", result)
+	}
+}
+
+func TestLifecycleRemoteUnavailableFailsClosedWhileEnforcing(t *testing.T) {
+	t.Parallel()
+
+	lifecycle := Lifecycle{Mode: "remote", RemoteEnforce: func() bool { return true }}
+	result := lifecycle.daemonUnavailable(hook.Event{HookName: hook.HookPreToolUse})
+	if result.Decision != hook.DecisionDeny || result.Mode != "enforce" {
+		t.Fatalf("daemonUnavailable() = %+v, want fail-closed deny while distribution claims enforce", result)
+	}
+
+	nonBlocking := lifecycle.daemonUnavailable(hook.Event{HookName: hook.HookPostToolUse})
+	if nonBlocking.Decision != hook.DecisionAllow {
+		t.Fatalf("daemonUnavailable(non-blocking) = %+v, want allow", nonBlocking)
+	}
+}
+
+func TestLifecycleRemoteUnavailableFailsOpenWithoutEnforceClaim(t *testing.T) {
+	t.Parallel()
+
+	for name, lifecycle := range map[string]Lifecycle{
+		"no enforce claim": {Mode: "remote", RemoteEnforce: func() bool { return false }},
+		"no probe":         {Mode: "remote"},
+	} {
+		lifecycle := lifecycle
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			result := lifecycle.daemonUnavailable(hook.Event{HookName: hook.HookPreToolUse})
+			if result.Decision != hook.DecisionAllow || result.Mode != string(guardhookruntime.ModeObserve) {
+				t.Fatalf("daemonUnavailable() = %+v, want observe fail-open", result)
+			}
+		})
+	}
+}

--- a/internal/managedobserve/lifecycle_test.go
+++ b/internal/managedobserve/lifecycle_test.go
@@ -336,7 +336,7 @@ func TestLifecycleEnforceUnavailableNonBlockingHookDoesNotDeny(t *testing.T) {
 }
 
 func TestObserveResultFormatsBlockingPromptSubmit(t *testing.T) {
-	result := observeResult(hook.Event{HookName: hook.HookUserPromptSubmit}, hook.Result{
+	result := guardhookruntime.ObserveResult(hook.Event{HookName: hook.HookUserPromptSubmit}, hook.Result{
 		Decision: hook.DecisionDeny,
 		Reason:   "prompt policy",
 	})

--- a/internal/managedobserve/remote_enforce_test.go
+++ b/internal/managedobserve/remote_enforce_test.go
@@ -1,0 +1,89 @@
+package managedobserve
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/cedareval"
+	"github.com/kontext-security/kontext-cli/internal/cedarpolicy"
+)
+
+const remoteEnforceTestPolicy = `@id("permit-read")
+permit (
+  principal,
+  action == Kontext::Action::"ToolUse",
+  resource == Kontext::Tool::"Read"
+);`
+
+// remoteEnforceTestDeployment mirrors the daemon-side deployment shape so the
+// cache write below goes through the exact production persistence path.
+func remoteEnforceTestDeployment(t *testing.T, mode cedareval.RolloutMode) cedarpolicy.Deployment {
+	t.Helper()
+	principal := cedareval.EvaluationPrincipal{
+		EntityType: cedareval.PrincipalEntityType,
+		EntityID:   "user@example.com",
+	}
+	policyHash := cedareval.ComputePolicyHash(remoteEnforceTestPolicy)
+	identity, err := cedareval.ComputeDeploymentIdentity(cedareval.DeploymentIdentityInput{
+		ResponseVersion:        cedarpolicy.ResponseVersion,
+		RequestContractVersion: cedarpolicy.RequestContractVersion,
+		PolicyHash:             policyHash,
+		RolloutMode:            string(mode),
+		EvaluationPrincipal:    principal,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cedarpolicy.Deployment{
+		ResponseVersion:        cedarpolicy.ResponseVersion,
+		RequestContractVersion: cedarpolicy.RequestContractVersion,
+		PolicyHash:             policyHash,
+		RolloutMode:            mode,
+		EvaluationPrincipal:    principal,
+		PolicyText:             remoteEnforceTestPolicy,
+		DeploymentIdentity:     identity,
+	}
+}
+
+// TestRemoteEnforceFromCacheRoundTrip pins the cross-process file contract:
+// the hook's outage fallback must read the enforcement claim from a cache
+// file the daemon wrote. A cedarpolicy cache-format change that breaks this
+// silently turns remote-mode outages fail-open; this test makes it loud.
+func TestRemoteEnforceFromCacheRoundTrip(t *testing.T) {
+	writeCache := func(t *testing.T, mode cedareval.RolloutMode) {
+		t.Helper()
+		dbPath := filepath.Join(t.TempDir(), "guard.db")
+		t.Setenv("KONTEXT_MANAGED_OBSERVE_DB", dbPath)
+		deployment := remoteEnforceTestDeployment(t, mode)
+		cache := cedarpolicy.NewCache(cedarpolicy.DefaultCachePathForDB(DefaultDBPath()), time.Hour)
+		if err := cache.Apply(cedarpolicy.FetchResult{
+			State:      cedarpolicy.StateSuccess,
+			Deployment: &deployment,
+			ETag:       deployment.DeploymentIdentity,
+		}, time.Now()); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("enforce deployment claims enforcement", func(t *testing.T) {
+		writeCache(t, cedareval.RolloutModeEnforce)
+		if !remoteEnforceFromCache() {
+			t.Fatal("remoteEnforceFromCache() = false, want enforcement claim from daemon-written cache")
+		}
+	})
+
+	t.Run("observe deployment claims nothing", func(t *testing.T) {
+		writeCache(t, cedareval.RolloutModeObserve)
+		if remoteEnforceFromCache() {
+			t.Fatal("remoteEnforceFromCache() = true, want no enforcement claim for observe deployment")
+		}
+	})
+
+	t.Run("missing cache fails open", func(t *testing.T) {
+		t.Setenv("KONTEXT_MANAGED_OBSERVE_DB", filepath.Join(t.TempDir(), "guard.db"))
+		if remoteEnforceFromCache() {
+			t.Fatal("remoteEnforceFromCache() = true, want no claim without a cache")
+		}
+	})
+}

--- a/internal/runtimehost/host.go
+++ b/internal/runtimehost/host.go
@@ -41,7 +41,7 @@ type Options struct {
 	JudgeDownloadProgress     judge.DownloadProgressHandler
 	ProviderPolicies          []server.ProviderPolicyBinding
 	CedarPolicies             cedarpolicy.SnapshotProvider
-	CedarEnforcement          bool
+	CedarEnforcement          server.CedarEnforcementSource
 	EndpointID                string
 	Mode                      guardhookruntime.Mode
 	Diagnostic                diagnostic.Logger
@@ -222,24 +222,43 @@ func Start(ctx context.Context, opts Options) (*Host, error) {
 }
 
 func clientResultTransform(mode guardhookruntime.Mode) func(hook.Event, hook.Result) hook.Result {
-	if mode != guardhookruntime.ModeObserve {
-		return nil
-	}
-	return func(event hook.Event, result hook.Result) hook.Result {
-		result.Mode = string(mode)
-		if result.Decision == "" {
-			result.Decision = hook.DecisionAllow
+	switch mode {
+	case guardhookruntime.ModeEnforce:
+		// The whole pipeline is authoritative under a static enforce posture;
+		// stamp results so hook edges recognize them as such.
+		return func(event hook.Event, result hook.Result) hook.Result {
+			result.Mode = string(guardhookruntime.ModeEnforce)
+			return result
 		}
-		if event.HookName.CanBlock() {
-			decision := result.Decision
-			if result.Reason == "" {
-				result.Reason = "no reason provided"
+	case guardhookruntime.ModeRemote:
+		// Only decisions the runtime already marked enforce (a Cedar decision
+		// applied under an enforce rollout) are authoritative; everything else
+		// gets observe semantics.
+		return func(event hook.Event, result hook.Result) hook.Result {
+			if result.Mode == string(guardhookruntime.ModeEnforce) {
+				return result
 			}
-			result.Reason = "Kontext observe mode: would " + string(decision) + "; " + result.Reason
+			return observeResultTransform(event, result)
 		}
-		result.Decision = hook.DecisionAllow
-		return result
+	default:
+		return observeResultTransform
 	}
+}
+
+func observeResultTransform(event hook.Event, result hook.Result) hook.Result {
+	result.Mode = string(guardhookruntime.ModeObserve)
+	if result.Decision == "" {
+		result.Decision = hook.DecisionAllow
+	}
+	if event.HookName.CanBlock() {
+		decision := result.Decision
+		if result.Reason == "" {
+			result.Reason = "no reason provided"
+		}
+		result.Reason = "Kontext observe mode: would " + string(decision) + "; " + result.Reason
+	}
+	result.Decision = hook.DecisionAllow
+	return result
 }
 
 func (h *Host) SetPayloadCaptureConfiguration(config payloadcapture.RuntimeConfiguration) {

--- a/internal/runtimehost/host.go
+++ b/internal/runtimehost/host.go
@@ -231,34 +231,13 @@ func clientResultTransform(mode guardhookruntime.Mode) func(hook.Event, hook.Res
 			return result
 		}
 	case guardhookruntime.ModeRemote:
-		// Only decisions the runtime already marked enforce (a Cedar decision
-		// applied under an enforce rollout) are authoritative; everything else
-		// gets observe semantics.
-		return func(event hook.Event, result hook.Result) hook.Result {
-			if result.Mode == string(guardhookruntime.ModeEnforce) {
-				return result
-			}
-			return observeResultTransform(event, result)
-		}
+		// The single remote posture rule lives in hookruntime; only decisions
+		// the runtime already marked enforce (a Cedar decision applied under
+		// an enforce rollout) are authoritative.
+		return guardhookruntime.ApplyRemote
 	default:
-		return observeResultTransform
+		return guardhookruntime.ObserveResult
 	}
-}
-
-func observeResultTransform(event hook.Event, result hook.Result) hook.Result {
-	result.Mode = string(guardhookruntime.ModeObserve)
-	if result.Decision == "" {
-		result.Decision = hook.DecisionAllow
-	}
-	if event.HookName.CanBlock() {
-		decision := result.Decision
-		if result.Reason == "" {
-			result.Reason = "no reason provided"
-		}
-		result.Reason = "Kontext observe mode: would " + string(decision) + "; " + result.Reason
-	}
-	result.Decision = hook.DecisionAllow
-	return result
 }
 
 func (h *Host) SetPayloadCaptureConfiguration(config payloadcapture.RuntimeConfiguration) {


### PR DESCRIPTION
## Summary

Adds a third managed mode, `remote`: instead of pinning the guard posture at install time, the endpoint follows the rollout mode of the Cedar policy deployment it already fetches (~60s refresh). Flipping the deployment between observe and enforce in the dashboard changes endpoint behavior within one refresh interval — no reinstall, no config push.

- `managedconfig`: accept `"mode": "remote"` (`observe`/`enforce` stay static pins)
- `guard/server`: the boolean Cedar cutover gate becomes an enforcement source (`off`/`static`/`remote`); `remote` claims authority exactly when the fetched deployment (or last-known-good) says enforce
- `guard/runtime`: results carry `mode: enforce` when a Cedar decision was applied under an enforce rollout, so hook edges can recognize authoritative decisions. The static enforce transform now stamps results too — previously enforce-mode daemon results were never stamped, so the hook lifecycle treated them as non-authoritative
- `lifecycle`: in remote mode, only daemon results stamped enforce pass through; everything else is downgraded to observe. When the daemon is unreachable, the hook fails closed only while the cached policy distribution claims enforcement, and fails open otherwise

Fail-state semantics in remote mode: before any deployment is fetched the endpoint observes (a fresh install never hard-blocks); once an enforce deployment is cached, stale/expired cache holds enforcement (deny with `enforcement_not_ready`) rather than silently degrading to observe.

## Verification

- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] `go vet ./...`
- [ ] `buf generate` if protobuf or generated code changed (n/a)

## Release notes

- [x] conventional commit title matches semver intent

🤖 Generated with [Claude Code](https://claude.com/claude-code)