### PR TITLE
chore(guard): fix the empty llm_raw column and drop a dead judge default

### DIFF
--- a/docs/guard.md
+++ b/docs/guard.md
@@ -155,16 +155,18 @@ The SVM is precise but blind to `rm -rf /`, `dd if=/dev/zero of=/dev/disk0`, and
 
 `KONTEXT_RISK_CLASSIFIER_MODE` is `on` (default, both models) or `off` (SVM only, no sidecar needed).
 
-Which paths run the LLM depends on whether a local model is resolved:
+Whether the LLM runs depends on whether a local model is resolved, and that is opt-in everywhere. Nothing downloads a model or starts a `llama-server` child unless an operator asked for it:
 
 | path | guardrail LLM |
 |---|---|
-| `kontext guard start` (local daemon) | yes, same |
-| `managed-observe` daemon | only when `KONTEXT_JUDGE_URL` + `KONTEXT_JUDGE_MODEL` point at an endpoint, or `KONTEXT_JUDGE_MANAGED=1` |
+| `managed-observe` daemon — what a plain `claude` session hits | `KONTEXT_JUDGE_URL` + `KONTEXT_JUDGE_MODEL` for an endpoint you already run, or `KONTEXT_JUDGE_MANAGED=1` to have the daemon manage one |
+| `kontext guard start` — local-only, no org | the same env, or `--judge-managed` |
 
-The managed daemon deliberately does **not** manage a model by default: that would have every endpoint download one and run a `llama-server` child unprompted. With neither variable set it records the SVM verdict and `llm_error: "guardrail not configured"`, which is what it did before the guardrail existed.
+With neither set, both paths record the SVM verdict and `llm_error: "guardrail not configured"`.
 
-That default is worth knowing when reading collected data, because the managed daemon is the path that reaches the hosted ledger — so an endpoint without a model produces uploads whose `classifier.llm` is null.
+**Today that means Homebrew installs only.** The formula depends on `llama.cpp`, so `llama-server` is on PATH after `brew install`; nothing else provisions it, and the CLI deliberately does not ship or download it — `exec.LookPath` finds it or the guardrail degrades to SVM-only. An MDM-deployed endpoint therefore collects SVM verdicts and nothing more, which is the accepted starting point rather than an oversight: enabling the LLM fleet-wide would mean shipping a signed native binary, ~1.1 GB of resident memory per endpoint, and a `llama-server` child process that endpoint security tooling has every reason to flag.
+
+Read collected data with that in mind. The managed daemon is the path that reaches the hosted ledger, so an endpoint without a model produces uploads whose `classifier.llm` is null — and the SVM is the weaker half of the pair.
 
 **The model name must contain `qwen3`.** That is what makes the client send `/no_think`; without it Qwen3 reasons instead of answering and returns nothing inside the token budget.
 

--- a/internal/guard/app/server/riskclassifier_test.go
+++ b/internal/guard/app/server/riskclassifier_test.go
@@ -622,3 +622,41 @@ func TestUnreachableGuardrailCostsNothingAfterBreakerOpens(t *testing.T) {
 		}
 	}
 }
+
+// The model's literal answer has to reach the row. The column, the struct field
+// and the write all existed, but the hand-off from the guardrail to the record
+// dropped it, so llm_raw was empty on every row ever written — which is exactly
+// the field you reach for when a verdict looks wrong.
+func TestRawModelOutputReachesTheRow(t *testing.T) {
+	var calls int32
+	stub := newGuardrailStub(t, "  SAFE.  ", &calls)
+	server, store := newClassifierServerWithOptions(t, &RiskClassifierOptions{
+		Mode:             riskclassifier.ModeOn,
+		GuardrailBaseURL: stub.URL,
+		GuardrailModel:   "qwen3-0.6b",
+	})
+
+	if _, err := server.RuntimeCore().EvaluateHook(context.Background(), hook.Event{
+		SessionID: "sess_e2e",
+		HookName:  hook.HookPreToolUse,
+		ToolName:  "Bash",
+		ToolInput: map[string]any{"command": "ls -la"},
+	}); err != nil {
+		t.Fatalf("evaluate hook: %v", err)
+	}
+
+	record := verdictsFor(t, store, "sess_e2e", 1)[0]
+	if record.LLM == nil {
+		t.Fatalf("llm verdict missing (err %q)", record.LLMError)
+	}
+	// Trimmed of surrounding whitespace, but otherwise the model's own wording —
+	// the trailing period survives, and that is the point: "SAFE." and "safe"
+	// both normalize to not_risky, and only the raw tells them apart.
+	if record.LLM.Raw != "SAFE." {
+		t.Errorf("llm raw = %q, want the model's answer", record.LLM.Raw)
+	}
+	// The normalized verdict is still what everything else reads.
+	if record.LLM.Verdict != "not_risky" {
+		t.Errorf("llm verdict = %q, want not_risky", record.LLM.Verdict)
+	}
+}

