### PR TITLE
fix(payloadcapture): sync rules/2 review fixes from kontext#655

### DIFF
--- a/internal/guard/risk/risk_test.go
+++ b/internal/guard/risk/risk_test.go
@@ -191,7 +191,8 @@ func TestNormalizeRedactsCredentialValuesFromSummaries(t *testing.T) {
 		{"bearer header", `curl -H "Authorization: Bearer bearer-secret-123"`, "bearer-secret-123", `curl -H "Authorization: Bearer [REDACTED_SECRET]"`},
 		{"plain authorization header", `curl -H 'Authorization: header-secret-123' example.com`, "header-secret-123", `curl -H 'Authorization: [REDACTED_SECRET]' example.com`},
 		{"basic authorization header", `curl -H 'Authorization: Basic dXNlcjpwYXNzd29yZA==' example.com`, "dXNlcjpwYXNzd29yZA==", `curl -H 'Authorization: Basic [REDACTED_SECRET]' example.com`},
-		{"short bearer", `echo Bearer abc123`, "abc123", `echo Bearer [REDACTED_SECRET]`},
+		{"bare bearer token", `echo Bearer bearer-secret-123`, "bearer-secret-123", `echo Bearer [REDACTED_SECRET]`},
+		{"short bearer in header context", `curl -H 'Authorization: Bearer ab12' https://x.test`, "ab12", `curl -H 'Authorization: Bearer [REDACTED_SECRET]' https://x.test`},
 		{"password assignment", `mysql --password=password-secret-123 -u root`, "password-secret-123", `mysql --password=[REDACTED_SECRET] -u root`},
 		{"pwd assignment", `PWD=pwd-secret-123 echo ok`, "pwd-secret-123", `PWD=[REDACTED_SECRET] echo ok`},
 		{"pass flag", `login --pass pass-secret-123`, "pass-secret-123", `login --pass [REDACTED_SECRET]`},
@@ -207,7 +208,10 @@ func TestNormalizeRedactsCredentialValuesFromSummaries(t *testing.T) {
 		{"json command", `curl -d '{"password":"json-secret-123"}'`, "json-secret-123", `curl -d '{"password":"[REDACTED_SECRET]"}'`},
 		{"curl user password", `curl -u user:curl-secret-123 https://x.test`, "curl-secret-123", `curl -u [REDACTED_SECRET] https://x.test`},
 		{"unclosed quote", `TOKEN="unterminated-secret`, "unterminated-secret", `TOKEN=[REDACTED_SECRET]`},
-		{"unclosed quote mid-value", `TOKEN=a"broken-secret deploy`, "broken-secret", `TOKEN=[REDACTED_SECRET] deploy`},
+		{"unclosed quote multiword", `TOKEN="alpha-secret beta gamma`, "alpha-secret", `TOKEN=[REDACTED_SECRET]`},
+		{"unclosed quote mid-value", `TOKEN=a"broken-secret deploy`, "broken-secret", `TOKEN=[REDACTED_SECRET]`},
+		{"attached curl user password", `curl -uadmin:attached-secret-123 https://x.test`, "attached-secret-123", `curl -u[REDACTED_SECRET] https://x.test`},
+		{"passwd flag", `tool --passwd passwd-secret-123 run`, "passwd-secret-123", `tool --passwd [REDACTED_SECRET] run`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/payloadcapture/ruleset.json
+++ b/internal/payloadcapture/ruleset.json
@@ -5,7 +5,7 @@
     {
       "id": "sensitive-key",
       "description": "Object keys that denote credentials; their values are replaced wholesale.",
-      "pattern": "(^|[_-])(authorization|auth|api[_-]?key|access[_-]?(?:key|token)|refresh[_-]?token|client[_-]?secret|token|secret|password|pwd|pass|credential|private[_-]?key|session[_-]?key)($|[_-])",
+      "pattern": "(^|[_-])(authorization|auth|api[_-]?key|access[_-]?(?:key|token)|refresh[_-]?token|client[_-]?secret|token|secret|password|passwd|pwd|pass|credential|private[_-]?key|session[_-]?key)($|[_-])",
       "caseInsensitive": true,
       "provenance": "structural"
     }
@@ -21,15 +21,15 @@
     {
       "id": "authorization-header",
       "description": "Authorization header values, with or without an authentication scheme.",
-      "pattern": "\\b(Authorization\\s*:\\s*(?:(?:Bearer|Basic)\\s+)?)(?:\"(?:\\\\.|[^\"\\\\])*\"|'[^']*'|`(?:\\\\.|[^`\\\\])*`|[^\\s&;|)\"'`]+|[\"'`]\\S+)+",
+      "pattern": "\\b(Authorization\\s*:\\s*(?:(?:Bearer|Basic)\\s+)?)(?:\"(?:\\\\.|[^\"\\\\])*\"|'[^']*'|`(?:\\\\.|[^`\\\\])*`|[^\\s&;|)\"'`]+|\"[^\"]*$|'[^']*$|`[^`]*$)(?:\"(?:\\\\.|[^\"\\\\])*\"|'[^']*'|`(?:\\\\.|[^`\\\\])*`|[^\\s&;|)\"'`]+|\"[^\\s\"][^\"]*$|'[^\\s'][^']*$|`[^\\s`][^`]*$)*",
       "replacement": "$1[REDACTED_SECRET]",
       "caseInsensitive": true,
       "provenance": "structural"
     },
     {
       "id": "bearer-auth",
-      "description": "Bearer authorization values of any non-empty length; fallback for non-header contexts. authorization-header runs first, so re-matching its placeholder output in header context is an intentional idempotent overlap.",
-      "pattern": "\\b(Bearer\\s+)(?:\"(?:\\\\.|[^\"\\\\])*\"|'[^']*'|`(?:\\\\.|[^`\\\\])*`|[^\\s&;|)\"'`]+|[\"'`]\\S+)+",
+      "description": "Bare Bearer authorization values shaped like credentials (8+ token characters); header context of any length is covered by authorization-header.",
+      "pattern": "\\b(Bearer\\s+)[A-Za-z0-9._~+/=-]{8,}",
       "replacement": "$1[REDACTED_SECRET]",
       "caseInsensitive": true,
       "provenance": "structural"
@@ -116,7 +116,7 @@
     {
       "id": "sensitive-assignment",
       "description": "key=value / key: value assignments where the key names a credential.",
-      "pattern": "\\b((?:[A-Za-z0-9_-]*(?:api[_-]?key|access[_-]?(?:key|token)|refresh[_-]?token|client[_-]?secret|token|secret|password|passwd|credential|private[_-]?key)[A-Za-z0-9_-]*|(?:[A-Za-z0-9]+[_-])*(?:pwd|pass)(?:[_-][A-Za-z0-9]+)*)\\s*[:=]\\s*)(?:\"(?:\\\\.|[^\"\\\\])*\"|'[^']*'|`(?:\\\\.|[^`\\\\])*`|[^\\s&;|)\"'`]+|[\"'`]\\S+)+",
+      "pattern": "\\b((?:[A-Za-z0-9_-]*(?:api[_-]?key|access[_-]?(?:key|token)|refresh[_-]?token|client[_-]?secret|token|secret|password|passwd|credential|private[_-]?key)[A-Za-z0-9_-]*|(?:[A-Za-z0-9]+[_-])*(?:pwd|pass)(?:[_-][A-Za-z0-9]+)*)\\s*[:=]\\s*)(?:\"(?:\\\\.|[^\"\\\\])*\"|'[^']*'|`(?:\\\\.|[^`\\\\])*`|[^\\s&;|)\"'`]+|\"[^\"]*$|'[^']*$|`[^`]*$)(?:\"(?:\\\\.|[^\"\\\\])*\"|'[^']*'|`(?:\\\\.|[^`\\\\])*`|[^\\s&;|)\"'`]+|\"[^\\s\"][^\"]*$|'[^\\s'][^']*$|`[^\\s`][^`]*$)*",
       "replacement": "$1[REDACTED_SECRET]",
       "caseInsensitive": true,
       "provenance": "structural"
@@ -124,15 +124,15 @@
     {
       "id": "sensitive-cli-flag",
       "description": "CLI flags carrying credentials (--token x, --token=x).",
-      "pattern": "(--(?:api[-_]?key|access[-_]?(?:key|token)|refresh[-_]?token|client[-_]?secret|token|secret|password|pwd|pass|credential|private[-_]?key)[= ])(?:\"(?:\\\\.|[^\"\\\\])*\"|'[^']*'|`(?:\\\\.|[^`\\\\])*`|[^\\s&;|)\"'`]+|[\"'`]\\S+)+",
+      "pattern": "(--(?:api[-_]?key|access[-_]?(?:key|token)|refresh[-_]?token|client[-_]?secret|token|secret|password|passwd|pwd|pass|credential|private[-_]?key)[= ])(?:\"(?:\\\\.|[^\"\\\\])*\"|'[^']*'|`(?:\\\\.|[^`\\\\])*`|[^\\s&;|)\"'`]+|\"[^\"]*$|'[^']*$|`[^`]*$)(?:\"(?:\\\\.|[^\"\\\\])*\"|'[^']*'|`(?:\\\\.|[^`\\\\])*`|[^\\s&;|)\"'`]+|\"[^\\s\"][^\"]*$|'[^\\s'][^']*$|`[^\\s`][^`]*$)*",
       "replacement": "$1[REDACTED_SECRET]",
       "caseInsensitive": true,
       "provenance": "structural"
     },
     {
       "id": "basic-auth-userinfo",
-      "description": "user:password credentials passed to command-line -u/--user flags.",
-      "pattern": "((?:^|\\s)(?:-u|--user)(?:=|\\s+))(?:\"(?:\\\\.|[^\"\\\\])*:[^\"]*\"|'[^']*:[^']*'|[^\\s:]+:[^\\s&;|)]+)",
+      "description": "user:password credentials passed to command-line -u/--user flags, including attached (-uuser:pass) and empty-username (-u :pass) forms.",
+      "pattern": "((?:^|\\s)(?:--user(?:=|\\s+)|-u(?:=|\\s+)?))(?:\"(?:\\\\.|[^\"\\\\])*:[^\"]*\"|'[^']*:[^']*'|[^\\s:]*:[^\\s&;|)]+)",
       "replacement": "$1[REDACTED_SECRET]",
       "caseInsensitive": true,
       "provenance": "structural"
@@ -140,7 +140,7 @@
     {
       "id": "sensitive-query-param",
       "description": "Credential-bearing URL query parameters.",
-      "pattern": "([?&](?:access[-_]?token|api[-_]?key|client[-_]?secret|code|key|password|pwd|pass|refresh[-_]?token|secret|token)=)[^&\\s\"']+",
+      "pattern": "([?&](?:access[-_]?token|api[-_]?key|client[-_]?secret|code|key|password|passwd|pwd|pass|refresh[-_]?token|secret|token)=)[^&\\s\"']+",
       "replacement": "$1[REDACTED_SECRET]",
       "caseInsensitive": true,
       "provenance": "structural"

--- a/internal/payloadcapture/testdata/redaction-coverage-vectors.json
+++ b/internal/payloadcapture/testdata/redaction-coverage-vectors.json
@@ -7,11 +7,11 @@
       "mustNotSurvive": ["MIIfakekeymaterialFAKE"]
     },
     {
-      "name": "bearer-header",
+      "name": "bare-bearer-token",
       "ruleId": "bearer-auth",
-      "input": "echo Bearer abc123",
-      "mustNotSurvive": ["abc123"],
-      "expected": "echo Bearer [REDACTED_SECRET]"
+      "input": "echo Bearer bearer-secret-FAKE done",
+      "mustNotSurvive": ["bearer-secret-FAKE"],
+      "expected": "echo Bearer [REDACTED_SECRET] done"
     },
     {
       "name": "bare-basic-auth",
@@ -26,6 +26,27 @@
       "input": "curl -H \"Authorization: header-secret-FAKE\" https://api.example.test",
       "mustNotSurvive": ["header-secret-FAKE"],
       "expected": "curl -H \"Authorization: [REDACTED_SECRET]\" https://api.example.test"
+    },
+    {
+      "name": "short-bearer-value-in-header-context",
+      "ruleId": "authorization-header",
+      "input": "curl -H 'Authorization: Bearer ab12' https://api.example.test",
+      "mustNotSurvive": ["ab12"],
+      "expected": "curl -H 'Authorization: Bearer [REDACTED_SECRET]' https://api.example.test"
+    },
+    {
+      "name": "header-bearer-unclosed-quote-multiword",
+      "ruleId": "authorization-header",
+      "input": "set-header Authorization: Bearer \"multi word bearer-FAKE",
+      "mustNotSurvive": ["multi word bearer-FAKE"],
+      "expected": "set-header Authorization: Bearer [REDACTED_SECRET]"
+    },
+    {
+      "name": "header-swallows-following-quoted-args",
+      "ruleId": "authorization-header",
+      "input": "curl -H \"Authorization: Bearer tok-FAKE\" -d '{\"k\":\"v\"}' https://api.example.test",
+      "mustNotSurvive": ["tok-FAKE"],
+      "expected": "curl -H \"Authorization: Bearer [REDACTED_SECRET]"
     },
     {
       "name": "github-classic-token",
@@ -129,8 +150,15 @@
       "name": "assignment-unclosed-quote-mid-value",
       "ruleId": "sensitive-assignment",
       "input": "TOKEN=a\"broken-secret-FAKE deploy",
-      "mustNotSurvive": ["broken-secret-FAKE"],
-      "expected": "TOKEN=[REDACTED_SECRET] deploy"
+      "mustNotSurvive": ["broken-secret-FAKE", "deploy"],
+      "expected": "TOKEN=[REDACTED_SECRET]"
+    },
+    {
+      "name": "assignment-unclosed-quote-multiword",
+      "ruleId": "sensitive-assignment",
+      "input": "TOKEN=\"alpha-secret-FAKE beta gamma",
+      "mustNotSurvive": ["alpha-secret-FAKE", "beta gamma"],
+      "expected": "TOKEN=[REDACTED_SECRET]"
     },
     {
       "name": "json-embedded-password",
@@ -147,10 +175,38 @@
       "expected": "mytool login --password [REDACTED_SECRET] --verbose"
     },
     {
+      "name": "cli-flag-passwd-alias",
+      "ruleId": "sensitive-cli-flag",
+      "input": "tool --passwd cli-passwd-secret-FAKE run",
+      "mustNotSurvive": ["cli-passwd-secret-FAKE"],
+      "expected": "tool --passwd [REDACTED_SECRET] run"
+    },
+    {
+      "name": "cli-flag-unclosed-quote-multiword",
+      "ruleId": "sensitive-cli-flag",
+      "input": "mytool login --password \"multi word secret-FAKE",
+      "mustNotSurvive": ["multi word secret-FAKE"],
+      "expected": "mytool login --password [REDACTED_SECRET]"
+    },
+    {
       "name": "curl-user-password",
       "ruleId": "basic-auth-userinfo",
       "input": "curl -u user:curl-secret-FAKE https://api.example.test",
       "mustNotSurvive": ["user:curl-secret-FAKE", "curl-secret-FAKE"],
+      "expected": "curl -u [REDACTED_SECRET] https://api.example.test"
+    },
+    {
+      "name": "curl-attached-user-password",
+      "ruleId": "basic-auth-userinfo",
+      "input": "curl -uadmin:attached-secret-FAKE https://api.example.test",
+      "mustNotSurvive": ["admin:attached-secret-FAKE", "attached-secret-FAKE"],
+      "expected": "curl -u[REDACTED_SECRET] https://api.example.test"
+    },
+    {
+      "name": "curl-empty-username-password",
+      "ruleId": "basic-auth-userinfo",
+      "input": "curl -u :nouser-secret-FAKE https://api.example.test",
+      "mustNotSurvive": [":nouser-secret-FAKE", "nouser-secret-FAKE"],
       "expected": "curl -u [REDACTED_SECRET] https://api.example.test"
     },
     {
@@ -159,6 +215,13 @@
       "input": "GET /callback?code=authcodeFAKEsecret&state=xyz",
       "mustNotSurvive": ["authcodeFAKEsecret"],
       "expected": "GET /callback?code=[REDACTED_SECRET]&state=xyz"
+    },
+    {
+      "name": "query-param-passwd-alias",
+      "ruleId": "sensitive-query-param",
+      "input": "GET /login?passwd=query-passwd-secret-FAKE&next=1",
+      "mustNotSurvive": ["query-passwd-secret-FAKE"],
+      "expected": "GET /login?passwd=[REDACTED_SECRET]&next=1"
     }
   ],
   "keyVectors": [
@@ -174,6 +237,7 @@
     { "name": "session-key", "key": "sessionKey", "sensitive": true },
     { "name": "access-key", "key": "accessKey", "sensitive": true },
     { "name": "password-alias", "key": "pwd", "sensitive": true },
+    { "name": "passwd-alias", "key": "passwd", "sensitive": true },
     { "name": "author-is-not-auth", "key": "author", "sensitive": false },
     {
       "name": "tokenizer-is-not-token",


### PR DESCRIPTION
## Summary

Byte-for-byte sync of the shared redaction-ruleset artifact (`internal/payloadcapture/ruleset.json`) and coverage vectors after the review fixes landed on kontext-security/kontext#655 (commit `753c639b` there). #377 merged before that review round was addressed, so the two mirrors had diverged; this restores the cross-repo "do not edit independently of the source artifact" contract.

## What changed (behavior, via the synced artifact)

- **Leak fixes from the #655 review** (michiosw): attached `-uuser:pass` and empty-username `-u :pass` userinfo forms now redact; a value opening with a quote that never closes is consumed to end of input (fail closed), so multi-word unterminated secrets no longer leak their tail; `--passwd` flags, `?passwd=` query params, and `passwd` object keys are now classified sensitive.
- **False-positive fix**: bare `Bearer` values require 8+ token characters again, matching bare `Basic` ("the bearer of bad news" is prose); `Authorization:` header context keeps any-length coverage.
- **Structure preservation retained**: in continuation position a quote followed by whitespace still reads as the enclosing argument's closing quote, so `-H "Authorization: X" <url>` keeps redacting to `…[REDACTED_SECRET]" <url>`. The quoted-argument swallowing shape is documented as a known over-redaction limitation and pinned by a vector.

## Repo-side changes

`internal/guard/risk/risk_test.go`: updated the two summary cases that pinned the old behavior (bare-Bearer floor, fail-closed unterminated quote) and added cases for attached `-u` userinfo, `--passwd`, and short-Bearer-in-header.

No `redactorVersion` bump: rules/2 has not shipped in any released binary (v0.15.1 predates #377's merge).

## Testing

- `go test ./...` — all pass (payloadcapture conformance compiles every pattern under real RE2; exact-output vector assertions hold in Go, confirming JS/Go semantic parity)
- `go vet`, `gofmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)