### PR TITLE
feat(doctor): identify builds by source revision, not version string

### DIFF
--- a/cmd/kontext/main.go
+++ b/cmd/kontext/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/kontext-security/kontext-cli/internal/agent"
+	"github.com/kontext-security/kontext-cli/internal/buildinfo"
 	"github.com/kontext-security/kontext-cli/internal/claudemanaged"
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 	guardcli "github.com/kontext-security/kontext-cli/internal/guard/cli"
@@ -41,9 +42,14 @@ func main() {
 
 func newRootCmd() *cobra.Command {
 	root := &cobra.Command{
-		Use:     "kontext",
-		Short:   "Kontext CLI — governed agent sessions",
-		Version: version,
+		Use:   "kontext",
+		Short: "Kontext CLI — governed agent sessions",
+		// Reported with the source revision appended, because the version
+		// string on its own cannot answer "which build is this": it is a
+		// link-time label, and release channels that name builds by date give
+		// no way to tell two sources apart. Every other use of `version` stays
+		// the bare string — only what a human reads gains the revision.
+		Version: buildinfo.Describe(version),
 	}
 
 	root.AddCommand(setupCmd())

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -1,0 +1,103 @@
+// Package buildinfo exposes the source revision compiled into this binary.
+//
+// The version string alone cannot identify a build. It is injected at link time
+// (`-X main.version=…`), so it carries whatever the release pipeline chose to
+// call the build and nothing about what was compiled: two binaries can share a
+// version string and differ in source, and one source tree can be published
+// under several strings. Release channels that label builds by date rather than
+// by source make this routine rather than theoretical.
+//
+// The Go toolchain already stamps the real answer into every binary built from
+// a repository — `vcs.revision`, plus `vcs.modified` for an uncommitted tree —
+// and it is not spoofable by a link-time flag. This package reads it so the CLI
+// can report which source it is, and so two processes from the same install
+// (the CLI and the long-lived daemon) can be compared for real.
+package buildinfo
+
+import (
+	"runtime/debug"
+	"strings"
+)
+
+// shortRevisionLength matches the abbreviation git uses in log output, which is
+// what a reader will compare it against.
+const shortRevisionLength = 8
+
+// read is a test seam for debug.ReadBuildInfo, which cannot be made to report a
+// VCS stamp from inside `go test` (the test binary has no stamp of its own).
+var read = debug.ReadBuildInfo
+
+// Revision is the full VCS revision this binary was built from, or "" when the
+// binary carries no VCS stamp. Builds produced by `go build` outside a
+// repository, or with -buildvcs=false, legitimately have none.
+func Revision() string {
+	return setting("vcs.revision")
+}
+
+// Modified reports whether the working tree had uncommitted changes at build
+// time. A modified tree means Revision names the commit the build was based on,
+// not the source that was actually compiled, so it must never be presented as
+// an exact identity.
+func Modified() bool {
+	return setting("vcs.modified") == "true"
+}
+
+// ShortRevision abbreviates Revision for display, returning "" when there is no
+// stamp to abbreviate.
+func ShortRevision() string {
+	return Short(Revision())
+}
+
+// Short abbreviates any revision for display, including one read back from
+// another process's breadcrumb rather than from this binary.
+func Short(revision string) string {
+	revision = strings.TrimSpace(revision)
+	if len(revision) > shortRevisionLength {
+		return revision[:shortRevisionLength]
+	}
+	return revision
+}
+
+// DescribeRevision renders a revision for display as a single token, marking one
+// that was built from a modified tree. Kept to one token because callers embed
+// it inside longer lines ("daemon: running (v0.14.1 cac15fd6+modified, pid 12)")
+// where a comma-separated qualifier would read as a separate field.
+//
+//	cac15fd6
+//	cac15fd6+modified
+//	""            (no stamp to describe)
+func DescribeRevision(revision string, modified bool) string {
+	revision = Short(revision)
+	if revision == "" || !modified {
+		return revision
+	}
+	return revision + "+modified"
+}
+
+// Describe renders version together with the source it was built from, for
+// `kontext --version` and any other human-facing identity. The revision is
+// additive: a binary with no stamp reports exactly what it did before.
+//
+//	0.14.1 (cac15fd6)
+//	0.14.1 (cac15fd6+modified)
+//	0.14.1
+func Describe(version string) string {
+	revision := DescribeRevision(Revision(), Modified())
+	if revision == "" {
+		return version
+	}
+	return version + " (" + revision + ")"
+}
+
+func setting(key string) string {
+	info, ok := read()
+	if !ok {
+		return ""
+	}
+	for _, s := range info.Settings {
+		if s.Key == key {
+			return s.Value
+		}
+	}
+	return ""
+}

--- a/internal/buildinfo/buildinfo_test.go
+++ b/internal/buildinfo/buildinfo_test.go
@@ -1,0 +1,128 @@
+package buildinfo
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+// stubBuildInfo replaces the debug.ReadBuildInfo seam for one test. The real
+// function cannot report a VCS stamp under `go test` — the test binary has none
+// — so every assertion about stamp handling has to go through the seam.
+func stubBuildInfo(t *testing.T, settings map[string]string, ok bool) {
+	t.Helper()
+	previous := read
+	t.Cleanup(func() { read = previous })
+	read = func() (*debug.BuildInfo, bool) {
+		if !ok {
+			return nil, false
+		}
+		info := &debug.BuildInfo{}
+		for key, value := range settings {
+			info.Settings = append(info.Settings, debug.BuildSetting{Key: key, Value: value})
+		}
+		return info, true
+	}
+}
+
+func TestRevisionReadsVCSStamp(t *testing.T) {
+	stubBuildInfo(t, map[string]string{"vcs.revision": "cac15fd669a7e4b0bfbdd78413d25fc0999e3a11"}, true)
+	if got, want := Revision(), "cac15fd669a7e4b0bfbdd78413d25fc0999e3a11"; got != want {
+		t.Fatalf("Revision() = %q, want %q", got, want)
+	}
+	if got, want := ShortRevision(), "cac15fd6"; got != want {
+		t.Fatalf("ShortRevision() = %q, want %q", got, want)
+	}
+}
+
+// A binary with no stamp must report nothing rather than something misleading:
+// `go build` outside a repo and -buildvcs=false are both legitimate.
+func TestRevisionEmptyWithoutStamp(t *testing.T) {
+	stubBuildInfo(t, map[string]string{"GOARCH": "arm64"}, true)
+	if got := Revision(); got != "" {
+		t.Fatalf("Revision() = %q, want empty", got)
+	}
+	if got := ShortRevision(); got != "" {
+		t.Fatalf("ShortRevision() = %q, want empty", got)
+	}
+}
+
+func TestRevisionEmptyWhenBuildInfoUnavailable(t *testing.T) {
+	stubBuildInfo(t, nil, false)
+	if got := Revision(); got != "" {
+		t.Fatalf("Revision() = %q, want empty", got)
+	}
+}
+
+func TestModifiedReportsDirtyTree(t *testing.T) {
+	stubBuildInfo(t, map[string]string{"vcs.modified": "true"}, true)
+	if !Modified() {
+		t.Fatal("Modified() = false, want true")
+	}
+	stubBuildInfo(t, map[string]string{"vcs.modified": "false"}, true)
+	if Modified() {
+		t.Fatal("Modified() = true, want false")
+	}
+}
+
+func TestDescribe(t *testing.T) {
+	for name, test := range map[string]struct {
+		settings map[string]string
+		want     string
+	}{
+		"stamped": {
+			settings: map[string]string{"vcs.revision": "cac15fd669a7e4b", "vcs.modified": "false"},
+			want:     "0.14.1 (cac15fd6)",
+		},
+		// A modified tree must say so: the revision names the commit the build
+		// was based on, not what was compiled, so it is not an identity.
+		"stamped and modified": {
+			settings: map[string]string{"vcs.revision": "cac15fd669a7e4b", "vcs.modified": "true"},
+			want:     "0.14.1 (cac15fd6+modified)",
+		},
+		"unstamped falls back to the bare version": {
+			settings: map[string]string{},
+			want:     "0.14.1",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			stubBuildInfo(t, test.settings, true)
+			if got := Describe("0.14.1"); got != test.want {
+				t.Fatalf("Describe() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+// One token, so callers can embed it mid-line without the marker reading as a
+// separate field.
+func TestDescribeRevision(t *testing.T) {
+	for _, test := range []struct {
+		revision string
+		modified bool
+		want     string
+	}{
+		{revision: "cac15fd669a7e4b", modified: false, want: "cac15fd6"},
+		{revision: "cac15fd669a7e4b", modified: true, want: "cac15fd6+modified"},
+		// Nothing to describe stays nothing to describe, dirty tree or not: a
+		// build with no stamp must not start reporting a phantom identity.
+		{revision: "", modified: true, want: ""},
+		{revision: "", modified: false, want: ""},
+	} {
+		if got := DescribeRevision(test.revision, test.modified); got != test.want {
+			t.Fatalf("DescribeRevision(%q, %v) = %q, want %q", test.revision, test.modified, got, test.want)
+		}
+	}
+}
+
+func TestShortHandlesArbitraryRevisions(t *testing.T) {
+	for input, want := range map[string]string{
+		"cac15fd669a7e4b0bfbdd78413d25fc0999e3a11": "cac15fd6",
+		"  cac15fd669a7e4b  ":                      "cac15fd6",
+		"short":                                    "short",
+		"":                                         "",
+	} {
+		if got := Short(input); got != want {
+			t.Fatalf("Short(%q) = %q, want %q", input, got, want)
+		}
+	}
+}

--- a/internal/managedobserve/doctor.go
+++ b/internal/managedobserve/doctor.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/kontext-security/kontext-cli/internal/buildinfo"
 	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
 	"github.com/kontext-security/kontext-cli/internal/installation"
 	"github.com/kontext-security/kontext-cli/internal/managedconfig"
@@ -129,12 +130,12 @@ func printStatus(out io.Writer, installedVersion string, opts doctorOptions) Doc
 	if conn, err := opts.Dial("unix", opts.SocketPath, 500*time.Millisecond); err == nil {
 		conn.Close()
 		if daemonStatus := LoadDaemonStatus(opts.DBPath); daemonStatus != nil && pidAlive(daemonStatus.PID) {
-			fmt.Fprintf(out, "  daemon: running (v%s, pid %d)\n", daemonStatus.Version, daemonStatus.PID)
-			if comparableVersion(daemonStatus.Version) && comparableVersion(installedVersion) && daemonStatus.Version != installedVersion {
+			fmt.Fprintf(out, "  daemon: running (%s, pid %d)\n", describeDaemonBuild(daemonStatus), daemonStatus.PID)
+			if reason, stale := daemonSkew(daemonStatus, installedVersion, buildinfo.Revision(), buildinfo.Modified()); stale {
 				if repairTargetAvailable {
-					fmt.Fprintf(out, "  WARNING: daemon is running v%s but v%s is installed — run 'kontext doctor --fix' to restart it\n", daemonStatus.Version, installedVersion)
+					fmt.Fprintf(out, "  WARNING: %s — run 'kontext doctor --fix' to restart it\n", reason)
 				} else {
-					fmt.Fprintf(out, "  WARNING: daemon is running v%s but v%s is installed — restart it through its managing installation\n", daemonStatus.Version, installedVersion)
+					fmt.Fprintf(out, "  WARNING: %s — restart it through its managing installation\n", reason)
 				}
 				staleDaemon = true
 			}
@@ -240,19 +241,29 @@ func describeScope(scope managedconfig.Scope) string {
 }
 
 // WaitForDaemonRestart polls until the socket is serving AND the status
-// breadcrumb reports a live daemon on wantVersion (any live daemon when the
-// version is not comparable, e.g. dev builds). `doctor --fix` uses it so
-// "restarted" is only printed for a verified comeback — launchd can accept a
-// kickstart and still have the new daemon exit immediately (unreadable token,
-// missing Cellar path).
+// breadcrumb reports a live daemon that is no longer skewed from this binary.
+// `doctor --fix` uses it so "restarted" is only printed for a verified comeback
+// — launchd can accept a kickstart and still have the new daemon exit
+// immediately (unreadable token, missing Cellar path).
+//
+// It reuses daemonSkew rather than comparing versions directly so that "came
+// back" means the same thing here as "up to date" does in the readout above. It
+// also narrows a hole: on builds that share a version string (notably `dev`) the
+// old version comparison accepted ANY live daemon, so a daemon that never
+// restarted was reported as restarted. Stamped builds now have to match by
+// revision. Two dirty builds of one commit remain indistinguishable, so a
+// modified local build can still satisfy this without having restarted —
+// unavoidable from the stamp alone, and never the case for a release build.
 func WaitForDaemonRestart(ctx context.Context, dbPath, socketPath, wantVersion string) (*DaemonStatus, error) {
 	ticker := time.NewTicker(250 * time.Millisecond)
 	defer ticker.Stop()
+	installedRevision := buildinfo.Revision()
+	installedModified := buildinfo.Modified()
 	for {
 		if conn, err := net.DialTimeout("unix", socketPath, 500*time.Millisecond); err == nil {
 			conn.Close()
 			if status := LoadDaemonStatus(dbPath); status != nil && pidAlive(status.PID) {
-				if !comparableVersion(wantVersion) || status.Version == wantVersion {
+				if _, stale := daemonSkew(status, wantVersion, installedRevision, installedModified); !stale {
 					return status, nil
 				}
 			}
@@ -282,6 +293,61 @@ func pidAlive(pid int) bool {
 func comparableVersion(version string) bool {
 	version = strings.TrimSpace(version)
 	return version != "" && version != "dev"
+}
+
+// describeDaemonBuild renders the running daemon's identity, including the
+// source revision when the daemon recorded one. Older daemons wrote no revision
+// and still print exactly as they used to.
+func describeDaemonBuild(status *DaemonStatus) string {
+	build := "v" + status.Version
+	if revision := buildinfo.DescribeRevision(status.Revision, status.Modified); revision != "" {
+		build += " " + revision
+	}
+	return build
+}
+
+// daemonSkew decides whether the running daemon is a different build from the
+// installed binary, preferring evidence over labels.
+//
+// REVISION FIRST, when both sides have one: it is the only field that identifies
+// a build. A version string is injected at link time, so a channel that labels
+// builds by date can hand two different sources the same version — or, for local
+// and unlabeled builds, hand every source the same "dev" — and a version
+// comparison then reports a match that is not one.
+//
+// Version is the fallback for daemons that predate the revision breadcrumb.
+// A missing revision on either side is NOT treated as a mismatch: unstamped
+// builds are legitimate, and warning on them would make the check unusable for
+// everyone who builds with -buildvcs=false.
+//
+// Equal revisions prove equal source only for CLEAN builds. With a modified tree
+// on either side the revision names the commit that build was based on, not what
+// was compiled, so equality is unproven rather than established — two different
+// dirty builds of one commit look identical here. That stays quiet on purpose:
+// nothing in the stamp can tell those apart (the toolchain records no content
+// hash), and a warning would then fire on every local build and make `doctor
+// --fix` unable to ever verify a restart. The readout marks such builds
+// "+modified" so the reader can see the match is approximate. Release builds are
+// never modified, so this costs the production path nothing.
+func daemonSkew(status *DaemonStatus, installedVersion, installedRevision string, installedModified bool) (string, bool) {
+	daemonRevision := strings.TrimSpace(status.Revision)
+	installedRevision = strings.TrimSpace(installedRevision)
+	if daemonRevision != "" && installedRevision != "" {
+		if daemonRevision == installedRevision {
+			return "", false
+		}
+		installed := "v" + installedVersion
+		if short := buildinfo.DescribeRevision(installedRevision, installedModified); short != "" {
+			installed += " " + short
+		}
+		return fmt.Sprintf("daemon is running build %s but %s is installed",
+			describeDaemonBuild(status), installed), true
+	}
+
+	if comparableVersion(status.Version) && comparableVersion(installedVersion) && status.Version != installedVersion {
+		return fmt.Sprintf("daemon is running v%s but v%s is installed", status.Version, installedVersion), true
+	}
+	return "", false
 }
 
 func printHeartbeat(out io.Writer, state managedstream.State, now time.Time) bool {

--- a/internal/managedobserve/doctor_test.go
+++ b/internal/managedobserve/doctor_test.go
@@ -92,6 +92,116 @@ func TestPrintStatusDoesNotWarnOnSupportedConfigMode(t *testing.T) {
 	}
 }
 
+// The identity check this whole breadcrumb exists for. Table-driven because the
+// interesting behavior is entirely in which signal wins.
+func TestDaemonSkew(t *testing.T) {
+	const revisionA = "cac15fd669a7e4b0bfbdd78413d25fc0999e3a11"
+	const revisionB = "f7be605aaaa1111bbbb2222cccc3333dddd4444e"
+
+	for name, test := range map[string]struct {
+		status            DaemonStatus
+		installedVersion  string
+		installedRevision string
+		installedModified bool
+		wantStale         bool
+		wantContains      string
+	}{
+		"same revision is not skew even when versions differ": {
+			// A rebuild of one source can be labeled twice. The source is what
+			// matters, so this must stay quiet.
+			status:            DaemonStatus{Version: "0.0.0-staging.20260730.9", Revision: revisionA},
+			installedVersion:  "0.0.0-staging.20260731.15",
+			installedRevision: revisionA,
+			wantStale:         false,
+		},
+		"different revision is skew even when versions match": {
+			// The case a version comparison cannot see: two builds sharing a
+			// label. Date-stamped channels and "dev" both produce it.
+			status:            DaemonStatus{Version: "dev", Revision: revisionA},
+			installedVersion:  "dev",
+			installedRevision: revisionB,
+			wantStale:         true,
+			wantContains:      "daemon is running build vdev cac15fd6 but vdev f7be605a is installed",
+		},
+		"falls back to version when the daemon predates the revision field": {
+			status:            DaemonStatus{Version: "0.14.1"},
+			installedVersion:  "0.16.0",
+			installedRevision: revisionB,
+			wantStale:         true,
+			wantContains:      "daemon is running v0.14.1 but v0.16.0 is installed",
+		},
+		"unstamped installed binary still compares versions": {
+			status:            DaemonStatus{Version: "0.14.1", Revision: revisionA},
+			installedVersion:  "0.16.0",
+			installedRevision: "",
+			wantStale:         true,
+			wantContains:      "daemon is running v0.14.1 but v0.16.0 is installed",
+		},
+		// Warning on a missing stamp would make the check unusable for anyone
+		// building with -buildvcs=false.
+		"no revisions and equal versions is not skew": {
+			status:           DaemonStatus{Version: "0.16.0"},
+			installedVersion: "0.16.0",
+			wantStale:        false,
+		},
+		"dev builds with no stamps stay quiet": {
+			status:           DaemonStatus{Version: "dev"},
+			installedVersion: "dev",
+			wantStale:        false,
+		},
+		// A dirty tree makes equality unprovable, not false. Warning here would
+		// fire on every local build and leave `doctor --fix` unable to verify a
+		// restart, so it stays quiet and the readout marks it "+modified".
+		"same revision from modified trees is unproven, not skew": {
+			status:            DaemonStatus{Version: "dev", Revision: revisionA, Modified: true},
+			installedVersion:  "dev",
+			installedRevision: revisionA,
+			installedModified: true,
+			wantStale:         false,
+		},
+		// Different revisions are still conclusive whatever the tree state, and
+		// the message must show which side is not a clean build.
+		"different revisions from modified trees are still skew": {
+			status:            DaemonStatus{Version: "dev", Revision: revisionA, Modified: true},
+			installedVersion:  "dev",
+			installedRevision: revisionB,
+			installedModified: true,
+			wantStale:         true,
+			wantContains:      "daemon is running build vdev cac15fd6+modified but vdev f7be605a+modified is installed",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			status := test.status
+			reason, stale := daemonSkew(&status, test.installedVersion, test.installedRevision, test.installedModified)
+			if stale != test.wantStale {
+				t.Fatalf("daemonSkew() stale = %v, want %v (reason %q)", stale, test.wantStale, reason)
+			}
+			if test.wantContains != "" && !strings.Contains(reason, test.wantContains) {
+				t.Fatalf("daemonSkew() reason = %q, want it to contain %q", reason, test.wantContains)
+			}
+		})
+	}
+}
+
+func TestDescribeDaemonBuildIncludesRevisionWhenRecorded(t *testing.T) {
+	withRevision := DaemonStatus{Version: "0.14.1", Revision: "cac15fd669a7e4b0bfbdd78413d25fc0999e3a11"}
+	if got, want := describeDaemonBuild(&withRevision), "v0.14.1 cac15fd6"; got != want {
+		t.Fatalf("describeDaemonBuild() = %q, want %q", got, want)
+	}
+	// A daemon built from a dirty tree must not read as an exact build: this is
+	// the reader's only cue that comparing it to the installed binary is
+	// approximate.
+	modified := DaemonStatus{Version: "0.14.1", Revision: "cac15fd669a7e4b0bfbdd78413d25fc0999e3a11", Modified: true}
+	if got, want := describeDaemonBuild(&modified), "v0.14.1 cac15fd6+modified"; got != want {
+		t.Fatalf("describeDaemonBuild() = %q, want %q", got, want)
+	}
+	// Daemons started before the field existed must render exactly as before.
+	legacy := DaemonStatus{Version: "0.14.1"}
+	if got, want := describeDaemonBuild(&legacy), "v0.14.1"; got != want {
+		t.Fatalf("describeDaemonBuild() = %q, want %q", got, want)
+	}
+}
+
 func TestPrintStatusDaemonVersionMatch(t *testing.T) {
 	env := newDoctorTestEnv(t)
 	env.writeDaemonStatus(t, os.Getpid(), "1.2.3")

--- a/internal/managedobserve/status.go
+++ b/internal/managedobserve/status.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/buildinfo"
 )
 
 // DaemonStatus is the on-disk breadcrumb a daemon leaves after its socket is
@@ -12,7 +14,19 @@ import (
 // alive before trusting it. A stale file from a dead daemon is expected and
 // harmless.
 type DaemonStatus struct {
-	Version   string `json:"version"`
+	Version string `json:"version"`
+	// Revision is the VCS revision the running daemon was built from. It is the
+	// only field here that identifies the build: Version is a link-time label
+	// and two different sources can share one. Empty for daemons built without a
+	// VCS stamp, and for every daemon started before this field existed, so
+	// readers must tolerate its absence rather than treat "" as a mismatch.
+	Revision string `json:"revision,omitempty"`
+	// Modified records that the daemon was built from a tree with uncommitted
+	// changes, which makes Revision the commit it was based on rather than the
+	// source that ran. Without this field two different dirty builds of one
+	// commit are indistinguishable, and a reader comparing revisions alone would
+	// call them the same build.
+	Modified  bool   `json:"modified,omitempty"`
 	PID       int    `json:"pid"`
 	StartedAt string `json:"started_at"`
 }
@@ -23,9 +37,15 @@ func DaemonStatusPath(dbPath string) string {
 	return filepath.Join(filepath.Dir(dbPath), "daemon-status.json")
 }
 
+// WriteDaemonStatus records the running daemon's identity. The build stamp is
+// read from this process rather than passed in: the daemon is the authority on
+// what the daemon is, and a caller-supplied value could disagree with the code
+// actually executing.
 func WriteDaemonStatus(dbPath, version string) error {
 	return writeJSONBreadcrumb(DaemonStatusPath(dbPath), DaemonStatus{
 		Version:   version,
+		Revision:  buildinfo.Revision(),
+		Modified:  buildinfo.Modified(),
 		PID:       os.Getpid(),
 		StartedAt: time.Now().UTC().Format(time.RFC3339),
 	})

--- a/internal/managedobserve/status_test.go
+++ b/internal/managedobserve/status_test.go
@@ -22,6 +22,33 @@ func TestDaemonStatusRoundTrip(t *testing.T) {
 	}
 }
 
+// The build stamp has to survive the file, not just the struct: doctor reads
+// these fields back from a breadcrumb another process wrote. (WriteDaemonStatus
+// reads the running binary's own stamp, and a test binary has none, so the
+// written values are exercised through JSON here rather than through a stub.)
+func TestDaemonStatusRoundTripsBuildStamp(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "guard.db")
+	const revision = "cac15fd669a7e4b0bfbdd78413d25fc0999e3a11"
+	written := `{"version":"1.2.3","revision":"` + revision + `","modified":true,"pid":1,"started_at":"2026-07-31T12:00:00Z"}`
+	if err := os.WriteFile(DaemonStatusPath(dbPath), []byte(written), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := LoadDaemonStatus(dbPath)
+	if got == nil || got.Revision != revision || !got.Modified {
+		t.Fatalf("LoadDaemonStatus = %+v, want the revision and modified flag preserved", got)
+	}
+
+	// Absent fields must read as "no stamp recorded", which is what every daemon
+	// predating them wrote.
+	legacy := filepath.Join(t.TempDir(), "guard.db")
+	if err := os.WriteFile(DaemonStatusPath(legacy), []byte(`{"version":"1.2.3","pid":1}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := LoadDaemonStatus(legacy); got == nil || got.Revision != "" || got.Modified {
+		t.Fatalf("LoadDaemonStatus legacy = %+v, want no revision and not modified", got)
+	}
+}
+
 func TestLoadDaemonStatusMissingFile(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "guard.db")
 


### PR DESCRIPTION
Stacked on #434.

## Problem

The version string cannot identify a build. It is injected at link time (`-X main.version=…`), so it reports whatever the release pipeline chose to call the binary and nothing about what was compiled. Two binaries can carry the same string and different source; every unlabeled local build is just `dev`.

That makes "is the running daemon the same build as the installed CLI" unanswerable from the tools we ship. Today it takes reading the stamp out of both binaries by hand:

```
$ go version -m "$(which kontext)" | grep vcs
  build vcs.revision=cac15fd669a7e4b0bfbdd78413d25fc0999e3a11
  build vcs.time=2026-07-08T14:08:02Z
```

`doctor` does compare daemon vs installed, but only on the version string — so it is blind exactly where labels collide.

## Fix

Read the VCS stamp the Go toolchain already writes into every binary built from a repository, and use it where identity matters. New `internal/buildinfo` wraps `debug.ReadBuildInfo`; unlike a link-time flag, this stamp is not something a pipeline can set to the wrong thing.

```
$ kontext --version
kontext version 0.16.0 (f7be605a)

$ kontext doctor
Managed observe:
  daemon: running (v0.16.0 cac15fd6, pid 4711)
  WARNING: daemon is running build v0.16.0 cac15fd6 but v0.16.0 f7be605a is installed
  — run 'kontext doctor --fix' to restart it
```

`daemon-status.json` gains `revision` and `modified` fields, written from the daemon's **own** build stamp rather than passed in by the caller — the daemon is the authority on what the daemon is.

## Compatibility

Skew detection prefers revision when both sides have one, and falls back to the version comparison otherwise:

| daemon | installed | verdict |
|---|---|---|
| same revision, different version | | not skewed — source is what matters |
| different revision, **same** version | | **skewed** — the case a version comparison cannot see |
| no revision (predates this field) | any | falls back to version comparison, unchanged |
| any | no stamp | falls back to version comparison, unchanged |

A missing stamp is never a mismatch. Builds made outside a repository or with `-buildvcs=false` legitimately have none, and warning on them would make the check unusable.

## Dirty builds are marked, not assumed equal

Equal revisions only prove equal source for a **clean** build (thanks @greptile-apps). For a modified tree the revision names the commit the build was based on, not what was compiled, so two different dirty builds of one commit are indistinguishable by revision alone. The breadcrumb therefore records `modified`, and such builds render as a single token that cannot be misread as an exact identity:

```
kontext version 0.16.0 (cac15fd6+modified)
  daemon: running (v0.16.0 cac15fd6+modified, pid 4711)
```

They are treated as **unproven rather than skewed** — deliberately quiet:

- nothing in the stamp can distinguish two dirty builds of one commit (the toolchain records no content hash), so a warning would be asserting something it cannot know;
- it would fire on every local build, and would leave `doctor --fix` unable to ever verify a restart — `WaitForDaemonRestart` would spin for its full 10s on any dev build.

Release builds are never modified, so the production path is unaffected. The readout carrying `+modified` is what tells a developer the comparison is approximate.

## `doctor --fix` verification

This narrows a hole: `WaitForDaemonRestart` accepted **any** live daemon whenever the version string was not comparable (`dev`), so a daemon that never restarted was reported as restarted. It now waits for the absence of skew, using the same primitive as the readout, so "came back" and "up to date" cannot disagree.

**Known residual:** on a modified local build the check can still be satisfied without a restart, for the reason above. Making that airtight needs a signal other than the build stamp (the pre-restart PID, or the binary's mtime against the daemon's `started_at`) and is left out of this PR.

## Rebase note

Rebased onto main after #440 (`newRootCmd` extraction, legacy commands retired) and #441 (`DoctorStatus`, `repairTargetAvailable`). Two conflicts, both resolved in favor of main's structure:

- `cmd/kontext/main.go` — `buildinfo.Describe(version)` now sets `Version` inside `newRootCmd`;
- `internal/managedobserve/doctor.go` — the skew warning goes through main's two-branch messaging, so a non-repairable install is still told to "restart it through its managing installation" rather than to run `--fix`.

## Note for reviewers

Go skips VCS stamping in a git **worktree** — `.git` is a file there, not a directory — so a worktree build prints the bare version. That is the designed fallback, not a failure. Verified in a normal clone:

```
$ go build -ldflags "-X main.version=0.16.0" -o /tmp/kontext ./cmd/kontext
$ /tmp/kontext --version
kontext version 0.16.0 (923c1445)
$ go version -m /tmp/kontext | grep vcs.revision
  build vcs.revision=923c144522d14eb1ffabc4ee44719a8c31f9c678
```

## Tests

`internal/buildinfo`: stamped / unstamped / unavailable-buildinfo, `modified` handling, `Describe` and `DescribeRevision` rendering, `Short` on arbitrary input. The `debug.ReadBuildInfo` seam exists because a test binary has no stamp of its own.

`daemonSkew` is a pure function taking the installed revision and tree state as parameters, table-tested across all cases above — including the two that motivated the change (same revision/different version, different revision/same version) and both dirty-tree cases (same revision → unproven, different revision → still skewed).

`DaemonStatus` round-trips the stamp through the file, and a breadcrumb written before these fields existed still reads as "no stamp recorded".

`gofmt`, `go vet`, `go test -race ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