--- a/internal/guard/app/server/runtime.go
+++ b/internal/guard/app/server/runtime.go
@@ -147,6 +147,7 @@ func (r guardHookRuntime) annotate(ctx context.Context, event risk.HookEvent, de
 	}
 	if verdicts.LLM != nil {
 		annotation.LLMPromptID = verdicts.LLM.PromptID
+		annotation.LLMRaw = verdicts.LLM.Raw
 		annotation.LLM = &risk.ClassifierLLM{
 			Verdict:    verdicts.LLM.Verdict,
 			Model:      verdicts.LLM.Model,
@@ -187,6 +188,7 @@ func (r guardHookRuntime) recordAnnotation(ctx context.Context, actionID string,
 		record.LLM = &riskclassifier.LLMVerdict{
 			Verdict:    annotation.LLM.Verdict,
 			Model:      annotation.LLM.Model,
+			Raw:        annotation.LLMRaw,
 			PromptID:   annotation.LLMPromptID,
 			DurationMs: annotation.LLM.DurationMs,
 			Cached:     annotation.LLM.Cached,

--- a/internal/guard/judgeruntime/config.go
+++ b/internal/guard/judgeruntime/config.go
@@ -30,17 +30,18 @@ type Config struct {
 	DownloadProgress judge.DownloadProgressHandler
 }
 
-func ConfigFromEnv(dbPath string, managedDefault bool) (Config, error) {
+// ConfigFromEnv resolves the local model from the environment. Managed mode is
+// opt-in only: nothing defaults it on, because the only caller that used to —
+// the retired `kontext start` wrapper — managed a llama-server child on the
+// user's behalf, and no remaining path should download a model unprompted.
+func ConfigFromEnv(dbPath string) (Config, error) {
 	timeout, err := envDuration("KONTEXT_JUDGE_TIMEOUT", judge.DefaultTimeout)
 	if err != nil {
 		return Config{}, err
 	}
-	managed, err := envBoolDefault("KONTEXT_JUDGE_MANAGED", managedDefault)
+	managed, err := envBoolDefault("KONTEXT_JUDGE_MANAGED", false)
 	if err != nil {
 		return Config{}, err
-	}
-	if os.Getenv("KONTEXT_JUDGE_MANAGED") == "" && strings.TrimSpace(os.Getenv("KONTEXT_JUDGE_URL")) != "" {
-		managed = false
 	}
 	port, err := envInt("KONTEXT_JUDGE_PORT", judge.DefaultLlamaServerPort)
 	if err != nil {

--- a/internal/guard/judgeruntime/config_test.go
+++ b/internal/guard/judgeruntime/config_test.go
@@ -5,18 +5,32 @@ import (
 	"testing"
 )
 
-func TestConfigFromEnvDefaultsManagedJudgeOn(t *testing.T) {
+// Managed mode is opt-in. Nothing defaults it on, so no path downloads a model
+// or runs a llama-server child unless an operator asked for it.
+func TestConfigFromEnvLeavesManagedOffByDefault(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "guard.db")
 
-	cfg, err := ConfigFromEnv(dbPath, true)
+	cfg, err := ConfigFromEnv(dbPath)
+	if err != nil {
+		t.Fatalf("ConfigFromEnv() error = %v", err)
+	}
+	if cfg.Managed {
+		t.Fatal("Managed = true, want false without an explicit opt-in")
+	}
+	if cfg.CacheDir != filepath.Join(filepath.Dir(dbPath), "judge-models") {
+		t.Fatalf("CacheDir = %q, want db-adjacent judge-models", cfg.CacheDir)
+	}
+}
+
+func TestConfigFromEnvManagedIsOptIn(t *testing.T) {
+	t.Setenv("KONTEXT_JUDGE_MANAGED", "1")
+
+	cfg, err := ConfigFromEnv(filepath.Join(t.TempDir(), "guard.db"))
 	if err != nil {
 		t.Fatalf("ConfigFromEnv() error = %v", err)
 	}
 	if !cfg.Managed {
-		t.Fatal("Managed = false, want true")
-	}
-	if cfg.CacheDir != filepath.Join(filepath.Dir(dbPath), "judge-models") {
-		t.Fatalf("CacheDir = %q, want db-adjacent judge-models", cfg.CacheDir)
+		t.Fatal("Managed = false, want true when explicitly opted in")
 	}
 }
 
@@ -24,7 +38,7 @@ func TestConfigFromEnvTreatsJudgeURLAsExternalByDefault(t *testing.T) {
 	t.Setenv("KONTEXT_JUDGE_URL", "http://127.0.0.1:18080")
 	t.Setenv("KONTEXT_JUDGE_MODEL", "qwen3")
 
-	cfg, err := ConfigFromEnv(filepath.Join(t.TempDir(), "guard.db"), true)
+	cfg, err := ConfigFromEnv(filepath.Join(t.TempDir(), "guard.db"))
 	if err != nil {
 		t.Fatalf("ConfigFromEnv() error = %v", err)
 	}

--- a/internal/guard/risk/types.go
+++ b/internal/guard/risk/types.go
@@ -140,7 +140,11 @@ type ClassifierAnnotation struct {
 	LLMError string         `json:"llm_error,omitempty"`
 	// LLMPromptID records which prompt variant produced the verdict. Local
 	// only: the hosted block deliberately omits it.
-	LLMPromptID      string `json:"-"`
+	LLMPromptID string `json:"-"`
+	// LLMRaw is what the model literally answered, also local only. The model is
+	// the weak half of this pair, so its exact words are what make an odd verdict
+	// diagnosable later; the normalized verdict alone loses that.
+	LLMRaw           string `json:"-"`
 	Command          string `json:"-"`
 	CommandHash      string `json:"-"`
 	CommandTruncated bool   `json:"-"`

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -186,9 +186,9 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 		// sessions that reach the hosted ledger — the LLM verdict would have
 		// been null in exactly the place the data is collected.
 		//
-		// JudgeManagedDefault stays false on purpose. Defaulting it to true
-		// would have every managed endpoint download a model and run a
-		// llama-server child unprompted; the operator opts in with
+		// Managed mode is never defaulted on: that would have every managed
+		// endpoint download a model and run a llama-server child unprompted.
+		// The operator opts in with
 		// KONTEXT_JUDGE_MANAGED, or points at an endpoint they already run with
 		// KONTEXT_JUDGE_URL and KONTEXT_JUDGE_MODEL. An incomplete optional
 		// configuration resolves to no judge, so the daemon behaves as before.

--- a/internal/runtimehost/host.go
+++ b/internal/runtimehost/host.go
@@ -32,7 +32,6 @@ type Options struct {
 	DBPath                string
 	SocketPath            string
 	JudgeConfigFromEnv    bool
-	JudgeManagedDefault   bool
 	JudgeDownloadProgress judge.DownloadProgressHandler
 	CedarPolicies         cedarpolicy.SnapshotProvider
 	CedarEnforcement      server.CedarEnforcementSource
@@ -94,7 +93,7 @@ func Start(ctx context.Context, opts Options) (*Host, error) {
 	var judgeStatus string
 	var judgeRuntime judgeruntime.Runtime
 	if opts.JudgeConfigFromEnv {
-		judgeConfig, err := judgeruntime.ConfigFromEnv(dbPath, opts.JudgeManagedDefault)
+		judgeConfig, err := judgeruntime.ConfigFromEnv(dbPath)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Three loose ends, two of which I found by running the classifier against a real model rather than by reading the code.

## `llm_raw` was empty on every row ever written

The column, the `LLMVerdict.Raw` field and the insert all existed, and the guardrail populates it — but the hand-off dropped it. The uploaded annotation carries only contract fields by design, so the local-only ones are re-attached by hand on the way to the row, and this one was missed.

It is worth having rather than deleting: `"SAFE."` and `"safe"` both normalize to `not_risky`, and only the raw tells them apart when a verdict looks wrong. The model is the weak half of this pair, so its exact words are the thing you reach for. Local only — it never reaches the wire.

`TestRawModelOutputReachesTheRow` fails on the old code with `llm raw = ""`.

## `JudgeManagedDefault` was dead

The retired `kontext start` wrapper was its only caller, so after #440 nothing set it and `ConfigFromEnv` took a parameter that was always false. Removed, so managed mode is opt-in in the type rather than by convention.

The clause forcing managed off when a judge URL was set went with it: once the default is false it can no longer change any outcome. Its two tests asserted the old defaulting behaviour and now pin the new contract — off unless `KONTEXT_JUDGE_MANAGED` says otherwise.

## Docs

The path table still listed the retired wrapper. It now records where the LLM actually runs, and why:

Homebrew installs only. The formula depends on `llama.cpp`, so `llama-server` is on PATH after `brew install`; nothing else provisions it, and the CLI deliberately does not ship or download it. An MDM endpoint therefore collects SVM verdicts and nothing more — the accepted starting point rather than an oversight, since enabling it fleet-wide would mean shipping a signed native binary, ~1.1 GB resident per endpoint (measured), and a `llama-server` child that endpoint security tooling has every reason to flag.

Worth keeping in view when reading collected data: the managed daemon is the path that reaches the hosted ledger, so an endpoint without a model uploads `classifier.llm: null`, and the SVM is the weaker half.

## Verification

- [x] `go test ./...` serially, `go vet ./...`, `gofmt` clean
- [x] both new/changed tests fail on the previous code
- [ ] `buf generate` — n/a