### PR TITLE
fix(daemon): make the homebrew updater recognize staging installs

### DIFF
--- a/internal/managedobserve/updater.go
+++ b/internal/managedobserve/updater.go
@@ -18,12 +18,20 @@ import (
 const (
 	envNoUpdateCheck            = "KONTEXT_NO_UPDATE_CHECK"
 	envDaemonUpdateInterval     = "KONTEXT_DAEMON_UPDATE_INTERVAL"
-	homebrewFormula             = "kontext-security/tap/kontext"
 	defaultDaemonUpdateInterval = 24 * time.Hour
 	brewListTimeout             = 15 * time.Second
 	brewUpdateTimeout           = 2 * time.Minute
 	brewUpgradeTimeout          = 5 * time.Minute
 )
+
+// homebrewFormulae maps the Cellar directory the running binary lives in to
+// the formula the updater must upgrade. Staging installs live under
+// Cellar/kontext-staging and must upgrade the staging formula — matching
+// only Cellar/kontext left staging daemons permanently ineligible.
+var homebrewFormulae = map[string]string{
+	"kontext":         "kontext-security/tap/kontext",
+	"kontext-staging": "kontext-security/tap/kontext-staging",
+}
 
 type commandRunner func(ctx context.Context, path string, args ...string) (string, error)
 
@@ -48,6 +56,7 @@ func startHomebrewUpdater(ctx context.Context, loadedConfig managedconfig.Loaded
 
 type homebrewUpdaterConfigValue struct {
 	brewPath string
+	formula  string
 	interval time.Duration
 }
 
@@ -61,17 +70,18 @@ func homebrewUpdaterConfig(ctx context.Context, loadedConfig managedconfig.Loade
 	if strings.TrimSpace(os.Getenv(envNoUpdateCheck)) != "" {
 		return homebrewUpdaterConfigValue{}, false
 	}
-	brewPath, ok := currentExecutableBrewPath()
+	brewPath, formula, ok := currentExecutableBrewPath()
 	if !ok {
-		logHomebrewUpdater(log, "daemon updater eligibility: brew not found\n")
+		logHomebrewUpdater(log, "daemon updater eligibility: not a homebrew-managed install\n")
 		return homebrewUpdaterConfigValue{}, false
 	}
-	if _, err := brewInstalledVersion(ctx, brewPath); err != nil {
+	if _, err := brewInstalledVersion(ctx, brewPath, formula); err != nil {
 		logHomebrewUpdater(log, "daemon updater eligibility: brew list failed: %v\n", err)
 		return homebrewUpdaterConfigValue{}, false
 	}
 	return homebrewUpdaterConfigValue{
 		brewPath: brewPath,
+		formula:  formula,
 		interval: daemonUpdateInterval(),
 	}, true
 }
@@ -84,13 +94,13 @@ func runHomebrewUpdater(ctx context.Context, cfg homebrewUpdaterConfigValue, log
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			changed, err := checkHomebrewUpgrade(ctx, cfg.brewPath)
+			changed, err := checkHomebrewUpgrade(ctx, cfg.brewPath, cfg.formula)
 			if err != nil {
 				logHomebrewUpdater(log, "daemon updater: %v\n", err)
 				continue
 			}
 			if changed {
-				logHomebrewUpdater(log, "daemon updater: upgraded %s; exiting for launchd restart\n", homebrewFormula)
+				logHomebrewUpdater(log, "daemon updater: upgraded %s; exiting for launchd restart\n", cfg.formula)
 				select {
 				case upgraded <- struct{}{}:
 				default:
@@ -101,26 +111,26 @@ func runHomebrewUpdater(ctx context.Context, cfg homebrewUpdaterConfigValue, log
 	}
 }
 
-func checkHomebrewUpgrade(ctx context.Context, brewPath string) (bool, error) {
-	before, err := brewInstalledVersion(ctx, brewPath)
+func checkHomebrewUpgrade(ctx context.Context, brewPath string, formula string) (bool, error) {
+	before, err := brewInstalledVersion(ctx, brewPath, formula)
 	if err != nil {
 		return false, fmt.Errorf("version before upgrade: %w", err)
 	}
 	if _, err := runBrewWithTimeout(ctx, brewUpdateTimeout, brewPath, "update-if-needed"); err != nil {
 		return false, fmt.Errorf("brew update-if-needed: %w", err)
 	}
-	if _, err := runBrewWithTimeout(ctx, brewUpgradeTimeout, brewPath, "upgrade", "--formula", "--no-ask", homebrewFormula); err != nil {
+	if _, err := runBrewWithTimeout(ctx, brewUpgradeTimeout, brewPath, "upgrade", "--formula", "--no-ask", formula); err != nil {
 		return false, fmt.Errorf("brew upgrade: %w", err)
 	}
-	after, err := brewInstalledVersion(ctx, brewPath)
+	after, err := brewInstalledVersion(ctx, brewPath, formula)
 	if err != nil {
 		return false, fmt.Errorf("version after upgrade: %w", err)
 	}
 	return after != "" && before != after, nil
 }
 
-func brewInstalledVersion(ctx context.Context, brewPath string) (string, error) {
-	output, err := runBrewWithTimeout(ctx, brewListTimeout, brewPath, "list", "--versions", homebrewFormula)
+func brewInstalledVersion(ctx context.Context, brewPath string, formula string) (string, error) {
+	output, err := runBrewWithTimeout(ctx, brewListTimeout, brewPath, "list", "--versions", formula)
 	if err != nil {
 		return "", err
 	}
@@ -141,26 +151,43 @@ func runBrewWithTimeout(parent context.Context, timeout time.Duration, brewPath 
 	return output, err
 }
 
-func currentExecutableBrewPath() (string, bool) {
+func currentExecutableBrewPath() (string, string, bool) {
 	exe, err := executablePath()
 	if err != nil {
-		return "", false
+		return "", "", false
 	}
 	resolved, err := evalSymlinksPath(exe)
 	if err != nil {
-		return "", false
+		return "", "", false
 	}
 	for _, path := range []string{"/opt/homebrew/bin/brew", "/usr/local/bin/brew"} {
 		prefix := strings.TrimSuffix(path, "/bin/brew")
-		if !strings.HasPrefix(resolved, prefix+"/Cellar/kontext/") {
+		formula, ok := homebrewFormulaForCellar(resolved, prefix)
+		if !ok {
 			continue
 		}
 		info, err := statPath(path)
 		if err == nil && !info.IsDir() {
-			return path, true
+			return path, formula, true
 		}
 	}
-	return "", false
+	return "", "", false
+}
+
+// homebrewFormulaForCellar matches the resolved executable against the
+// prefix's Cellar and returns the formula that owns that Cellar directory.
+func homebrewFormulaForCellar(resolved, prefix string) (string, bool) {
+	cellarRoot := prefix + "/Cellar/"
+	if !strings.HasPrefix(resolved, cellarRoot) {
+		return "", false
+	}
+	rest := strings.TrimPrefix(resolved, cellarRoot)
+	cellar, _, found := strings.Cut(rest, "/")
+	if !found {
+		return "", false
+	}
+	formula, ok := homebrewFormulae[cellar]
+	return formula, ok
 }
 
 func daemonUpdateInterval() time.Duration {

--- a/internal/managedobserve/updater_test.go
+++ b/internal/managedobserve/updater_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/managedconfig"
 )
 
+const prodFormula = "kontext-security/tap/kontext"
+
 func TestHomebrewUpdaterEligibility(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -27,6 +29,7 @@ func TestHomebrewUpdaterEligibility(t *testing.T) {
 		noUpdate     string
 		want         bool
 		wantBrewPath string
+		wantFormula  string
 	}{
 		{
 			name:         "user scope brew install enables updater",
@@ -36,6 +39,26 @@ func TestHomebrewUpdaterEligibility(t *testing.T) {
 			optBrew:      true,
 			want:         true,
 			wantBrewPath: "/opt/homebrew/bin/brew",
+			wantFormula:  "kontext-security/tap/kontext",
+		},
+		{
+			name:         "staging install upgrades the staging formula",
+			goos:         "darwin",
+			scope:        managedconfig.ScopeUser,
+			exe:          "/opt/homebrew/Cellar/kontext-staging/0.0.0-staging.20260729.5/bin/kontext",
+			optBrew:      true,
+			want:         true,
+			wantBrewPath: "/opt/homebrew/bin/brew",
+			wantFormula:  "kontext-security/tap/kontext-staging",
+		},
+		{
+			name:      "unknown cellar directory skips updater",
+			goos:      "darwin",
+			scope:     managedconfig.ScopeUser,
+			exe:       "/opt/homebrew/Cellar/kontext-shim/1.0.0/bin/kontext",
+			optBrew:   true,
+			intelBrew: true,
+			want:      false,
 		},
 		{
 			name:         "intel brew install uses matching brew path",
@@ -46,6 +69,7 @@ func TestHomebrewUpdaterEligibility(t *testing.T) {
 			intelBrew:    true,
 			want:         true,
 			wantBrewPath: "/usr/local/bin/brew",
+			wantFormula:  "kontext-security/tap/kontext",
 		},
 		{
 			name:      "system scope skips updater",
@@ -80,6 +104,7 @@ func TestHomebrewUpdaterEligibility(t *testing.T) {
 			listErr:      errors.New("formula missing"),
 			want:         false,
 			wantBrewPath: "/opt/homebrew/bin/brew",
+			wantFormula:  "kontext-security/tap/kontext",
 		},
 		{
 			name:     "no update check env skips updater",
@@ -117,13 +142,15 @@ func TestHomebrewUpdaterEligibility(t *testing.T) {
 				return nil, os.ErrNotExist
 			}
 			var gotBrewPath string
+			var gotFormula string
 			runCommand = func(_ context.Context, path string, args ...string) (string, error) {
-				if reflect.DeepEqual(args, []string{"list", "--versions", homebrewFormula}) {
+				if len(args) == 3 && args[0] == "list" && args[1] == "--versions" {
 					gotBrewPath = path
+					gotFormula = args[2]
 					if tc.listErr != nil {
 						return "", tc.listErr
 					}
-					return "kontext-security/tap/kontext 1.2.3\n", nil
+					return gotFormula + " 1.2.3\n", nil
 				}
 				t.Fatalf("unexpected command args = %v", args)
 				return "", nil
@@ -138,6 +165,9 @@ func TestHomebrewUpdaterEligibility(t *testing.T) {
 			}
 			if gotBrewPath != tc.wantBrewPath {
 				t.Fatalf("brew path = %q, want %q", gotBrewPath, tc.wantBrewPath)
+			}
+			if gotFormula != tc.wantFormula {
+				t.Fatalf("formula = %q, want %q", gotFormula, tc.wantFormula)
 			}
 		})
 	}
@@ -154,7 +184,7 @@ func TestCheckHomebrewUpgradeNoVersionChange(t *testing.T) {
 		return "", nil
 	}
 
-	changed, err := checkHomebrewUpgrade(context.Background(), "/opt/homebrew/bin/brew")
+	changed, err := checkHomebrewUpgrade(context.Background(), "/opt/homebrew/bin/brew", prodFormula)
 	if err != nil {
 		t.Fatalf("checkHomebrewUpgrade() error = %v", err)
 	}
@@ -162,10 +192,10 @@ func TestCheckHomebrewUpgradeNoVersionChange(t *testing.T) {
 		t.Fatal("checkHomebrewUpgrade() changed = true, want false")
 	}
 	want := [][]string{
-		{"list", "--versions", homebrewFormula},
+		{"list", "--versions", prodFormula},
 		{"update-if-needed"},
-		{"upgrade", "--formula", "--no-ask", homebrewFormula},
-		{"list", "--versions", homebrewFormula},
+		{"upgrade", "--formula", "--no-ask", prodFormula},
+		{"list", "--versions", prodFormula},
 	}
 	if !reflect.DeepEqual(calls, want) {
 		t.Fatalf("commands = %#v, want %#v", calls, want)
@@ -187,7 +217,7 @@ func TestHomebrewUpdaterEligibilityHonorsCanceledContext(t *testing.T) {
 	}
 	sawCanceledContext := false
 	runCommand = func(ctx context.Context, _ string, args ...string) (string, error) {
-		if !reflect.DeepEqual(args, []string{"list", "--versions", homebrewFormula}) {
+		if !reflect.DeepEqual(args, []string{"list", "--versions", prodFormula}) {
 			t.Fatalf("unexpected command args = %v", args)
 		}
 		if errors.Is(ctx.Err(), context.Canceled) {
@@ -221,7 +251,7 @@ func TestCheckHomebrewUpgradeVersionChange(t *testing.T) {
 		return "kontext-security/tap/kontext 1.2.4\n", nil
 	}
 
-	changed, err := checkHomebrewUpgrade(context.Background(), "/opt/homebrew/bin/brew")
+	changed, err := checkHomebrewUpgrade(context.Background(), "/opt/homebrew/bin/brew", prodFormula)
 	if err != nil {
 		t.Fatalf("checkHomebrewUpgrade() error = %v", err)
 	}
@@ -287,7 +317,7 @@ func TestCheckHomebrewUpgradeUpgradeFailure(t *testing.T) {
 		return "kontext-security/tap/kontext 1.2.3\n", nil
 	}
 
-	changed, err := checkHomebrewUpgrade(context.Background(), "/opt/homebrew/bin/brew")
+	changed, err := checkHomebrewUpgrade(context.Background(), "/opt/homebrew/bin/brew", prodFormula)
 	if err == nil || !strings.Contains(err.Error(), "brew upgrade") {
 		t.Fatalf("checkHomebrewUpgrade() error = %v, want brew upgrade error", err)
 	}
@@ -308,7 +338,7 @@ func TestCheckHomebrewUpgradeTimeout(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
-	changed, err := checkHomebrewUpgrade(ctx, "/opt/homebrew/bin/brew")
+	changed, err := checkHomebrewUpgrade(ctx, "/opt/homebrew/bin/brew", prodFormula)
 	if err == nil || !strings.Contains(err.Error(), "brew update-if-needed") {
 		t.Fatalf("checkHomebrewUpgrade() error = %v, want update timeout error", err)
 	}


### PR DESCRIPTION
## What

The managed-observe daemon's homebrew updater derived eligibility by matching the running binary against `Cellar/kontext` only, so staging installs (`Cellar/kontext-staging`) were permanently ineligible — every daemon start logged the misleading `brew not found`, and staging endpoints only picked up updates when the binary watchdog noticed an external `brew upgrade` replacing the file.

The Cellar directory the binary lives in now selects the formula to upgrade (`kontext-security/tap/kontext` or `kontext-security/tap/kontext-staging`), and the ineligibility log says what it actually means: `not a homebrew-managed install`.

## Why

Observed live: a staging daemon running `0.0.0-staging.20260729.5` logs `daemon updater eligibility: brew not found` on every boot despite brew managing the install. With this fix the staging fleet self-updates on the daemon's own interval again.

## Verification

- [x] `go test ./...` (new table cases: staging Cellar → staging formula; unknown Cellar → ineligible)
- [x] `go vet ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
