### PR TITLE
feat(setup): default self-serve installs to remote mode

### DIFF
--- a/internal/managedconfig/config.go
+++ b/internal/managedconfig/config.go
@@ -392,3 +392,74 @@ func resolveKeychainInstallToken(ctx context.Context, name string) (string, erro
 	}
 	return token, nil
 }
+
+// RewriteMode atomically rewrites the managed config file behind loaded with
+// the given mode. Every other field's value is preserved verbatim, including
+// legacy fields the parser only tolerates — but the document is re-serialized,
+// so key order and whitespace are normalized. The write is refused when the
+// file changed since it was loaded, and the result is round-tripped through
+// Parse so a config the daemon would refuse to load is never written. The
+// whole read-verify-replace sequence runs under the config write lock, so a
+// cooperating writer (`kontext setup`) cannot slip a rewrite in between the
+// checksum verification and the final rename.
+func RewriteMode(loaded LoadedConfig, mode string) error {
+	if loaded.Path == "" {
+		return errors.New("managed config path is required")
+	}
+	return WithWriteLock(loaded.Path, func() error {
+		return rewriteModeLocked(loaded, mode)
+	})
+}
+
+func rewriteModeLocked(loaded LoadedConfig, mode string) error {
+	data, err := os.ReadFile(loaded.Path)
+	if err != nil {
+		return err
+	}
+	digest := sha256.Sum256(data)
+	if hex.EncodeToString(digest[:]) != loaded.Checksum {
+		return errors.New("managed config changed since it was loaded")
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	encodedMode, err := json.Marshal(mode)
+	if err != nil {
+		return err
+	}
+	raw["mode"] = encodedMode
+	rewritten, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return err
+	}
+	rewritten = append(rewritten, '\n')
+	if _, err := Parse(rewritten); err != nil {
+		return fmt.Errorf("rewritten managed config is invalid: %w", err)
+	}
+
+	dir := filepath.Dir(loaded.Path)
+	temp, err := os.CreateTemp(dir, ".managed-*.tmp")
+	if err != nil {
+		return err
+	}
+	tempPath := temp.Name()
+	defer os.Remove(tempPath)
+	if err := temp.Chmod(0o600); err != nil {
+		temp.Close()
+		return err
+	}
+	if _, err := temp.Write(rewritten); err != nil {
+		temp.Close()
+		return err
+	}
+	if err := temp.Sync(); err != nil {
+		temp.Close()
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tempPath, loaded.Path)
+}

