### PR TITLE
feat(doctor): report core setup health

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,12 @@ agents, and starts a background daemon.
 kontext doctor
 ```
 
-Use `doctor` to check hook status, daemon health, and the managed export
-backlog. Re-run `kontext setup` to rotate the token. Run `kontext setup
---uninstall` to remove the self-serve installation. Self-serve setup currently
-supports macOS.
+Use `doctor` to check self-serve hook status, daemon health, and the managed
+export backlog. It exits non-zero when a configured installation is unhealthy.
+For a self-serve stale daemon, `kontext doctor --fix` performs the verified
+restart; other findings include their manual remediation. Re-run `kontext
+setup` to rotate the token. Run `kontext setup --uninstall` to remove the
+self-serve installation. Self-serve setup currently supports macOS.
 
 ## How it works
 

--- a/cmd/kontext/main.go
+++ b/cmd/kontext/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -57,17 +58,31 @@ func newRootCmd() *cobra.Command {
 func doctorCmd() *cobra.Command {
 	var fix bool
 	cmd := &cobra.Command{
-		Use:   "doctor",
-		Short: "Inspect local Kontext CLI setup",
+		Use:           "doctor",
+		Short:         "Inspect local Kontext CLI setup",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			guardcli.PrintHookStatus(cmd.OutOrStdout())
-			staleDaemon := managedobserve.PrintStatus(cmd.OutOrStdout(), version)
+			managed := managedobserve.PrintStatus(cmd.OutOrStdout(), version)
+			hooksHealthy := true
+			if managed.SelfServe {
+				hooksHealthy = guardcli.PrintManagedHookStatus(cmd.OutOrStdout()).Healthy
+			} else if managed.Configured {
+				hooksHealthy = guardcli.PrintOrganizationManagedHookStatus(cmd.OutOrStdout()).Healthy
+			}
+			localHooks := guardcli.PrintHookStatus(cmd.OutOrStdout())
+			healthy := managed.Healthy && hooksHealthy && (!managed.Configured || localHooks.Healthy)
 			if fix {
-				if !staleDaemon {
-					fmt.Fprintln(cmd.OutOrStdout(), "nothing to fix")
-					return nil
+				if !managed.Repairable {
+					if healthy {
+						fmt.Fprintln(cmd.OutOrStdout(), "nothing to fix")
+						return nil
+					}
+					fmt.Fprintln(cmd.OutOrStdout(), "no automatic fixes are available for the reported issues")
+					return errDoctorUnhealthy
 				}
-				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)
 				defer cancel()
 				if err := managedobserve.KickstartLaunchdKill(ctx, managedobserve.DefaultLabel()); err != nil {
 					fmt.Fprintf(cmd.ErrOrStderr(), "failed to restart managed-observe daemon: %v\n", err)
@@ -77,7 +92,7 @@ func doctorCmd() *cobra.Command {
 				// daemon can exit immediately (unreadable token, codesigning
 				// kill). Only report success once the restarted daemon is
 				// serving on the installed version.
-				waitCtx, waitCancel := context.WithTimeout(context.Background(), 10*time.Second)
+				waitCtx, waitCancel := context.WithTimeout(cmd.Context(), 10*time.Second)
 				defer waitCancel()
 				status, err := managedobserve.WaitForDaemonRestart(
 					waitCtx,
@@ -90,6 +105,19 @@ func doctorCmd() *cobra.Command {
 					return err
 				}
 				fmt.Fprintf(cmd.OutOrStdout(), "restarted managed-observe daemon (v%s, pid %d)\n", status.Version, status.PID)
+				fmt.Fprintln(cmd.OutOrStdout(), "\nAfter repair:")
+				managed = managedobserve.PrintStatus(cmd.OutOrStdout(), version)
+				hooksHealthy = true
+				if managed.SelfServe {
+					hooksHealthy = guardcli.PrintManagedHookStatus(cmd.OutOrStdout()).Healthy
+				} else if managed.Configured {
+					hooksHealthy = guardcli.PrintOrganizationManagedHookStatus(cmd.OutOrStdout()).Healthy
+				}
+				localHooks = guardcli.PrintHookStatus(cmd.OutOrStdout())
+				healthy = managed.Healthy && hooksHealthy && (!managed.Configured || localHooks.Healthy)
+			}
+			if !healthy {
+				return errDoctorUnhealthy
 			}
 			return nil
 		},
@@ -97,6 +125,8 @@ func doctorCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&fix, "fix", false, "restart the managed-observe daemon when it is running a stale binary")
 	return cmd
 }
+
+var errDoctorUnhealthy = errors.New("local Kontext setup is unhealthy")
 
 func guardCmd() *cobra.Command {
 	return &cobra.Command{

--- a/internal/claudemanaged/settings.go
+++ b/internal/claudemanaged/settings.go
@@ -194,6 +194,44 @@ func HasManagedObserveHooks(data []byte) bool {
 	return true
 }
 
+// ManagedObserveHookBinary returns the common binary path referenced by every
+// managed-observe hook. It validates the same effective hook shape as
+// HasManagedObserveHooks while preserving the path for read-only diagnostics.
+func ManagedObserveHookBinary(data []byte) (string, bool) {
+	var settings Settings
+	if err := json.Unmarshal(data, &settings); err != nil || (settings.DisableAllHooks != nil && *settings.DisableAllHooks) {
+		return "", false
+	}
+	binary := ""
+	for _, event := range SupportedEvents {
+		found := false
+		for _, group := range settings.Hooks[event.Name.String()] {
+			if !isAllMatcher(group.Matcher) {
+				continue
+			}
+			for _, handler := range group.Hooks {
+				if handler.Type != "command" || len(handler.Args) != 0 || validateAsync(event, handler.Async) != nil {
+					continue
+				}
+				fields, ok := agenthooks.SplitCommand(handler.Command)
+				if !ok || len(fields) != 3 || filepath.Base(fields[0]) != "kontext" || fields[1] != "hook" || fields[2] != event.Alias {
+					continue
+				}
+				if binary == "" {
+					binary = fields[0]
+				} else if binary != fields[0] {
+					return "", false
+				}
+				found = true
+			}
+		}
+		if !found {
+			return "", false
+		}
+	}
+	return binary, binary != ""
+}
+
 func DisablesAllHooks(data []byte) bool {
 	var settings Settings
 	if err := json.Unmarshal(data, &settings); err != nil {

--- a/internal/codexmanaged/config.go
+++ b/internal/codexmanaged/config.go
@@ -89,6 +89,16 @@ func EnsureHooksEnabled(path, backupLabel string) (changed bool, err error) {
 	return true, nil
 }
 
+// HooksEnabled reports whether the Codex hook engine is enabled at path. It is
+// read-only so callers such as doctor never create or rewrite config.toml.
+func HooksEnabled(path string) (bool, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	return hooksFeatureEnabled(string(raw)), nil
+}
+
 // hooksFeatureEnabled reports whether config.toml already turns the Codex hook
 // engine on, via either the canonical `hooks` key or the deprecated
 // `codex_hooks` alias, in `[features]` table or top-level dotted form.

--- a/internal/codexmanaged/config_test.go
+++ b/internal/codexmanaged/config_test.go
@@ -2,6 +2,7 @@ package codexmanaged
 
 import (
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -37,6 +38,20 @@ func TestEnsureHooksEnabledCreatesMissingFile(t *testing.T) {
 	}
 	if got := readConfig(t, path); got != "[features]\nhooks = true\n" {
 		t.Fatalf("created config = %q", got)
+	}
+}
+
+func TestHooksEnabledIsReadOnly(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if _, err := HooksEnabled(path); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("HooksEnabled(missing) error = %v, want not exist", err)
+	}
+	if err := os.WriteFile(path, []byte("[features]\ncodex_hooks = true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	enabled, err := HooksEnabled(path)
+	if err != nil || !enabled {
+		t.Fatalf("HooksEnabled() = (%v, %v), want (true, nil)", enabled, err)
 	}
 }
 

--- a/internal/codexmanaged/hooks.go
+++ b/internal/codexmanaged/hooks.go
@@ -129,6 +129,56 @@ func Validate(data []byte, kontextBinary string) error {
 	return nil
 }
 
+// ValidateInstalled validates hooks without assuming the path of the running
+// binary. Setup deliberately writes a stable Homebrew symlink while the
+// process itself can run from a versioned Cellar path. It returns that shared
+// configured binary path so diagnostics can check that it still exists.
+func ValidateInstalled(data []byte) (string, error) {
+	var settings Settings
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return "", fmt.Errorf("parse Codex hooks: %w", err)
+	}
+	if settings.Hooks == nil {
+		return "", errors.New("hooks missing")
+	}
+	var binary string
+	var problems []string
+	for _, event := range SupportedEvents {
+		groups := settings.Hooks[event.Name.String()]
+		found := false
+		for _, group := range groups {
+			for _, handler := range group.Hooks {
+				if !IsManagedHookCommand(handler.Command) {
+					continue
+				}
+				if handler.Type != "command" || len(handler.Args) > 0 || handler.Timeout <= 0 || (handler.Async != nil && *handler.Async) || !isAllMatcher(group.Matcher) {
+					problems = append(problems, fmt.Sprintf("%s hook is invalid", event.Name))
+					continue
+				}
+				fields, _ := agenthooks.SplitCommand(handler.Command)
+				if fields[4] != event.Alias {
+					problems = append(problems, fmt.Sprintf("%s hook uses %q, want %q", event.Name, fields[4], event.Alias))
+					continue
+				}
+				if binary == "" {
+					binary = fields[0]
+				} else if binary != fields[0] {
+					problems = append(problems, "Kontext hooks use different binary paths")
+					continue
+				}
+				found = true
+			}
+		}
+		if !found {
+			problems = append(problems, fmt.Sprintf("%s hook missing", event.Name))
+		}
+	}
+	if len(problems) > 0 {
+		return "", errors.New(strings.Join(problems, "; "))
+	}
+	return binary, nil
+}
+
 // IsManagedHookCommand reports whether a hook command is one of OUR Codex
 // self-serve hooks. Matching on the alias rather than the exact binary path
 // lets setup replace stale entries after the binary moves.

--- a/internal/codexmanaged/hooks_test.go
+++ b/internal/codexmanaged/hooks_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/hook"
 )
 
 const testBinary = "/opt/homebrew/bin/kontext"
@@ -221,6 +223,50 @@ func TestIsManagedHookCommand(t *testing.T) {
 		if got := IsManagedHookCommand(tc.command); got != tc.want {
 			t.Errorf("IsManagedHookCommand(%q) = %v, want %v", tc.command, got, tc.want)
 		}
+	}
+}
+
+func TestValidateInstalledAcceptsStableBinaryAndRejectsIncompleteHooks(t *testing.T) {
+	data, err := TemplateJSON("/opt/homebrew/bin/kontext")
+	if err != nil {
+		t.Fatal(err)
+	}
+	binary, err := ValidateInstalled(data)
+	if err != nil {
+		t.Fatalf("ValidateInstalled() error = %v", err)
+	}
+	if binary != "/opt/homebrew/bin/kontext" {
+		t.Fatalf("ValidateInstalled() binary = %q", binary)
+	}
+
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatal(err)
+	}
+	delete(settings["hooks"].(map[string]any), hook.HookStop.String())
+	broken, err := json.Marshal(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ValidateInstalled(broken); err == nil || !strings.Contains(err.Error(), "Stop hook missing") {
+		t.Fatalf("ValidateInstalled() error = %v, want missing Stop hook", err)
+	}
+
+	data, err = TemplateJSON("/opt/homebrew/bin/kontext")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatal(err)
+	}
+	stop := settings["hooks"].(map[string]any)[hook.HookStop.String()].([]any)
+	stop[0].(map[string]any)["hooks"].([]any)[0].(map[string]any)["command"] = "'/opt/homebrew/bin/kontext' hook --agent 'codex' 'pre-tool-use'"
+	wrongAlias, err := json.Marshal(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ValidateInstalled(wrongAlias); err == nil || !strings.Contains(err.Error(), "Stop hook uses") {
+		t.Fatalf("ValidateInstalled() error = %v, want wrong alias", err)
 	}
 }
 

--- a/internal/guard/cli/cli.go
+++ b/internal/guard/cli/cli.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/kontext-security/kontext-cli/internal/claudemanaged"
+	"github.com/kontext-security/kontext-cli/internal/codexmanaged"
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 	"github.com/kontext-security/kontext-cli/internal/guard/app/server"
 	"github.com/kontext-security/kontext-cli/internal/guard/judge"
@@ -263,48 +264,141 @@ func runDoctor(ctx context.Context, args []string, out io.Writer) error {
 	return nil
 }
 
-func PrintHookStatus(out io.Writer) {
+// HookStatus is the read-only health result of installed agent integrations.
+type HookStatus struct{ Healthy bool }
+
+// PrintHookStatus reports local Guard hooks only. Hosted setup checks are
+// separate so `kontext guard doctor` stays useful on a Guard-only machine.
+func PrintHookStatus(out io.Writer) HookStatus {
+	status := HookStatus{Healthy: true}
 	settingsPath, settings, err := readClaudeSettings()
 	if err != nil {
-		fmt.Fprintf(out, "Claude Code hooks: unavailable (%v)\n", err)
-		return
-	}
-	fmt.Fprintf(out, "Claude Code settings: %s\n", settingsPath)
-	hooks, ok := settings["hooks"].(map[string]any)
-	if !ok || len(hooks) == 0 {
-		fmt.Fprintln(out, "Claude Code hooks: none installed")
-		return
-	}
-	hosted := false
-	guard := false
-	for _, raw := range hooks {
-		visitHookCommands(raw, func(command string) {
-			switch {
-			case isGuardHookCommand(command):
-				guard = true
-				fmt.Fprintf(out, "Claude Code Guard hook: %s\n", command)
-			// Managed-observe hooks are quoted ('<bin>' hook '<alias>'); use the
-			// shared predicate so wrapper commands containing "kontext" are not
-			// misclassified as hosted hooks.
-			case claudemanaged.IsManagedHookCommand(command):
-				hosted = true
-				fmt.Fprintf(out, "Claude Code hosted hook: %s\n", command)
+		fmt.Fprintf(out, "Claude Code local Guard hooks: unavailable (%v)\n", err)
+	} else {
+		fmt.Fprintf(out, "Claude Code local Guard settings: %s\n", settingsPath)
+		hooks, ok := settings["hooks"].(map[string]any)
+		if !ok || len(hooks) == 0 {
+			fmt.Fprintln(out, "Claude Code local Guard hooks: none installed")
+		} else {
+			hosted, guard := false, false
+			for _, raw := range hooks {
+				visitHookCommands(raw, func(command string) {
+					switch {
+					case isGuardHookCommand(command):
+						guard = true
+						fmt.Fprintf(out, "Claude Code Guard hook: %s\n", command)
+					case claudemanaged.IsManagedHookCommand(command):
+						hosted = true
+						fmt.Fprintf(out, "Claude Code hosted hook: %s\n", command)
+					}
+				})
 			}
-		})
+			switch {
+			case guard && hosted:
+				fmt.Fprintln(out, "Claude Code local Guard hook mode: conflict (hosted and Guard hooks are both installed)")
+				status.Healthy = false
+			case guard:
+				fmt.Fprintln(out, "Claude Code local Guard hook mode: local Guard")
+			case hosted:
+				fmt.Fprintln(out, "Claude Code local Guard hook mode: hosted")
+			default:
+				fmt.Fprintln(out, "Claude Code local Guard hook mode: no Kontext hook detected")
+			}
+		}
+		if disabled, _ := settings["disableAllHooks"].(bool); disabled {
+			fmt.Fprintln(out, "Claude Code local Guard hooks: disabled by disableAllHooks")
+			status.Healthy = false
+		}
 	}
-	if guard && hosted {
-		fmt.Fprintln(out, "Claude Code hook mode: conflict (hosted and Guard hooks are both installed)")
-		return
+	return status
+}
+
+// PrintManagedHookStatus verifies the integrations installed by `kontext
+// setup`: Claude Code managed settings and Codex hooks plus their feature flag.
+func PrintManagedHookStatus(out io.Writer) HookStatus {
+	claudeHealthy := printManagedClaudeHookStatus(out, claudemanaged.ManagedSettingsDropInPath)
+	codexHealthy := printCodexHookStatus(out)
+	return HookStatus{Healthy: claudeHealthy && codexHealthy}
+}
+
+// PrintOrganizationManagedHookStatus checks the policy-owned Claude settings
+// used by organization-managed installs. Codex user hooks are intentionally a
+// self-serve requirement only.
+func PrintOrganizationManagedHookStatus(out io.Writer) HookStatus {
+	return HookStatus{Healthy: printManagedClaudeHookStatus(out, claudemanaged.DefaultManagedSettingsPath())}
+}
+
+func printManagedClaudeHookStatus(out io.Writer, paths ...string) bool {
+	found, healthy := false, true
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			fmt.Fprintf(out, "Claude Code managed hooks: ERROR reading %s: %v\n", path, err)
+			return false
+		}
+		found = true
+		if binary, ok := claudemanaged.ManagedObserveHookBinary(data); ok {
+			if info, err := os.Stat(binary); err != nil || info.IsDir() || info.Mode()&0o111 == 0 {
+				fmt.Fprintf(out, "Claude Code managed hooks: configured binary is not executable (%s)\n", binary)
+				healthy = false
+				continue
+			}
+			fmt.Fprintf(out, "Claude Code managed hooks: installed (%s; binary %s)\n", path, binary)
+			continue
+		}
+		fmt.Fprintf(out, "Claude Code managed hooks: incomplete or disabled (%s)\n", path)
+		healthy = false
 	}
