### PR TITLE
feat(managedstream): emit the clean ledger-ingest v1 wire contract

### DIFF
--- a/internal/guard/store/sqlite/ledger.go
+++ b/internal/guard/store/sqlite/ledger.go
@@ -26,7 +26,17 @@ type LedgerBatch struct {
 	Receipts           []LedgerRecord            `json:"authorization_receipts"`
 	ReceiptChainAnchor *LedgerReceiptChainAnchor `json:"receipt_chain_anchor,omitempty"`
 	Cursor             *LedgerCursor             `json:"-"`
+	// Form is the wire contract this page must ship under, decided
+	// deterministically from the rows themselves: any receipt stored before
+	// the clean-payload cutover, or any decided action without its decision
+	// fact, pins the page to "legacy". Pages of post-cutover rows ship "v1".
+	Form string `json:"-"`
 }
+
+const (
+	LedgerFormLegacy = "legacy"
+	LedgerFormV1     = "v1"
+)
 
 type LedgerReceiptChainAnchor struct {
 	PreviousReceiptHash string `json:"previous_receipt_hash"`
@@ -70,8 +80,11 @@ select id, action_id, session_id, receipt_type, decision_result, decision_catego
   reason_code, approval_channel, approval_result, approver_id, approved_at,
   policy_hash, context_hash, identity_hash, risk_evaluation_hash, action_hash,
   outcome_hash, receipt_payload_json, previous_receipt_hash, receipt_hash,
-  signature, signature_algorithm, key_id, created_at
+  signature, signature_algorithm, key_id, payload_form, created_at
 from authorization_receipts`
+
+// ledgerReceiptPayloadFormColumn is local cutover state, never a wire field.
+const ledgerReceiptPayloadFormColumn = "payload_form"
 
 func (s *Store) LedgerBatch(ctx context.Context, opts LedgerExportOptions) (LedgerBatch, error) {
 	actions, cursor, err := s.authorizationActionCursorPage(ctx, opts)
@@ -98,13 +111,46 @@ func (s *Store) LedgerBatch(ctx context.Context, opts LedgerExportOptions) (Ledg
 	if err != nil {
 		return LedgerBatch{}, err
 	}
+	form := ledgerContractForm(actions, receipts)
+	stripLedgerLocalColumns(receipts)
 	return LedgerBatch{
 		Sessions:           sessions,
 		Actions:            actions,
 		Receipts:           receipts,
 		ReceiptChainAnchor: receiptChainAnchor(receipts),
 		Cursor:             cursor,
+		Form:               form,
 	}, nil
+}
+
+// ledgerContractForm picks the wire form for one export page. Deterministic
+// from the rows alone — never error-driven: a page is v1 only when every
+// receipt carries a clean-form payload and every decided action carries its
+// decision fact. Anything older pins the page to the legacy form, which is
+// how pre-upgrade backlog (including rows written during a temporary
+// downgrade) drains without a separate cutover marker.
+func ledgerContractForm(actions, receipts []LedgerRecord) string {
+	for _, receipt := range receipts {
+		if form, _ := receipt[ledgerReceiptPayloadFormColumn].(string); form != LedgerFormV1 {
+			return LedgerFormLegacy
+		}
+	}
+	for _, action := range actions {
+		eventType, _ := action["canonical_event_type"].(string)
+		if eventType != "request.decided" {
+			continue
+		}
+		if action["decision_fact_json"] == nil {
+			return LedgerFormLegacy
+		}
+	}
+	return LedgerFormV1
+}
+
+func stripLedgerLocalColumns(receipts []LedgerRecord) {
+	for _, receipt := range receipts {
+		delete(receipt, ledgerReceiptPayloadFormColumn)
+	}
 }
 
 func (s *Store) authorizationActionCursorPage(ctx context.Context, opts LedgerExportOptions) ([]LedgerRecord, *LedgerCursor, error) {
@@ -264,7 +310,12 @@ func (s *Store) AuthorizationReceipts(ctx context.Context, opts LedgerExportOpti
 		query += "\nlimit ?"
 		args = append(args, opts.Limit)
 	}
-	return queryLedgerRecords(ctx, s.db, query, args...)
+	receipts, err := queryLedgerRecords(ctx, s.db, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	stripLedgerLocalColumns(receipts)
+	return receipts, nil
 }
 
 func (s *Store) authorizationReceiptRangeForActions(ctx context.Context, actionIDs []string, limit int) ([]LedgerRecord, error) {

--- a/internal/guard/store/sqlite/receipt_signing.go
+++ b/internal/guard/store/sqlite/receipt_signing.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/kontext-security/kontext-cli/internal/ledgerfact"
+	"github.com/kontext-security/kontext-cli/internal/payloadcapture"
 )
 
 const (
@@ -191,11 +192,14 @@ func verifyReceiptDecisionFact(payload, stored string, mirrors decisionFactMirro
 	if receipt.Action.ID == "" {
 		return fmt.Errorf("decision-fact receipt has no action id")
 	}
-	canonicalReceipt, err := canonicalJSON(json.RawMessage(receipt.Action.DecisionFact))
+	// JCS on both sides: clean-form receipt payloads are stored as JCS
+	// bytes, so the embedded fact's key order/escaping differs from the
+	// stored fact column even when the values are identical.
+	canonicalReceipt, err := payloadcapture.CanonicalJSON(json.RawMessage(receipt.Action.DecisionFact))
 	if err != nil {
 		return fmt.Errorf("canonicalize receipt decision fact: %w", err)
 	}
-	canonicalStored, err := canonicalJSON(json.RawMessage(stored))
+	canonicalStored, err := payloadcapture.CanonicalJSON(json.RawMessage(stored))
 	if err != nil {
 		return fmt.Errorf("canonicalize stored decision fact: %w", err)
 	}

--- a/internal/guard/store/sqlite/store.go
+++ b/internal/guard/store/sqlite/store.go
@@ -17,6 +17,7 @@ import (
 	_ "modernc.org/sqlite"
 
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
+	"github.com/kontext-security/kontext-cli/internal/ledgeringest"
 	"github.com/kontext-security/kontext-cli/internal/payloadcapture"
 )
 
@@ -343,6 +344,13 @@ func (s *Store) migrate(ctx context.Context) error {
 		return err
 	}
 	if err := s.ensureClassifierVerdictColumns(ctx); err != nil {
+		return err
+	}
+	// Marks receipts whose stored payload is the clean-v1 wire shape (JCS
+	// bytes, published field names). Rows written by earlier builds keep the
+	// 'legacy' default, and the exporter ships any page containing one in
+	// the legacy form — the deterministic cutover for pre-upgrade backlog.
+	if err := s.ensureColumn(ctx, "authorization_receipts", "payload_form", "text not null default 'legacy'"); err != nil {
 		return err
 	}
 	return nil
@@ -900,6 +908,13 @@ func (s *Store) insertActionRecord(ctx context.Context, tx *sql.Tx, action map[s
 	); err != nil {
 		return err
 	}
+	// Session lifecycle rows are local activity records only: the wire
+	// contract carries session state via session records, receipts attest
+	// tool-call actions, and a receipt minted here would force the whole
+	// export page back onto the legacy form.
+	if eventType := stringValue(action["canonical_event_type"]); eventType == canonicalEventSessionStart || eventType == canonicalEventSessionEnd {
+		return nil
+	}
 	return s.appendReceipt(ctx, tx, receiptInputFromAction(action, receiptType, now))
 }
 
@@ -1106,23 +1121,32 @@ type receiptInput struct {
 	CreatedAt          time.Time
 }
 
+// receiptInputFromAction builds the clean-v1 receipt payload: the exact
+// object the receipt hash commits to, in the published wire shape. Every
+// member is omitted when empty (never committed as an empty string or
+// null), section values stay inside their closed vocabularies, and
+// tool_call_id is the sole tool-call correlation field.
 func receiptInputFromAction(action map[string]any, receiptType string, now time.Time) receiptInput {
 	riskEventJSON, _ := action["risk_event_json"].(string)
 	riskHash := hashString(riskEventJSON)
 	decisionResult := stringValue(action["decision_result"])
 	actionPayload := map[string]any{
-		"id":              action["id"],
-		"session_id":      action["session_id"],
-		"tool_use_id":     action["tool_use_id"],
-		"tool_name":       action["tool_name"],
-		"parameters_hash": action["parameters_hash"],
-		"context_hash":    action["context_hash"],
-		"identity_hash":   action["identity_hash"],
-		"policy_hash":     action["policy_hash"],
-		"reason_code":     action["reason_code"],
-		"risk_hash":       riskHash,
-		"outcome_hash":    action["output_hash"],
+		"id":         action["id"],
+		"session_id": action["session_id"],
 	}
+	toolCallID := stringValue(action["tool_call_id"])
+	if toolCallID == "" {
+		toolCallID = stringValue(action["tool_use_id"])
+	}
+	setNonEmpty(actionPayload, "tool_call_id", toolCallID)
+	setNonEmpty(actionPayload, "tool_name", stringValue(action["tool_name"]))
+	setHashMember(actionPayload, "parameters_hash", stringValue(action["parameters_hash"]))
+	setHashMember(actionPayload, "context_hash", stringValue(action["context_hash"]))
+	setHashMember(actionPayload, "identity_hash", stringValue(action["identity_hash"]))
+	setHashMember(actionPayload, "policy_hash", stringValue(action["policy_hash"]))
+	setNonEmpty(actionPayload, "reason_code", stringValue(action["reason_code"]))
+	setHashMember(actionPayload, "risk_hash", riskHash)
+	setHashMember(actionPayload, "outcome_hash", stringValue(action["output_hash"]))
 	if decisionFactJSON := stringValue(action["decision_fact_json"]); decisionFactJSON != "" {
 		// The decision fact is the authoritative decision record. Keep its
 		// complete canonical JSON inside the signed receipt payload, rather
@@ -1136,41 +1160,64 @@ func receiptInputFromAction(action map[string]any, receiptType string, now time.
 	payload := map[string]any{
 		"receipt_type": receiptType,
 		"action":       actionPayload,
-		"risk": map[string]any{
-			"risk_level": action["risk_level"],
-			"risk_score": action["risk_score"],
-			"threshold":  action["risk_threshold"],
-			"signals":    json.RawMessage(action["risk_signals_json"].(string)),
-		},
-		"policy": map[string]any{
-			"policy_id":      action["policy_id"],
-			"policy_version": action["policy_version"],
-			"policy_hash":    action["policy_hash"],
-			"matched_rules":  json.RawMessage(action["matched_rules_json"].(string)),
-		},
-		"hashes": map[string]any{
-			"context_hash":         action["context_hash"],
-			"identity_hash":        action["identity_hash"],
-			"risk_evaluation_hash": riskHash,
-			"action_hash":          actionHash,
-			"outcome_hash":         action["output_hash"],
-		},
 	}
-	if decisionResult != "" {
-		payload["decision"] = map[string]any{
-			"result":      decisionResult,
-			"category":    action["decision_category"],
-			"reason_code": action["reason_code"],
-			"reason":      action["reason"],
+
+	risk := map[string]any{}
+	if level := stringValue(action["risk_level"]); ledgeringest.ValidRiskLevel(level) {
+		risk["risk_level"] = level
+	}
+	setUnitInterval(risk, "risk_score", action["risk_score"])
+	setUnitInterval(risk, "threshold", action["risk_threshold"])
+	if signals := decodedStringList(action["risk_signals_json"]); len(signals) > 0 {
+		risk["signals"] = signals
+	}
+	if len(risk) > 0 {
+		payload["risk"] = risk
+	}
+
+	policy := map[string]any{}
+	setNonEmpty(policy, "policy_id", stringValue(action["policy_id"]))
+	setNonEmpty(policy, "policy_version", stringValue(action["policy_version"]))
+	setHashMember(policy, "policy_hash", stringValue(action["policy_hash"]))
+	if rules := decodedStringList(action["matched_rules_json"]); len(rules) > 0 {
+		policy["matched_rules"] = rules
+	}
+	if len(policy) > 0 {
+		payload["policy"] = policy
+	}
+
+	hashes := map[string]any{}
+	setHashMember(hashes, "context_hash", stringValue(action["context_hash"]))
+	setHashMember(hashes, "identity_hash", stringValue(action["identity_hash"]))
+	setHashMember(hashes, "risk_evaluation_hash", riskHash)
+	setHashMember(hashes, "action_hash", actionHash)
+	setHashMember(hashes, "outcome_hash", stringValue(action["output_hash"]))
+	if len(hashes) > 0 {
+		payload["hashes"] = hashes
+	}
+
+	if receiptType == "decision" {
+		decision := map[string]any{
+			"result": decisionResult,
 		}
+		if category := stringValue(action["decision_category"]); ledgeringest.ValidDecisionCategory(category) {
+			decision["category"] = category
+		}
+		setNonEmpty(decision, "reason_code", stringValue(action["reason_code"]))
+		setNonEmpty(decision, "reason", stringValue(action["reason"]))
+		payload["decision"] = decision
 	}
 	if receiptType == "outcome" {
-		payload["outcome"] = map[string]any{
-			"outcome":        action["outcome"],
-			"output_summary": action["output_summary"],
-			"output_hash":    action["output_hash"],
-			"error_redacted": action["error_redacted"],
+		outcome := map[string]any{}
+		if value := stringValue(action["outcome"]); ledgeringest.ValidActionOutcome(value) {
+			outcome["outcome"] = value
+		} else {
+			outcome["outcome"] = "not_executed"
 		}
+		setNonEmpty(outcome, "output_summary", stringValue(action["output_summary"]))
+		setHashMember(outcome, "output_hash", stringValue(action["output_hash"]))
+		setNonEmpty(outcome, "error_redacted", stringValue(action["error_redacted"]))
+		payload["outcome"] = outcome
 	}
 	return receiptInput{
 		ActionID:           action["id"].(string),
@@ -1260,11 +1307,20 @@ func (s *Store) appendReceipt(ctx context.Context, tx *sql.Tx, input receiptInpu
 		return err
 	}
 	payload := copyMap(input.Payload)
-	payload["previous_receipt_hash"] = previousHash
-	receiptPayloadJSON, err := jsonText(payload)
+	// Genesis omits the chain link entirely; the stored column keeps the
+	// empty string so local chain verification stays uniform.
+	if previousHash != "" {
+		payload["previous_receipt_hash"] = previousHash
+	}
+	// Store the RFC 8785 (JCS) bytes as the payload of record: the hash is
+	// computed over them, local verification re-hashes the stored string,
+	// and the server recomputes JCS over the parsed payload — all three see
+	// the same bytes.
+	canonicalPayload, err := payloadcapture.CanonicalJSON(payload)
 	if err != nil {
 		return err
 	}
+	receiptPayloadJSON := string(canonicalPayload)
 	receiptHash := hashString(receiptPayloadJSON)
 	signatureAlgorithm := "none"
 	signature := ""
@@ -1281,14 +1337,52 @@ insert into authorization_receipts(
   decision_result, decision_category, reason_code,
   policy_hash, context_hash, identity_hash, risk_evaluation_hash, action_hash, outcome_hash,
   receipt_payload_json, previous_receipt_hash, receipt_hash, signature, signature_algorithm, key_id,
-  created_at
-) values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  payload_form, created_at
+) values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, "rcpt_"+uuid.NewString(), input.ActionID, input.SessionID, input.ReceiptType,
 		input.DecisionResult, input.DecisionCategory, input.ReasonCode,
 		input.PolicyHash, input.ContextHash, input.IdentityHash, input.RiskEvaluationHash, input.ActionHash, input.OutcomeHash,
 		receiptPayloadJSON, previousHash, receiptHash, signature, signatureAlgorithm, keyID,
-		input.CreatedAt.Format(time.RFC3339Nano))
+		ledgeringest.BatchVersion, input.CreatedAt.Format(time.RFC3339Nano))
 	return err
+}
+
+func setNonEmpty(payload map[string]any, key, value string) {
+	if value != "" {
+		payload[key] = value
+	}
+}
+
+func setHashMember(payload map[string]any, key, value string) {
+	if ledgeringest.ValidHash(value) {
+		payload[key] = value
+	}
+}
+
+func setUnitInterval(payload map[string]any, key string, value any) {
+	number, ok := value.(float64)
+	if !ok || number < 0 || number > 1 {
+		return
+	}
+	payload[key] = number
+}
+
+func decodedStringList(value any) []string {
+	text, _ := value.(string)
+	if text == "" {
+		return nil
+	}
+	var values []string
+	if err := json.Unmarshal([]byte(text), &values); err != nil {
+		return nil
+	}
+	out := values[:0]
+	for _, item := range values {
+		if item != "" {
+			out = append(out, item)
+		}
+	}
+	return out
 }
 
 func previousReceiptHash(ctx context.Context, tx *sql.Tx) (string, error) {

--- a/internal/ledgeringest/map.go
+++ b/internal/ledgeringest/map.go
@@ -1,0 +1,533 @@
+package ledgeringest
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Maps exported ledger rows (the store's map[string]any records) onto the
+// typed clean-v1 wire model. This file is the single legacy->v1 name
+// authority on the CLI: every rename, drop, and closed-vocabulary guard
+// lives here, and the transport test validates the mapped output against
+// the pinned schema bundle.
+//
+// Guards are deliberately drop-not-fail for optional fields: an optional
+// value outside its closed vocabulary is omitted (the record stays true,
+// just less detailed), while a record that cannot satisfy a *required*
+// contract rule returns an error so the flush loop can isolate it instead
+// of poisoning the batch.
+
+// BatchInput carries one export page plus envelope facts.
+type BatchInput struct {
+	BatchID        string
+	InstallationID string
+	SentAt         string
+	Device         *Device
+	Sessions       []map[string]any
+	Actions        []map[string]any
+	Receipts       []map[string]any
+	// AnchorPreviousReceiptHash is non-nil exactly when receipts are present;
+	// the empty string marks a chain genesis.
+	AnchorPreviousReceiptHash *string
+}
+
+// MapBatch converts one export page to the clean v1 envelope. Session
+// lifecycle rows (session.start/session.end) are local records only — the
+// clean contract carries session lifecycle via session records — so they
+// are dropped from the actions array here.
+func MapBatch(in BatchInput) (Batch, error) {
+	batch := Batch{
+		BatchVersion:   BatchVersion,
+		BatchID:        in.BatchID,
+		InstallationID: in.InstallationID,
+		SentAt:         in.SentAt,
+		Device:         in.Device,
+		Sessions:       []SessionRecord{},
+		Actions:        []ActionRecord{},
+		Receipts:       []ReceiptRecord{},
+	}
+	for _, record := range in.Sessions {
+		session, err := mapSession(record)
+		if err != nil {
+			return Batch{}, fmt.Errorf("session %s: %w", stringField(record, "id"), err)
+		}
+		batch.Sessions = append(batch.Sessions, session)
+	}
+	for _, record := range in.Actions {
+		action, err := mapAction(record)
+		if err != nil {
+			return Batch{}, fmt.Errorf("action %s: %w", stringField(record, "id"), err)
+		}
+		if action == nil {
+			continue
+		}
+		batch.Actions = append(batch.Actions, *action)
+	}
+	for _, record := range in.Receipts {
+		receipt, err := mapReceipt(record)
+		if err != nil {
+			return Batch{}, fmt.Errorf("receipt %s: %w", stringField(record, "id"), err)
+		}
+		batch.Receipts = append(batch.Receipts, receipt)
+	}
+	if len(batch.Receipts) > 0 {
+		if in.AnchorPreviousReceiptHash == nil {
+			return Batch{}, fmt.Errorf("receipts present without a chain anchor")
+		}
+		batch.ReceiptChainAnchor = &ReceiptChainAnchor{
+			PreviousReceiptHash: *in.AnchorPreviousReceiptHash,
+		}
+	}
+	return batch, nil
+}
+
+const (
+	eventSessionStart = "session.start"
+	eventSessionEnd   = "session.end"
+)
+
+var (
+	timestampPattern = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?Z$`)
+	hashPattern      = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+	safeIDPattern    = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._/:@-]{0,255}$`)
+
+	sessionSources     = stringSet("wrapper_owned", "daemon_observed")
+	sessionModes       = stringSet("disabled", "observe", "enforce")
+	actionEventTypes   = stringSet("request.proposed", "request.decided", "request.observed", "request.failed")
+	actionOutcomes     = stringSet("success", "error", "not_executed")
+	riskLevels         = stringSet("LOW", "MEDIUM", "HIGH", "CRITICAL")
+	decisionCategories = stringSet(
+		"cedar_policy", "deterministic_deny", "advisory",
+		"judge_allow", "judge_deny", "judge_fail_open", "default",
+	)
+	captureModes = stringSet("omitted", "summary", "full")
+)
+
+func mapSession(record map[string]any) (SessionRecord, error) {
+	session := SessionRecord{
+		ID:                stringField(record, "id"),
+		Source:            stringField(record, "source"),
+		Status:            stringField(record, "status"),
+		CreatedAt:         stringField(record, "created_at"),
+		UpdatedAt:         stringField(record, "updated_at"),
+		RuntimeKind:       boundedField(record, "runtime_kind", 128),
+		RuntimeInstanceID: boundedField(record, "runtime_instance_id", 128),
+		AdapterKind:       boundedField(record, "adapter_kind", 128),
+		AdapterVersion:    boundedField(record, "adapter_version", 128),
+		AgentProvider:     boundedField(record, "agent_provider", 128),
+		Agent:             boundedField(record, "agent", 128),
+		ConversationID:    safeIDField(record, "conversation_id"),
+		PrincipalID:       boundedField(record, "principal_id", 320),
+		Identity:          mapIdentity(record["identity_context_json"]),
+		IdentityHash:      hashField(record, "identity_hash"),
+		PolicyVersion:     boundedField(record, "policy_version", 128),
+		PolicyHash:        hashField(record, "policy_hash"),
+		CWD:               boundedField(record, "cwd", 4096),
+		ExternalID:        safeIDField(record, "external_id"),
+		ClosedAt:          stringField(record, "closed_at"),
+	}
+	if !safeIDPattern.MatchString(session.ID) {
+		return SessionRecord{}, fmt.Errorf("id is not a SafeId")
+	}
+	if !sessionSources[session.Source] {
+		// Historical rows can predate the source column default.
+		session.Source = "daemon_observed"
+	}
+	if mode := stringField(record, "mode"); sessionModes[mode] {
+		session.Mode = mode
+	}
+	if err := requireTimestamp("created_at", session.CreatedAt); err != nil {
+		return SessionRecord{}, err
+	}
+	if err := requireTimestamp("updated_at", session.UpdatedAt); err != nil {
+		return SessionRecord{}, err
+	}
+	// Lifecycle coherence: closed requires closed_at, open forbids it, and
+	// timestamps never contradict the row's own update stamp.
+	switch session.Status {
+	case "closed":
+		if !timestampPattern.MatchString(session.ClosedAt) {
+			session.ClosedAt = session.UpdatedAt
+		}
+	default:
+		session.Status = "open"
+		session.ClosedAt = ""
+	}
+	if compareTimestamps(session.CreatedAt, session.UpdatedAt) > 0 {
+		session.CreatedAt = session.UpdatedAt
+	}
+	if session.ClosedAt != "" && compareTimestamps(session.ClosedAt, session.UpdatedAt) > 0 {
+		session.ClosedAt = session.UpdatedAt
+	}
+	return session, nil
+}
+
+// mapAction returns nil for session lifecycle rows: they stay local, and
+// the clean contract carries session state via session records instead.
+func mapAction(record map[string]any) (*ActionRecord, error) {
+	eventType := stringField(record, "canonical_event_type")
+	if eventType == eventSessionStart || eventType == eventSessionEnd {
+		return nil, nil
+	}
+	if !actionEventTypes[eventType] {
+		return nil, fmt.Errorf("event type %q is outside the clean v1 vocabulary", eventType)
+	}
+
+	action := ActionRecord{
+		ID:               stringField(record, "id"),
+		SessionID:        stringField(record, "session_id"),
+		EventType:        eventType,
+		Status:           stringField(record, "status"),
+		CreatedAt:        stringField(record, "created_at"),
+		UpdatedAt:        stringField(record, "updated_at"),
+		ToolCallID:       safeIDField(record, "tool_use_id"),
+		AdapterEventName: boundedField(record, "adapter_event_name", 128),
+		CorrelationKey:   safeIDField(record, "correlation_key"),
+		ToolName:         boundedField(record, "tool_name", 128),
+		Provider:         boundedField(record, "provider", 128),
+		Operation:        boundedField(record, "operation", 128),
+		OperationClass:   boundedField(record, "operation_class", 128),
+		ResourceClass:    boundedField(record, "resource_class", 128),
+		ResourceID:       boundedField(record, "resource_id", 4096),
+		Parameters:       objectField(record, "parameters_redacted_json"),
+		ParametersHash:   hashField(record, "parameters_hash"),
+		Identity:         mapIdentity(record["identity_context_json"]),
+		IdentityHash:     hashField(record, "identity_hash"),
+		Context:          mapContext(record["context_json"]),
+		ContextHash:      hashField(record, "context_hash"),
+		PolicyID:         boundedField(record, "policy_id", 128),
+		PolicyVersion:    boundedField(record, "policy_version", 128),
+		PolicyHash:       hashField(record, "policy_hash"),
+		AdapterDecision:  boundedField(record, "adapter_decision", 128),
+		ReasonCode:       boundedField(record, "reason_code", 128),
+		Reason:           summaryField(record, "reason"),
+		ModelVersion:     boundedField(record, "model_version", 128),
+		RiskScore:        unitIntervalField(record, "risk_score"),
+		RiskThreshold:    unitIntervalField(record, "risk_threshold"),
+		Confidence:       unitIntervalField(record, "confidence"),
+		MatchedRules:     stringListField(record, "matched_rules_json"),
+		RiskSignals:      stringListField(record, "risk_signals_json"),
+		OutputSummary:    summaryField(record, "output_summary"),
+		OutputHash:       hashField(record, "output_hash"),
+		ErrorRedacted:    summaryField(record, "error_redacted"),
+		ToolInput:        record["tool_input_captured_json"],
+		ToolOutput:       record["tool_output_captured_json"],
+		ProposedAt:       timestampField(record, "proposed_at"),
+		CompletedAt:      timestampField(record, "completed_at"),
+	}
+	if category := stringField(record, "decision_category"); decisionCategories[category] {
+		action.DecisionCategory = category
+	}
+	if level := stringField(record, "risk_level"); riskLevels[level] {
+		action.RiskLevel = level
+	}
+	if outcome := stringField(record, "outcome"); actionOutcomes[outcome] {
+		action.Outcome = outcome
+	}
+	if err := requireTimestamp("created_at", action.CreatedAt); err != nil {
+		return nil, err
+	}
+	if err := requireTimestamp("updated_at", action.UpdatedAt); err != nil {
+		return nil, err
+	}
+	if compareTimestamps(action.CreatedAt, action.UpdatedAt) > 0 {
+		action.CreatedAt = action.UpdatedAt
+	}
+
+	if eventType == "request.decided" {
+		if err := applyDecidedMirrors(&action, record); err != nil {
+			return nil, err
+		}
+	}
+	if err := requireLifecycleFields(&action); err != nil {
+		return nil, err
+	}
+	return &action, nil
+}
+
+// applyDecidedMirrors derives every decision mirror from the fact itself,
+// so the mirrors the server cross-checks (tool_call_id, decided_at,
+// decision_result, status) cannot disagree with it.
+func applyDecidedMirrors(action *ActionRecord, record map[string]any) error {
+	factValue := record["decision_fact_json"]
+	if factValue == nil {
+		return fmt.Errorf("request.decided row carries no decision fact")
+	}
+	factJSON, err := json.Marshal(factValue)
+	if err != nil {
+		return fmt.Errorf("encode decision fact: %w", err)
+	}
+	var fact struct {
+		ToolCallID      string `json:"tool_call_id"`
+		DecidedAt       string `json:"decided_at"`
+		ExecutionAction string `json:"execution_action"`
+	}
+	if err := json.Unmarshal(factJSON, &fact); err != nil {
+		return fmt.Errorf("decode decision fact: %w", err)
+	}
+	if fact.ToolCallID == "" || fact.DecidedAt == "" {
+		return fmt.Errorf("decision fact is missing correlation fields")
+	}
+	action.DecisionFact = json.RawMessage(factJSON)
+	action.ToolCallID = fact.ToolCallID
+	action.DecidedAt = fact.DecidedAt
+	switch fact.ExecutionAction {
+	case "allow":
+		action.DecisionResult = "allow"
+		action.Status = "authorized"
+	case "deny":
+		action.DecisionResult = "deny"
+		action.Status = "blocked"
+	default:
+		return fmt.Errorf("decision fact execution action %q", fact.ExecutionAction)
+	}
+	return nil
+}
+
+func requireLifecycleFields(action *ActionRecord) error {
+	switch action.EventType {
+	case "request.proposed":
+		action.Status = "proposed"
+		if action.ProposedAt == "" {
+			action.ProposedAt = action.CreatedAt
+		}
+	case "request.decided":
+		if action.DecidedAt == "" {
+			return fmt.Errorf("request.decided requires decided_at")
+		}
+	case "request.observed":
+		action.Status = "completed"
+		action.Outcome = "success"
+		if action.CompletedAt == "" {
+			action.CompletedAt = action.UpdatedAt
+		}
+	case "request.failed":
+		action.Status = "failed"
+		action.Outcome = "error"
+		if action.ErrorRedacted == "" {
+			action.ErrorRedacted = "tool call failed"
+		}
+		if action.CompletedAt == "" {
+			action.CompletedAt = action.UpdatedAt
+		}
+	}
+	return nil
+}
+
+func mapReceipt(record map[string]any) (ReceiptRecord, error) {
+	receipt := ReceiptRecord{
+		ID:          stringField(record, "id"),
+		ActionID:    stringField(record, "action_id"),
+		SessionID:   stringField(record, "session_id"),
+		ReceiptType: stringField(record, "receipt_type"),
+		Payload:     record["receipt_payload_json"],
+		Proof: ReceiptProof{
+			ReceiptHash: stringField(record, "receipt_hash"),
+		},
+		CreatedAt: stringField(record, "created_at"),
+	}
+	if receipt.Payload == nil {
+		return ReceiptRecord{}, fmt.Errorf("receipt has no payload")
+	}
+	if !hashPattern.MatchString(receipt.Proof.ReceiptHash) {
+		return ReceiptRecord{}, fmt.Errorf("receipt hash %q is not a sha256 hash", receipt.Proof.ReceiptHash)
+	}
+	if err := requireTimestamp("created_at", receipt.CreatedAt); err != nil {
+		return ReceiptRecord{}, err
+	}
+	// Unsigned receipts omit the signature entirely; the legacy
+	// empty-string/"none" encoding never crosses this wire.
+	if stringField(record, "signature_algorithm") == "ed25519" {
+		signature := stringField(record, "signature")
+		keyID := stringField(record, "key_id")
+		if signature != "" && keyID != "" {
+			receipt.Proof.Signature = &ReceiptSignature{
+				Algorithm: "ed25519",
+				KeyID:     keyID,
+				Value:     signature,
+			}
+		}
+	}
+	return receipt, nil
+}
+
+func mapIdentity(value any) *Identity {
+	object, ok := value.(map[string]any)
+	if !ok {
+		return nil
+	}
+	identity := Identity{
+		Agent:         boundedString(object["agent"], 128),
+		AgentProvider: boundedString(object["agent_provider"], 128),
+	}
+	if identity == (Identity{}) {
+		return nil
+	}
+	return &identity
+}
+
+func mapContext(value any) *ActionContext {
+	object, ok := value.(map[string]any)
+	if !ok {
+		return nil
+	}
+	context := ActionContext{
+		CWD:           boundedString(object["cwd"], 4096),
+		HookEventName: boundedString(object["hook_event_name"], 128),
+	}
+	// Locally the capture setting is a configuration object; the wire
+	// carries only the effective mode.
+	if capture, ok := object["payload_capture"].(map[string]any); ok {
+		if mode := boundedString(capture["effective_mode"], 128); captureModes[mode] {
+			context.PayloadCapture = mode
+		}
+	} else if mode := boundedString(object["payload_capture"], 128); captureModes[mode] {
+		context.PayloadCapture = mode
+	}
+	if github, ok := object["github"].(map[string]any); ok {
+		if branch := boundedString(github["branch_or_ref"], 512); branch != "" {
+			context.GitHub = &ContextGitHub{BranchOrRef: branch}
+		}
+	}
+	if context == (ActionContext{}) {
+		return nil
+	}
+	return &context
+}
+
+// --- field helpers -----------------------------------------------------------
+
+func stringField(record map[string]any, key string) string {
+	value, _ := record[key].(string)
+	return value
+}
+
+func boundedField(record map[string]any, key string, max int) string {
+	return boundedString(record[key], max)
+}
+
+func boundedString(value any, max int) string {
+	text, _ := value.(string)
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+	if len(text) > max {
+		return truncateUTF8(text, max)
+	}
+	return text
+}
+
+func summaryField(record map[string]any, key string) string {
+	return boundedField(record, key, 4096)
+}
+
+func safeIDField(record map[string]any, key string) string {
+	value := stringField(record, key)
+	if !safeIDPattern.MatchString(value) {
+		return ""
+	}
+	return value
+}
+
+func hashField(record map[string]any, key string) string {
+	value := stringField(record, key)
+	if !hashPattern.MatchString(value) {
+		return ""
+	}
+	return value
+}
+
+func timestampField(record map[string]any, key string) string {
+	value := stringField(record, key)
+	if !timestampPattern.MatchString(value) {
+		return ""
+	}
+	return value
+}
+
+func requireTimestamp(field, value string) error {
+	if !timestampPattern.MatchString(value) {
+		return fmt.Errorf("%s %q is not a UTC RFC 3339 timestamp", field, value)
+	}
+	return nil
+}
+
+func unitIntervalField(record map[string]any, key string) *float64 {
+	value, ok := record[key].(float64)
+	if !ok || value < 0 || value > 1 {
+		return nil
+	}
+	return &value
+}
+
+func objectField(record map[string]any, key string) map[string]any {
+	object, ok := record[key].(map[string]any)
+	if !ok || len(object) == 0 {
+		return nil
+	}
+	return object
+}
+
+func stringListField(record map[string]any, key string) []string {
+	values, ok := record[key].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		text := boundedString(value, 256)
+		if text == "" {
+			continue
+		}
+		out = append(out, text)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// compareTimestamps orders two contract timestamps. Lexicographic
+// comparison is only correct at equal fractional length, so compare on the
+// zero-padded nine-digit form.
+func compareTimestamps(a, b string) int {
+	return strings.Compare(padTimestamp(a), padTimestamp(b))
+}
+
+func padTimestamp(value string) string {
+	trimmed := strings.TrimSuffix(value, "Z")
+	whole, fraction, _ := strings.Cut(trimmed, ".")
+	return whole + "." + fraction + strings.Repeat("0", 9-len(fraction))
+}
+
+func truncateUTF8(text string, max int) string {
+	for max > 0 && max < len(text) {
+		if text[max]&0xC0 != 0x80 {
+			return text[:max]
+		}
+		max--
+	}
+	return text
+}
+
+func stringSet(values ...string) map[string]bool {
+	set := make(map[string]bool, len(values))
+	for _, value := range values {
+		set[value] = true
+	}
+	return set
+}
+
+// Closed-vocabulary guards shared with the store's receipt builder, so the
+// payloads it commits to hashes only ever contain contract values.
+
+func ValidRiskLevel(value string) bool { return riskLevels[value] }
+
+func ValidDecisionCategory(value string) bool { return decisionCategories[value] }
+
+func ValidActionOutcome(value string) bool { return actionOutcomes[value] }
+
+func ValidHash(value string) bool { return hashPattern.MatchString(value) }

--- a/internal/ledgeringest/wire.go
+++ b/internal/ledgeringest/wire.go
@@ -1,0 +1,157 @@
+package ledgeringest
+
+import "encoding/json"
+
+// Typed clean-v1 wire model for POST /api/v1/authorization-ledger/batches.
+//
+// Field names and optionality mirror the pinned contract bundle exactly;
+// the transport test validates real flush bytes against the vendored batch
+// schema, so a drifting tag fails CI rather than the server. Optional
+// fields are omitted, never null — hence string zero values and pointer
+// numerics.
+
+// Batch is the clean v1 envelope.
+type Batch struct {
+	BatchVersion       string              `json:"batch_version"`
+	BatchID            string              `json:"batch_id"`
+	InstallationID     string              `json:"installation_id"`
+	SentAt             string              `json:"sent_at"`
+	Device             *Device             `json:"device,omitempty"`
+	Sessions           []SessionRecord     `json:"sessions"`
+	Actions            []ActionRecord      `json:"actions"`
+	Receipts           []ReceiptRecord     `json:"receipts"`
+	ReceiptChainAnchor *ReceiptChainAnchor `json:"receipt_chain_anchor,omitempty"`
+}
+
+type Device struct {
+	Label             string `json:"label,omitempty"`
+	DeploymentVersion string `json:"deployment_version,omitempty"`
+	CLIVersion        string `json:"cli_version,omitempty"`
+	UserEmail         string `json:"user_email,omitempty"`
+}
+
+// ReceiptChainAnchor repeats the first receipt's chain link; the empty
+// string marks a chain genesis.
+type ReceiptChainAnchor struct {
+	PreviousReceiptHash string `json:"previous_receipt_hash"`
+}
+
+// Identity is the closed object replacing identity_context_json.
+type Identity struct {
+	Agent         string `json:"agent,omitempty"`
+	AgentProvider string `json:"agent_provider,omitempty"`
+}
+
+type SessionRecord struct {
+	ID                string    `json:"id"`
+	Source            string    `json:"source"`
+	Status            string    `json:"status"`
+	CreatedAt         string    `json:"created_at"`
+	UpdatedAt         string    `json:"updated_at"`
+	RuntimeKind       string    `json:"runtime_kind,omitempty"`
+	RuntimeInstanceID string    `json:"runtime_instance_id,omitempty"`
+	AdapterKind       string    `json:"adapter_kind,omitempty"`
+	AdapterVersion    string    `json:"adapter_version,omitempty"`
+	AgentProvider     string    `json:"agent_provider,omitempty"`
+	Agent             string    `json:"agent,omitempty"`
+	ConversationID    string    `json:"conversation_id,omitempty"`
+	TraceID           string    `json:"trace_id,omitempty"`
+	PrincipalID       string    `json:"principal_id,omitempty"`
+	Identity          *Identity `json:"identity,omitempty"`
+	IdentityHash      string    `json:"identity_hash,omitempty"`
+	PolicyVersion     string    `json:"policy_version,omitempty"`
+	PolicyHash        string    `json:"policy_hash,omitempty"`
+	CWD               string    `json:"cwd,omitempty"`
+	Mode              string    `json:"mode,omitempty"`
+	ExternalID        string    `json:"external_id,omitempty"`
+	ClosedAt          string    `json:"closed_at,omitempty"`
+}
+
+// ActionContext is the closed object replacing context_json.
+type ActionContext struct {
+	CWD            string         `json:"cwd,omitempty"`
+	HookEventName  string         `json:"hook_event_name,omitempty"`
+	PayloadCapture string         `json:"payload_capture,omitempty"`
+	GitHub         *ContextGitHub `json:"github,omitempty"`
+}
+
+type ContextGitHub struct {
+	BranchOrRef string `json:"branch_or_ref,omitempty"`
+}
+
+type ActionRecord struct {
+	ID        string `json:"id"`
+	SessionID string `json:"session_id"`
+	EventType string `json:"event_type"`
+	Status    string `json:"status"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+
+	ToolCallID       string `json:"tool_call_id,omitempty"`
+	AdapterEventName string `json:"adapter_event_name,omitempty"`
+	CorrelationKey   string `json:"correlation_key,omitempty"`
+
+	ToolName       string         `json:"tool_name,omitempty"`
+	Provider       string         `json:"provider,omitempty"`
+	Operation      string         `json:"operation,omitempty"`
+	OperationClass string         `json:"operation_class,omitempty"`
+	ResourceClass  string         `json:"resource_class,omitempty"`
+	ResourceID     string         `json:"resource_id,omitempty"`
+	Parameters     map[string]any `json:"parameters,omitempty"`
+	ParametersHash string         `json:"parameters_hash,omitempty"`
+
+	Identity     *Identity      `json:"identity,omitempty"`
+	IdentityHash string         `json:"identity_hash,omitempty"`
+	Context      *ActionContext `json:"context,omitempty"`
+	ContextHash  string         `json:"context_hash,omitempty"`
+
+	PolicyID         string          `json:"policy_id,omitempty"`
+	PolicyVersion    string          `json:"policy_version,omitempty"`
+	PolicyHash       string          `json:"policy_hash,omitempty"`
+	DecisionResult   string          `json:"decision_result,omitempty"`
+	DecisionCategory string          `json:"decision_category,omitempty"`
+	AdapterDecision  string          `json:"adapter_decision,omitempty"`
+	ReasonCode       string          `json:"reason_code,omitempty"`
+	Reason           string          `json:"reason,omitempty"`
+	DecisionFact     json.RawMessage `json:"decision_fact,omitempty"`
+
+	RiskLevel     string   `json:"risk_level,omitempty"`
+	RiskScore     *float64 `json:"risk_score,omitempty"`
+	RiskThreshold *float64 `json:"risk_threshold,omitempty"`
+	ModelVersion  string   `json:"model_version,omitempty"`
+	Confidence    *float64 `json:"confidence,omitempty"`
+	MatchedRules  []string `json:"matched_rules,omitempty"`
+	RiskSignals   []string `json:"risk_signals,omitempty"`
+
+	Outcome       string `json:"outcome,omitempty"`
+	OutputSummary string `json:"output_summary,omitempty"`
+	OutputHash    string `json:"output_hash,omitempty"`
+	ErrorRedacted string `json:"error_redacted,omitempty"`
+	ToolInput     any    `json:"tool_input,omitempty"`
+	ToolOutput    any    `json:"tool_output,omitempty"`
+
+	ProposedAt  string `json:"proposed_at,omitempty"`
+	DecidedAt   string `json:"decided_at,omitempty"`
+	CompletedAt string `json:"completed_at,omitempty"`
+}
+
+type ReceiptRecord struct {
+	ID          string       `json:"id"`
+	ActionID    string       `json:"action_id"`
+	SessionID   string       `json:"session_id"`
+	ReceiptType string       `json:"receipt_type"`
+	Payload     any          `json:"payload"`
+	Proof       ReceiptProof `json:"proof"`
+	CreatedAt   string       `json:"created_at"`
+}
+
+type ReceiptProof struct {
+	ReceiptHash string            `json:"receipt_hash"`
+	Signature   *ReceiptSignature `json:"signature,omitempty"`
+}
+
+type ReceiptSignature struct {
+	Algorithm string `json:"algorithm"`
+	KeyID     string `json:"key_id"`
+	Value     string `json:"value"`
+}

