### PR TITLE
feat(policy): the local chain is advisory — only Cedar decides

### DIFF
--- a/internal/guard/app/server/policy.go
+++ b/internal/guard/app/server/policy.go
@@ -68,22 +68,19 @@ func (p RiskPolicyProvider) DecideHook(ctx context.Context, event risk.HookEvent
 	riskEvent := risk.NormalizeHookEvent(event)
 	policyResult := p.policyEngine.Evaluate(riskEvent, p.activePolicyConfig(ctx))
 	applyPolicyMetadata(&riskEvent, policyResult)
-	// Local layering: deterministic guardrails > probabilistic signals. The
-	// synced provider-policy layer (GitHub/HubSpot hosted rules) was removed
-	// without ever being deployed; organization policy is native Cedar,
-	// evaluated by the cedarPolicyProvider wrapping this chain.
-	if policyResult.Decision == guardpolicy.DecisionDeny {
-		return deterministicDenyDecision(riskEvent, policyResult), nil
-	}
+	// The local chain is advisory: Cedar (the cedarPolicyProvider wrapping
+	// this chain) is the only engine that decides. Guardrail matches and
+	// judge analysis are recorded as risk signals on the decision fact; the
+	// chain's own outcome is always allow.
 	if p.judge == nil {
-		return deterministicAllowDecision(riskEvent, policyResult), nil
+		return advisoryDecision(riskEvent, policyResult), nil
 	}
 
 	result, err := p.judge.Decide(ctx, judgeInputFromRiskEvent(event, riskEvent))
 	if err != nil {
 		return judgeFailOpenDecision(riskEvent, p.judge, err), nil
 	}
-	return judgeDecision(riskEvent, result), nil
+	return judgeAdvisoryDecision(riskEvent, result), nil
 }
 
 func (p RiskPolicyProvider) asyncTelemetryDecision(event risk.HookEvent) risk.RiskDecision {
@@ -99,28 +96,19 @@ func (p RiskPolicyProvider) asyncTelemetryDecision(event risk.HookEvent) risk.Ri
 	}
 }
 
-func deterministicDenyDecision(riskEvent risk.RiskEvent, policyResult guardpolicy.Result) risk.RiskDecision {
-	riskEvent.Decision = risk.DecisionDeny
-	riskEvent.ReasonCode = policyResult.ReasonCode
-	riskEvent.GuardID = policyResult.RuleID
-	riskEvent.DecisionStage = risk.DecisionStageDeterministicDeny
-	return risk.RiskDecision{
-		Decision:   risk.DecisionDeny,
-		Reason:     policyResult.Reason,
-		ReasonCode: policyResult.ReasonCode,
-		GuardID:    policyResult.RuleID,
-		RiskEvent:  riskEvent,
-	}
-}
-
-func deterministicAllowDecision(riskEvent risk.RiskEvent, policyResult guardpolicy.Result) risk.RiskDecision {
+// advisoryDecision records the deterministic guardrail analysis without
+// deciding: matched rules survive as policy metadata and signals on the risk
+// event, and the chain's outcome is always allow. Cedar alone decides.
+func advisoryDecision(riskEvent risk.RiskEvent, policyResult guardpolicy.Result) risk.RiskDecision {
 	riskEvent.Decision = risk.DecisionAllow
 	riskEvent.ReasonCode = policyResult.ReasonCode
-	riskEvent.DecisionStage = "deterministic_allow"
+	riskEvent.GuardID = policyResult.RuleID
+	riskEvent.DecisionStage = risk.DecisionStageAdvisory
 	return risk.RiskDecision{
 		Decision:   risk.DecisionAllow,
 		Reason:     policyResult.Reason,
 		ReasonCode: policyResult.ReasonCode,
+		GuardID:    policyResult.RuleID,
 		RiskEvent:  riskEvent,
 	}
 }
@@ -142,16 +130,19 @@ func judgeFailOpenDecision(riskEvent risk.RiskEvent, localJudge judge.Judge, err
 	}
 }
 
