### PR TITLE
fix(endpointconfig): tolerate weak ETags and log refresh failures

### DIFF
--- a/internal/cedarpolicy/cache.go
+++ b/internal/cedarpolicy/cache.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 )
 
 const (
@@ -331,6 +333,13 @@ type Refresher struct {
 	Interval       time.Duration
 	MaxBackoff     time.Duration
 	Now            func() time.Time
+	// Diagnostic surfaces refresh state transitions in the daemon log. A
+	// refresh loop that fails silently leaves enforcement running on a stale
+	// policy with no operator-visible signal, so failures must not be
+	// log-invisible.
+	Diagnostic diagnostic.Logger
+
+	lastFailure string
 }
 
 func (r *Refresher) Refresh(ctx context.Context) error {
@@ -360,6 +369,7 @@ func (r *Refresher) Refresh(ctx context.Context) error {
 		r.recordFailure(err)
 		return err
 	}
+	r.recovered()
 	return nil
 }
 
@@ -399,6 +409,20 @@ func (r *Refresher) Run(ctx context.Context) {
 
 func (r *Refresher) recordFailure(err error) {
 	r.Cache.MarkFailed(err, r.now())
+	// Log once per distinct error, not once per attempt: the loop retries
+	// every minute and a repeated line per retry would drown the daemon log.
+	if message := err.Error(); message != r.lastFailure {
+		r.lastFailure = message
+		diagnostic.LogAlways(r.Diagnostic, "cedar policy refresh failed (running on the last cached policy until it recovers): %v\n", err)
+	}
+}
+
+func (r *Refresher) recovered() {
+	if r.lastFailure == "" {
+		return
+	}
+	r.lastFailure = ""
+	diagnostic.LogAlways(r.Diagnostic, "cedar policy refresh recovered\n")
 }
 
 func (r *Refresher) now() time.Time {

--- a/internal/endpointconfig/cache.go
+++ b/internal/endpointconfig/cache.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 	"github.com/kontext-security/kontext-cli/internal/payloadcapture"
 )
 
@@ -346,6 +347,12 @@ type Refresher struct {
 	Now            func() time.Time
 	Jitter         func(time.Duration) time.Duration
 	OnChanged      func(Snapshot)
+	// Diagnostic surfaces refresh state transitions in the daemon log. A
+	// refresh loop that fails silently leaves payload capture degraded with
+	// no operator-visible signal, so failures must not be log-invisible.
+	Diagnostic diagnostic.Logger
+
+	lastFailure string
 }
 
 func (r *Refresher) Refresh(ctx context.Context) error {
@@ -363,6 +370,7 @@ func (r *Refresher) Refresh(ctx context.Context) error {
 	if err := r.Cache.Apply(result, r.now()); err != nil {
 		return r.fail(err)
 	}
+	r.recovered()
 	r.notify()
 	return nil
 }
@@ -409,7 +417,21 @@ func (r *Refresher) fail(err error) error {
 		r.Cache.MarkFailed(err, r.now())
 		r.notify()
 	}
+	// Log once per distinct error, not once per attempt: the loop retries
+	// every minute and a repeated line per retry would drown the daemon log.
+	if message := err.Error(); message != r.lastFailure {
+		r.lastFailure = message
+		diagnostic.LogAlways(r.Diagnostic, "endpoint config refresh failed (capture degrades to summary until it recovers): %v\n", err)
+	}
 	return err
+}
+
+func (r *Refresher) recovered() {
+	if r.lastFailure == "" {
+		return
+	}
+	r.lastFailure = ""
+	diagnostic.LogAlways(r.Diagnostic, "endpoint config refresh recovered\n")
 }
 
 func (r *Refresher) notify() {

--- a/internal/endpointconfig/client.go
+++ b/internal/endpointconfig/client.go
@@ -97,8 +97,14 @@ func (c *Client) Fetch(ctx context.Context, installToken, installationID, config
 	return FetchResult{Response: &decoded, ETag: etag}, nil
 }
 
+// parseETag extracts the config identity from a strong or weak ETag. Weak
+// ETags are accepted because an intermediary that transforms the response
+// representation (compression, say) may legally weaken the validator
+// (RFC 9110 section 8.8.1); the identity inside is still the value the origin
+// computed. The Cedar policy client applies the same tolerance.
 func parseETag(value string) string {
 	value = strings.TrimSpace(value)
+	value = strings.TrimPrefix(value, "W/")
 	if len(value) != 66 || value[0] != '"' || value[len(value)-1] != '"' {
 		return ""
 	}

--- a/internal/endpointconfig/client_test.go
+++ b/internal/endpointconfig/client_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 	"github.com/kontext-security/kontext-cli/internal/payloadcapture"
 )
 
@@ -103,4 +104,131 @@ func TestClientRejectsUntrustedResponses(t *testing.T) {
 func marshalResponse(response Response) string {
 	data, _ := json.Marshal(response)
 	return string(data)
+}
+
+// TestClientAcceptsWeakETags covers the transformed-response path: an
+// intermediary that compresses the body (Cloudflare, corporate proxies)
+// legally weakens the validator to W/"<identity>". The identity inside is
+// still the origin's, so both the fresh and the not-modified paths must
+// accept it. Regression test for the silent refresh outage that pinned
+// payload capture to summary.
+func TestClientAcceptsWeakETags(t *testing.T) {
+	configuration := testResponse(t, payloadcapture.ModeFull)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		w.Header().Set("ETag", `W/"`+configuration.ConfigIdentity+`"`)
+		if request.Header.Get("If-None-Match") != "" {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(configuration)
+	}))
+	defer server.Close()
+	client, err := NewClient(server.URL, server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.Fetch(context.Background(), "token", testInstallationID, "")
+	if err != nil {
+		t.Fatalf("Fetch with weak ETag: %v", err)
+	}
+	if result.Response == nil || result.ETag != configuration.ConfigIdentity {
+		t.Fatalf("Fetch() = %#v", result)
+	}
+
+	result, err = client.Fetch(context.Background(), "token", testInstallationID, configuration.ConfigIdentity)
+	if err != nil {
+		t.Fatalf("conditional Fetch with weak ETag: %v", err)
+	}
+	if !result.NotModified || result.ETag != configuration.ConfigIdentity {
+		t.Fatalf("conditional Fetch() = %#v", result)
+	}
+}
+
+func TestParseETagAcceptsStrongAndWeakForms(t *testing.T) {
+	identity := strings.Repeat("a", 64)
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "strong", value: `"` + identity + `"`, want: identity},
+		{name: "weak", value: `W/"` + identity + `"`, want: identity},
+		{name: "weak with surrounding space", value: ` W/"` + identity + `" `, want: identity},
+		{name: "lowercase weak prefix is not a valid validator", value: `w/"` + identity + `"`, want: ""},
+		{name: "unquoted", value: identity, want: ""},
+		{name: "not hex", value: `"` + strings.Repeat("z", 64) + `"`, want: ""},
+		{name: "empty", value: "", want: ""},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := parseETag(test.value); got != test.want {
+				t.Fatalf("parseETag(%q) = %q, want %q", test.value, got, test.want)
+			}
+		})
+	}
+}
+
+// TestRefresherLogsFailureTransitions covers the observability contract: a
+// refresh loop that fails must say so in the daemon log exactly once per
+// distinct error, and must log recovery. The outage this guards against
+// failed every minute for a day without a single log line.
+func TestRefresherLogsFailureTransitions(t *testing.T) {
+	configuration := testResponse(t, payloadcapture.ModeFull)
+	healthy := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if !healthy {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("ETag", `"`+configuration.ConfigIdentity+`"`)
+		_ = json.NewEncoder(w).Encode(configuration)
+	}))
+	defer server.Close()
+	client, err := NewClient(server.URL, server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var log strings.Builder
+	refresher := Refresher{
+		Client:         client,
+		Cache:          NewCache(""),
+		TokenSource:    func(context.Context) (string, error) { return "token", nil },
+		InstallationID: testInstallationID,
+		Diagnostic:     diagnostic.New(&log, true),
+	}
+
+	// Two failing attempts with the same error: one log line.
+	if err := refresher.Refresh(context.Background()); err == nil {
+		t.Fatal("Refresh succeeded against a failing server")
+	}
+	if err := refresher.Refresh(context.Background()); err == nil {
+		t.Fatal("Refresh succeeded against a failing server")
+	}
+	failures := strings.Count(log.String(), "endpoint config refresh failed")
+	if failures != 1 {
+		t.Fatalf("failure lines = %d, want 1 (log: %q)", failures, log.String())
+	}
+
+	// Recovery: exactly one recovery line, and a later steady-state success
+	// stays quiet.
+	healthy = true
+	for range 2 {
+		if err := refresher.Refresh(context.Background()); err != nil {
+			t.Fatalf("Refresh after recovery: %v", err)
+		}
+	}
+	if recoveries := strings.Count(log.String(), "endpoint config refresh recovered"); recoveries != 1 {
+		t.Fatalf("recovery lines = %d, want 1 (log: %q)", recoveries, log.String())
+	}
+
+	// A new, different failure logs again.
+	server.Close()
+	if err := refresher.Refresh(context.Background()); err == nil {
+		t.Fatal("Refresh succeeded against a closed server")
+	}
+	if failures := strings.Count(log.String(), "endpoint config refresh failed"); failures != 2 {
+		t.Fatalf("failure lines after new error = %d, want 2 (log: %q)", failures, log.String())
+	}
 }

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -239,8 +239,9 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 	policyCtx, stopPolicyRefresh := context.WithCancel(ctx)
 	defer stopPolicyRefresh()
 	cedarRefresher := cedarpolicy.Refresher{
-		Client: cedarClient,
-		Cache:  cedarCache,
+		Client:     cedarClient,
+		Cache:      cedarCache,
+		Diagnostic: opts.Diagnostic,
 		TokenSource: func(refreshCtx context.Context) (string, error) {
 			loaded, err := managedconfig.Load()
 			if err != nil {
@@ -253,8 +254,9 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 	}
 	go cedarRefresher.Run(policyCtx)
 	endpointConfigRefresher := endpointconfig.Refresher{
-		Client: endpointConfigClient,
-		Cache:  endpointConfigCache,
+		Client:     endpointConfigClient,
+		Cache:      endpointConfigCache,
+		Diagnostic: opts.Diagnostic,
 		TokenSource: func(refreshCtx context.Context) (string, error) {
 			loaded, err := managedconfig.Load()
 			if err != nil {


### PR DESCRIPTION
## Summary

Client-side half of the payload-capture outage fix (server-side: kontext#799 + the Cloudflare cache rule).

**Incident:** since Aug 5 ~12:56 UTC, edge compression on `GET /installations/:id/configuration` weakened the response ETag to `W/"<identity>"`. `parseETag` rejected that form, every refresh failed with `ETag does not match config identity`, the endpoint-config cache never confirmed, and `SafeRuntimeConfiguration` pinned payload capture to `summary` **for every agent on the endpoint** — with zero log lines from the refresh loop.

## Changes

- **`parseETag` accepts weak ETags** (`W/"…"`): an intermediary that transforms the representation may legally weaken the validator (RFC 9110 §8.8.1); the identity inside is still the origin's. This matches the tolerance `cedarpolicy`'s client already has — the two clients were inconsistent.
- **Refresh failures are now visible:** the `endpointconfig` and `cedarpolicy` refreshers log through the daemon diagnostic — once per **distinct** error plus one recovery line (not once per minute-retry), via `diagnostic.LogAlways` so it reaches the daemon log even without `KONTEXT_DEBUG`.
- Regression tests: weak-ETag fresh + not-modified fetches, `parseETag` form table, failure/recovery logging contract (dedup, recovery, re-log on new error).

## Why client-side too, when the server is being fixed

Kontext runs on customer machines behind corporate proxies and TLS-inspection middleboxes we don't control. Any RFC-compliant intermediary may weaken validators; hard-failing on that is the actual defect. The server-side `no-transform` fix removes the current trigger; this removes the class.

## Testing

`go build`, `go vet`, full `go test ./...` green. Root cause chain verified live against `api.kontext.security` (strong ETag via plain curl, `W/"…"` + `content-encoding: gzip` via `--compressed`, ledger rows carrying `"fallback_reason":"refresh_failed"`).

## Follow-up (not in this PR)

`kontext doctor` currently reports a healthy daemon while capture is degraded; a payload-capture/config-freshness status line would have surfaced this in seconds.
