### PR TITLE
test(guard): stop the llama-server startup tests racing the wall clock

### DIFF
--- a/internal/guard/judge/llama_server.go
+++ b/internal/guard/judge/llama_server.go
@@ -22,6 +22,7 @@ const (
 	DefaultLlamaServerHost            = "127.0.0.1"
 	DefaultLlamaServerPort            = 18080
 	DefaultLlamaServerStartupTimeout  = 30 * time.Second
+	DefaultLlamaServerStopTimeout     = 3 * time.Second
 	DefaultLlamaServerHFRepo          = "Qwen/Qwen3-0.6B-GGUF"
 	DefaultLlamaServerHFFile          = "Qwen3-0.6B-Q8_0.gguf"
 	DefaultLlamaServerHFRevision      = "main"
@@ -46,6 +47,7 @@ type LlamaServerOptions struct {
 	Port             int
 	ContextSize      int
 	StartupTimeout   time.Duration
+	StopTimeout      time.Duration
 	HTTPClient       *http.Client
 	Stdout           io.Writer
 	Stderr           io.Writer
@@ -53,10 +55,11 @@ type LlamaServerOptions struct {
 }
 
 type LlamaServer struct {
-	baseURL string
-	cancel  context.CancelFunc
-	wait    chan error
-	cmd     *exec.Cmd
+	baseURL     string
+	cancel      context.CancelFunc
+	wait        chan error
+	cmd         *exec.Cmd
+	stopTimeout time.Duration
 }
 
 type DownloadProgressEvent string
@@ -118,10 +121,11 @@ func StartLlamaServer(ctx context.Context, opts LlamaServerOptions) (*LlamaServe
 	}
 
 	server := &LlamaServer{
-		baseURL: llamaServerBaseURL(opts.Host, opts.Port),
-		cancel:  cancel,
-		wait:    make(chan error, 1),
-		cmd:     cmd,
+		baseURL:     llamaServerBaseURL(opts.Host, opts.Port),
+		cancel:      cancel,
+		wait:        make(chan error, 1),
+		cmd:         cmd,
+		stopTimeout: opts.StopTimeout,
 	}
 	go func() {
 		server.wait <- cmd.Wait()
@@ -240,6 +244,10 @@ func (s *LlamaServer) Stop() error {
 	if s == nil {
 		return nil
 	}
+	stopTimeout := s.stopTimeout
+	if stopTimeout <= 0 {
+		stopTimeout = DefaultLlamaServerStopTimeout
+	}
 	s.cancel()
 	select {
 	case err := <-s.wait:
@@ -254,7 +262,7 @@ func (s *LlamaServer) Stop() error {
 			return nil
 		}
 		return err
-	case <-time.After(3 * time.Second):
+	case <-time.After(stopTimeout):
 		if s.cmd != nil && s.cmd.Process != nil {
 			_ = s.cmd.Process.Kill()
 		}
@@ -321,6 +329,9 @@ func normalizeLlamaServerOptions(opts LlamaServerOptions) LlamaServerOptions {
 	}
 	if opts.StartupTimeout <= 0 {
 		opts.StartupTimeout = DefaultLlamaServerStartupTimeout
+	}
+	if opts.StopTimeout <= 0 {
+		opts.StopTimeout = DefaultLlamaServerStopTimeout
 	}
 	return opts
 }

--- a/internal/guard/judge/llama_server_test.go
+++ b/internal/guard/judge/llama_server_test.go
@@ -87,6 +87,18 @@ func TestStartLlamaServerRejectsOccupiedPort(t *testing.T) {
 	}
 }
 
+// testLlamaServerStartupTimeout is deliberately generous. The fake
+// llama-server re-execs the test binary, which can take seconds to serve its
+// first request when the rest of the suite is running in parallel, and a tight
+// budget here only buys a flaky "health check timed out" failure. The health
+// loop returns as soon as the fake is up, so a large budget costs nothing on a
+// healthy run.
+const testLlamaServerStartupTimeout = 30 * time.Second
+
+// testLlamaServerStopTimeout is long enough that a Stop() which actually waits
+// for its deadline is unmistakable next to normal startup jitter.
+const testLlamaServerStopTimeout = 10 * time.Second
+
 func TestStartLlamaServerHealthCheckAndStop(t *testing.T) {
 	modelPath := writeTestModel(t)
 	binaryPath := writeFakeLlamaServer(t)
@@ -95,7 +107,7 @@ func TestStartLlamaServerHealthCheckAndStop(t *testing.T) {
 		BinaryPath:     binaryPath,
 		ModelPath:      modelPath,
 		Port:           port,
-		StartupTimeout: 2 * time.Second,
+		StartupTimeout: testLlamaServerStartupTimeout,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -116,13 +128,23 @@ func TestStartLlamaServerEarlyExitDoesNotWaitForStopTimeout(t *testing.T) {
 		BinaryPath:     binaryPath,
 		ModelPath:      modelPath,
 		Port:           freeTCPPort(t),
-		StartupTimeout: 2 * time.Second,
+		StartupTimeout: testLlamaServerStartupTimeout,
+		StopTimeout:    testLlamaServerStopTimeout,
 	})
+	elapsed := time.Since(start)
 	if err == nil {
 		t.Fatal("StartLlamaServer() error = nil, want early exit error")
 	}
-	if elapsed := time.Since(start); elapsed > 1500*time.Millisecond {
-		t.Fatalf("early exit took %s, want less than 1.5s", elapsed)
+	// The startup path must notice the dead child itself rather than idle until
+	// the health deadline, and the Stop() it then runs must observe the same
+	// exit status instead of blocking until the stop deadline. Both are timeouts
+	// far longer than the process spawn jitter that dominates a healthy run, so
+	// the bound stays meaningful on a loaded machine.
+	if !strings.Contains(err.Error(), "exited before becoming healthy") {
+		t.Fatalf("err = %v, want early exit error", err)
+	}
+	if elapsed >= testLlamaServerStopTimeout {
+		t.Fatalf("early exit took %s, want well under the %s stop timeout", elapsed, testLlamaServerStopTimeout)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Two tests in `internal/guard/judge/llama_server_test.go` failed intermittently under `go test -count=1 ./...` but passed when the package ran alone. Pre-existing on a clean `main`, not caused by a recent change. Both spent fixed wall-clock budgets against a fake llama-server that re-execs the test binary, so they starved when the rest of the suite loaded the machine — `TestStartLlamaServerHealthCheckAndStop` timed out at its hard `2s`, and `TestStartLlamaServerEarlyExitDoesNotWaitForStopTimeout` tripped its `1500ms` bound at ~1.501s.
- `TestStartLlamaServerHealthCheckAndStop` only cares that the fake comes up and stops cleanly, so its startup budget is now a named 30s constant. The health loop returns the moment the fake serves `/v1/models`, so the larger budget costs nothing on a healthy run — it only lengthens how long a genuine hang takes to report.
- `TestStartLlamaServerEarlyExitDoesNotWaitForStopTimeout` was asserting two separate things through one absolute number: that startup notices the dead child rather than idling to the health deadline, and that the follow-up `Stop()` observes the same exit status rather than blocking on its own deadline. Both are now explicit — an error-content check for `"exited before becoming healthy"` (load-independent, pins the early-exit path) and an elapsed bound expressed against the stop timeout the test itself configures.
- Making that relative form possible needed `StopTimeout` on `LlamaServerOptions`, replacing the hardcoded `3 * time.Second` in `Stop()`. No caller sets the field, so production normalizes to the same 3s and behavior is unchanged.

Neither test checks less than before.

## Verification

- [x] `go test ./...` — three consecutive runs, all clean
- [x] `go test -race ./...`
- [x] `go vet ./...`
- [x] Mutation check: deleting the `s.wait <- err` re-push in `waitHealthy` (the line the early-exit test exists to guard) fails the test at 10.104s. Restored after.
- [x] Stressed both tests at `-count=8` while a second full-suite run loaded the machine: all pass, and the timings confirm the diagnosis — the health check hit exactly 2.00s (the old cliff) and the early exit hit 2.00s (past the old 1.5s bound).

## Release notes

- [x] conventional commit title matches semver intent — `test:`, no user-facing change