### PR TITLE
test(doctor): stop doctor tests inheriting this Mac's managed config

### DIFF
--- a/internal/managedobserve/doctor.go
+++ b/internal/managedobserve/doctor.go
@@ -47,6 +47,11 @@ type doctorOptions struct {
 	Dial               func(network, address string, timeout time.Duration) (net.Conn, error)
 	Now                func() time.Time
 	LaunchAgentPresent func() bool
+	// LoadConfig resolves the managed config whose scope drives most of this
+	// readout. Defaults to managedconfig.Load; injectable so callers can pin a
+	// scope instead of inheriting whatever this machine happens to have under
+	// /Library — a real MDM install would otherwise decide the answer.
+	LoadConfig func() (managedconfig.LoadedConfig, error)
 }
 
 func printStatus(out io.Writer, installedVersion string, opts doctorOptions) DoctorStatus {
@@ -68,10 +73,13 @@ func printStatus(out io.Writer, installedVersion string, opts doctorOptions) Doc
 	if opts.LaunchAgentPresent == nil {
 		opts.LaunchAgentPresent = selfServeLaunchAgentPresent
 	}
+	if opts.LoadConfig == nil {
+		opts.LoadConfig = managedconfig.Load
+	}
 
 	fmt.Fprintln(out, "Managed observe:")
 
-	loaded, err := managedconfig.Load()
+	loaded, err := opts.LoadConfig()
 	if errors.Is(err, managedconfig.ErrNotManaged) {
 		fmt.Fprintln(out, "  config: not configured (run `kontext setup` to connect this Mac to a workspace)")
 		return status

--- a/internal/managedobserve/doctor_test.go
+++ b/internal/managedobserve/doctor_test.go
@@ -438,10 +438,69 @@ func TestWaitForDaemonRestartTimesOutWithoutDaemon(t *testing.T) {
 	}
 }
 
+// Config scope decides the org-managed callout, and it must come from the
+// injected loader — not from whatever managed.json this Mac happens to have
+// under /Library. Before doctorOptions.LoadConfig existed, a developer with the
+// customer .pkg installed silently ran every doctor test at system scope and
+// saw this warning flip them all red.
+func TestPrintStatusOrgManagedWarningFollowsConfigScope(t *testing.T) {
+	const orgManagedWarning = "WARNING: this Mac is organization-managed but a self-serve agent is also installed"
+
+	// Everything except scope is healthy, so scope is the only thing that can
+	// move Healthy.
+	newHealthyEnv := func(t *testing.T) doctorTestEnv {
+		t.Helper()
+		env := newDoctorTestEnv(t)
+		env.writeDaemonStatus(t, os.Getpid(), "1.2.3")
+		cursor := env.seedLedger(t)
+		if err := managedstream.SaveState(managedstream.DefaultStatePathForDB(env.dbPath), managedstream.State{
+			UpdatedAfter:    &cursor.UpdatedAt,
+			ActionID:        cursor.ActionID,
+			LastHeartbeatAt: env.now.Add(-20 * time.Second).Format(time.RFC3339Nano),
+		}); err != nil {
+			t.Fatal(err)
+		}
+		return env
+	}
+
+	t.Run("user scope is a plain self-serve install", func(t *testing.T) {
+		env := newHealthyEnv(t)
+
+		var out bytes.Buffer
+		status := printStatus(&out, "1.2.3", env.options())
+
+		output := out.String()
+		if !status.Healthy || !status.SelfServe {
+			t.Fatalf("status = %+v, want healthy and self-serve; output = %q", status, output)
+		}
+		if strings.Contains(output, orgManagedWarning) {
+			t.Fatalf("output = %q, want no org-managed warning at user scope", output)
+		}
+	})
+
+	t.Run("system scope plus a user agent is a conflict", func(t *testing.T) {
+		env := newHealthyEnv(t)
+		opts := env.options()
+		opts.LoadConfig = env.loadConfig(managedconfig.ScopeSystem)
+
+		var out bytes.Buffer
+		status := printStatus(&out, "1.2.3", opts)
+
+		output := out.String()
+		if status.Healthy || status.SelfServe {
+			t.Fatalf("status = %+v, want unhealthy and not self-serve; output = %q", status, output)
+		}
+		if !strings.Contains(output, orgManagedWarning) {
+			t.Fatalf("output = %q, want warning %q", output, orgManagedWarning)
+		}
+	})
+}
+
 type doctorTestEnv struct {
 	dir        string
 	dbPath     string
 	socketPath string
+	configPath string
 	now        time.Time
 }
 
@@ -471,7 +530,23 @@ func newDoctorTestEnv(t *testing.T) doctorTestEnv {
 		dir:        dir,
 		dbPath:     filepath.Join(dir, "guard.db"),
 		socketPath: filepath.Join(dir, "kontext.sock"),
+		configPath: configPath,
 		now:        time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+// loadConfig reads this env's fixture at a caller-chosen scope. Tests must not
+// go through managedconfig.ResolvePath: it prefers an existing system config,
+// so on any Mac with a real pkg install the fixture would lose to
+// /Library/Application Support/Kontext/managed.json.
+func (e doctorTestEnv) loadConfig(scope managedconfig.Scope) func() (managedconfig.LoadedConfig, error) {
+	return func() (managedconfig.LoadedConfig, error) {
+		loaded, err := managedconfig.LoadFile(e.configPath)
+		if err != nil {
+			return managedconfig.LoadedConfig{}, err
+		}
+		loaded.Scope = scope
+		return loaded, nil
 	}
 }
 
@@ -486,6 +561,7 @@ func (e doctorTestEnv) options() doctorOptions {
 		},
 		Now:                func() time.Time { return e.now },
 		LaunchAgentPresent: func() bool { return true },
+		LoadConfig:         e.loadConfig(managedconfig.ScopeUser),
 	}
 }
 