--- a/internal/managedconfig/config_test.go
+++ b/internal/managedconfig/config_test.go
@@ -6,7 +6,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestLoadFileMissingReturnsErrNotManaged(t *testing.T) {
@@ -302,5 +305,119 @@ func TestParseModeRemote(t *testing.T) {
 	}
 	if cfg.Mode != ModeRemote {
 		t.Fatalf("Mode = %q, want %q", cfg.Mode, ModeRemote)
+	}
+}
+
+func TestRewriteModePreservesOtherFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "managed.json")
+	original := strings.Replace(validConfigJSON(), `"cloud_url":`, `"cowork_enabled": true,
+  "cloud_url":`, 1)
+	if err := os.WriteFile(path, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := LoadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RewriteMode(loaded, ModeRemote); err != nil {
+		t.Fatalf("RewriteMode() error = %v", err)
+	}
+
+	reloaded, err := LoadFile(path)
+	if err != nil {
+		t.Fatalf("reload after rewrite: %v", err)
+	}
+	if reloaded.Config.Mode != ModeRemote {
+		t.Fatalf("mode = %q, want %q", reloaded.Config.Mode, ModeRemote)
+	}
+	if reloaded.Config.CloudURL != loaded.Config.CloudURL ||
+		reloaded.Config.Device.Label != loaded.Config.Device.Label ||
+		reloaded.Config.Credentials.InstallTokenRef != loaded.Config.Credentials.InstallTokenRef {
+		t.Fatalf("rewritten config = %#v, want fields preserved from %#v", reloaded.Config, loaded.Config)
+	}
+	if !reloaded.Config.LegacyCoworkEnabled {
+		t.Fatal("legacy cowork_enabled field was dropped by rewrite")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("file mode = %v, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestRewriteModeRefusesConcurrentChange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "managed.json")
+	if err := os.WriteFile(path, []byte(validConfigJSON()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := LoadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changed := strings.Replace(validConfigJSON(), "Engineering Mac", "Another Mac", 1)
+	if err := os.WriteFile(path, []byte(changed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RewriteMode(loaded, ModeRemote); err == nil {
+		t.Fatal("RewriteMode() rewrote a config that changed since load")
+	}
+	reloaded, err := LoadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reloaded.Config.Mode != Mode {
+		t.Fatalf("mode = %q, want untouched %q", reloaded.Config.Mode, Mode)
+	}
+}
+
+func TestRewriteModeRefusesInvalidMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "managed.json")
+	if err := os.WriteFile(path, []byte(validConfigJSON()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := LoadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := RewriteMode(loaded, "block"); err == nil {
+		t.Fatal("RewriteMode() accepted an invalid mode")
+	}
+}
+
+func TestWithWriteLockSerializesWriters(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "managed.json")
+	var inCritical, maxConcurrent atomic.Int32
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := WithWriteLock(path, func() error {
+				now := inCritical.Add(1)
+				defer inCritical.Add(-1)
+				for {
+					seen := maxConcurrent.Load()
+					if now <= seen || maxConcurrent.CompareAndSwap(seen, now) {
+						break
+					}
+				}
+				time.Sleep(5 * time.Millisecond)
+				return nil
+			})
+			if err != nil {
+				t.Errorf("WithWriteLock() error = %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+	if got := maxConcurrent.Load(); got != 1 {
+		t.Fatalf("max concurrent writers = %d, want 1", got)
 	}
 }

--- a/internal/managedconfig/filelock_unix.go
+++ b/internal/managedconfig/filelock_unix.go
@@ -1,0 +1,31 @@
+//go:build !windows
+
+package managedconfig
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// WithWriteLock serializes cooperating writers of the managed config at path
+// (`kontext setup` and the daemon's mode migration) through a sidecar lock
+// file, so a read-verify-replace sequence cannot clobber a concurrent
+// rewrite. The lock is advisory: only our own writers take it. MDM-pushed
+// system configs are never rewritten by this code, so external writers are
+// out of scope. Writers hold the lock for the duration of one small file
+// write; blocking acquisition is fine.
+func WithWriteLock(path string, fn func() error) error {
+	lock, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return err
+	}
+	defer lock.Close()
+	if err := unix.Flock(int(lock.Fd()), unix.LOCK_EX); err != nil {
+		return err
+	}
+	defer func() {
+		_ = unix.Flock(int(lock.Fd()), unix.LOCK_UN)
+	}()
+	return fn()
+}

--- a/internal/managedconfig/filelock_windows.go
+++ b/internal/managedconfig/filelock_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package managedconfig
+
+// WithWriteLock is a no-op on Windows: the managed-observe daemon and
+// `kontext setup` are not shipped for Windows, this stub only keeps the
+// package compiling there.
+func WithWriteLock(_ string, fn func() error) error {
+	return fn()
+}

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -87,6 +87,7 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 	if err := requireManagedHooksForLegacyCowork(loadedConfig.Config); err != nil {
 		return err
 	}
+	loadedConfig = migrateSelfServeModeToRemote(loadedConfig, opts.Diagnostic)
 	installationState, err := installation.EnsureFile(installationPathForScope(loadedConfig.Scope))
 	if err != nil {
 		return fmt.Errorf("ensure installation identity: %w", err)
@@ -577,4 +578,30 @@ func cleanupInterval(idleTimeout time.Duration) time.Duration {
 		return time.Nanosecond
 	}
 	return interval
+}
+
+// migrateSelfServeModeToRemote rewrites a self-serve (user-scope) managed
+// config still carrying the pre-remote "observe" default to "remote", so the
+// policy deployment's rollout mode controls the posture without a reinstall.
+// Only user-scope configs are touched: those were written by `kontext setup`
+// with the era's default, not by an admin choosing a static pin. MDM
+// (system-scope) and env-override configs are an explicit posture choice and
+// are never rewritten. Migration failure is not fatal — the daemon runs with
+// the config it loaded and retries on next start.
+func migrateSelfServeModeToRemote(loaded managedconfig.LoadedConfig, log diagnostic.Logger) managedconfig.LoadedConfig {
+	if loaded.Scope != managedconfig.ScopeUser || loaded.Config.Mode != managedconfig.Mode {
+		return loaded
+	}
+	if err := managedconfig.RewriteMode(loaded, managedconfig.ModeRemote); err != nil {
+		log.Printf("migrate self-serve managed mode to remote: %v\n", err)
+		return loaded
+	}
+	logAlways(log, "migrated self-serve managed mode %q -> %q\n", managedconfig.Mode, managedconfig.ModeRemote)
+	reloaded, err := managedconfig.LoadFile(loaded.Path)
+	if err != nil {
+		log.Printf("reload managed config after mode migration: %v\n", err)
+		return loaded
+	}
+	reloaded.Scope = loaded.Scope
+	return reloaded
 }

--- a/internal/managedobserve/daemon_test.go
+++ b/internal/managedobserve/daemon_test.go
@@ -866,3 +866,77 @@ func waitForSession(t *testing.T, store *sqlite.Store, sessionID string) sqlite.
 	t.Fatalf("Session(%s) error = %v", sessionID, lastErr)
 	return sqlite.SessionRecord{}
 }
+
+func TestMigrateSelfServeModeToRemote(t *testing.T) {
+	writeConfig := func(t *testing.T, mode string) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "managed.json")
+		content := `{
+  "version": "managed-install-v1",
+  "cloud_url": "https://api.kontext.dev",
+  "mode": "` + mode + `",
+  "agent": "claude",
+  "credentials": {
+    "install_token_ref": "env:KONTEXT_INSTALL_TOKEN"
+  }
+}`
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	load := func(t *testing.T, path string, scope managedconfig.Scope) managedconfig.LoadedConfig {
+		t.Helper()
+		loaded, err := managedconfig.LoadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		loaded.Scope = scope
+		return loaded
+	}
+
+	t.Run("user-scope observe migrates to remote", func(t *testing.T) {
+		path := writeConfig(t, managedconfig.Mode)
+		migrated := migrateSelfServeModeToRemote(load(t, path, managedconfig.ScopeUser), diagnostic.Logger{})
+		if migrated.Config.Mode != managedconfig.ModeRemote {
+			t.Fatalf("returned mode = %q, want remote", migrated.Config.Mode)
+		}
+		onDisk, err := managedconfig.LoadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if onDisk.Config.Mode != managedconfig.ModeRemote {
+			t.Fatalf("on-disk mode = %q, want remote", onDisk.Config.Mode)
+		}
+	})
+
+	t.Run("static pins and non-user scopes are untouched", func(t *testing.T) {
+		cases := []struct {
+			name  string
+			mode  string
+			scope managedconfig.Scope
+		}{
+			{name: "user enforce pin", mode: managedconfig.ModeEnforce, scope: managedconfig.ScopeUser},
+			{name: "user already remote", mode: managedconfig.ModeRemote, scope: managedconfig.ScopeUser},
+			{name: "system observe", mode: managedconfig.Mode, scope: managedconfig.ScopeSystem},
+			{name: "env observe", mode: managedconfig.Mode, scope: managedconfig.ScopeEnv},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				path := writeConfig(t, tc.mode)
+				loaded := load(t, path, tc.scope)
+				migrated := migrateSelfServeModeToRemote(loaded, diagnostic.Logger{})
+				if migrated.Config.Mode != tc.mode {
+					t.Fatalf("returned mode = %q, want untouched %q", migrated.Config.Mode, tc.mode)
+				}
+				onDisk, err := managedconfig.LoadFile(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if onDisk.Config.Mode != tc.mode {
+					t.Fatalf("on-disk mode = %q, want untouched %q", onDisk.Config.Mode, tc.mode)
+				}
+			})
+		}
+	})
+}

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -491,8 +491,11 @@ func writeUserManagedConfig(cloudURL, label string) (string, error) {
 	cfg := managedconfig.Config{
 		Version:  managedconfig.Version,
 		CloudURL: cloudURL,
-		Mode:     managedconfig.Mode,
-		Agent:    managedconfig.Agent,
+		// Self-serve installs follow the policy deployment's rollout mode, so
+		// the posture is controlled from the dashboard. Static observe/enforce
+		// pins remain an MDM (system-scope) concern.
+		Mode:  managedconfig.ModeRemote,
+		Agent: managedconfig.Agent,
 		Credentials: managedconfig.Credentials{
 			InstallTokenRef: managedconfig.TokenRef{Source: "keychain", Name: KeychainItemName},
 		},
@@ -512,28 +515,33 @@ func writeUserManagedConfig(cloudURL, label string) (string, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return "", err
 	}
-	temp, err := os.CreateTemp(filepath.Dir(path), ".managed-*.tmp")
-	if err != nil {
-		return "", err
-	}
-	tempPath := temp.Name()
-	defer os.Remove(tempPath)
-	if err := temp.Chmod(0o600); err != nil {
-		temp.Close()
-		return "", err
-	}
-	if _, err := temp.Write(data); err != nil {
-		temp.Close()
-		return "", err
-	}
-	if err := temp.Sync(); err != nil {
-		temp.Close()
-		return "", err
-	}
-	if err := temp.Close(); err != nil {
-		return "", err
-	}
-	if err := os.Rename(tempPath, path); err != nil {
+	// Same write lock the daemon's mode migration takes, so the two
+	// cooperating writers of this file can never interleave a
+	// read-verify-replace sequence.
+	if err := managedconfig.WithWriteLock(path, func() error {
+		temp, err := os.CreateTemp(filepath.Dir(path), ".managed-*.tmp")
+		if err != nil {
+			return err
+		}
+		tempPath := temp.Name()
+		defer os.Remove(tempPath)
+		if err := temp.Chmod(0o600); err != nil {
+			temp.Close()
+			return err
+		}
+		if _, err := temp.Write(data); err != nil {
+			temp.Close()
+			return err
+		}
+		if err := temp.Sync(); err != nil {
+			temp.Close()
+			return err
+		}
+		if err := temp.Close(); err != nil {
+			return err
+		}
+		return os.Rename(tempPath, path)
+	}); err != nil {
 		return "", err
 	}
 	return path, nil


### PR DESCRIPTION
## Summary

Stacked on #412. Self-serve installs (`brew` + `kontext setup`) now write `"mode": "remote"`, so the dashboard's deployment rollout mode controls the guard posture from day one.

Existing self-serve installs still carry the pre-remote `observe` default, so the daemon migrates them once at startup: a **user-scope** managed config with mode `observe` is atomically rewritten to `remote` — every other field's value preserved verbatim (the document is re-serialized, so formatting/key order normalize), write refused if the file changed since load, round-tripped through the parser before replacing. MDM (system-scope) and env-override configs are an explicit admin posture choice and are never rewritten; a user-scope `enforce` pin is likewise left alone.

## Verification

- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] `go vet ./...`
- [ ] `buf generate` if protobuf or generated code changed (n/a)

## Release notes

- [x] conventional commit title matches semver intent

🤖 Generated with [Claude Code](https://claude.com/claude-code)