-func judgeDecision(riskEvent risk.RiskEvent, result judge.Result) risk.RiskDecision {
-	decision := risk.DecisionAllow
+// judgeAdvisoryDecision records the judge's analysis without deciding. The
+// judge's verdict survives as the reason code and risk fields on the fact's
+// advisory block; the chain's outcome is always allow.
+func judgeAdvisoryDecision(riskEvent risk.RiskEvent, result judge.Result) risk.RiskDecision {
 	reasonCode := risk.DecisionStageJudgeAllow
 	if result.Output.Decision == judge.DecisionDeny {
-		decision = risk.DecisionDeny
 		reasonCode = risk.DecisionStageJudgeDeny
 	}
 	duration := result.Metadata.DurationMs
-	riskEvent.Decision = decision
+	riskEvent.Decision = risk.DecisionAllow
 	riskEvent.ReasonCode = reasonCode
+	// The judge never controls execution here, but preserve its verdict as
+	// analysis so the dashboard can distinguish an advisory allow from deny.
 	riskEvent.DecisionStage = reasonCode
 	riskEvent.GuardID = "local_llm_judge"
 	riskEvent.JudgeRuntime = result.Metadata.Runtime
@@ -161,7 +152,7 @@ func judgeDecision(riskEvent risk.RiskEvent, result judge.Result) risk.RiskDecis
 	riskEvent.JudgeCategories = result.Output.Categories
 
 	return risk.RiskDecision{
-		Decision:   decision,
+		Decision:   risk.DecisionAllow,
 		Reason:     result.Output.Reason,
 		ReasonCode: reasonCode,
 		GuardID:    "local_llm_judge",

--- a/internal/guard/app/server/server_test.go
+++ b/internal/guard/app/server/server_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kontext-security/kontext-cli/internal/cedareval"
 	"github.com/kontext-security/kontext-cli/internal/guard/judge"
 	"github.com/kontext-security/kontext-cli/internal/guard/policy"
 	"github.com/kontext-security/kontext-cli/internal/guard/policyconfig"
@@ -46,6 +47,36 @@ func newTestServerWithPolicyConfig(t *testing.T, store *sqlite.Store, policyStor
 	return server
 }
 
+// enforcedDenyEvidence returns the Cedar evidence an injected provider must
+// carry for a deny: only an enforce deployment can deny execution, so a fake
+// that denies without it would be rejected by the decision-fact contract.
+func enforcedDenyEvidence() *risk.CedarEvidence {
+	return &risk.CedarEvidence{
+		PolicyHash:             strings.Repeat("a", 64),
+		DeploymentIdentity:     strings.Repeat("b", 64),
+		AppliedRolloutMode:     cedareval.RolloutModeEnforce,
+		ConfiguredRolloutMode:  cedareval.RolloutModeEnforce,
+		DistributionState:      "success",
+		EvaluatorVersion:       "cedar-go/test",
+		ResponseVersion:        1,
+		RequestContractVersion: 1,
+		Mapping: cedareval.DecisionMapping{
+			EvaluationState: cedareval.EvaluationStateEvaluated,
+			EvaluationPrincipal: &cedareval.EvaluationPrincipal{
+				EntityType: cedareval.PrincipalEntityType,
+				EntityID:   "user@example.com",
+			},
+			CedarDecision:            cedareval.DecisionDeny,
+			DerivedCedarAction:       cedareval.DerivedCedarActionDeny,
+			EffectiveExecutionAction: cedareval.EffectiveExecutionActionDeny,
+			EvaluationReasonCode:     cedareval.ReasonPolicyEvaluated,
+			DecisionReasonCode:       cedareval.ReasonExplicitForbid,
+			EffectiveReasonCode:      cedareval.ReasonExplicitForbid,
+			DeterminingPolicyIDs:     []string{"policy-test"},
+		},
+	}
+}
+
 func TestStorePersistsSummaryCounts(t *testing.T) {
 	store, err := sqlite.OpenStore(t.TempDir() + "/guard.db")
 	if err != nil {
@@ -67,7 +98,9 @@ func TestStorePersistsSummaryCounts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if summary.Actions != 3 || summary.Warnings != 0 || summary.Critical != 2 || summary.Sessions != 1 {
+	// The local chain is advisory: guardrail/judge analysis is recorded but
+	// nothing denies, so no action is critical.
+	if summary.Actions != 3 || summary.Warnings != 0 || summary.Critical != 0 || summary.Sessions != 1 {
 		t.Fatalf("summary = %+v", summary)
 	}
 }
@@ -86,6 +119,7 @@ func TestProcessHookEventUsesPolicyProvider(t *testing.T) {
 			RiskEvent: risk.RiskEvent{
 				Type: risk.EventUnknown,
 			},
+			Cedar: enforcedDenyEvidence(),
 		},
 	}
 	server := newTestServerWithPolicy(t, store, &policy)
@@ -401,6 +435,7 @@ func TestProcessHookEventPreservesRiskMetadata(t *testing.T) {
 				ModelVersion: "model-v1",
 				GuardID:      "guard-1",
 			},
+			Cedar: enforcedDenyEvidence(),
 		},
 	}
 	server := newTestServerWithPolicy(t, store, &policy)
@@ -443,6 +478,7 @@ func TestDashboardEventsHideModelMetadata(t *testing.T) {
 				JudgeModel:     "qwen3-0.6b-q4",
 				JudgeRiskLevel: "high",
 			},
+			Cedar: enforcedDenyEvidence(),
 		},
 	}
 	server := newTestServerWithPolicy(t, store, &policy)