--- a/internal/managedobserve/daemon_test.go
+++ b/internal/managedobserve/daemon_test.go
@@ -108,7 +108,7 @@ func TestDaemonStreamsLedgerBatches(t *testing.T) {
 		} `json:"device,omitempty"`
 		Actions []struct {
 			SessionID string `json:"session_id"`
-		} `json:"authorization_actions"`
+		} `json:"actions"`
 	}
 
 	requests := make(chan ledgerBatchRequest, 1)

--- a/internal/managedstream/stream.go
+++ b/internal/managedstream/stream.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
+	"github.com/kontext-security/kontext-cli/internal/ledgeringest"
 )
 
 const (
@@ -202,13 +203,26 @@ func Flush(ctx context.Context, opts Options) error {
 			return postHeartbeatIfDue(ctx, opts, statePath, state, now)
 		}
 
-		payload := newPayload(opts, batch.Sessions, batch.Actions, batch.Receipts, batch.ReceiptChainAnchor, now)
-
-		body, err := json.Marshal(payload)
+		body, counts, err := payloadBody(opts, batch, now)
 		if err != nil {
-			return err
+			// A page that cannot be represented on its contract form is
+			// isolated like any other poison page: shrink to find it, then
+			// advance past it rather than retrying it forever.
+			reason := fmt.Sprintf("payload mapping failed: %v", err)
+			if limit == 1 {
+				return advancePastMinimumBatch(statePath, batch, state, reason, err)
+			}
+			nextLimit := reducedBatchLimit(limit)
+			opts.Diagnostic.Printf(
+				"managed stream %s; reducing batch limit from %d to %d\n",
+				reason,
+				limit,
+				nextLimit,
+			)
+			limit = nextLimit
+			continue
 		}
-		if reason := payloadLimitViolation(payload, len(body)); reason != "" {
+		if reason := payloadLimitViolation(counts, len(body)); reason != "" {
 			if limit == 1 {
 				return advancePastMinimumBatch(statePath, batch, state, reason, nil)
 			}
@@ -223,29 +237,38 @@ func Flush(ctx context.Context, opts Options) error {
 			continue
 		}
 
-		if err := post(ctx, opts, body); err != nil {
-			var hostedErr *hostedIngestError
-			if errors.As(err, &hostedErr) && shouldRetryWithSmallerBatch(hostedErr.StatusCode) {
-				if limit == 1 {
-					return err
+		// A page can map to zero wire records (local-only session lifecycle
+		// rows); its cursor still advances below, it just posts nothing.
+		if body != nil {
+			if err := post(ctx, opts, body); err != nil {
+				var hostedErr *hostedIngestError
+				if errors.As(err, &hostedErr) && shouldIsolateBatch(hostedErr.StatusCode, batch.Form) {
+					if limit == 1 {
+						if hostedErr.StatusCode == http.StatusConflict {
+							// A replay conflict never resolves by retrying the
+							// same bytes; record it and move on.
+							return advancePastMinimumBatch(statePath, batch, state, "hosted replay conflict", err)
+						}
+						return err
+					}
+					nextLimit := reducedBatchLimit(limit)
+					opts.Diagnostic.Printf(
+						"managed stream hosted ingest returned status %d; reducing batch limit from %d to %d\n",
+						hostedErr.StatusCode,
+						limit,
+						nextLimit,
+					)
+					limit = nextLimit
+					continue
 				}
-				nextLimit := reducedBatchLimit(limit)
-				opts.Diagnostic.Printf(
-					"managed stream hosted ingest returned status %d; reducing batch limit from %d to %d\n",
-					hostedErr.StatusCode,
-					limit,
-					nextLimit,
-				)
-				limit = nextLimit
-				continue
+				return err
 			}
-			return err
-		}
 
-		// The hosted ledger accepted a post with this token — proof the
-		// credential works, which is what breadcrumb-clearing needs.
-		if opts.OnFlushSuccess != nil {
-			opts.OnFlushSuccess()
+			// The hosted ledger accepted a post with this token — proof the
+			// credential works, which is what breadcrumb-clearing needs.
+			if opts.OnFlushSuccess != nil {
+				opts.OnFlushSuccess()
+			}
 		}
 
 		// Reductions are multiplicative and per-region; recovery is additive
@@ -294,8 +317,12 @@ func postHeartbeatIfDue(ctx context.Context, opts Options, statePath string, sta
 		return err
 	}
 
-	payload := newPayload(opts, nil, nil, nil, nil, now)
-	body, err := json.Marshal(payload)
+	// Heartbeats carry no records, so nothing pins them to the legacy form.
+	heartbeat, err := v1Batch(opts, sqlite.LedgerBatch{}, now)
+	if err != nil {
+		return err
+	}
+	body, err := json.Marshal(heartbeat)
 	if err != nil {
 		return err
 	}
@@ -308,6 +335,80 @@ func postHeartbeatIfDue(ctx context.Context, opts Options, statePath string, sta
 	}
 	state.LastHeartbeatAt = now.Format(time.RFC3339Nano)
 	return SaveState(statePath, state)
+}
+
+type payloadCounts struct {
+	sessions int
+	actions  int
+	receipts int
+}
+
+// payloadBody serializes one export page under the wire form the store
+// selected for it. A nil body with a nil error is a page whose records are
+// all local-only (nothing to post; the cursor still advances).
+func payloadBody(opts Options, batch sqlite.LedgerBatch, now time.Time) ([]byte, payloadCounts, error) {
+	if batch.Form == sqlite.LedgerFormV1 {
+		mapped, err := v1Batch(opts, batch, now)
+		if err != nil {
+			return nil, payloadCounts{}, err
+		}
+		counts := payloadCounts{
+			sessions: len(mapped.Sessions),
+			actions:  len(mapped.Actions),
+			receipts: len(mapped.Receipts),
+		}
+		if counts.sessions == 0 && counts.actions == 0 && counts.receipts == 0 {
+			return nil, counts, nil
+		}
+		body, err := json.Marshal(mapped)
+		return body, counts, err
+	}
+
+	payload := newPayload(opts, batch.Sessions, batch.Actions, batch.Receipts, batch.ReceiptChainAnchor, now)
+	counts := payloadCounts{
+		sessions: len(payload.Sessions),
+		actions:  len(payload.Actions),
+		receipts: len(payload.Receipts),
+	}
+	body, err := json.Marshal(payload)
+	return body, counts, err
+}
+
+func v1Batch(opts Options, batch sqlite.LedgerBatch, now time.Time) (ledgeringest.Batch, error) {
+	var anchor *string
+	if batch.ReceiptChainAnchor != nil {
+		anchor = &batch.ReceiptChainAnchor.PreviousReceiptHash
+	}
+	return ledgeringest.MapBatch(ledgeringest.BatchInput{
+		BatchID:                   "batch_" + uuid.NewString(),
+		InstallationID:            opts.InstallationID,
+		SentAt:                    now.Format(time.RFC3339Nano),
+		Device:                    v1Device(opts),
+		Sessions:                  recordMaps(batch.Sessions),
+		Actions:                   recordMaps(batch.Actions),
+		Receipts:                  recordMaps(batch.Receipts),
+		AnchorPreviousReceiptHash: anchor,
+	})
+}
+
+func v1Device(opts Options) *ledgeringest.Device {
+	label, deploymentVersion, userEmail := deviceValues(opts)
+	if label == "" && deploymentVersion == "" && userEmail == "" {
+		return nil
+	}
+	return &ledgeringest.Device{
+		Label:             label,
+		DeploymentVersion: deploymentVersion,
+		UserEmail:         userEmail,
+	}
+}
+
+func recordMaps(records []sqlite.LedgerRecord) []map[string]any {
+	out := make([]map[string]any, len(records))
+	for index, record := range records {
+		out[index] = record
+	}
+	return out
 }
 
 func newPayload(
@@ -328,18 +429,22 @@ func newPayload(
 		Receipts:           nonNilRecords(receipts),
 		ReceiptChainAnchor: receiptChainAnchor,
 	}
-	// Resolve the deployment version per flush so an in-place package upgrade
-	// is reflected without restarting the daemon.
-	label := strings.TrimSpace(opts.DeviceLabel)
-	userEmail := strings.TrimSpace(opts.UserEmail)
-	deploymentVersion := ""
-	if opts.DeploymentVersion != nil {
-		deploymentVersion = strings.TrimSpace(opts.DeploymentVersion())
-	}
+	label, deploymentVersion, userEmail := deviceValues(opts)
 	if label != "" || deploymentVersion != "" || userEmail != "" {
 		payload.Device = &Device{Label: label, DeploymentVersion: deploymentVersion, UserEmail: userEmail}
 	}
 	return payload
+}
+
+// deviceValues resolves the deployment version per flush so an in-place
+// package upgrade is reflected without restarting the daemon.
+func deviceValues(opts Options) (label, deploymentVersion, userEmail string) {
+	label = strings.TrimSpace(opts.DeviceLabel)
+	userEmail = strings.TrimSpace(opts.UserEmail)
+	if opts.DeploymentVersion != nil {
+		deploymentVersion = strings.TrimSpace(opts.DeploymentVersion())
+	}
+	return label, deploymentVersion, userEmail
 }
 
 func nonNilRecords(records []sqlite.LedgerRecord) []sqlite.LedgerRecord {
@@ -419,14 +524,25 @@ func shouldRetryWithSmallerBatch(statusCode int) bool {
 	return statusCode == http.StatusRequestEntityTooLarge
 }
 
-func payloadLimitViolation(payload Payload, bodyBytes int) string {
+// shouldIsolateBatch reports whether shrinking the page can isolate the
+// failing record. Oversized bodies always qualify; on the v1 contract a
+// replay conflict (409) does too — the same bytes never succeed on retry,
+// so the poison row must be found and skipped.
+func shouldIsolateBatch(statusCode int, form string) bool {
+	if shouldRetryWithSmallerBatch(statusCode) {
+		return true
+	}
+	return form == sqlite.LedgerFormV1 && statusCode == http.StatusConflict
+}
+
+func payloadLimitViolation(counts payloadCounts, bodyBytes int) string {
 	switch {
-	case len(payload.Sessions) > maxPayloadSessions:
-		return fmt.Sprintf("agent_sessions=%d exceeds max %d", len(payload.Sessions), maxPayloadSessions)
-	case len(payload.Actions) > maxPayloadActions:
-		return fmt.Sprintf("authorization_actions=%d exceeds max %d", len(payload.Actions), maxPayloadActions)
-	case len(payload.Receipts) > maxPayloadReceipts:
-		return fmt.Sprintf("authorization_receipts=%d exceeds max %d", len(payload.Receipts), maxPayloadReceipts)
+	case counts.sessions > maxPayloadSessions:
+		return fmt.Sprintf("sessions=%d exceeds max %d", counts.sessions, maxPayloadSessions)
+	case counts.actions > maxPayloadActions:
+		return fmt.Sprintf("actions=%d exceeds max %d", counts.actions, maxPayloadActions)
+	case counts.receipts > maxPayloadReceipts:
+		return fmt.Sprintf("receipts=%d exceeds max %d", counts.receipts, maxPayloadReceipts)
 	case bodyBytes > MaxPayloadBytes:
 		return fmt.Sprintf("body_bytes=%d exceeds max %d", bodyBytes, MaxPayloadBytes)
 	default:

--- a/internal/managedstream/stream_test.go
+++ b/internal/managedstream/stream_test.go
@@ -41,7 +41,7 @@ func TestFlushPostsLedgerBatchWithInstallationIdentity(t *testing.T) {
 	store, dbPath := testStore(t)
 	saveTestDecision(t, store, "session-1", "toolu_1")
 
-	var got Payload
+	var got wireBatch
 	server := capturePayloadServer(t, &got)
 	t.Cleanup(server.Close)
 
@@ -59,8 +59,8 @@ func TestFlushPostsLedgerBatchWithInstallationIdentity(t *testing.T) {
 		t.Fatalf("Flush() error = %v", err)
 	}
 
-	if got.SchemaVersion != SchemaVersion {
-		t.Fatalf("schema_version = %q, want %q", got.SchemaVersion, SchemaVersion)
+	if got.BatchVersion != "v1" {
+		t.Fatalf("batch_version = %q, want v1", got.BatchVersion)
 	}
 	if got.InstallationID != "ins_0123456789abcdefghijklmnopqrstuv" {
 		t.Fatalf("installation_id = %q", got.InstallationID)
@@ -74,8 +74,8 @@ func TestFlushPostsLedgerBatchWithInstallationIdentity(t *testing.T) {
 	if len(got.Sessions) != 1 || len(got.Actions) != 2 || len(got.Receipts) != 2 {
 		t.Fatalf("batch counts = sessions %d actions %d receipts %d", len(got.Sessions), len(got.Actions), len(got.Receipts))
 	}
-	if got.Actions[0]["canonical_event_type"] != "request.proposed" ||
-		got.Actions[1]["canonical_event_type"] != "request.decided" ||
+	if got.Actions[0]["event_type"] != "request.proposed" ||
+		got.Actions[1]["event_type"] != "request.decided" ||
 		got.Actions[1]["decision_result"] != "allow" {
 		t.Fatalf("actions = %+v, want proposed and decided ledger events", got.Actions)
 	}
@@ -96,7 +96,7 @@ func TestFlushOmitsBlankDeviceLabel(t *testing.T) {
 	store, dbPath := testStore(t)
 	saveTestDecision(t, store, "session-1", "toolu_1")
 
-	var got Payload
+	var got wireBatch
 	server := capturePayloadServer(t, &got)
 	t.Cleanup(server.Close)
 
@@ -122,7 +122,7 @@ func TestFlushEmitsDeviceForUserEmailAlone(t *testing.T) {
 	store, dbPath := testStore(t)
 	saveTestDecision(t, store, "session-1", "toolu_1")
 
-	var got Payload
+	var got wireBatch
 	server := capturePayloadServer(t, &got)
 	t.Cleanup(server.Close)
 
@@ -147,7 +147,7 @@ func TestFlushResolvesDeploymentVersionPerFlush(t *testing.T) {
 	store, dbPath := testStore(t)
 	saveTestDecision(t, store, "session-1", "toolu_1")
 
-	var got Payload
+	var got wireBatch
 	server := capturePayloadServer(t, &got)
 	t.Cleanup(server.Close)
 
@@ -214,7 +214,7 @@ func TestFlushCapsBatchLimitBeforePosting(t *testing.T) {
 		saveTestDecision(t, store, fmt.Sprintf("session-%03d", i), fmt.Sprintf("toolu_%03d", i))
 	}
 
-	var got Payload
+	var got wireBatch
 	server := capturePayloadServer(t, &got)
 	t.Cleanup(server.Close)
 
@@ -247,7 +247,7 @@ func TestFlushDrainsBacklogInOneCall(t *testing.T) {
 	var posts int
 	shipped := map[string]bool{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var payload Payload
+		var payload wireBatch
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 			t.Errorf("decode payload: %v", err)
 		}
@@ -294,13 +294,13 @@ func TestFlushReexportsRowsThatCommitAfterCursorAdvance(t *testing.T) {
 	var mu sync.Mutex
 	shippedToolUseIDs := map[string]bool{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var payload Payload
+		var payload wireBatch
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 			t.Errorf("decode payload: %v", err)
 		}
 		mu.Lock()
 		for _, action := range payload.Actions {
-			if id, ok := action["tool_use_id"].(string); ok {
+			if id, ok := action["tool_call_id"].(string); ok {
 				shippedToolUseIDs[id] = true
 			}
 		}
@@ -383,7 +383,7 @@ func TestFlushRetriesWithSmallerBatchWhenHostedBackendRejectsSize(t *testing.T) 
 
 	var actionCounts []int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var got Payload
+		var got wireBatch
 		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
 			t.Fatalf("Decode() error = %v", err)
 		}
@@ -837,7 +837,7 @@ func TestFlushUsesUpdatedAfterCursor(t *testing.T) {
 func TestFlushPostsHeartbeatWhenNoActionsArePending(t *testing.T) {
 	_, dbPath := testStore(t)
 
-	var got Payload
+	var got wireBatch
 	server := capturePayloadServer(t, &got)
 	t.Cleanup(server.Close)
 
@@ -857,8 +857,8 @@ func TestFlushPostsHeartbeatWhenNoActionsArePending(t *testing.T) {
 		t.Fatalf("Flush() error = %v", err)
 	}
 
-	if got.SchemaVersion != SchemaVersion {
-		t.Fatalf("schema_version = %q, want %q", got.SchemaVersion, SchemaVersion)
+	if got.BatchVersion != "v1" {
+		t.Fatalf("batch_version = %q, want v1", got.BatchVersion)
 	}
 	if got.InstallationID != "ins_0123456789abcdefghijklmnopqrstuv" {
 		t.Fatalf("installation_id = %q", got.InstallationID)
@@ -1009,7 +1009,20 @@ func testStore(t *testing.T) (*sqlite.Store, string) {
 	return store, dbPath
 }
 
-func capturePayloadServer(t *testing.T, got *Payload) *httptest.Server {
+// wireBatch decodes the clean-v1 envelope the flush posts for pages of
+// post-cutover rows (the only kind a fresh test store produces).
+type wireBatch struct {
+	BatchVersion   string           `json:"batch_version"`
+	BatchID        string           `json:"batch_id"`
+	InstallationID string           `json:"installation_id"`
+	SentAt         string           `json:"sent_at"`
+	Device         *Device          `json:"device"`
+	Sessions       []map[string]any `json:"sessions"`
+	Actions        []map[string]any `json:"actions"`
+	Receipts       []map[string]any `json:"receipts"`
+}
+
+func capturePayloadServer(t *testing.T, got *wireBatch) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != DefaultEndpoint {
@@ -1097,7 +1110,7 @@ func TestFlushRestoresBatchLimitAfterReduction(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		var payload Payload
+		var payload wireBatch
 		if err := json.Unmarshal(body, &payload); err != nil {
 			t.Fatal(err)
 		}

--- a/internal/managedstream/wirecontract_test.go
+++ b/internal/managedstream/wirecontract_test.go
@@ -1,0 +1,226 @@
+package managedstream
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+
+	"github.com/kontext-security/kontext-cli/internal/guard/risk"
+)
+
+// Validates the bytes the daemon actually uploads against the pinned
+// published contract (docs/contracts/ledger-ingest/v1).
+//
+// It deliberately validates bytes captured off the wire, decoded into an
+// UNTYPED JSON value: records are assembled from database rows and mapped
+// field by field, so a typed test struct could silently hide a dropped or
+// misnamed field that the schema would reject.
+
+const batchSchemaPath = "../../docs/contracts/ledger-ingest/v1/ledger-batch.schema.json"
+
+func loadBatchSchema(t *testing.T) *jsonschema.Schema {
+	t.Helper()
+	raw, err := os.ReadFile(batchSchemaPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", batchSchemaPath, err)
+	}
+	doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("parse %s: %v", batchSchemaPath, err)
+	}
+	compiler := jsonschema.NewCompiler()
+	compiler.AssertFormat()
+	if err := compiler.AddResource("ledger-batch.schema.json", doc); err != nil {
+		t.Fatalf("add schema resource: %v", err)
+	}
+	schema, err := compiler.Compile("ledger-batch.schema.json")
+	if err != nil {
+		t.Fatalf("compile schema: %v", err)
+	}
+	return schema
+}
+
+// captureRawBodies returns a server recording every posted body verbatim.
+func captureRawBodies(t *testing.T, bodies *[][]byte) *httptest.Server {
+	t.Helper()
+	var mu sync.Mutex
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		mu.Lock()
+		*bodies = append(*bodies, raw)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
+func flushOptions(dbPath, statePath, serverURL string, client *http.Client) Options {
+	return Options{
+		DBPath:         dbPath,
+		StatePath:      statePath,
+		CloudURL:       serverURL,
+		InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
+		InstallToken:   "test-install-token",
+		DeviceLabel:    "wire-contract-runner",
+		UserEmail:      "operator@example.com",
+		HTTPClient:     client,
+	}
+}
+
+func TestFlushedBatchMatchesPinnedContract(t *testing.T) {
+	store, dbPath := testStore(t)
+
+	// Session lifecycle rows are local-only; the tool-call rows below cover
+	// every clean lifecycle stage including a captured output and a failure.
+	for _, hookEvent := range []string{"SessionStart", "PreToolUse", "PostToolUse", "PostToolUseFailure", "SessionEnd"} {
+		decision := risk.RiskDecision{
+			Decision:   risk.DecisionAllow,
+			ReasonCode: "normal_tool_call",
+			Reason:     "normal",
+			RiskEvent:  risk.RiskEvent{Type: risk.EventNormalToolCall, RequestSummary: "read a file"},
+		}
+		if _, err := store.SaveDecision(context.Background(), risk.HookEvent{
+			SessionID:     "sess-wire-contract",
+			Agent:         "claude",
+			CWD:           "/tmp/project",
+			HookEventName: hookEvent,
+			ToolName:      "Read",
+			ToolUseID:     "toolu_wire_contract",
+			ToolResponse:  map[string]any{"ok": true},
+		}, decision); err != nil {
+			t.Fatalf("SaveDecision(%s) error = %v", hookEvent, err)
+		}
+	}
+
+	var bodies [][]byte
+	server := captureRawBodies(t, &bodies)
+	t.Cleanup(server.Close)
+
+	statePath := filepath.Join(t.TempDir(), "stream-state.json")
+	if err := Flush(context.Background(), flushOptions(dbPath, statePath, server.URL, server.Client())); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if len(bodies) == 0 {
+		t.Fatal("no batch was posted")
+	}
+
+	schema := loadBatchSchema(t)
+	for index, raw := range bodies {
+		value, err := jsonschema.UnmarshalJSON(bytes.NewReader(raw))
+		if err != nil {
+			t.Fatalf("decode posted body %d: %v", index, err)
+		}
+		if err := schema.Validate(value); err != nil {
+			t.Fatalf("posted body %d violates the pinned contract: %v\n%s", index, err, raw)
+		}
+		for _, legacyMarker := range []string{
+			`"agent_sessions"`, `"authorization_actions"`, `"authorization_receipts"`,
+			`"schema_version"`, `"tool_use_id"`, `"canonical_event_type"`, `_json"`,
+		} {
+			// decision_fact carries its own schema_version; only the envelope
+			// marker is a legacy leak.
+			if legacyMarker == `"schema_version"` &&
+				bytes.Contains(raw, []byte(`"decision_fact"`)) {
+				continue
+			}
+			if bytes.Contains(raw, []byte(legacyMarker)) {
+				t.Fatalf("posted body %d contains legacy field %s:\n%s", index, legacyMarker, raw)
+			}
+		}
+		var batch wireBatch
+		if err := json.Unmarshal(raw, &batch); err != nil {
+			t.Fatalf("decode batch %d: %v", index, err)
+		}
+		for _, action := range batch.Actions {
+			eventType, _ := action["event_type"].(string)
+			if strings.HasPrefix(eventType, "session.") {
+				t.Fatalf("session lifecycle row leaked onto the wire: %v", action)
+			}
+		}
+	}
+}
+
+func TestHeartbeatMatchesPinnedContract(t *testing.T) {
+	_, dbPath := testStore(t)
+
+	var bodies [][]byte
+	server := captureRawBodies(t, &bodies)
+	t.Cleanup(server.Close)
+
+	statePath := filepath.Join(t.TempDir(), "stream-state.json")
+	if err := Flush(context.Background(), flushOptions(dbPath, statePath, server.URL, server.Client())); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if len(bodies) != 1 {
+		t.Fatalf("posted %d bodies, want one heartbeat", len(bodies))
+	}
+
+	value, err := jsonschema.UnmarshalJSON(bytes.NewReader(bodies[0]))
+	if err != nil {
+		t.Fatalf("decode heartbeat: %v", err)
+	}
+	if err := loadBatchSchema(t).Validate(value); err != nil {
+		t.Fatalf("heartbeat violates the pinned contract: %v\n%s", err, bodies[0])
+	}
+}
+
+// Pre-cutover rows (receipts stored before the clean-payload change, marked
+// by the payload_form column default) pin their page to the legacy form:
+// their payload bytes were hashed under the old serialization and can never
+// satisfy the clean contract. This is the deterministic drain path for the
+// backlog a daemon upgrade leaves behind.
+func TestFlushShipsPreCutoverPagesOnLegacyForm(t *testing.T) {
+	store, dbPath := testStore(t)
+	saveTestDecision(t, store, "sess-pre-cutover", "toolu_pre_cutover")
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(`update authorization_receipts set payload_form = 'legacy'`); err != nil {
+		t.Fatalf("mark receipts legacy: %v", err)
+	}
+
+	var bodies [][]byte
+	server := captureRawBodies(t, &bodies)
+	t.Cleanup(server.Close)
+
+	statePath := filepath.Join(t.TempDir(), "stream-state.json")
+	if err := Flush(context.Background(), flushOptions(dbPath, statePath, server.URL, server.Client())); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if len(bodies) != 1 {
+		t.Fatalf("posted %d bodies, want one legacy batch", len(bodies))
+	}
+
+	var legacy Payload
+	if err := json.Unmarshal(bodies[0], &legacy); err != nil {
+		t.Fatalf("decode legacy batch: %v", err)
+	}
+	if legacy.SchemaVersion != SchemaVersion {
+		t.Fatalf("schema_version = %q, want the legacy form for pre-cutover rows", legacy.SchemaVersion)
+	}
+	if bytes.Contains(bodies[0], []byte(`"batch_version"`)) {
+		t.Fatalf("legacy batch carries the v1 marker (hybrid form): %s", bodies[0])
+	}
+	if bytes.Contains(bodies[0], []byte(`"payload_form"`)) {
+		t.Fatalf("local cutover column leaked onto the wire: %s", bodies[0])
+	}
+	if len(legacy.Actions) == 0 || len(legacy.Receipts) == 0 {
+		t.Fatalf("legacy batch counts = actions %d receipts %d, want the full page", len(legacy.Actions), len(legacy.Receipts))
+	}
+}


### PR DESCRIPTION
## What

Stacked on #447. Moves the daemon's producer onto the published **ledger-ingest v1** contract — typed records, clean field names, JCS-hashed receipts — with a deterministic drain path for pre-upgrade backlog and **no error-driven form fallback**.

## How

- **Typed wire model + mapper** (`internal/ledgeringest`): the single legacy→v1 name authority. Renames (`canonical_event_type`→`event_type`, `decision_at`→`decided_at`, `*_json` names dropped, `tool_use_id`+`tool_call_id` collapsed), removals (fields no producer populates), closed-vocabulary guards, and decided-row mirrors derived from the decision fact itself so the server's cross-checks can never disagree.
- **Clean receipts at creation**: payload/proof shape, empty members omitted, stored payload is the RFC 8785 (JCS) bytes the hash commits to, unsigned receipts omit the signature entirely. A `payload_form` column (additive migration) marks clean rows. Local `VerifyReceipts` chain verification is unchanged for old and new receipts alike.
- **Session lifecycle stays local**: `session.start/end` rows no longer mint receipts and never reach the wire; session records carry open/close state, as the contract specifies.
- **Per-page deterministic form selection**: a page containing any pre-cutover receipt or fact-less decided action ships on the legacy form; pages of post-cutover rows (and heartbeats) ship v1. That drains upgrade backlog — including rows written during a temporary downgrade — with no cutover marker and no retry-as-legacy. A v1 `409` replay conflict is isolated like an oversized page (shrink → skip) instead of retrying identical bytes forever.

## Tests

- Transport contract test: captures real flush bytes, decodes them **untyped** (a typed struct could hide a dropped field), validates against the pinned schema from #447, asserts no legacy name leaks and no session rows on the wire; heartbeat covered too.
- Pre-cutover drain test: rows marked `payload_form='legacy'` ship on the legacy form with no hybrid markers.
- Full `go test ./...` green.

## Rollout

Ships only after the server accepts the v1 form in production (staging channel first). The legacy serializer stays for exactly one release to drain pre-upgrade rows; its removal is the follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)