### PR TITLE
fix(managed): survive a mode the running build does not implement

### DIFF
--- a/internal/managedconfig/config.go
+++ b/internal/managedconfig/config.go
@@ -91,13 +91,18 @@ func ResolvePath() (string, Scope) {
 }
 
 type Config struct {
-	Version             string      `json:"version"`
-	CloudURL            string      `json:"cloud_url"`
-	Mode                string      `json:"mode"`
-	Agent               string      `json:"agent"`
-	Credentials         Credentials `json:"credentials"`
-	Device              Device      `json:"device,omitempty"`
-	LegacyCoworkEnabled bool        `json:"-"`
+	Version     string      `json:"version"`
+	CloudURL    string      `json:"cloud_url"`
+	Mode        string      `json:"mode"`
+	Agent       string      `json:"agent"`
+	Credentials Credentials `json:"credentials"`
+	Device      Device      `json:"device,omitempty"`
+	// UnsupportedMode carries the raw mode this build did not recognize, after
+	// Mode has already been rewritten to the observe fallback. Empty on every
+	// config whose mode this build understands, so callers can treat a
+	// non-empty value as "the endpoint is running degraded" and say so.
+	UnsupportedMode     string `json:"-"`
+	LegacyCoworkEnabled bool   `json:"-"`
 }
 
 type configFile struct {
@@ -287,8 +292,24 @@ func normalizeAndValidate(cfg Config) (Config, error) {
 	if err := validateCloudURL(cfg.CloudURL); err != nil {
 		return Config{}, err
 	}
-	if cfg.Mode != Mode && cfg.Mode != ModeEnforce && cfg.Mode != ModeRemote {
-		return Config{}, fmt.Errorf("mode must be %q, %q, or %q", Mode, ModeEnforce, ModeRemote)
+	// An unrecognized mode is the signature of a DOWNGRADE: a newer build wrote
+	// a posture this one has no name for (as happened when `remote` was added
+	// and older binaries met it). Refusing to load is the worst available
+	// response — launchd then crash-loops the daemon, so the endpoint reports
+	// nothing at all and still enforces nothing, and no self-updater can
+	// recover a binary that will not boot. Falling back to observe is strictly
+	// better on both axes: it cannot enforce less than a process that never
+	// starts, and it keeps the telemetry that makes the skew diagnosable.
+	// Recorded rather than swallowed so startup and `kontext doctor` can say it
+	// out loud; the write path stays strict via ValidateMode.
+	// A MISSING mode is not a downgrade, it is a malformed config, and stays a
+	// hard error exactly as before.
+	if err := ValidateMode(cfg.Mode); err != nil {
+		if cfg.Mode == "" {
+			return Config{}, err
+		}
+		cfg.UnsupportedMode = cfg.Mode
+		cfg.Mode = Mode
 	}
 	if cfg.Agent != Agent {
 		return Config{}, fmt.Errorf("agent must be %q", Agent)
@@ -297,6 +318,19 @@ func normalizeAndValidate(cfg Config) (Config, error) {
 		return Config{}, err
 	}
 	return cfg, nil
+}
+
+// ValidateMode reports whether value is a posture this build implements. The
+// READ path (Parse) deliberately does not fail on a bad mode — see
+// normalizeAndValidate — so this is the gate for every WRITE path instead:
+// nothing should ever persist a mode that the writer itself cannot evaluate.
+func ValidateMode(value string) error {
+	switch strings.TrimSpace(value) {
+	case Mode, ModeEnforce, ModeRemote:
+		return nil
+	default:
+		return fmt.Errorf("mode must be %q, %q, or %q", Mode, ModeEnforce, ModeRemote)
+	}
 }
 
 // ValidateCloudURL enforces the managed.json cloud_url shape (https with
@@ -412,6 +446,12 @@ func RewriteMode(loaded LoadedConfig, mode string) error {
 }
 
 func rewriteModeLocked(loaded LoadedConfig, mode string) error {
+	// Explicit, because the Parse() round-trip below no longer rejects an
+	// unknown mode — it would quietly normalize one to observe and write that
+	// through as if the caller had asked for it.
+	if err := ValidateMode(mode); err != nil {
+		return err
+	}
 	data, err := os.ReadFile(loaded.Path)
 	if err != nil {
 		return err

--- a/internal/managedconfig/config_test.go
+++ b/internal/managedconfig/config_test.go
@@ -79,8 +79,76 @@ func TestParseModeObserveAndEnforce(t *testing.T) {
 	if cfg.Mode != ModeEnforce {
 		t.Fatalf("Mode = %q, want %q", cfg.Mode, ModeEnforce)
 	}
-	if _, err := Parse([]byte(strings.Replace(validConfigJSON(), `"mode": "observe"`, `"mode": "block"`, 1))); err == nil {
-		t.Fatal("Parse() accepted unknown mode")
+}
+
+// A mode this build does not implement must NOT fail the load: that is what a
+// downgrade looks like, and refusing to parse crash-loops the daemon under
+// launchd, costing all telemetry while enforcing nothing extra.
+func TestParseUnknownModeFallsBackToObserve(t *testing.T) {
+	cfg, err := Parse([]byte(strings.Replace(validConfigJSON(), `"mode": "observe"`, `"mode": "block"`, 1)))
+	if err != nil {
+		t.Fatalf("Parse() error = %v, want unknown mode to load in observe", err)
+	}
+	if cfg.Mode != Mode {
+		t.Fatalf("Mode = %q, want %q", cfg.Mode, Mode)
+	}
+	if cfg.UnsupportedMode != "block" {
+		t.Fatalf("UnsupportedMode = %q, want %q", cfg.UnsupportedMode, "block")
+	}
+}
+
+// The regression that motivated the fallback: `remote` was added after some
+// shipped builds, so those builds met it in a config they had to keep serving.
+func TestParseFutureModeFallsBackToObserve(t *testing.T) {
+	cfg, err := Parse([]byte(strings.Replace(validConfigJSON(), `"mode": "observe"`, `"mode": "some-future-posture"`, 1)))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if cfg.Mode != Mode || cfg.UnsupportedMode != "some-future-posture" {
+		t.Fatalf("Mode = %q, UnsupportedMode = %q; want %q / %q",
+			cfg.Mode, cfg.UnsupportedMode, Mode, "some-future-posture")
+	}
+}
+
+// Every mode this build DOES implement must round-trip untouched, with no
+// degraded-mode breadcrumb — otherwise doctor cries wolf on healthy installs.
+func TestParseSupportedModesRecordNoFallback(t *testing.T) {
+	for _, mode := range []string{Mode, ModeEnforce, ModeRemote} {
+		cfg, err := Parse([]byte(strings.Replace(validConfigJSON(), `"mode": "observe"`, `"mode": "`+mode+`"`, 1)))
+		if err != nil {
+			t.Fatalf("Parse(%q) error = %v", mode, err)
+		}
+		if cfg.Mode != mode {
+			t.Fatalf("Mode = %q, want %q", cfg.Mode, mode)
+		}
+		if cfg.UnsupportedMode != "" {
+			t.Fatalf("UnsupportedMode = %q for supported mode %q, want empty", cfg.UnsupportedMode, mode)
+		}
+	}
+}
+
+// The read path is lenient; the write path must not be. Persisting a mode the
+// writer cannot evaluate would turn one downgraded boot into a permanent
+// misconfiguration.
+func TestRewriteModeRejectsUnsupportedMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "managed.json")
+	if err := os.WriteFile(path, []byte(validConfigJSON()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+	if err := RewriteMode(loaded, "block"); err == nil {
+		t.Fatal("RewriteMode() accepted an unsupported mode")
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != validConfigJSON() {
+		t.Fatalf("config was modified by a rejected rewrite:\n%s", after)
 	}
 }
 

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -123,6 +123,17 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 		opts.Diagnostic.Printf("managed observe cleanup: %v\n", err)
 	}
 
+	// A mode this build cannot name means the install is newer than the running
+	// binary — a downgrade. The config loader already fell back to observe so
+	// the daemon still boots and still reports; this is the only place that
+	// says why, so it logs unconditionally rather than behind a diagnostic
+	// flag.
+	if unsupported := loadedConfig.Config.UnsupportedMode; unsupported != "" {
+		logAlways(opts.Diagnostic,
+			"managed config declares mode %q, which this build (%s) does not implement; running in %q — the installed binary is older than the install that wrote this config\n",
+			unsupported, binaryVersion, loadedConfig.Config.Mode)
+	}
+
 	// The deployment-level mode from managed.json drives every hook edge:
 	// observe records would-decisions, enforce returns real denies, remote
 	// defers to the fetched policy deployment's rollout mode so the posture
@@ -548,6 +559,15 @@ func cleanupInterval(idleTimeout time.Duration) time.Duration {
 // the config it loaded and retries on next start.
 func migrateSelfServeModeToRemote(loaded managedconfig.LoadedConfig, log diagnostic.Logger) managedconfig.LoadedConfig {
 	if loaded.Scope != managedconfig.ScopeUser || loaded.Config.Mode != managedconfig.Mode {
+		return loaded
+	}
+	// Observe is not always the era's default: it is also what the loader
+	// substitutes for a mode this build cannot name. Migrating that one would
+	// overwrite the operator's declared posture with this binary's guess, erase
+	// the only on-disk record that the install is newer than the binary, and
+	// silence the downgrade warning on the very next load. A downgraded endpoint
+	// is exactly the case where nothing should be rewritten.
+	if loaded.Config.UnsupportedMode != "" {
 		return loaded
 	}
 	if err := managedconfig.RewriteMode(loaded, managedconfig.ModeRemote); err != nil {

--- a/internal/managedobserve/daemon_test.go
+++ b/internal/managedobserve/daemon_test.go
@@ -802,6 +802,32 @@ func TestMigrateSelfServeModeToRemote(t *testing.T) {
 		}
 	})
 
+	// The observe a downgraded build falls back to is not the era's default, and
+	// migrating it would overwrite the declared posture and destroy the evidence
+	// of the skew — leaving doctor and the startup log with nothing to report.
+	t.Run("fallback observe from an unsupported mode is untouched", func(t *testing.T) {
+		path := writeConfig(t, "some-future-posture")
+		loaded := load(t, path, managedconfig.ScopeUser)
+		if loaded.Config.UnsupportedMode != "some-future-posture" {
+			t.Fatalf("UnsupportedMode = %q, want the raw mode recorded", loaded.Config.UnsupportedMode)
+		}
+		migrated := migrateSelfServeModeToRemote(loaded, diagnostic.Logger{})
+		if migrated.Config.Mode != managedconfig.Mode {
+			t.Fatalf("returned mode = %q, want the observe fallback", migrated.Config.Mode)
+		}
+		if migrated.Config.UnsupportedMode != "some-future-posture" {
+			t.Fatalf("UnsupportedMode = %q, want it preserved so the downgrade stays reportable", migrated.Config.UnsupportedMode)
+		}
+		onDisk, err := managedconfig.LoadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if onDisk.Config.UnsupportedMode != "some-future-posture" {
+			t.Fatalf("on-disk mode was rewritten to %q, want the operator's %q left in place",
+				onDisk.Config.Mode, "some-future-posture")
+		}
+	})
+
 	t.Run("static pins and non-user scopes are untouched", func(t *testing.T) {
 		cases := []struct {
 			name  string

--- a/internal/managedobserve/doctor.go
+++ b/internal/managedobserve/doctor.go
@@ -91,6 +91,18 @@ func printStatus(out io.Writer, installedVersion string, opts doctorOptions) Doc
 		status.Healthy = false
 	}
 
+	// The endpoint is running, but on a posture the operator did not choose.
+	// Worth a WARNING rather than a status line: the fix is reinstalling a build
+	// that is at least as new as the config, and nothing else here hints at it.
+	// Unhealthy, and deliberately not repairable — restarting the daemon cannot
+	// teach this binary a mode it does not implement, so --fix must not claim it
+	// has a repair for this.
+	if unsupported := loaded.Config.UnsupportedMode; unsupported != "" {
+		fmt.Fprintf(out, "  WARNING: config requests mode %q, which v%s does not implement — running in %q; this binary is older than the install, reinstall to catch up\n",
+			unsupported, installedVersion, loaded.Config.Mode)
+		status.Healthy = false
+	}
+
 	identityPath := installationPathForScope(loaded.Scope)
 	if state, err := installation.LoadFile(identityPath); err == nil {
 		fmt.Fprintf(out, "  installation: %s\n", state.InstallationID)

--- a/internal/managedobserve/doctor_test.go
+++ b/internal/managedobserve/doctor_test.go
@@ -45,6 +45,53 @@ func TestPrintStatusReportsInstallationLoadError(t *testing.T) {
 	}
 }
 
+// A downgraded endpoint still loads, so the only thing standing between the
+// operator and a silently wrong posture is this warning.
+func TestPrintStatusWarnsOnUnsupportedConfigMode(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "managed.json")
+	writeTestManagedConfig(t, configPath)
+	config, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	degraded := strings.Replace(string(config), `"mode": "observe"`, `"mode": "some-future-posture"`, 1)
+	if err := os.WriteFile(configPath, []byte(degraded), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	status := PrintStatus(&out, "1.2.3")
+	output := out.String()
+	if !strings.Contains(output, `WARNING: config requests mode "some-future-posture"`) {
+		t.Fatalf("PrintStatus() output = %q, want unsupported mode warning", output)
+	}
+	if strings.Contains(output, "config: ERROR") {
+		t.Fatalf("PrintStatus() output = %q, an unsupported mode must not read as an unloadable config", output)
+	}
+	if status.Healthy {
+		t.Fatal("PrintStatus() reported healthy while running a posture the operator did not choose")
+	}
+	// Reinstalling is the only fix; --fix must not offer a daemon restart that
+	// cannot possibly help.
+	if status.Repairable {
+		t.Fatal("PrintStatus() reported a downgraded endpoint as repairable")
+	}
+}
+
+// The complement: a healthy install must stay quiet, or the warning is noise.
+func TestPrintStatusDoesNotWarnOnSupportedConfigMode(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "managed.json")
+	writeTestManagedConfig(t, configPath)
+
+	var out bytes.Buffer
+	PrintStatus(&out, "1.2.3")
+	if output := out.String(); strings.Contains(output, "config requests mode") {
+		t.Fatalf("PrintStatus() output = %q, want no unsupported mode warning", output)
+	}
+}
+
 func TestPrintStatusDaemonVersionMatch(t *testing.T) {
 	env := newDoctorTestEnv(t)
 	env.writeDaemonStatus(t, os.Getpid(), "1.2.3")


### PR DESCRIPTION
## Problem

An unrecognized `mode` in `managed.json` fails the config load, and that takes the whole endpoint down rather than degrading it. launchd `KeepAlive` respawns the daemon, it exits 1 on the same config, and it settles into a permanent crash-loop:

```
$ launchctl list security.kontext.managed-observe
  "LastExitStatus" = 256;

$ tail ~/Library/Logs/Kontext/managed-observe.log
Error: load managed config: mode must be "observe" or "enforce"
Error: load managed config: mode must be "observe" or "enforce"
Error: load managed config: mode must be "observe" or "enforce"
```

No daemon means no telemetry *and* no enforcement, and nothing self-heals it:

- the Homebrew updater lives inside the binary that will not boot;
- the binary watchdog only reacts to the old binary being replaced, so it cannot help when the **new** binary is the one refusing to start;
- `kontext doctor` reports `config: ERROR` and never mentions that the daemon is dead.

It needs hands on the machine.

This is reachable any time the installed binary is **older than the install that wrote the config**, because `mode` gains values over time. `remote` is the live example: builds from before it was introduced meet it in configs written by a newer `kontext setup` and die on it. Installing an older build onto a configured Mac is enough to trigger it.

## Fix

Treat an unrecognized mode as the downgrade signal it is, rather than a fatal error: fall back to observe, record the raw value, and say so loudly in both places that can.

```
managed config declares mode "remote", which this build (0.14.1) does not
implement; running in "observe" — the installed binary is older than the
install that wrote this config
```

```
$ kontext doctor
Managed observe:
  config: /Users/…/managed.json (self-serve)
  WARNING: config requests mode "remote", which v0.14.1 does not implement —
  running in "observe"; this binary is older than the install, reinstall to catch up
```

Observe **strictly dominates** the old behavior, so this loosens nothing:

| | crash-loop (before) | observe fallback (after) |
|---|---|---|
| enforcement | none — no process | none |
| telemetry | none | full |
| diagnosable | `config: ERROR` only | names the mode and the cause |

A process that never starts cannot enforce, so falling back to observe cannot enforce *less* than today. It only recovers the visibility that makes the skew findable.

This also matches what the rest of the codebase already does with an unknown mode — `loadManagedMode` (`lifecycle.go`) and `ParseMode`'s `""` case both resolve to observe. `managedconfig.Parse` was the one layer that turned it into a fatal.

## The read path is lenient, so the write paths are now explicitly strict

Two write paths had to be closed, both for the same reason: they treated observe as a value the caller had chosen, when it can now be a value the loader substituted.

**1. `rewriteModeLocked`** validated by round-tripping through `Parse`. With `Parse` lenient that check silently *normalizes* an unsupported mode to observe and writes it through as though the caller had asked for it. New exported `ValidateMode` is the gate for write paths, called before anything is persisted; `TestRewriteModeRejectsUnsupportedMode` asserts the file is left byte-identical on rejection.

**2. `migrateSelfServeModeToRemote`** (thanks @greptile-apps) fired on the fallback. It rewrites a user-scope config whose mode is observe to `remote` — and a downgraded config now *looks* like one, so it would:

- overwrite the operator's declared posture with this binary's guess,
- erase the only on-disk record that the install is newer than the binary,
- and clear `UnsupportedMode` on the reload, silencing **both** the startup log and the doctor warning.

On the self-serve path — every `kontext setup` install — that removed the diagnostic this PR exists to add. The migration now skips any config carrying `UnsupportedMode`; `TestMigrateSelfServeModeToRemote/fallback_observe_from_an_unsupported_mode_is_untouched` covers it and fails without the guard (`returned mode = "remote", want the observe fallback`).

A **missing** mode stays a hard error — that is a malformed config, not a downgrade, and the existing required-field test still covers it.

## Rebased onto main's doctor rework

`DoctorStatus` (#441) landed after this branch was written, so the new warning now participates in it: a downgraded endpoint is **unhealthy but not repairable**. Restarting the daemon cannot teach this binary a mode it does not implement — only reinstalling helps — so `--fix` must not claim it has a repair. This matches the convention on main, where every WARNING in `printStatus` clears `Healthy`.

## Tests

- `TestParseUnknownModeFallsBackToObserve` — unknown mode loads, in observe, with the raw value recorded
- `TestParseFutureModeFallsBackToObserve` — the `remote`-style regression
- `TestParseSupportedModesRecordNoFallback` — all three real modes round-trip with no breadcrumb, so doctor cannot cry wolf
- `TestRewriteModeRejectsUnsupportedMode` — write path stays strict, file untouched
- `TestMigrateSelfServeModeToRemote/fallback observe …` — the migration leaves a downgraded config alone, on disk and in memory
- `TestPrintStatusWarnsOnUnsupportedConfigMode` / `…DoesNotWarnOnSupportedConfigMode` — doctor warns, reports unhealthy and not repairable, and only when it should

`gofmt`, `go vet`, and `go test -race ./...` all clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