### PR DESCRIPTION
## Summary

No user-facing change: this fixes seven `internal/managedobserve` doctor tests that fail on any machine with an enterprise/MDM install present at `/Library/Application Support/Kontext/managed.json`. Pre-existing on `main`, unrelated to any feature branch.

`newDoctorTestEnv` wrote its fixture at the user-scope path and relied on `managedconfig.ResolvePath()` to pick it up. `ResolvePath` checks the **system** path first and returns `ScopeSystem` whenever it exists, so with the customer `.pkg` installed the tests resolved the real system config instead of their fixture. Scope then drove two things — `installationPathForScope` and the "this Mac is organization-managed but a self-serve agent is also installed" callout — flipping `Healthy` to false.

Failing before this change:

- `TestPrintStatusDaemonVersionMatch`
- `TestPrintStatusDaemonVersionMismatch`
- `TestPrintStatusDaemonDevVersionDoesNotWarn`
- `TestPrintStatusDaemonDeadPIDTreatedAsUnknownAndFixable`
- `TestPrintStatusDaemonWithoutBreadcrumbIsFixable`
- `TestPrintStatusDaemonWithoutBreadcrumbDevInstallDoesNotWarn`
- `TestPrintStatusHeartbeatFreshAndExportUpToDate`

CI runners have no `/Library` install, so this only bites locally — precisely when someone is testing the `.pkg` on their own machine and doctor test signal matters most.

### Approach

`doctorOptions` gains a `LoadConfig func() (managedconfig.LoadedConfig, error)` seam alongside the existing `Dial` / `Now` / `LaunchAgentPresent` ones, defaulted to `managedconfig.Load`. Tests pin the scope they mean; `PrintStatus` passes nothing, so production behavior is byte-identical and `ResolvePath` keeps its security-relevant system-wins precedence untouched. No test-only knob is added to production code — this is the seam idiom the struct already uses.

`KONTEXT_MANAGED_CONFIG` was not usable here: it forces `ScopeEnv`, so it cannot express "user scope, no system config". (It works in `doctor_report_test.go` on another branch only because those tests assert the UNCONFIGURED case.)

Also adds `TestPrintStatusOrgManagedWarningFollowsConfigScope`, pinning both scopes deterministically. The `ScopeSystem` branch had no real coverage before — it only ever fired by accident on developer machines, which is how this went unnoticed.

### How it was verified

The bug could not be reproduced by simply running the tests: the tool sandbox hides `/Library` from Go (`os.Lstat` returns `ErrNotExist`), so a sandboxed run silently behaves like CI. The condition was built instead, by temporarily pointing the unexported `managedconfig.systemPath` test seam at a fixture so `ResolvePath` returns `ScopeSystem`. On that simulated MDM machine the original code failed **exactly those seven tests, no more and no less**; with this change all pass. `systemPath` was then restored — it is untouched in this diff.

## Verification

- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] `go vet ./...`

`gofmt` clean and `go build ./...` OK.

## Release notes

- [x] conventional commit title matches semver intent — `test:`, no user-facing behavior change, no release bump

## Note for reviewers

`doctor_report_test.go` is not on `main`; it lives on `hasan/kontext-cli-env-switching-b0541e` (added in 41e283f). Its `KONTEXT_MANAGED_CONFIG`-at-a-nonexistent-path workaround can collapse into this seam when that branch merges, and `doctorOptions` is a likely conflict point there.
