### PR TITLE
feat(managedstream)!: retire the legacy ledger wire form

### DIFF
--- a/internal/managedstream/replay_live_test.go
+++ b/internal/managedstream/replay_live_test.go
@@ -30,7 +30,7 @@ func TestReplayLiveDB(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		bytesTotal += int64(len(body))
-		var p Payload
+		var p wireBatch
 		if err := json.Unmarshal(body, &p); err != nil {
 			t.Errorf("bad payload: %v", err)
 		}

--- a/internal/managedstream/stream.go
+++ b/internal/managedstream/stream.go
@@ -23,7 +23,6 @@ import (
 )
 
 const (
-	SchemaVersion   = "authorization-ledger-v1"
 	DefaultEndpoint = "/api/v1/authorization-ledger/batches"
 
 	DefaultBatchLimit        = 100
@@ -86,24 +85,6 @@ const (
 	// the default interval.
 	authFailureRefire = 50
 )
-
-type Payload struct {
-	SchemaVersion      string                           `json:"schema_version"`
-	InstallationID     string                           `json:"installation_id"`
-	BatchID            string                           `json:"batch_id"`
-	SentAt             string                           `json:"sent_at"`
-	Device             *Device                          `json:"device,omitempty"`
-	Sessions           []sqlite.LedgerRecord            `json:"agent_sessions"`
-	Actions            []sqlite.LedgerRecord            `json:"authorization_actions"`
-	Receipts           []sqlite.LedgerRecord            `json:"authorization_receipts"`
-	ReceiptChainAnchor *sqlite.LedgerReceiptChainAnchor `json:"receipt_chain_anchor,omitempty"`
-}
-
-type Device struct {
-	Label             string `json:"label,omitempty"`
-	DeploymentVersion string `json:"deployment_version,omitempty"`
-	UserEmail         string `json:"user_email,omitempty"`
-}
 
 type State struct {
 	UpdatedAfter           *time.Time
@@ -343,34 +324,38 @@ type payloadCounts struct {
 	receipts int
 }
 
-// payloadBody serializes one export page under the wire form the store
-// selected for it. A nil body with a nil error is a page whose records are
-// all local-only (nothing to post; the cursor still advances).
+// payloadBody serializes one export page on the v1 contract. A nil body
+// with a nil error is a page with nothing to post (local-only rows, or
+// pre-cutover rows the retired legacy form used to carry); the cursor still
+// advances.
+//
+// The legacy serializer is gone: pages pinned to the legacy form by
+// pre-cutover rows are skipped with a diagnostic. Such rows exist only on a
+// device that jumped straight past the transitional release; they stay in
+// the local ledger and are simply never uploaded.
 func payloadBody(opts Options, batch sqlite.LedgerBatch, now time.Time) ([]byte, payloadCounts, error) {
-	if batch.Form == sqlite.LedgerFormV1 {
-		mapped, err := v1Batch(opts, batch, now)
-		if err != nil {
-			return nil, payloadCounts{}, err
-		}
-		counts := payloadCounts{
-			sessions: len(mapped.Sessions),
-			actions:  len(mapped.Actions),
-			receipts: len(mapped.Receipts),
-		}
-		if counts.sessions == 0 && counts.actions == 0 && counts.receipts == 0 {
-			return nil, counts, nil
-		}
-		body, err := json.Marshal(mapped)
-		return body, counts, err
+	if batch.Form == sqlite.LedgerFormLegacy {
+		opts.Diagnostic.Printf(
+			"managed stream skipped %d pre-cutover actions and %d receipts; the legacy wire form is retired and these rows remain local-only\n",
+			len(batch.Actions),
+			len(batch.Receipts),
+		)
+		return nil, payloadCounts{}, nil
 	}
 
-	payload := newPayload(opts, batch.Sessions, batch.Actions, batch.Receipts, batch.ReceiptChainAnchor, now)
-	counts := payloadCounts{
-		sessions: len(payload.Sessions),
-		actions:  len(payload.Actions),
-		receipts: len(payload.Receipts),
+	mapped, err := v1Batch(opts, batch, now)
+	if err != nil {
+		return nil, payloadCounts{}, err
 	}
-	body, err := json.Marshal(payload)
+	counts := payloadCounts{
+		sessions: len(mapped.Sessions),
+		actions:  len(mapped.Actions),
+		receipts: len(mapped.Receipts),
+	}
+	if counts.sessions == 0 && counts.actions == 0 && counts.receipts == 0 {
+		return nil, counts, nil
+	}
+	body, err := json.Marshal(mapped)
 	return body, counts, err
 }
 
@@ -411,31 +396,6 @@ func recordMaps(records []sqlite.LedgerRecord) []map[string]any {
 	return out
 }
 
-func newPayload(
-	opts Options,
-	sessions []sqlite.LedgerRecord,
-	actions []sqlite.LedgerRecord,
-	receipts []sqlite.LedgerRecord,
-	receiptChainAnchor *sqlite.LedgerReceiptChainAnchor,
-	now time.Time,
-) Payload {
-	payload := Payload{
-		SchemaVersion:      SchemaVersion,
-		InstallationID:     opts.InstallationID,
-		BatchID:            "batch_" + uuid.NewString(),
-		SentAt:             now.Format(time.RFC3339Nano),
-		Sessions:           nonNilRecords(sessions),
-		Actions:            nonNilRecords(actions),
-		Receipts:           nonNilRecords(receipts),
-		ReceiptChainAnchor: receiptChainAnchor,
-	}
-	label, deploymentVersion, userEmail := deviceValues(opts)
-	if label != "" || deploymentVersion != "" || userEmail != "" {
-		payload.Device = &Device{Label: label, DeploymentVersion: deploymentVersion, UserEmail: userEmail}
-	}
-	return payload
-}
-
 // deviceValues resolves the deployment version per flush so an in-place
 // package upgrade is reflected without restarting the daemon.
 func deviceValues(opts Options) (label, deploymentVersion, userEmail string) {
@@ -445,13 +405,6 @@ func deviceValues(opts Options) (label, deploymentVersion, userEmail string) {
 		deploymentVersion = strings.TrimSpace(opts.DeploymentVersion())
 	}
 	return label, deploymentVersion, userEmail
-}
-
-func nonNilRecords(records []sqlite.LedgerRecord) []sqlite.LedgerRecord {
-	if records != nil {
-		return records
-	}
-	return []sqlite.LedgerRecord{}
 }
 
 func post(ctx context.Context, opts Options, body []byte) error {

--- a/internal/managedstream/stream_test.go
+++ b/internal/managedstream/stream_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/kontext-security/kontext-cli/internal/guard/risk"
 	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
+	"github.com/kontext-security/kontext-cli/internal/ledgeringest"
 )
 
 func TestDefaultTimeoutFromEnv(t *testing.T) {
@@ -1012,14 +1013,14 @@ func testStore(t *testing.T) (*sqlite.Store, string) {
 // wireBatch decodes the clean-v1 envelope the flush posts for pages of
 // post-cutover rows (the only kind a fresh test store produces).
 type wireBatch struct {
-	BatchVersion   string           `json:"batch_version"`
-	BatchID        string           `json:"batch_id"`
-	InstallationID string           `json:"installation_id"`
-	SentAt         string           `json:"sent_at"`
-	Device         *Device          `json:"device"`
-	Sessions       []map[string]any `json:"sessions"`
-	Actions        []map[string]any `json:"actions"`
-	Receipts       []map[string]any `json:"receipts"`
+	BatchVersion   string               `json:"batch_version"`
+	BatchID        string               `json:"batch_id"`
+	InstallationID string               `json:"installation_id"`
+	SentAt         string               `json:"sent_at"`
+	Device         *ledgeringest.Device `json:"device"`
+	Sessions       []map[string]any     `json:"sessions"`
+	Actions        []map[string]any     `json:"actions"`
+	Receipts       []map[string]any     `json:"receipts"`
 }
 
 func capturePayloadServer(t *testing.T, got *wireBatch) *httptest.Server {

--- a/internal/managedstream/wirecontract_test.go
+++ b/internal/managedstream/wirecontract_test.go
@@ -178,11 +178,12 @@ func TestHeartbeatMatchesPinnedContract(t *testing.T) {
 }
 
 // Pre-cutover rows (receipts stored before the clean-payload change, marked
-// by the payload_form column default) pin their page to the legacy form:
-// their payload bytes were hashed under the old serialization and can never
-// satisfy the clean contract. This is the deterministic drain path for the
-// backlog a daemon upgrade leaves behind.
-func TestFlushShipsPreCutoverPagesOnLegacyForm(t *testing.T) {
+// by the payload_form column default) can never satisfy the clean contract:
+// their payload bytes were hashed under the retired serialization. With the
+// legacy form gone, such pages are skipped deterministically — the rows stay
+// in the local ledger, the cursor advances, and no hybrid or legacy bytes
+// ever reach the wire.
+func TestFlushSkipsPreCutoverPages(t *testing.T) {
 	store, dbPath := testStore(t)
 	saveTestDecision(t, store, "sess-pre-cutover", "toolu_pre_cutover")
 
@@ -203,24 +204,33 @@ func TestFlushShipsPreCutoverPagesOnLegacyForm(t *testing.T) {
 	if err := Flush(context.Background(), flushOptions(dbPath, statePath, server.URL, server.Client())); err != nil {
 		t.Fatalf("Flush() error = %v", err)
 	}
-	if len(bodies) != 1 {
-		t.Fatalf("posted %d bodies, want one legacy batch", len(bodies))
+	for _, raw := range bodies {
+		var batch wireBatch
+		if err := json.Unmarshal(raw, &batch); err != nil {
+			t.Fatalf("decode posted body: %v", err)
+		}
+		if batch.BatchVersion != "v1" {
+			t.Fatalf("posted body is not clean v1: %s", raw)
+		}
+		if len(batch.Actions) != 0 || len(batch.Receipts) != 0 {
+			t.Fatalf("pre-cutover records reached the wire: %s", raw)
+		}
 	}
 
-	var legacy Payload
-	if err := json.Unmarshal(bodies[0], &legacy); err != nil {
-		t.Fatalf("decode legacy batch: %v", err)
+	state, err := LoadState(statePath)
+	if err != nil {
+		t.Fatalf("LoadState() error = %v", err)
 	}
-	if legacy.SchemaVersion != SchemaVersion {
-		t.Fatalf("schema_version = %q, want the legacy form for pre-cutover rows", legacy.SchemaVersion)
+	if state.UpdatedAfter == nil {
+		t.Fatal("cursor did not advance past the skipped pre-cutover page")
 	}
-	if bytes.Contains(bodies[0], []byte(`"batch_version"`)) {
-		t.Fatalf("legacy batch carries the v1 marker (hybrid form): %s", bodies[0])
+
+	// The rows themselves stay local: skipping is a wire decision only.
+	var receipts int
+	if err := db.QueryRow(`select count(*) from authorization_receipts`).Scan(&receipts); err != nil {
+		t.Fatal(err)
 	}
-	if bytes.Contains(bodies[0], []byte(`"payload_form"`)) {
-		t.Fatalf("local cutover column leaked onto the wire: %s", bodies[0])
-	}
-	if len(legacy.Actions) == 0 || len(legacy.Receipts) == 0 {
-		t.Fatalf("legacy batch counts = actions %d receipts %d, want the full page", len(legacy.Actions), len(legacy.Receipts))
+	if receipts == 0 {
+		t.Fatal("pre-cutover receipts were deleted; they must remain local")
 	}
 }


### PR DESCRIPTION
## What

Stacked on #448. Deletes the legacy wire serializer — the daemon speaks only the published **ledger-ingest v1** contract from here on.

- Removes the legacy `Payload`/`Device` envelope, the `schema_version` marker, and the legacy record array names from the wire code.
- Pages pinned to the legacy form by pre-cutover rows are **skipped with a diagnostic** rather than shipped: after the transitional release (#448) has been in the field, such rows only exist on a device that jumped straight past it. They stay in the local ledger (nothing is deleted), the cursor advances deterministically, and no hybrid or legacy bytes ever reach the wire.

## Release gating

Must ship **one release after** #448, so fleet upgrade backlog has already drained on the legacy form. Merging it into the same release as #448 would strand pre-upgrade rows on devices upgrading from older builds. Keep draft until #448 has shipped through the staging channel to production.

## Tests

- Pre-cutover pages: skipped, cursor advances, rows remain local, nothing non-v1 posts.
- Full `go test ./...` green; the transport contract test continues to validate real flush bytes against the pinned schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)