-	if guard {
-		fmt.Fprintln(out, "Claude Code hook mode: local Guard")
-		return
+	if !found {
+		fmt.Fprintln(out, "Claude Code managed hooks: none installed")
 	}
-	if hosted {
-		fmt.Fprintln(out, "Claude Code hook mode: hosted")
-		return
+	return found && healthy
+}
+
+func printCodexHookStatus(out io.Writer) bool {
+	hooksPath, err := codexmanaged.UserHooksPathNoCreate()
+	if err != nil {
+		fmt.Fprintf(out, "Codex hooks: unavailable (%v)\n", err)
+		return false
 	}
-	fmt.Fprintln(out, "Claude Code hook mode: no Kontext hook detected")
+	raw, err := os.ReadFile(hooksPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Fprintf(out, "Codex hooks: none installed (%s)\n", hooksPath)
+		} else {
+			fmt.Fprintf(out, "Codex hooks: ERROR %v\n", err)
+		}
+		return false
+	}
+	binary, err := codexmanaged.ValidateInstalled(raw)
+	if err != nil {
+		fmt.Fprintf(out, "Codex hooks: incomplete (%v)\n", err)
+		return false
+	}
+	if info, err := os.Stat(binary); err != nil || info.IsDir() || info.Mode()&0o111 == 0 {
+		fmt.Fprintf(out, "Codex hooks: configured binary is not executable (%s)\n", binary)
+		return false
+	}
+	configPath, err := codexmanaged.UserConfigPathNoCreate()
+	if err != nil {
+		fmt.Fprintf(out, "Codex hooks feature: unavailable (%v)\n", err)
+		return false
+	}
+	enabled, err := codexmanaged.HooksEnabled(configPath)
+	if err != nil || !enabled {
+		if err != nil && !os.IsNotExist(err) {
+			fmt.Fprintf(out, "Codex hooks feature: ERROR %v\n", err)
+		} else {
+			fmt.Fprintf(out, "Codex hooks feature: disabled (set [features].hooks = true in %s)\n", configPath)
+		}
+		return false
+	}
+	fmt.Fprintf(out, "Codex hooks: installed (%s; binary %s)\n", hooksPath, binary)
+	fmt.Fprintf(out, "Codex hooks feature: enabled (%s)\n", configPath)
+	return true
 }
 
 func visitHookCommands(raw any, visit func(string)) {
@@ -361,6 +455,9 @@ func installClaudeHooks(out io.Writer, socketPath string) error {
 	if err != nil {
 		return err
 	}
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		return err
+	}
 	if err := backupFile(settingsPath, "kontext-guard"); err != nil {
 		return err
 	}
@@ -413,11 +510,7 @@ func readClaudeSettings() (string, map[string]any, error) {
 	if err != nil {
 		return "", nil, err
 	}
-	claudeDir := filepath.Join(home, ".claude")
-	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
-		return "", nil, err
-	}
-	settingsPath := filepath.Join(claudeDir, "settings.json")
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
 	settings := map[string]any{}
 	raw, err := os.ReadFile(settingsPath)
 	if err == nil {

--- a/internal/guard/cli/cli_test.go
+++ b/internal/guard/cli/cli_test.go
@@ -236,7 +236,7 @@ func TestPrintHookStatusReportsGuardAndHostedConflict(t *testing.T) {
 	if strings.Contains(got, "not-kontext") {
 		t.Fatalf("PrintHookStatus() = %q, want foreign hook ignored", got)
 	}
-	if !strings.Contains(got, "Claude Code hook mode: conflict (hosted and Guard hooks are both installed)") {
+	if !strings.Contains(got, "Claude Code local Guard hook mode: conflict (hosted and Guard hooks are both installed)") {
 		t.Fatalf("PrintHookStatus() = %q, want conflict mode", got)
 	}
 }

--- a/internal/managedobserve/doctor.go
+++ b/internal/managedobserve/doctor.go
@@ -23,7 +23,16 @@ import (
 // which managed config (if any) this machine resolves, the installation
 // identity, whether the daemon is reachable, the self-serve LaunchAgent, and
 // any token-rejection breadcrumb the daemon left behind.
-func PrintStatus(out io.Writer, installedVersion string) (staleDaemon bool) {
+// DoctorStatus is the managed-observe health result. Repairable is deliberately
+// narrower than Healthy: --fix only performs a repair that is known safe.
+type DoctorStatus struct {
+	Configured bool
+	SelfServe  bool
+	Healthy    bool
+	Repairable bool
+}
+
+func PrintStatus(out io.Writer, installedVersion string) DoctorStatus {
 	return printStatus(out, installedVersion, doctorOptions{
 		DBPath:     DefaultDBPath(),
 		SocketPath: DefaultSocketPath(),
@@ -32,13 +41,17 @@ func PrintStatus(out io.Writer, installedVersion string) (staleDaemon bool) {
 }
 
 type doctorOptions struct {
-	DBPath     string
-	SocketPath string
-	Dial       func(network, address string, timeout time.Duration) (net.Conn, error)
-	Now        func() time.Time
+	DBPath             string
+	SocketPath         string
+	Dial               func(network, address string, timeout time.Duration) (net.Conn, error)
+	Now                func() time.Time
+	LaunchAgentPresent func() bool
 }
 
-func printStatus(out io.Writer, installedVersion string, opts doctorOptions) (staleDaemon bool) {
+func printStatus(out io.Writer, installedVersion string, opts doctorOptions) DoctorStatus {
+	status := DoctorStatus{Healthy: true}
+	staleDaemon := false
+	repairTargetAvailable := false
 	if opts.DBPath == "" {
 		opts.DBPath = DefaultDBPath()
 	}
@@ -51,28 +64,42 @@ func printStatus(out io.Writer, installedVersion string, opts doctorOptions) (st
 	if opts.Now == nil {
 		opts.Now = time.Now
 	}
+	if opts.LaunchAgentPresent == nil {
+		opts.LaunchAgentPresent = selfServeLaunchAgentPresent
+	}
 
 	fmt.Fprintln(out, "Managed observe:")
 
 	loaded, err := managedconfig.Load()
 	if errors.Is(err, managedconfig.ErrNotManaged) {
 		fmt.Fprintln(out, "  config: not configured (run `kontext setup` to connect this Mac to a workspace)")
-		return false
+		return status
 	}
 	if err != nil {
 		fmt.Fprintf(out, "  config: ERROR %v\n", err)
-		return false
+		status.Healthy = false
+		return status
 	}
+	status.Configured = true
+	status.SelfServe = loaded.Scope == managedconfig.ScopeUser
 
 	fmt.Fprintf(out, "  config: %s (%s)\n", loaded.Path, describeScope(loaded.Scope))
+	launchAgentPresent := opts.LaunchAgentPresent()
+	repairTargetAvailable = runtime.GOOS == "darwin" && loaded.Scope == managedconfig.ScopeUser && launchAgentPresent
+	if loaded.Scope == managedconfig.ScopeUser && !launchAgentPresent {
+		fmt.Fprintln(out, "  launch agent: missing (run `kontext setup` to restore the background agent)")
+		status.Healthy = false
+	}
 
 	identityPath := installationPathForScope(loaded.Scope)
 	if state, err := installation.LoadFile(identityPath); err == nil {
 		fmt.Fprintf(out, "  installation: %s\n", state.InstallationID)
 	} else if errors.Is(err, installation.ErrNotFound) {
 		fmt.Fprintf(out, "  installation: not created yet (%s)\n", identityPath)
+		status.Healthy = false
 	} else {
 		fmt.Fprintf(out, "  installation: ERROR %v (%s)\n", err, identityPath)
+		status.Healthy = false
 	}
 
 	// Resolve the token through the daemon's exact read path: a locked or
@@ -84,14 +111,19 @@ func printStatus(out io.Writer, installedVersion string, opts doctorOptions) (st
 		fmt.Fprintf(out, "  install token: readable (%s)\n", loaded.Config.Credentials.InstallTokenRef)
 	} else {
 		fmt.Fprintf(out, "  WARNING: install token is not readable (%v) — the agent cannot stream; re-run `kontext setup` or unlock your login keychain\n", err)
+		status.Healthy = false
 	}
 
 	if conn, err := opts.Dial("unix", opts.SocketPath, 500*time.Millisecond); err == nil {
 		conn.Close()
-		if status := LoadDaemonStatus(opts.DBPath); status != nil && pidAlive(status.PID) {
-			fmt.Fprintf(out, "  daemon: running (v%s, pid %d)\n", status.Version, status.PID)
-			if comparableVersion(status.Version) && comparableVersion(installedVersion) && status.Version != installedVersion {
-				fmt.Fprintf(out, "  WARNING: daemon is running v%s but v%s is installed — run 'kontext doctor --fix' to restart it\n", status.Version, installedVersion)
+		if daemonStatus := LoadDaemonStatus(opts.DBPath); daemonStatus != nil && pidAlive(daemonStatus.PID) {
+			fmt.Fprintf(out, "  daemon: running (v%s, pid %d)\n", daemonStatus.Version, daemonStatus.PID)
+			if comparableVersion(daemonStatus.Version) && comparableVersion(installedVersion) && daemonStatus.Version != installedVersion {
+				if repairTargetAvailable {
+					fmt.Fprintf(out, "  WARNING: daemon is running v%s but v%s is installed — run 'kontext doctor --fix' to restart it\n", daemonStatus.Version, installedVersion)
+				} else {
+					fmt.Fprintf(out, "  WARNING: daemon is running v%s but v%s is installed — restart it through its managing installation\n", daemonStatus.Version, installedVersion)
+				}
 				staleDaemon = true
 			}
 		} else {
@@ -102,12 +134,17 @@ func printStatus(out io.Writer, installedVersion string, opts doctorOptions) (st
 			// this feature, so it must be fixable; a verified restart of an
 			// already-current daemon is the harmless worst case.
 			if comparableVersion(installedVersion) {
-				fmt.Fprintf(out, "  WARNING: daemon version is unknown — it likely predates v%s; run 'kontext doctor --fix' to restart it\n", installedVersion)
+				if repairTargetAvailable {
+					fmt.Fprintf(out, "  WARNING: daemon version is unknown — it likely predates v%s; run 'kontext doctor --fix' to restart it\n", installedVersion)
+				} else {
+					fmt.Fprintf(out, "  WARNING: daemon version is unknown — restart it through its managing installation\n")
+				}
 				staleDaemon = true
 			}
 		}
 	} else {
 		fmt.Fprintln(out, "  daemon: not running (it starts with your next Claude Code session)")
+		status.Healthy = false
 	}
 
 	exportCtx, exportCancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -116,9 +153,14 @@ func printStatus(out io.Writer, installedVersion string, opts doctorOptions) (st
 	if err != nil {
 		fmt.Fprintf(out, "  heartbeat: ERROR %v\n", err)
 		fmt.Fprintf(out, "  export: ERROR %v\n", err)
+		status.Healthy = false
 	} else {
-		printHeartbeat(out, state, opts.Now())
-		printExportLag(exportCtx, out, opts.DBPath, state)
+		if !printHeartbeat(out, state, opts.Now()) {
+			status.Healthy = false
+		}
+		if !printExportLag(exportCtx, out, opts.DBPath, state) {
+			status.Healthy = false
+		}
 	}
 
 	// Self-serve installs have a user LaunchAgent; MDM installs manage theirs
@@ -126,10 +168,11 @@ func printStatus(out io.Writer, installedVersion string, opts doctorOptions) (st
 	// system config wins and the user agent should be removed.
 	if home, err := os.UserHomeDir(); err == nil && home != "" {
 		userPlist := filepath.Join(home, "Library", "LaunchAgents", DefaultLaunchdLabel+".plist")
-		if _, err := os.Lstat(userPlist); err == nil {
+		if launchAgentPresent {
 			fmt.Fprintf(out, "  launch agent: %s\n", userPlist)
 			if loaded.Scope == managedconfig.ScopeSystem {
 				fmt.Fprintln(out, "  WARNING: this Mac is organization-managed but a self-serve agent is also installed; run `kontext setup --uninstall` to remove it")
+				status.Healthy = false
 			}
 		}
 	}
@@ -138,6 +181,7 @@ func printStatus(out io.Writer, installedVersion string, opts doctorOptions) (st
 	// sits next to the default database. A custom --db (dev-only hidden flag)
 	// is invisible here — acceptable for a diagnostics readout.
 	if authErr := LoadAuthError(opts.DBPath); authErr != nil {
+		status.Healthy = false
 		switch authErr.Kind {
 		case "startup":
 			fmt.Fprintf(out, "  WARNING: the agent failed to start — %s (%s)\n", authErr.Message, authErr.At)
@@ -151,7 +195,23 @@ func printStatus(out io.Writer, installedVersion string, opts doctorOptions) (st
 			fmt.Fprintf(out, "  WARNING: hosted ingest is failing — install token rejected%s; run `kontext setup` with a new token from the dashboard\n", detail)
 		}
 	}
-	return staleDaemon
+	// Restarting a stale daemon is safe only when every other prerequisite is
+	// healthy and the self-serve LaunchAgent is a verified Darwin repair target.
+	status.Repairable = staleDaemon && status.Healthy && repairTargetAvailable
+	if staleDaemon {
+		status.Healthy = false
+	}
+	return status
+}
+
+func selfServeLaunchAgentPresent() bool {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return false
+	}
+	path := filepath.Join(home, "Library", "LaunchAgents", DefaultLaunchdLabel+".plist")
+	info, err := os.Lstat(path)
+	return err == nil && info.Mode().IsRegular()
 }
 
 func describeScope(scope managedconfig.Scope) string {
@@ -212,15 +272,15 @@ func comparableVersion(version string) bool {
 	return version != "" && version != "dev"
 }
 
-func printHeartbeat(out io.Writer, state managedstream.State, now time.Time) {
+func printHeartbeat(out io.Writer, state managedstream.State, now time.Time) bool {
 	if strings.TrimSpace(state.LastHeartbeatAt) == "" {
-		fmt.Fprintln(out, "  heartbeat: none recorded yet")
-		return
+		fmt.Fprintln(out, "  heartbeat: none recorded yet (the daemon has not reported healthy)")
+		return false
 	}
 	last, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(state.LastHeartbeatAt))
 	if err != nil {
-		fmt.Fprintln(out, "  heartbeat: none recorded yet")
-		return
+		fmt.Fprintln(out, "  heartbeat: ERROR invalid timestamp")
+		return false
 	}
 	age := now.Sub(last)
 	if age < 0 {
@@ -229,10 +289,12 @@ func printHeartbeat(out io.Writer, state managedstream.State, now time.Time) {
 	fmt.Fprintf(out, "  heartbeat: %s ago\n", doctorDuration(age))
 	if age > 5*time.Minute {
 		fmt.Fprintf(out, "  WARNING: last heartbeat was %s ago — the daemon may be stalled\n", doctorDuration(age))
+		return false
 	}
+	return true
 }
 
-func printExportLag(ctx context.Context, out io.Writer, dbPath string, state managedstream.State) {
+func printExportLag(ctx context.Context, out io.Writer, dbPath string, state managedstream.State) bool {
 	var cursor *sqlite.LedgerCursor
 	if state.UpdatedAfter != nil {
 		cursor = &sqlite.LedgerCursor{UpdatedAt: *state.UpdatedAfter, ActionID: state.ActionID}
@@ -240,17 +302,15 @@ func printExportLag(ctx context.Context, out io.Writer, dbPath string, state man
 	newest, pending, err := sqlite.LedgerLag(ctx, dbPath, cursor)
 	if err != nil {
 		fmt.Fprintf(out, "  export: ERROR %v\n", err)
-		return
+		return false
 	}
 	if newest == nil {
 		fmt.Fprintln(out, "  export: no ledger events yet")
-		return
+		return true
 	}
 	if cursor == nil {
-		// Events exist but no export cursor yet — normal in the first seconds
-		// after setup, so report without warning.
 		fmt.Fprintf(out, "  export: not started yet (%d pending)\n", pending)
-		return
+		return false
 	}
 	lag := newest.Sub(cursor.UpdatedAt)
 	if lag < 0 {
@@ -260,15 +320,16 @@ func printExportLag(ctx context.Context, out io.Writer, dbPath string, state man
 	// hence the 10m warning threshold.
 	if lag > 10*time.Minute && pending > 0 {
 		fmt.Fprintf(out, "  WARNING: export lagging %s (%d events pending) — the daemon may be stalled\n", doctorDuration(lag), pending)
-		return
+		return false
 	}
 	if pending == 0 {
 		fmt.Fprintln(out, "  export: up to date (0 pending)")
-		return
+		return true
 	}
 	// Never claim "up to date" while rows are waiting — report the facts and
 	// let the operator judge.
 	fmt.Fprintf(out, "  export: %d pending (cursor %s behind newest)\n", pending, doctorDuration(lag))
+	return true
 }
 
 func doctorDuration(d time.Duration) string {

--- a/internal/managedobserve/doctor_test.go
+++ b/internal/managedobserve/doctor_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -49,11 +50,11 @@ func TestPrintStatusDaemonVersionMatch(t *testing.T) {
 	env.writeDaemonStatus(t, os.Getpid(), "1.2.3")
 
 	var out bytes.Buffer
-	stale := printStatus(&out, "1.2.3", env.options())
+	status := printStatus(&out, "1.2.3", env.options())
 
 	output := out.String()
-	if stale {
-		t.Fatal("staleDaemon = true, want false")
+	if !status.Healthy || status.Repairable {
+		t.Fatalf("status = %+v, want healthy and not repairable", status)
 	}
 	if !strings.Contains(output, "  daemon: running (v1.2.3, pid ") {
 		t.Fatalf("output = %q, want daemon version and pid", output)
@@ -68,11 +69,11 @@ func TestPrintStatusDaemonVersionMismatch(t *testing.T) {
 	env.writeDaemonStatus(t, os.Getpid(), "1.2.2")
 
 	var out bytes.Buffer
-	stale := printStatus(&out, "1.2.3", env.options())
+	status := printStatus(&out, "1.2.3", env.options())
 
 	output := out.String()
-	if !stale {
-		t.Fatal("staleDaemon = false, want true")
+	if status.Healthy || status.Repairable != wantAutomaticDaemonRepair() {
+		t.Fatalf("status = %+v, want unhealthy and repairable=%v", status, wantAutomaticDaemonRepair())
 	}
 	if !strings.Contains(output, "WARNING: daemon is running v1.2.2 but v1.2.3 is installed") {
 		t.Fatalf("output = %q, want mismatch warning", output)
@@ -84,11 +85,11 @@ func TestPrintStatusDaemonDevVersionDoesNotWarn(t *testing.T) {
 	env.writeDaemonStatus(t, os.Getpid(), "dev")
 
 	var out bytes.Buffer
-	stale := printStatus(&out, "1.2.3", env.options())
+	status := printStatus(&out, "1.2.3", env.options())
 
 	output := out.String()
-	if stale {
-		t.Fatal("staleDaemon = true, want false")
+	if !status.Healthy || status.Repairable {
+		t.Fatalf("status = %+v, want healthy and not repairable", status)
 	}
 	if strings.Contains(output, "WARNING: daemon is running") {
 		t.Fatalf("output = %q, want no dev mismatch warning", output)
@@ -100,11 +101,11 @@ func TestPrintStatusDaemonDeadPIDTreatedAsUnknownAndFixable(t *testing.T) {
 	env.writeDaemonStatus(t, deadPID(t), "1.2.2")
 
 	var out bytes.Buffer
-	stale := printStatus(&out, "1.2.3", env.options())
+	status := printStatus(&out, "1.2.3", env.options())
 
 	output := out.String()
-	if !stale {
-		t.Fatal("staleDaemon = false, want true")
+	if status.Healthy || status.Repairable != wantAutomaticDaemonRepair() {
+		t.Fatalf("status = %+v, want unhealthy and repairable=%v", status, wantAutomaticDaemonRepair())
 	}
 	if !strings.Contains(output, "  daemon: running\n") {
 		t.Fatalf("output = %q, want plain running line", output)
@@ -131,14 +132,18 @@ func TestPrintStatusDaemonWithoutBreadcrumbIsFixable(t *testing.T) {
 	env := newDoctorTestEnv(t)
 
 	var out bytes.Buffer
-	stale := printStatus(&out, "1.2.3", env.options())
+	status := printStatus(&out, "1.2.3", env.options())
 
 	output := out.String()
-	if !stale {
-		t.Fatal("staleDaemon = false, want true")
+	if status.Healthy || status.Repairable != wantAutomaticDaemonRepair() {
+		t.Fatalf("status = %+v, want unhealthy and repairable=%v", status, wantAutomaticDaemonRepair())
 	}
-	if !strings.Contains(output, "WARNING: daemon version is unknown — it likely predates v1.2.3") {
-		t.Fatalf("output = %q, want unknown-version warning", output)
+	wantWarning := "WARNING: daemon version is unknown — it likely predates v1.2.3"
+	if !wantAutomaticDaemonRepair() {
+		wantWarning = "WARNING: daemon version is unknown — restart it through its managing installation"
+	}
+	if !strings.Contains(output, wantWarning) {
+		t.Fatalf("output = %q, want warning %q", output, wantWarning)
 	}
 }
 
@@ -146,11 +151,11 @@ func TestPrintStatusDaemonWithoutBreadcrumbDevInstallDoesNotWarn(t *testing.T) {
 	env := newDoctorTestEnv(t)
 
 	var out bytes.Buffer
-	stale := printStatus(&out, "dev", env.options())
+	status := printStatus(&out, "dev", env.options())
 
 	output := out.String()
-	if stale {
-		t.Fatal("staleDaemon = true, want false")
+	if !status.Healthy || status.Repairable {
+		t.Fatalf("status = %+v, want healthy and not repairable", status)
 	}
 	if strings.Contains(output, "WARNING: daemon version is unknown") {
 		t.Fatalf("output = %q, want no warning for dev install", output)
@@ -170,11 +175,11 @@ func TestPrintStatusHeartbeatFreshAndExportUpToDate(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	stale := printStatus(&out, "1.2.3", env.options())
+	status := printStatus(&out, "1.2.3", env.options())
 
 	output := out.String()
-	if stale {
-		t.Fatal("staleDaemon = true, want false")
+	if !status.Healthy || status.Repairable {
+		t.Fatalf("status = %+v, want healthy and not repairable", status)
 	}
 	if !strings.Contains(output, "  heartbeat: 20s ago") {
 		t.Fatalf("output = %q, want fresh heartbeat", output)
@@ -197,11 +202,11 @@ func TestPrintStatusHeartbeatOldAndExportLagging(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	stale := printStatus(&out, "1.2.3", env.options())
+	status := printStatus(&out, "1.2.3", env.options())
 
 	output := out.String()
-	if stale {
-		t.Fatal("staleDaemon = true, want false")
+	if status.Healthy || status.Repairable {
+		t.Fatalf("status = %+v, want unhealthy and not repairable", status)
 	}
 	if !strings.Contains(output, "WARNING: last heartbeat was 6m0s ago") {
 		t.Fatalf("output = %q, want old heartbeat warning", output)
@@ -283,15 +288,28 @@ type doctorTestEnv struct {
 	now        time.Time
 }
 
+func wantAutomaticDaemonRepair() bool {
+	return runtime.GOOS == "darwin"
+}
+
 func newDoctorTestEnv(t *testing.T) doctorTestEnv {
 	t.Helper()
 	dir := t.TempDir()
-	configPath := filepath.Join(dir, "managed.json")
+	t.Setenv("HOME", dir)
+	configPath := filepath.Join(dir, "Library", "Application Support", "Kontext", "managed.json")
 	installationPath := filepath.Join(dir, "installation.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
 	writeTestManagedConfig(t, configPath)
+	t.Setenv(managedconfig.EnvPath, "")
 	writeTestInstallation(t, installationPath)
 	t.Setenv(installation.EnvPath, installationPath)
-	t.Setenv("HOME", dir)
+	if err := managedstream.SaveState(managedstream.DefaultStatePathForDB(filepath.Join(dir, "guard.db")), managedstream.State{
+		LastHeartbeatAt: time.Date(2026, 7, 9, 11, 59, 40, 0, time.UTC).Format(time.RFC3339Nano),
+	}); err != nil {
+		t.Fatal(err)
+	}
 	return doctorTestEnv{
 		dir:        dir,
 		dbPath:     filepath.Join(dir, "guard.db"),
@@ -309,7 +327,8 @@ func (e doctorTestEnv) options() doctorOptions {
 			_ = server.Close()
 			return client, nil
 		},
-		Now: func() time.Time { return e.now },
+		Now:                func() time.Time { return e.now },
+		LaunchAgentPresent: func() bool { return true },
 	}
 }
 


### PR DESCRIPTION
## Summary
- make managed-observe diagnostics return explicit configured, healthy, and safely-repairable state; unhealthy configured installations now exit non-zero
- inspect the actual Claude managed settings and validate Codex hooks, their feature flag, and configured binary without mutating user configuration
- keep the fix flag narrow: it only restarts a stale daemon, then rechecks health; document the behavior and current Codex support

## Safety and scope
- doctor is read-only unless the fix flag is passed
- local Guard diagnostics remain separate from hosted setup checks
- JSON/stable machine output and broader automated repairs are intentionally deferred

## Verification
- go test ./...