@@ -526,7 +562,9 @@ func TestJudgePolicyDeniesFromLocalJudge(t *testing.T) {
 	if localJudge.input.ToolName != "Bash" || localJudge.input.ToolInput.Command != "python scripts/deploy.py --dry-run" {
 		t.Fatalf("judge input = %+v", localJudge.input)
 	}
-	if decision.Decision != risk.DecisionDeny || decision.ReasonCode != "judge_deny" {
+	// The judge is advisory: its deny verdict is recorded as analysis, but
+	// the chain never decides — only Cedar can block.
+	if decision.Decision != risk.DecisionAllow || decision.ReasonCode != "judge_deny" {
 		t.Fatalf("decision = %+v", decision)
 	}
 	if decision.RiskEvent.DecisionStage != risk.DecisionStageJudgeDeny || decision.RiskEvent.JudgeModel != "qwen3-0.6b-q4" || decision.RiskEvent.JudgeRiskLevel != "high" {
@@ -791,7 +829,10 @@ func TestJudgePolicyFailsOpenWhenJudgeUnavailable(t *testing.T) {
 	}
 }
 
-func TestJudgePolicyDeterministicDecisionSkipsJudge(t *testing.T) {
+// A matched guardrail no longer short-circuits anything: the chain is
+// advisory, so the judge still runs and the match survives as policy
+// metadata on an allow.
+func TestJudgePolicyGuardrailMatchIsAdvisory(t *testing.T) {
 	store, err := sqlite.OpenStore(t.TempDir() + "/guard.db")
 	if err != nil {
 		t.Fatal(err)
@@ -811,10 +852,10 @@ func TestJudgePolicyDeterministicDecisionSkipsJudge(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if localJudge.calls != 0 {
-		t.Fatalf("judge calls = %d, want 0", localJudge.calls)
+	if localJudge.calls != 1 {
+		t.Fatalf("judge calls = %d, want 1", localJudge.calls)
 	}
-	if decision.Decision != risk.DecisionDeny || decision.RiskEvent.DecisionStage != risk.DecisionStageDeterministicDeny {
+	if decision.Decision != risk.DecisionAllow {
 		t.Fatalf("decision = %+v", decision)
 	}
 	if decision.RiskEvent.PolicyRuleID != "guard.destructive_persistent_resource.v1" ||
@@ -1045,7 +1086,9 @@ func TestStoreListsSessions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(sessions) != 1 || sessions[0].SessionID != "s1" || sessions[0].Critical != 1 {
+	// Advisory chain: the credential-access read is recorded as risk
+	// analysis, not a deny, so nothing is critical.
+	if len(sessions) != 1 || sessions[0].SessionID != "s1" || sessions[0].Critical != 0 {
 		t.Fatalf("sessions = %+v", sessions)
 	}
 }

--- a/internal/guard/cli/cli.go
+++ b/internal/guard/cli/cli.go
@@ -384,7 +384,7 @@ func installClaudeHooks(out io.Writer, socketPath string) error {
 	}
 	fmt.Fprintf(out, "Installed Kontext Guard Claude Code hooks into %s\n", settingsPath)
 	fmt.Fprintf(out, "Hook command: %s\n", hookCommand)
-	fmt.Fprintln(out, "Default mode is observe. Set KONTEXT_MODE=enforce later to block deny decisions.")
+	fmt.Fprintln(out, "Local hooks run in observe mode. Cedar enforcement is provided by the managed daemon configured through kontext setup or MDM.")
 	return nil
 }
 
@@ -587,10 +587,10 @@ func runSmokeTest(ctx context.Context, args []string, out io.Writer) error {
 		want hook.Decision
 	}{
 		{"safe read", hook.Event{SessionID: "smoke", HookName: hook.HookPreToolUse, ToolName: "Read", ToolInput: map[string]any{"file_path": "README.md"}}, hook.DecisionAllow},
-		{"env read", hook.Event{SessionID: "smoke", HookName: hook.HookPreToolUse, ToolName: "Read", ToolInput: map[string]any{"file_path": ".env"}}, hook.DecisionDeny},
-		{"cat env", hook.Event{SessionID: "smoke", HookName: hook.HookPreToolUse, ToolName: "Bash", ToolInput: map[string]any{"command": "cat .env"}}, hook.DecisionDeny},
-		{"provider token", hook.Event{SessionID: "smoke", HookName: hook.HookPreToolUse, ToolName: "Bash", ToolInput: map[string]any{"command": "curl https://api.railway.app/graphql -H 'Authorization: Bearer secret'"}}, hook.DecisionDeny},
-		{"drop database", hook.Event{SessionID: "smoke", HookName: hook.HookPreToolUse, ToolName: "Bash", ToolInput: map[string]any{"command": "drop database"}}, hook.DecisionDeny},
+		{"env read", hook.Event{SessionID: "smoke", HookName: hook.HookPreToolUse, ToolName: "Read", ToolInput: map[string]any{"file_path": ".env"}}, hook.DecisionAllow},
+		{"cat env", hook.Event{SessionID: "smoke", HookName: hook.HookPreToolUse, ToolName: "Bash", ToolInput: map[string]any{"command": "cat .env"}}, hook.DecisionAllow},
+		{"provider token", hook.Event{SessionID: "smoke", HookName: hook.HookPreToolUse, ToolName: "Bash", ToolInput: map[string]any{"command": "curl https://api.railway.app/graphql -H 'Authorization: Bearer secret'"}}, hook.DecisionAllow},
+		{"drop database", hook.Event{SessionID: "smoke", HookName: hook.HookPreToolUse, ToolName: "Bash", ToolInput: map[string]any{"command": "drop database"}}, hook.DecisionAllow},
 	}
 	for _, item := range cases {
 		result, err := client.Process(ctx, item.ev)
@@ -606,8 +606,11 @@ func runSmokeTest(ctx context.Context, args []string, out io.Writer) error {
 	if err != nil {
 		return err
 	}
-	if summary.Actions != 5 || summary.Warnings != 0 || summary.Critical != 4 {
-		return fmt.Errorf("summary=%+v, want actions=5 critical=4 and no warnings", summary)
+	// The local chain is advisory: every decision is allow, and blocking is
+	// Cedar's alone (not exercisable here without a policy deployment). The
+	// smoke test verifies runtime plumbing and persistence, not enforcement.
+	if summary.Actions != 5 || summary.Warnings != 0 || summary.Critical != 0 {
+		return fmt.Errorf("summary=%+v, want actions=5 and no critical/warnings", summary)
 	}
 	fmt.Fprintf(out, "summary critical=%d actions=%d\n", summary.Critical, summary.Actions)
 	return nil
@@ -810,7 +813,7 @@ func installedHookCommand(socketPath string) string {
 }
 
 func installedHookInvocation(launcher, socketPath string) string {
-	return fmt.Sprintf("%s hook --agent claude --mode \"${KONTEXT_MODE:-observe}\" --socket %s", launcher, shellQuote(socketPath))
+	return fmt.Sprintf("%s hook --agent claude --mode observe --socket %s", launcher, shellQuote(socketPath))
 }
 
 func shellQuote(value string) string {

--- a/internal/guard/cli/cli_test.go
+++ b/internal/guard/cli/cli_test.go
@@ -49,11 +49,8 @@ func TestInstalledHookCommandUsesCanonicalRootHookHandler(t *testing.T) {
 	if !strings.Contains(got, "hook --agent claude") {
 		t.Fatalf("hook command did not use canonical root handler: %s", got)
 	}
-	if !strings.Contains(got, `--mode "${KONTEXT_MODE:-observe}"`) {
-		t.Fatalf("hook command did not leave mode overridable through KONTEXT_MODE: %s", got)
-	}
-	if strings.Contains(got, "--mode observe") {
-		t.Fatalf("hook command hardcoded observe mode: %s", got)
+	if !strings.Contains(got, `--mode observe`) {
+		t.Fatalf("hook command did not pin local hooks to observe mode: %s", got)
 	}
 	if !strings.Contains(got, "--socket ") || !strings.Contains(got, "/tmp/kontext-custom.sock") {
 		t.Fatalf("hook command did not carry custom socket path: %s", got)
@@ -69,7 +66,7 @@ func TestIsGuardHookCommandRecognizesInstalledGuardHooks(t *testing.T) {
 		"/usr/local/bin/kontext hook --agent claude --mode observe",
 		"'/usr/local/bin/kontext' hook --agent claude --mode observe",
 		"cd '/repo' && go run ./cmd/kontext hook --agent claude --mode observe",
-		`/usr/local/bin/kontext hook --agent claude --mode "${KONTEXT_MODE:-observe}" --socket /tmp/kontext-custom.sock`,
+		`/usr/local/bin/kontext hook --agent claude --mode observe --socket /tmp/kontext-custom.sock`,
 	} {
 		if !isGuardHookCommand(command) {
 			t.Fatalf("isGuardHookCommand(%q) = false, want true", command)
@@ -94,7 +91,7 @@ func TestMergeHooksInstallsOnlyToolHooks(t *testing.T) {
 				},
 			},
 		},
-	}, `/usr/local/bin/kontext hook --agent claude --mode "${KONTEXT_MODE:-observe}" --socket /tmp/kontext.sock`)
+	}, `/usr/local/bin/kontext hook --agent claude --mode observe --socket /tmp/kontext.sock`)
 
 	if _, ok := hooks["PreToolUse"]; !ok {
 		t.Fatal("PreToolUse hook missing")
@@ -126,7 +123,7 @@ func TestMergeHooksPreservesNonGuardHookInMixedGroup(t *testing.T) {
 				},
 			},
 		},
-	}, `/usr/local/bin/kontext hook --agent claude --mode "${KONTEXT_MODE:-observe}" --socket /tmp/kontext.sock`)
+	}, `/usr/local/bin/kontext hook --agent claude --mode observe --socket /tmp/kontext.sock`)
 
 	list := hooks["PreToolUse"].([]any)
 	group := list[0].(map[string]any)

--- a/internal/guard/policy/engine_test.go
+++ b/internal/guard/policy/engine_test.go
@@ -116,7 +116,7 @@ func TestEngineEvaluateProfileBehavior(t *testing.T) {
 			profile:  ProfileBalanced,
 			decision: DecisionDeny,
 			category: CategoryProductionMutation,
-			reason:   "production mutation blocked by deterministic policy",
+			reason:   "production mutation flagged by deterministic guardrails",
 		},
 		{
 			name: "production mutation denies in strict",
@@ -127,7 +127,7 @@ func TestEngineEvaluateProfileBehavior(t *testing.T) {
 			profile:  ProfileStrict,
 			decision: DecisionDeny,
 			category: CategoryProductionMutation,
-			reason:   "production mutation blocked by deterministic policy",
+			reason:   "production mutation flagged by deterministic guardrails",
 		},
 		{
 			name: "credential access without intent allows in relaxed",
@@ -146,7 +146,7 @@ func TestEngineEvaluateProfileBehavior(t *testing.T) {
 			profile:  ProfileBalanced,
 			decision: DecisionDeny,
 			category: CategoryCredentialAccess,
-			reason:   "credential access blocked by deterministic policy",
+			reason:   "credential access flagged by deterministic guardrails",
 		},
 		{
 			name: "credential access without intent denies in strict",
@@ -156,7 +156,7 @@ func TestEngineEvaluateProfileBehavior(t *testing.T) {
 			profile:  ProfileStrict,
 			decision: DecisionDeny,
 			category: CategoryCredentialAccess,
-			reason:   "credential access blocked by deterministic policy",
+			reason:   "credential access flagged by deterministic guardrails",
 		},
 		{
 			name: "unknown high-risk command allows in relaxed",

--- a/internal/guard/policy/pack_default.go
+++ b/internal/guard/policy/pack_default.go
@@ -37,7 +37,7 @@ func DefaultRulePack() RulePack {
 				ID:             "guard.production_mutation.v1",
 				Category:       CategoryProductionMutation,
 				ReasonCode:     "production_mutation",
-				Reason:         "production mutation blocked by deterministic policy",
+				Reason:         "production mutation flagged by deterministic guardrails",
 				MatchedSignals: []string{"production", "mutation"},
 				When: func(event risk.RiskEvent) bool {
 					return event.Environment == "production" &&
@@ -50,7 +50,7 @@ func DefaultRulePack() RulePack {
 				ID:             "guard.credential_access.v1",
 				Category:       CategoryCredentialAccess,
 				ReasonCode:     "credential_access_without_intent",
-				Reason:         "credential access blocked by deterministic policy",
+				Reason:         "credential access flagged by deterministic guardrails",
 				MatchedSignals: []string{"credential_path", "shell_credential_access", "credential_observed"},
 				When: func(event risk.RiskEvent) bool {
 					return event.Type == risk.EventCredentialAccess && !event.ExplicitUserIntent

--- a/internal/guard/risk/decision.go
+++ b/internal/guard/risk/decision.go
@@ -65,7 +65,7 @@ func guardDecision(event RiskEvent) RiskDecision {
 	if event.Environment == "production" && event.OperationClass != "unknown" && event.OperationClass != "read" {
 		return RiskDecision{
 			Decision:   DecisionDeny,
-			Reason:     "production mutation blocked by deterministic policy",
+			Reason:     "production mutation flagged by deterministic guardrails",
 			ReasonCode: "production_mutation",
 			GuardID:    "guard_production_mutation",
 		}
@@ -73,7 +73,7 @@ func guardDecision(event RiskEvent) RiskDecision {
 	if event.Type == EventCredentialAccess && !event.ExplicitUserIntent {
 		return RiskDecision{
 			Decision:   DecisionDeny,
-			Reason:     "credential access blocked by deterministic policy",
+			Reason:     "credential access flagged by deterministic guardrails",
 			ReasonCode: "credential_access_without_intent",
 			GuardID:    "guard_credential_access",
 		}
@@ -81,7 +81,7 @@ func guardDecision(event RiskEvent) RiskDecision {
 	if event.Type == EventUnknown {
 		return RiskDecision{
 			Decision:   DecisionDeny,
-			Reason:     "unknown high-risk command blocked by deterministic policy",
+			Reason:     "unknown high-risk command flagged by deterministic guardrails",
 			ReasonCode: "unknown_high_risk_command",
 			GuardID:    "guard_unknown_high_risk",
 		}

--- a/internal/guard/risk/types.go
+++ b/internal/guard/risk/types.go
@@ -50,6 +50,7 @@ const (
 
 const (
 	DecisionStageDeterministicDeny = "deterministic_deny"
+	DecisionStageAdvisory          = "advisory"
 	DecisionStageJudgeAllow        = "judge_allow"
 	DecisionStageJudgeDeny         = "judge_deny"
 	DecisionStageJudgeFailOpen     = "judge_fail_open"

--- a/internal/run/local.go
+++ b/internal/run/local.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
+	guardhookruntime "github.com/kontext-security/kontext-cli/internal/guard/hookruntime"
 	"github.com/kontext-security/kontext-cli/internal/runtimehost"
 	"github.com/kontext-security/kontext-cli/internal/startupui"
 )
@@ -21,7 +22,7 @@ func StartLocal(ctx context.Context, opts Options) error {
 	}
 	diagnostics.Printf("agent preflight: %s -> %s\n", opts.Agent, agentPath)
 
-	mode, err := runtimehost.ResolveMode(os.Getenv("KONTEXT_MODE"))
+	mode, err := resolveLocalMode(os.Getenv("KONTEXT_MODE"))
 	if err != nil {
 		return err
 	}
@@ -72,4 +73,15 @@ func StartLocal(ctx context.Context, opts Options) error {
 	}
 
 	return launchAgentWithSettings(ctx, opts.Agent, agentPath, env, opts.Args, settingsPath)
+}
+
+func resolveLocalMode(value string) (guardhookruntime.Mode, error) {
+	mode, err := runtimehost.ResolveMode(value)
+	if err != nil {
+		return "", err
+	}
+	if mode != guardhookruntime.ModeObserve {
+		return "", fmt.Errorf("local runs support observe mode only; Cedar enforcement is provided by the managed daemon configured through kontext setup or MDM")
+	}
+	return mode, nil
 }

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -22,7 +22,24 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/auth"
 	"github.com/kontext-security/kontext-cli/internal/credential"
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
+	guardhookruntime "github.com/kontext-security/kontext-cli/internal/guard/hookruntime"
 )
+
+func TestResolveLocalModeAllowsOnlyObserve(t *testing.T) {
+	t.Parallel()
+
+	for _, mode := range []string{"", "observe"} {
+		got, err := resolveLocalMode(mode)
+		if err != nil || got != guardhookruntime.ModeObserve {
+			t.Fatalf("resolveLocalMode(%q) = %q, %v; want observe, nil", mode, got, err)
+		}
+	}
+	for _, mode := range []string{"enforce", "remote"} {
+		if _, err := resolveLocalMode(mode); err == nil || !strings.Contains(err.Error(), "managed daemon") {
+			t.Fatalf("resolveLocalMode(%q) error = %v, want managed-daemon guidance", mode, err)
+		}
+	}
+}
 
 func TestFilterArgs(t *testing.T) {
 	t.Parallel()

--- a/internal/runtimehost/host.go
+++ b/internal/runtimehost/host.go
@@ -77,6 +77,9 @@ func Start(ctx context.Context, opts Options) (*Host, error) {
 	if err != nil {
 		return nil, err
 	}
+	if mode != guardhookruntime.ModeObserve && (opts.CedarPolicies == nil || opts.CedarEnforcement == server.CedarEnforcementOff) {
+		return nil, errors.New("enforce and remote modes require a managed Cedar policy source")
+	}
 	sessionID := strings.TrimSpace(opts.SessionID)
 	if sessionID == "" {
 		sessionID = NewSessionID()

--- a/internal/runtimehost/host_test.go
+++ b/internal/runtimehost/host_test.go
@@ -218,8 +218,14 @@ func TestStartWiresLocalJudgeFromEnv(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("events len = %d, want 1", len(events))
 	}
-	if events[0].Decision != risk.DecisionDeny || events[0].RiskEvent.DecisionStage != risk.DecisionStageJudgeDeny {
-		t.Fatalf("stored decision = %q stage = %q, want judge deny", events[0].Decision, events[0].RiskEvent.DecisionStage)
+	// The judge is advisory: its deny verdict survives as analysis on the
+	// risk event, never as the decision. The row's flat reason belongs to
+	// the decision fact (no Cedar deployment is wired here, so the fact is
+	// the disabled shape).
+	if events[0].Decision != risk.DecisionAllow ||
+		events[0].RiskEvent.DecisionStage != risk.DecisionStageJudgeDeny ||
+		events[0].RiskEvent.ReasonCode != risk.DecisionStageJudgeDeny {
+		t.Fatalf("stored decision = %q stage = %q analysis reason = %q, want advisory judge-deny analysis", events[0].Decision, events[0].RiskEvent.DecisionStage, events[0].RiskEvent.ReasonCode)
 	}
 	if events[0].RiskEvent.JudgeModel != "test-local-judge" {
 		t.Fatalf("judge model = %q, want test-local-judge", events[0].RiskEvent.JudgeModel)

--- a/scripts/guard-e2e-local.sh
+++ b/scripts/guard-e2e-local.sh
@@ -14,6 +14,7 @@ SESSION_ID="e2e-local"
 
 cleanup() {
   if [[ -n "${DAEMON_PID:-}" ]] && kill -0 "$DAEMON_PID" 2>/dev/null; then
+    pkill -P "$DAEMON_PID" 2>/dev/null || true
     kill "$DAEMON_PID" 2>/dev/null || true
     wait "$DAEMON_PID" 2>/dev/null || true
   fi
@@ -106,14 +107,14 @@ assert_hook \
 assert_hook \
   "credential read" \
   "{\"session_id\":\"${SESSION_ID}\",\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\".env\"}}" \
-  "credential access blocked by deterministic policy" \
-  "would deny"
+  "credential access flagged by deterministic guardrails" \
+  "would allow"
 
 assert_hook \
   "provider credential" \
   "{\"session_id\":\"${SESSION_ID}\",\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"curl https://api.railway.app/graphql -H 'Authorization: Bearer secret'\"}}" \
   "direct infrastructure API call included credential material" \
-  "would deny"
+  "would allow"
 
 assert_telemetry_hook \
   "async telemetry" \
@@ -126,7 +127,7 @@ let raw = "";
 process.stdin.on("data", (chunk) => raw += chunk);
 process.stdin.on("end", () => {
   const summary = JSON.parse(raw);
-  if (summary.critical !== 2 || summary.warnings !== 0 || summary.actions !== 4 || summary.sessions !== 1) {
+  if (summary.critical !== 0 || summary.warnings !== 0 || summary.actions !== 4 || summary.sessions !== 1) {
     throw new Error(`unexpected summary ${JSON.stringify(summary)}`);
   }
 });
@@ -141,7 +142,7 @@ let raw = "";
 process.stdin.on("data", (chunk) => raw += chunk);
 process.stdin.on("end", () => {
   const summary = JSON.parse(raw);
-  if (summary.critical !== 2 || summary.warnings !== 0 || summary.actions !== 4 || summary.sessions !== 1) {
+  if (summary.critical !== 0 || summary.warnings !== 0 || summary.actions !== 4 || summary.sessions !== 1) {
     throw new Error(`unexpected summary ${JSON.stringify(summary)}`);
   }
 });
@@ -153,8 +154,19 @@ process.stdin.on("data", (chunk) => raw += chunk);
 process.stdin.on("end", () => {
   const events = JSON.parse(raw);
   const decisions = events.map((event) => event.decision).sort().join(",");
-  if (events.length !== 3 || decisions !== "allow,deny,deny") {
+  if (events.length !== 3 || decisions !== "allow,allow,allow") {
     throw new Error(`unexpected decisions ${decisions} in ${JSON.stringify(events)}`);
+  }
+  // The chain is advisory: decisions are allow, and the guardrail analysis
+  // survives as reason codes on the recorded events.
+  const reasonCodes = events.map((event) => event.reason_code).sort().join(",");
+  const expectedReasonCodes = [
+    "credential_access_without_intent",
+    "direct_infra_api_with_credential",
+    "no_policy_rule_matched",
+  ].join(",");
+  if (reasonCodes !== expectedReasonCodes) {
+    throw new Error(`unexpected reason codes ${reasonCodes}`);
   }
 });
 '
@@ -162,7 +174,7 @@ process.stdin.on("end", () => {
 echo "==> checking served dashboard"
 curl -fsS "$BASE_URL" | grep -q "<title>Kontext Guard</title>"
 
-go run ./cmd/kontext guard status --daemon-url "$BASE_URL" | grep -q "2 critical"
+go run ./cmd/kontext guard status --daemon-url "$BASE_URL" | grep -q "0 critical"
 go run ./cmd/kontext guard doctor --daemon-url "$BASE_URL" | grep -q "daemon healthy"
 
 echo "E2E passed: hook -> local runtime -> RuntimeCore -> deterministic policy -> SQLite -> dashboard API"


### PR DESCRIPTION
## What

The local decision chain becomes advisory: guardrail matches and judge analysis are recorded as risk metadata, but the chain's own outcome is always allow. Only Cedar (the `cedarPolicyProvider` wrapping this chain) decides and can block.

## Why

Two-engine model: Cedar is the sole authoritative deterministic policy engine; the local LLM judge is advisory-only risk analysis. A local deny outside Cedar enforce would contradict the Decision Fact contract that lands at the top of this stack (`only an enforce deployment can deny execution`) — this PR makes the runtime honest about that before the fact writer exists.

## Verification

- [x] `go test ./...`
- [x] `go vet ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
