### PR TITLE
fix(daemon): answer decision hooks before annotation and persistence

### DIFF
--- a/internal/diagnostic/diagnostic.go
+++ b/internal/diagnostic/diagnostic.go
@@ -34,6 +34,18 @@ func (l Logger) Printf(format string, args ...any) {
 	fmt.Fprint(l.out, Redact(fmt.Sprintf(format, args...)))
 }
 
+// LogAlways writes a redacted line even when verbose output is disabled: an
+// enabled logger keeps its configured sink, a disabled one falls back to
+// stderr. For messages that must reach the process log unconditionally —
+// Printf is debug-gated and silently drops them.
+func LogAlways(log Logger, format string, args ...any) {
+	if log.Enabled() {
+		log.Printf(format, args...)
+		return
+	}
+	fmt.Fprint(os.Stderr, Redact(fmt.Sprintf(format, args...)))
+}
+
 var secretPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)Bearer\s+[A-Za-z0-9._~+/=-]+`),
 	regexp.MustCompile(`(?i)(access_token|id_token|refresh_token|authorization|cookie)=([^&\s]+)`),

--- a/internal/guard/app/server/defer_record_test.go
+++ b/internal/guard/app/server/defer_record_test.go
@@ -1,0 +1,107 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/guard/risk"
+	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
+)
+
+// A deferred-recording server must settle the hook response without touching
+// the store: the response carries a pre-minted action ID, and the persistence
+// job — run later, on the executor's schedule — writes the row under that
+// same ID.
+func TestDeferRecordAnswersWithoutPersisting(t *testing.T) {
+	store, err := sqlite.OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	var jobs []func(context.Context) error
+	server, err := NewServerWithPolicyAndOptions(store, nil, Options{
+		DeferRecord: func(job func(context.Context) error) {
+			jobs = append(jobs, job)
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	event := risk.HookEvent{
+		SessionID:     "s1",
+		HookEventName: "PreToolUse",
+		ToolName:      "Bash",
+		ToolInput:     map[string]any{"command": "echo hi"},
+	}
+	decision, err := server.ProcessHookEvent(context.Background(), event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.EventID == "" || !strings.HasPrefix(decision.EventID, "act_") {
+		t.Fatalf("EventID = %q, want pre-minted act_ id", decision.EventID)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("deferred jobs = %d, want 1", len(jobs))
+	}
+
+	summary, err := store.Summary(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.Actions != 0 {
+		t.Fatalf("actions before job ran = %d, want 0 (response must not wait on the store)", summary.Actions)
+	}
+
+	if err := jobs[0](context.Background()); err != nil {
+		t.Fatalf("deferred job error = %v", err)
+	}
+
+	events, err := store.Events(context.Background(), "s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, record := range events {
+		if record.ID == decision.EventID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no persisted decision with the response's EventID %q; got %d events", decision.EventID, len(events))
+	}
+}
+
+// Without a DeferRecord executor the historical behavior holds: the response
+// waits on the write and carries the persisted row's ID.
+func TestNilDeferRecordStaysSynchronous(t *testing.T) {
+	store, err := sqlite.OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	server := newTestServer(t, store)
+
+	event := risk.HookEvent{
+		SessionID:     "s1",
+		HookEventName: "PreToolUse",
+		ToolName:      "Bash",
+		ToolInput:     map[string]any{"command": "echo hi"},
+	}
+	decision, err := server.ProcessHookEvent(context.Background(), event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	summary, err := store.Summary(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.Actions != 1 {
+		t.Fatalf("actions = %d, want 1 persisted synchronously", summary.Actions)
+	}
+	if decision.EventID == "" {
+		t.Fatal("EventID empty on synchronous path")
+	}
+}

--- a/internal/guard/app/server/defer_record_test.go
+++ b/internal/guard/app/server/defer_record_test.go
@@ -133,6 +133,79 @@ func TestDeferRecordSkipsNonBlockingHooks(t *testing.T) {
 	}
 }
 
+// A deferred record can land after a SessionEnd already closed its session:
+// the job waits on classifier inference and a possibly cold store while the
+// session winds down in order. Late bookkeeping must not undo that close.
+func TestDeferredRecordDoesNotReopenClosedSession(t *testing.T) {
+	store, err := sqlite.OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	var jobs []func(context.Context) error
+	server, err := NewServerWithPolicyAndOptions(store, nil, Options{
+		DeferRecord: func(job func(context.Context) error) {
+			jobs = append(jobs, job)
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	event := risk.HookEvent{
+		SessionID:     "s1",
+		HookEventName: "PreToolUse",
+		ToolName:      "Bash",
+		ToolInput:     map[string]any{"command": "echo hi"},
+	}
+	decision, err := server.ProcessHookEvent(context.Background(), event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("deferred jobs = %d, want 1", len(jobs))
+	}
+
+	// The session ends in causal order while the deferred job is still
+	// pending: SessionEnd ingests synchronously (creating the row), then the
+	// runtime closes the session, exactly as the socket service does.
+	if _, err := server.ProcessHookEvent(context.Background(), risk.HookEvent{
+		SessionID:     "s1",
+		HookEventName: "SessionEnd",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CloseSession(context.Background(), "s1"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := jobs[0](context.Background()); err != nil {
+		t.Fatalf("deferred job error = %v", err)
+	}
+
+	session, err := store.Session(context.Background(), "s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.Status != "closed" {
+		t.Fatalf("session status after late deferred write = %q, want closed", session.Status)
+	}
+	events, err := store.Events(context.Background(), "s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, record := range events {
+		if record.ID == decision.EventID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("late deferred job must still persist the decision %q", decision.EventID)
+	}
+}
+
 // An event with no session ID must land under the store's catch-all session
 // on the deferred path exactly as it does on the synchronous one: the
 // normalization happens before the response, the upsert after.

--- a/internal/guard/app/server/defer_record_test.go
+++ b/internal/guard/app/server/defer_record_test.go
@@ -54,6 +54,13 @@ func TestDeferRecordAnswersWithoutPersisting(t *testing.T) {
 	if summary.Actions != 0 {
 		t.Fatalf("actions before job ran = %d, want 0 (response must not wait on the store)", summary.Actions)
 	}
+	sessions, err := store.Sessions(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 0 {
+		t.Fatalf("sessions before job ran = %d, want 0 (session upsert must not wait on the store either)", len(sessions))
+	}
 
 	if err := jobs[0](context.Background()); err != nil {
 		t.Fatalf("deferred job error = %v", err)
@@ -71,6 +78,109 @@ func TestDeferRecordAnswersWithoutPersisting(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("no persisted decision with the response's EventID %q; got %d events", decision.EventID, len(events))
+	}
+	session, err := store.Session(context.Background(), "s1")
+	if err != nil {
+		t.Fatalf("session after job ran: %v", err)
+	}
+	if session.Status != "open" {
+		t.Fatalf("session status = %q, want open (deferred job must run the full session upsert)", session.Status)
+	}
+}
+
+// Non-blocking hooks must not defer: their response never waits on the store
+// (async ingest answers them before ingestion), so deferring their writes
+// would only nest one background hop inside another and reorder rows for no
+// latency win.
+func TestDeferRecordSkipsNonBlockingHooks(t *testing.T) {
+	store, err := sqlite.OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	var jobs []func(context.Context) error
+	server, err := NewServerWithPolicyAndOptions(store, nil, Options{
+		DeferRecord: func(job func(context.Context) error) {
+			jobs = append(jobs, job)
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	event := risk.HookEvent{
+		SessionID:     "s1",
+		HookEventName: "PostToolUse",
+		ToolName:      "Bash",
+		ToolInput:     map[string]any{"command": "echo hi"},
+	}
+	if _, err := server.ProcessHookEvent(context.Background(), event); err != nil {
+		t.Fatal(err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("deferred jobs = %d, want 0 (non-blocking hooks stay synchronous)", len(jobs))
+	}
+	summary, err := store.Summary(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.Actions != 1 {
+		t.Fatalf("actions = %d, want 1 persisted synchronously for the non-blocking hook", summary.Actions)
+	}
+	if _, err := store.Session(context.Background(), "s1"); err != nil {
+		t.Fatalf("session after synchronous ingest: %v", err)
+	}
+}
+
+// An event with no session ID must land under the store's catch-all session
+// on the deferred path exactly as it does on the synchronous one: the
+// normalization happens before the response, the upsert after.
+func TestDeferRecordNormalizesEmptySessionID(t *testing.T) {
+	store, err := sqlite.OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	var jobs []func(context.Context) error
+	server, err := NewServerWithPolicyAndOptions(store, nil, Options{
+		DeferRecord: func(job func(context.Context) error) {
+			jobs = append(jobs, job)
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	event := risk.HookEvent{
+		HookEventName: "PreToolUse",
+		ToolName:      "Bash",
+		ToolInput:     map[string]any{"command": "echo hi"},
+	}
+	decision, err := server.ProcessHookEvent(context.Background(), event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("deferred jobs = %d, want 1", len(jobs))
+	}
+	if err := jobs[0](context.Background()); err != nil {
+		t.Fatalf("deferred job error = %v", err)
+	}
+
+	events, err := store.Events(context.Background(), sqlite.NormalizeSessionID(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, record := range events {
+		if record.ID == decision.EventID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no decision under the catch-all session with EventID %q; got %d events", decision.EventID, len(events))
 	}
 }
 

--- a/internal/guard/app/server/runtime.go
+++ b/internal/guard/app/server/runtime.go
@@ -20,15 +20,23 @@ type guardHookRuntime struct {
 	currentSessionID string
 	mode             string
 	classifier       *riskclassifier.Classifier
+	// deferRecord, when non-nil, runs annotation + persistence off the hook
+	// response path. The decision itself (Cedar) is always computed before
+	// the response; only the advisory annotation and the SQLite write are
+	// deferred. The executor owns lifetime (context, draining on shutdown)
+	// and reporting the job's error. Nil keeps the historical synchronous
+	// behavior.
+	deferRecord func(job func(context.Context) error)
 }
 
-func newGuardHookRuntime(store *sqlite.Store, policy PolicyProvider, currentSessionID, mode string, classifier *riskclassifier.Classifier) guardHookRuntime {
+func newGuardHookRuntime(store *sqlite.Store, policy PolicyProvider, currentSessionID, mode string, classifier *riskclassifier.Classifier, deferRecord func(job func(context.Context) error)) guardHookRuntime {
 	return guardHookRuntime{
 		store:            store,
 		policy:           policy,
 		currentSessionID: currentSessionID,
 		mode:             mode,
 		classifier:       classifier,
+		deferRecord:      deferRecord,
 	}
 }
 
@@ -106,6 +114,27 @@ func (r guardHookRuntime) decideAndRecord(ctx context.Context, event risk.HookEv
 	// observe, enforce, managed — passes through, so one call site covers them
 	// all. It is also what keeps the classifier advisory: the decision is
 	// already settled and annotate may write nothing but its Classifier field.
+	if r.deferRecord != nil {
+		// The decision is settled; nothing after this point may change it.
+		// Hand the agent its answer now and run annotation + persistence in
+		// the background: classifier inference and a write into a large,
+		// possibly cold guard.db both routinely outlive the hook client's
+		// budget, and a hook that times out here is treated as a dead daemon
+		// — fail-open in observe, fail-closed (every tool call denied) in
+		// enforce.
+		decision.EventID = sqlite.NewActionID()
+		deferredEvent, deferredDecision := event, decision
+		r.deferRecord(func(recordCtx context.Context) error {
+			r.annotate(recordCtx, deferredEvent, &deferredDecision)
+			record, err := r.store.SaveDecision(recordCtx, deferredEvent, deferredDecision)
+			if err != nil {
+				return err
+			}
+			r.recordAnnotation(recordCtx, record.ID, deferredEvent, deferredDecision)
+			return nil
+		})
+		return decision, nil
+	}
 	r.annotate(ctx, event, &decision)
 	record, err := r.store.SaveDecision(ctx, event, decision)
 	if err != nil {

--- a/internal/guard/app/server/runtime.go
+++ b/internal/guard/app/server/runtime.go
@@ -147,9 +147,11 @@ func (r guardHookRuntime) decideAndRecord(ctx context.Context, event risk.HookEv
 		deferredEvent, deferredDecision := event, decision
 		r.deferRecord(func(recordCtx context.Context) error {
 			// The session upsert EnsureSessionForEvent skipped lands first,
-			// mirroring the synchronous order: it carries the mode stamp and
-			// the reopen semantics SaveDecision's own upsert lacks.
-			session, sessionErr := r.store.EnsureObservedSessionWithMode(recordCtx, deferredEvent.SessionID, deferredEvent.Agent, deferredEvent.CWD, r.modeForSession(deferredEvent.SessionID))
+			// mirroring the synchronous order: it carries the mode stamp
+			// SaveDecision's own upsert lacks. Backfill, not Ensure: this
+			// write can run after a SessionEnd that already closed the
+			// session, and it must not reopen it.
+			session, sessionErr := r.store.BackfillObservedSessionWithMode(recordCtx, deferredEvent.SessionID, deferredEvent.Agent, deferredEvent.CWD, r.modeForSession(deferredEvent.SessionID))
 			if sessionErr == nil && deferredEvent.Agent == "" {
 				deferredEvent.Agent = session.Agent
 			}

--- a/internal/guard/app/server/runtime.go
+++ b/internal/guard/app/server/runtime.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
@@ -20,12 +21,13 @@ type guardHookRuntime struct {
 	currentSessionID string
 	mode             string
 	classifier       *riskclassifier.Classifier
-	// deferRecord, when non-nil, runs annotation + persistence off the hook
+	// deferRecord, when non-nil, runs every store write for decision-gating
+	// hooks — session upsert, annotation, decision row — off the hook
 	// response path. The decision itself (Cedar) is always computed before
-	// the response; only the advisory annotation and the SQLite write are
-	// deferred. The executor owns lifetime (context, draining on shutdown)
-	// and reporting the job's error. Nil keeps the historical synchronous
-	// behavior.
+	// the response. Non-blocking hooks keep their synchronous writes: they
+	// are already ingested behind an immediate response. The executor owns
+	// lifetime (context, draining on shutdown) and reporting the job's
+	// error. Nil keeps the historical synchronous behavior.
 	deferRecord func(job func(context.Context) error)
 }
 
@@ -63,6 +65,17 @@ func (r guardHookRuntime) CloseSession(ctx context.Context, sessionID string) er
 }
 
 func (r guardHookRuntime) EnsureSessionForEvent(ctx context.Context, event hook.Event) (hook.Event, error) {
+	// A deferred-recording runtime answers decision-gating hooks without
+	// touching the store, and the session upsert is a store write like any
+	// other: on a cold guard.db it alone can outlive the hook client's budget.
+	// The upsert rides along with the deferred decision record instead (see
+	// decideAndRecord); only the store's session-ID normalization — a pure
+	// function — happens here, so the decision, the classifier, and the
+	// eventual rows key alike.
+	if r.defersRecording(event.HookName) {
+		event.SessionID = sqlite.NormalizeSessionID(event.SessionID)
+		return event, nil
+	}
 	session, err := r.store.EnsureObservedSessionWithMode(ctx, event.SessionID, event.Agent, event.CWD, r.modeForSession(event.SessionID))
 	if err != nil {
 		return hook.Event{}, err
@@ -72,6 +85,14 @@ func (r guardHookRuntime) EnsureSessionForEvent(ctx context.Context, event hook.
 		event.Agent = session.Agent
 	}
 	return event, nil
+}
+
+// defersRecording reports whether this event's store writes run off the hook
+// response path. Only decision-gating hooks defer: non-blocking hooks are
+// already answered before ingestion (async ingest), so deferring their writes
+// would only nest one background hop inside another.
+func (r guardHookRuntime) defersRecording(hookName hook.HookName) bool {
+	return r.deferRecord != nil && hookName.CanBlock()
 }
 
 func (r guardHookRuntime) modeForSession(sessionID string) string {
@@ -114,7 +135,7 @@ func (r guardHookRuntime) decideAndRecord(ctx context.Context, event risk.HookEv
 	// observe, enforce, managed — passes through, so one call site covers them
 	// all. It is also what keeps the classifier advisory: the decision is
 	// already settled and annotate may write nothing but its Classifier field.
-	if r.deferRecord != nil {
+	if r.defersRecording(hook.HookName(event.HookEventName)) {
 		// The decision is settled; nothing after this point may change it.
 		// Hand the agent its answer now and run annotation + persistence in
 		// the background: classifier inference and a write into a large,
@@ -125,13 +146,20 @@ func (r guardHookRuntime) decideAndRecord(ctx context.Context, event risk.HookEv
 		decision.EventID = sqlite.NewActionID()
 		deferredEvent, deferredDecision := event, decision
 		r.deferRecord(func(recordCtx context.Context) error {
+			// The session upsert EnsureSessionForEvent skipped lands first,
+			// mirroring the synchronous order: it carries the mode stamp and
+			// the reopen semantics SaveDecision's own upsert lacks.
+			session, sessionErr := r.store.EnsureObservedSessionWithMode(recordCtx, deferredEvent.SessionID, deferredEvent.Agent, deferredEvent.CWD, r.modeForSession(deferredEvent.SessionID))
+			if sessionErr == nil && deferredEvent.Agent == "" {
+				deferredEvent.Agent = session.Agent
+			}
 			r.annotate(recordCtx, deferredEvent, &deferredDecision)
 			record, err := r.store.SaveDecision(recordCtx, deferredEvent, deferredDecision)
 			if err != nil {
-				return err
+				return errors.Join(sessionErr, err)
 			}
 			r.recordAnnotation(recordCtx, record.ID, deferredEvent, deferredDecision)
-			return nil
+			return sessionErr
 		})
 		return decision, nil
 	}

--- a/internal/guard/app/server/server.go
+++ b/internal/guard/app/server/server.go
@@ -53,12 +53,13 @@ type Options struct {
 	// RiskClassifier enables observe-mode risk-classifier logging for
 	// intercepted bash commands. Nil disables it.
 	RiskClassifier *RiskClassifierOptions
-	// DeferRecord, when non-nil, receives the annotation + persistence work
-	// for each settled decision so the hook response does not wait on
-	// classifier inference or SQLite. The executor owns the context the job
+	// DeferRecord, when non-nil, receives every store write for each settled
+	// decision-gating hook — session upsert, annotation, decision row — so
+	// the hook response does not wait on classifier inference or SQLite.
+	// Non-blocking hooks keep synchronous writes; they are already ingested
+	// behind an immediate response. The executor owns the context the job
 	// runs under, draining before the store closes, and surfacing the job's
-	// error. Nil keeps annotation and persistence synchronous with the
-	// response, as before.
+	// error. Nil keeps every write synchronous with the response, as before.
 	DeferRecord func(job func(context.Context) error)
 }
 

--- a/internal/guard/app/server/server.go
+++ b/internal/guard/app/server/server.go
@@ -53,6 +53,13 @@ type Options struct {
 	// RiskClassifier enables observe-mode risk-classifier logging for
 	// intercepted bash commands. Nil disables it.
 	RiskClassifier *RiskClassifierOptions
+	// DeferRecord, when non-nil, receives the annotation + persistence work
+	// for each settled decision so the hook response does not wait on
+	// classifier inference or SQLite. The executor owns the context the job
+	// runs under, draining before the store closes, and surfacing the job's
+	// error. Nil keeps annotation and persistence synchronous with the
+	// response, as before.
+	DeferRecord func(job func(context.Context) error)
 }
 
 // RiskClassifierOptions configure the risk classifier. The SVM is embedded and
@@ -128,7 +135,7 @@ func NewServerWithPolicyAndOptions(store *sqlite.Store, policy PolicyProvider, o
 		opts.RiskClassifier.Gate = riskclassifier.NewLLMGate()
 	}
 	classifier := newRiskClassifier(opts.RiskClassifier)
-	runtime := newGuardHookRuntime(store, policy, currentSessionID, mode, classifier)
+	runtime := newGuardHookRuntime(store, policy, currentSessionID, mode, classifier, opts.DeferRecord)
 	core, err := runtimecore.New(runtime)
 	if err != nil {
 		return nil, fmt.Errorf("create runtime core: %w", err)

--- a/internal/guard/store/sqlite/store.go
+++ b/internal/guard/store/sqlite/store.go
@@ -712,17 +712,29 @@ func (s *Store) EnsureObservedSession(ctx context.Context, sessionID, agent, cwd
 }
 
 func (s *Store) EnsureObservedSessionWithMode(ctx context.Context, sessionID, agent, cwd, mode string) (SessionRecord, error) {
+	return s.upsertObservedSession(ctx, sessionID, agent, cwd, mode, true)
+}
+
+// BackfillObservedSessionWithMode refreshes the session row for a record whose
+// hook was answered before anything persisted. Unlike
+// EnsureObservedSessionWithMode it never reopens a closed session: the
+// deferred write can land after a SessionEnd already closed the session, and
+// late bookkeeping must not undo a liveness fact that arrived in order.
+func (s *Store) BackfillObservedSessionWithMode(ctx context.Context, sessionID, agent, cwd, mode string) (SessionRecord, error) {
+	return s.upsertObservedSession(ctx, sessionID, agent, cwd, mode, false)
+}
+
+func (s *Store) upsertObservedSession(ctx context.Context, sessionID, agent, cwd, mode string, reopen bool) (SessionRecord, error) {
 	now := time.Now().UTC()
 	sessionID = NormalizeSessionID(sessionID)
 	agentProvider, canonicalAgent := hostedAgentIdentity(agent)
-	_, err := s.db.ExecContext(ctx, `
-insert into agent_sessions(id, agent_provider, agent, cwd, source, status, mode, created_at, updated_at)
-values(?, ?, ?, ?, 'daemon_observed', 'open', ?, ?, ?)
-on conflict(id) do update set
-  agent_provider = coalesce(nullif(excluded.agent_provider, ''), agent_sessions.agent_provider),
-  agent = coalesce(nullif(excluded.agent, ''), agent_sessions.agent),
-  cwd = coalesce(nullif(excluded.cwd, ''), agent_sessions.cwd),
-  mode = coalesce(nullif(excluded.mode, ''), agent_sessions.mode),
+	// A hook observed in order is proof of life and reopens anything the
+	// daemon owns; a backfilled row keeps whatever liveness it already has.
+	liveness := `
+  status = agent_sessions.status,
+  closed_at = agent_sessions.closed_at,`
+	if reopen {
+		liveness = `
   status = case
     when agent_sessions.source = 'wrapper_owned' then agent_sessions.status
     else 'open'
@@ -730,7 +742,16 @@ on conflict(id) do update set
   closed_at = case
     when agent_sessions.source = 'wrapper_owned' then agent_sessions.closed_at
     else null
-  end,
+  end,`
+	}
+	_, err := s.db.ExecContext(ctx, `
+insert into agent_sessions(id, agent_provider, agent, cwd, source, status, mode, created_at, updated_at)
+values(?, ?, ?, ?, 'daemon_observed', 'open', ?, ?, ?)
+on conflict(id) do update set
+  agent_provider = coalesce(nullif(excluded.agent_provider, ''), agent_sessions.agent_provider),
+  agent = coalesce(nullif(excluded.agent, ''), agent_sessions.agent),
+  cwd = coalesce(nullif(excluded.cwd, ''), agent_sessions.cwd),
+  mode = coalesce(nullif(excluded.mode, ''), agent_sessions.mode),`+liveness+`
   updated_at = excluded.updated_at
 	`, sessionID, agentProvider, canonicalAgent, cwd, mode, now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano))
 	if err != nil {

--- a/internal/guard/store/sqlite/store.go
+++ b/internal/guard/store/sqlite/store.go
@@ -678,7 +678,7 @@ func (s *Store) OpenSession(ctx context.Context, sessionID, agent, cwd, source, 
 
 func (s *Store) OpenSessionWithMode(ctx context.Context, sessionID, agent, cwd, source, externalID, mode string) (SessionRecord, error) {
 	now := time.Now().UTC()
-	sessionID = normalizeSessionID(sessionID)
+	sessionID = NormalizeSessionID(sessionID)
 	agentProvider, canonicalAgent := hostedAgentIdentity(agent)
 	if source == "" {
 		source = "daemon_observed"
@@ -713,7 +713,7 @@ func (s *Store) EnsureObservedSession(ctx context.Context, sessionID, agent, cwd
 
 func (s *Store) EnsureObservedSessionWithMode(ctx context.Context, sessionID, agent, cwd, mode string) (SessionRecord, error) {
 	now := time.Now().UTC()
-	sessionID = normalizeSessionID(sessionID)
+	sessionID = NormalizeSessionID(sessionID)
 	agentProvider, canonicalAgent := hostedAgentIdentity(agent)
 	_, err := s.db.ExecContext(ctx, `
 insert into agent_sessions(id, agent_provider, agent, cwd, source, status, mode, created_at, updated_at)
@@ -740,7 +740,7 @@ on conflict(id) do update set
 }
 
 func (s *Store) CloseSession(ctx context.Context, sessionID string) error {
-	sessionID = normalizeSessionID(sessionID)
+	sessionID = NormalizeSessionID(sessionID)
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 	_, err := s.db.ExecContext(ctx, `
 update agent_sessions
@@ -781,7 +781,7 @@ func NewActionID() string {
 
 func (s *Store) SaveDecision(ctx context.Context, event risk.HookEvent, decision risk.RiskDecision) (DecisionRecord, error) {
 	now := time.Now().UTC()
-	sessionID := normalizeSessionID(event.SessionID)
+	sessionID := NormalizeSessionID(event.SessionID)
 	event.SessionID = sessionID
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -1826,7 +1826,11 @@ func nullableFloat(value *float64) any {
 	return *value
 }
 
-func normalizeSessionID(sessionID string) string {
+// NormalizeSessionID maps an absent session ID to the store's catch-all
+// session. Exported so a runtime that defers the session upsert can key the
+// decision, the classifier, and the eventual rows by the same ID the store
+// would choose.
+func NormalizeSessionID(sessionID string) string {
 	if sessionID == "" {
 		return "local"
 	}

--- a/internal/guard/store/sqlite/store.go
+++ b/internal/guard/store/sqlite/store.go
@@ -772,6 +772,13 @@ where id = ?
 	return scanSession(row)
 }
 
+// NewActionID mints the identifier for one decision row. Exported so a
+// runtime that answers the hook before persisting can hand the same ID to
+// both the agent and the eventual SaveDecision call.
+func NewActionID() string {
+	return "act_" + uuid.NewString()
+}
+
 func (s *Store) SaveDecision(ctx context.Context, event risk.HookEvent, decision risk.RiskDecision) (DecisionRecord, error) {
 	now := time.Now().UTC()
 	sessionID := normalizeSessionID(event.SessionID)
@@ -801,9 +808,15 @@ on conflict(id) do update set
 	// under the same policy, even if the mode flips concurrently.
 	captureConfig := s.payloadCaptureConfiguration()
 
-	actionID := "act_" + uuid.NewString()
+	// A caller that answered the hook before persisting has already handed
+	// the action ID to the agent; honoring it here keeps the eventual row
+	// addressable by the ID the hook response carried.
+	actionID := decision.EventID
+	if actionID == "" {
+		actionID = NewActionID()
+	}
 	if event.HookEventName == "PreToolUse" {
-		proposedID := "act_" + uuid.NewString()
+		proposedID := NewActionID()
 		if err := s.insertAction(ctx, tx, proposedID, sessionID, event, decision, canonicalEventRequestProposed, "event", captureConfig, now); err != nil {
 			return DecisionRecord{}, err
 		}

--- a/internal/guard/store/sqlite/store_test.go
+++ b/internal/guard/store/sqlite/store_test.go
@@ -1862,3 +1862,32 @@ func assertRecordIDs(t *testing.T, records []LedgerRecord, want map[string]bool)
 		}
 	}
 }
+
+// SaveDecision must honor a pre-set EventID: a runtime that answers the hook
+// before persisting has already handed that ID to the agent.
+func TestSaveDecisionHonorsPresetEventID(t *testing.T) {
+	store, err := OpenStore(t.TempDir() + "/guard.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	preset := NewActionID()
+	event := risk.HookEvent{
+		SessionID:     "s1",
+		HookEventName: "PreToolUse",
+		ToolName:      "Bash",
+		ToolInput:     map[string]any{"command": "echo hi"},
+	}
+	record, err := store.SaveDecision(context.Background(), event, risk.RiskDecision{
+		Decision: risk.DecisionAllow,
+		Reason:   "test",
+		EventID:  preset,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.ID != preset {
+		t.Fatalf("record.ID = %q, want preset %q", record.ID, preset)
+	}
+}

--- a/internal/localruntime/conversions.go
+++ b/internal/localruntime/conversions.go
@@ -95,6 +95,7 @@ func EvaluateResultFromResult(result hook.Result) EvaluateResult {
 		RequestID:    result.RequestID,
 		Mode:         result.Mode,
 		Epoch:        result.Epoch,
+		EventID:      result.EventID,
 		UpdatedInput: result.UpdatedInput,
 	}
 }
@@ -111,6 +112,7 @@ func ResultFromEvaluateResult(result EvaluateResult) hook.Result {
 		RequestID:    result.RequestID,
 		Mode:         result.Mode,
 		Epoch:        result.Epoch,
+		EventID:      result.EventID,
 		UpdatedInput: result.UpdatedInput,
 	}
 }

--- a/internal/localruntime/protocol.go
+++ b/internal/localruntime/protocol.go
@@ -25,14 +25,18 @@ type EvaluateRequest struct {
 }
 
 type EvaluateResult struct {
-	Type         string         `json:"type"`
-	Decision     string         `json:"decision,omitempty"`
-	Allowed      bool           `json:"allowed"`
-	Reason       string         `json:"reason"`
-	ReasonCode   string         `json:"reason_code,omitempty"`
-	RequestID    string         `json:"request_id,omitempty"`
-	Mode         string         `json:"mode,omitempty"`
-	Epoch        string         `json:"epoch,omitempty"`
+	Type       string `json:"type"`
+	Decision   string `json:"decision,omitempty"`
+	Allowed    bool   `json:"allowed"`
+	Reason     string `json:"reason"`
+	ReasonCode string `json:"reason_code,omitempty"`
+	RequestID  string `json:"request_id,omitempty"`
+	Mode       string `json:"mode,omitempty"`
+	Epoch      string `json:"epoch,omitempty"`
+	// EventID is the persisted decision row's ID — pre-minted when the
+	// runtime answers before persisting — so a hook client can correlate
+	// its response with the eventual record.
+	EventID      string         `json:"event_id,omitempty"`
 	UpdatedInput map[string]any `json:"updated_input,omitempty"`
 }
 

--- a/internal/localruntime/service_test.go
+++ b/internal/localruntime/service_test.go
@@ -42,6 +42,33 @@ func TestServiceEvaluatesBlockingHook(t *testing.T) {
 	}
 }
 
+// The decision ID must survive the socket protocol: a runtime that answers
+// before persisting hands the client the only handle it will ever have to the
+// eventual record.
+func TestServiceCarriesEventIDOverSocket(t *testing.T) {
+	t.Parallel()
+
+	runtime := &stubRuntime{
+		evaluateResult: hook.Result{
+			Decision: hook.DecisionAllow,
+			EventID:  "act_pre-minted",
+		},
+	}
+	service := newTestService(t, runtime, false)
+	client := NewClient(service.SocketPath())
+
+	result, err := client.Process(context.Background(), hook.Event{
+		HookName: hook.HookPreToolUse,
+		ToolName: "Bash",
+	})
+	if err != nil {
+		t.Fatalf("Process() error = %v", err)
+	}
+	if result.EventID != "act_pre-minted" {
+		t.Fatalf("EventID over the socket = %q, want %q", result.EventID, "act_pre-minted")
+	}
+}
+
 func TestServiceCanAckTelemetryBeforeAsyncIngest(t *testing.T) {
 	t.Parallel()
 

--- a/internal/managedobserve/binarywatch.go
+++ b/internal/managedobserve/binarywatch.go
@@ -143,9 +143,5 @@ func binaryWatchInterval() time.Duration {
 }
 
 func logAlways(log diagnostic.Logger, format string, args ...any) {
-	if log.Enabled() {
-		log.Printf(format, args...)
-		return
-	}
-	fmt.Fprint(os.Stderr, diagnostic.Redact(fmt.Sprintf(format, args...)))
+	diagnostic.LogAlways(log, format, args...)
 }

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -211,6 +211,16 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 		// deadline — Claude Code timed the hook out and the event was lost
 		// (ENG-474). Decision-gating hooks (PreToolUse, UserPromptSubmit)
 		// stay synchronous, and Shutdown drains pending writes.
+		//
+		// Decision recording is deferred the same way: the hook still waits
+		// for the policy verdict (Cedar is in-memory and fast), but not for
+		// classifier inference or the guard.db write. On a long-running
+		// install the first write after idle drags cold pages of a large
+		// database back from disk for seconds, which the hook client reads
+		// as a dead daemon — fail-open in observe (silent), fail-closed in
+		// enforce (every tool call denied). Close drains pending writes
+		// before the store shuts.
+		AsyncDecisionRecording: true,
 	})
 	if err != nil {
 		return err

--- a/internal/runtimehost/host.go
+++ b/internal/runtimehost/host.go
@@ -27,6 +27,13 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/runtimecore"
 )
 
+// maxConcurrentDeferredRecords caps how many deferred decision-record jobs run
+// at once. Classifier inference is the expensive stage — the store write
+// behind it is serialized by SQLite's single connection anyway — and one local
+// model serves every job, so a small bound keeps a hook burst from queueing a
+// stampede of concurrent inferences.
+const maxConcurrentDeferredRecords = 4
+
 type Options struct {
 	AgentName             string
 	SessionID             string
@@ -134,6 +141,11 @@ func Start(ctx context.Context, opts Options) (*Host, error) {
 	var deferRecord func(job func(context.Context) error)
 	if opts.AsyncDecisionRecording {
 		diag := opts.Diagnostic
+		// Bounds jobs, not goroutines: a burst of hooks parks its cheap
+		// goroutines here instead of stampeding the classifier's local model
+		// with concurrent inference. Acquired inside the goroutine so the
+		// hook response path never waits for a slot.
+		slots := make(chan struct{}, maxConcurrentDeferredRecords)
 		deferRecord = func(job func(context.Context) error) {
 			recordWG.Add(1)
 			// Detached from the request context on purpose: the hook client
@@ -141,10 +153,14 @@ func Start(ctx context.Context, opts Options) (*Host, error) {
 			// finish anyway. Close bounds the drain via recordWG.
 			go func() {
 				defer recordWG.Done()
+				slots <- struct{}{}
+				defer func() { <-slots }()
 				if err := job(context.WithoutCancel(ctx)); err != nil {
-					// The hook response is long gone, so this log line and its
+					// The hook response is long gone, so this line and its
 					// running total are the only trace the record was lost.
-					diag.Printf("deferred decision record: %v (%d failed since start)\n", err, recordFailures.Add(1))
+					// Printf is debug-gated; a lost audit record must reach
+					// the daemon log unconditionally.
+					diagnostic.LogAlways(diag, "deferred decision record: %v (%d failed since start)\n", err, recordFailures.Add(1))
 				}
 			}()
 		}

--- a/internal/runtimehost/host.go
+++ b/internal/runtimehost/host.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/kontext-security/kontext-cli/internal/cedarpolicy"
@@ -41,12 +42,13 @@ type Options struct {
 	SkipInitialSession    bool
 	DisableAsyncIngest    bool
 	// AsyncDecisionRecording answers decision-gating hooks (PreToolUse) as
-	// soon as the policy verdict is settled and runs annotation + the SQLite
-	// write in the background, mirroring what AsyncIngest already does for
-	// non-blocking hooks. Without it, a cold or contended guard.db routinely
-	// outlives the hook client's budget, which reads as a dead daemon:
-	// fail-open in observe, fail-closed (every tool call denied) in enforce.
-	// Close drains pending writes before the store closes.
+	// soon as the policy verdict is settled and runs every store write —
+	// session upsert, annotation, decision row — in the background,
+	// mirroring what AsyncIngest already does for non-blocking hooks.
+	// Without it, a cold or contended guard.db routinely outlives the hook
+	// client's budget, which reads as a dead daemon: fail-open in observe,
+	// fail-closed (every tool call denied) in enforce. Close drains pending
+	// writes before the store closes.
 	AsyncDecisionRecording bool
 }
 
@@ -128,6 +130,7 @@ func Start(ctx context.Context, opts Options) (*Host, error) {
 		serverSessionID = ""
 	}
 	var recordWG sync.WaitGroup
+	var recordFailures atomic.Int64
 	var deferRecord func(job func(context.Context) error)
 	if opts.AsyncDecisionRecording {
 		diag := opts.Diagnostic
@@ -139,7 +142,9 @@ func Start(ctx context.Context, opts Options) (*Host, error) {
 			go func() {
 				defer recordWG.Done()
 				if err := job(context.WithoutCancel(ctx)); err != nil {
-					diag.Printf("deferred decision record: %v\n", err)
+					// The hook response is long gone, so this log line and its
+					// running total are the only trace the record was lost.
+					diag.Printf("deferred decision record: %v (%d failed since start)\n", err, recordFailures.Add(1))
 				}
 			}()
 		}

--- a/internal/runtimehost/host.go
+++ b/internal/runtimehost/host.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/kontext-security/kontext-cli/internal/cedarpolicy"
@@ -39,6 +40,14 @@ type Options struct {
 	Diagnostic            diagnostic.Logger
 	SkipInitialSession    bool
 	DisableAsyncIngest    bool
+	// AsyncDecisionRecording answers decision-gating hooks (PreToolUse) as
+	// soon as the policy verdict is settled and runs annotation + the SQLite
+	// write in the background, mirroring what AsyncIngest already does for
+	// non-blocking hooks. Without it, a cold or contended guard.db routinely
+	// outlives the hook client's budget, which reads as a dead daemon:
+	// fail-open in observe, fail-closed (every tool call denied) in enforce.
+	// Close drains pending writes before the store closes.
+	AsyncDecisionRecording bool
 }
 
 type Host struct {
@@ -57,6 +66,7 @@ type Host struct {
 	runtimeService   *localruntime.Service
 	sessionOpened    bool
 	sessionCloseOnce bool
+	drainRecords     func(context.Context) error
 }
 
 func Start(ctx context.Context, opts Options) (*Host, error) {
@@ -117,6 +127,23 @@ func Start(ctx context.Context, opts Options) (*Host, error) {
 	if opts.SkipInitialSession {
 		serverSessionID = ""
 	}
+	var recordWG sync.WaitGroup
+	var deferRecord func(job func(context.Context) error)
+	if opts.AsyncDecisionRecording {
+		diag := opts.Diagnostic
+		deferRecord = func(job func(context.Context) error) {
+			recordWG.Add(1)
+			// Detached from the request context on purpose: the hook client
+			// disconnects the moment it has its answer, and the write must
+			// finish anyway. Close bounds the drain via recordWG.
+			go func() {
+				defer recordWG.Done()
+				if err := job(context.WithoutCancel(ctx)); err != nil {
+					diag.Printf("deferred decision record: %v\n", err)
+				}
+			}()
+		}
+	}
 	localServer, closeStore, err := server.OpenDefaultServerWithOptions(dbPath, server.Options{
 		Judge:            localJudge,
 		CedarPolicies:    opts.CedarPolicies,
@@ -124,6 +151,7 @@ func Start(ctx context.Context, opts Options) (*Host, error) {
 		CurrentSessionID: serverSessionID,
 		Mode:             string(mode),
 		RiskClassifier:   classifierOpts,
+		DeferRecord:      deferRecord,
 	})
 	if err != nil {
 		closeJudge()
@@ -158,6 +186,21 @@ func Start(ctx context.Context, opts Options) (*Host, error) {
 		server:                localServer,
 		closeStore:            closeStore,
 		closeJudge:            closeJudge,
+	}
+	if opts.AsyncDecisionRecording {
+		host.drainRecords = func(drainCtx context.Context) error {
+			done := make(chan struct{})
+			go func() {
+				recordWG.Wait()
+				close(done)
+			}()
+			select {
+			case <-done:
+				return nil
+			case <-drainCtx.Done():
+				return fmt.Errorf("drain deferred decision records: %w", drainCtx.Err())
+			}
+		}
 	}
 
 	serviceSessionID := sessionID
@@ -272,6 +315,14 @@ func (h *Host) Close(ctx context.Context) error {
 			errs = append(errs, err)
 		}
 		h.runtimeService = nil
+	}
+	// Deferred decision writes must land before the store closes underneath
+	// them; runtimeService is already down, so no new work can arrive.
+	if h.drainRecords != nil {
+		if err := h.drainRecords(ctx); err != nil {
+			errs = append(errs, err)
+		}
+		h.drainRecords = nil
 	}
 	if h.sessionOpened && !h.sessionCloseOnce && h.server != nil {
 		if err := h.server.RuntimeCore().CloseSession(context.Background(), h.SessionID); err != nil {


### PR DESCRIPTION
## Problem

The managed daemon settles the policy verdict quickly — Cedar evaluation is in-memory — but the hook response then waits synchronously on (1) classifier annotation, including optional guardrail inference, and (2) the guard.db write. On a long-running install the first write after an idle period pulls cold pages of a large database back from disk for **multiple seconds**, while the hook client's PreToolUse budget is **250 ms** (`preToolUseWait`, `internal/managedobserve/lifecycle.go`).

Every post-idle tool call therefore times out and reads as `managed policy daemon unavailable`:

- **observe**: fails open — silent, invisible, but every decision is recorded late by a daemon the hook already gave up on
- **enforce / remote-enforce**: fails closed — **every tool call on the endpoint is denied**, including the agent's ability to diagnose or revert anything

Measured on a real install (1.4 GB guard.db, pure-Go sqlite): ~5.4 s cold decision, 11 ms warm; a profiler sample during the cold window shows ~87% of the time in `pread` against the database file.

## Fix

Extend the ENG-474 async-ingest pattern to decision-gating hooks. The response is settled the moment the verdict is:

- `decideAndRecord` pre-mints the action ID (`sqlite.NewActionID`), returns the decision immediately, and hands annotation + persistence to a `DeferRecord` executor
- the executor (owned by `runtimehost`) runs jobs on a detached context (`context.WithoutCancel`) — a disconnected hook client can no longer abort the write — and `Host.Close` drains pending jobs **before** the store closes
- `SaveDecision` honors a pre-set `decision.EventID`, so the row lands under the same ID the hook response carried
- opt-in via `runtimehost.Options.AsyncDecisionRecording`; **only the managed daemon enables it**. Wrapper-owned sessions (`kontext start`, guard CLI) keep the synchronous path unchanged

The classifier stays advisory by construction — it now cannot even race the response, which is the intent the code comments already document.

## Not in this PR (follow-ups)

- guard.db retention/pruning — the underlying disease; exported rows currently live locally forever
- recording the hook's *effective* outcome when it times out (today the ledger shows the daemon's late verdict, not what the agent experienced)
- distinguishing "daemon slow" from "daemon absent" in the hook's error string
- `EnsureSessionForEvent` still writes synchronously before the decision; small table, but worth measuring

## Testing

- `TestDeferRecordAnswersWithoutPersisting`: response carries a pre-minted `act_` ID with zero store writes; running the captured job persists under that exact ID
- `TestNilDeferRecordStaysSynchronous`: historical behavior unchanged when the executor is nil
- `TestSaveDecisionHonorsPresetEventID`
- full test suites green: `guard/...`, `runtimehost`, `managedobserve`, `localruntime`

🤖 Generated with [Claude Code](https://claude.com/claude-code)