### PR TITLE
fix(hook): label Cowork sessions that run on the host

### DIFF
--- a/cmd/kontext/main.go
+++ b/cmd/kontext/main.go
@@ -32,6 +32,8 @@ var version = "dev"
 
 var userHomeDir = os.UserHomeDir
 
+var lookupEnv = os.Getenv
+
 func main() {
 	root := newRootCmd()
 	if err := root.Execute(); err != nil {
@@ -291,6 +293,9 @@ func (a managedHookAgent) DecodeHookInput(input []byte) (hook.Event, error) {
 }
 
 func isCoworkHookContext(input []byte, event hook.Event) bool {
+	if isCoworkHostSession() {
+		return true
+	}
 	if isCoworkPath(event.CWD) {
 		return true
 	}
@@ -309,6 +314,17 @@ func isCoworkHookContext(input []byte, event hook.Event) bool {
 		}
 	}
 	return false
+}
+
+// isCoworkHostSession reports whether the hook was spawned by a Cowork session
+// running on the host. Cowork opened on a folder or repository runs the bundled
+// CLI directly on the host with the working directory set to the user's own
+// checkout, so the session-path heuristic below never matches it. The desktop
+// app does mark those processes: it sets CLAUDE_CODE_HOST_SESSION_ID to the
+// Cowork session id, which carries a "local_" prefix, and hooks inherit it as
+// child processes. Plain Claude Code leaves the variable unset.
+func isCoworkHostSession() bool {
+	return strings.HasPrefix(lookupEnv("CLAUDE_CODE_HOST_SESSION_ID"), "local_")
 }
 
 func isCoworkPath(value string) bool {

--- a/cmd/kontext/main_test.go
+++ b/cmd/kontext/main_test.go
@@ -119,6 +119,7 @@ func TestManagedHookAgentIdentifiesCoworkOnlyInManagedSessionPath(t *testing.T) 
 	oldHome := userHomeDir
 	userHomeDir = func() (string, error) { return "/Users/michel", nil }
 	t.Cleanup(func() { userHomeDir = oldHome })
+	stubEnv(t, nil)
 	a, ok := agent.Get("claude")
 	if !ok {
 		t.Fatal("claude agent not registered")
@@ -132,6 +133,53 @@ func TestManagedHookAgentIdentifiesCoworkOnlyInManagedSessionPath(t *testing.T) 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			event, err := (managedHookAgent{Agent: a}).DecodeHookInput([]byte(tt.input))
+			if err != nil {
+				t.Fatalf("DecodeHookInput() error = %v", err)
+			}
+			if event.Agent != tt.want {
+				t.Fatalf("Agent = %q, want %q", event.Agent, tt.want)
+			}
+		})
+	}
+}
+
+// stubEnv replaces the process environment lookup for the duration of a test.
+func stubEnv(t *testing.T, env map[string]string) {
+	t.Helper()
+	old := lookupEnv
+	lookupEnv = func(key string) string { return env[key] }
+	t.Cleanup(func() { lookupEnv = old })
+}
+
+// Cowork opened on a folder or repository runs on the host with the working
+// directory set to the user's own checkout and a transcript under ~/.claude, so
+// no path in the hook payload identifies it. Before the host-session check these
+// sessions were recorded as plain Claude Code and never appeared under Cowork.
+func TestManagedHookAgentIdentifiesCoworkRunningOnHost(t *testing.T) {
+	oldHome := userHomeDir
+	userHomeDir = func() (string, error) { return "/Users/michel", nil }
+	t.Cleanup(func() { userHomeDir = oldHome })
+	a, ok := agent.Get("claude")
+	if !ok {
+		t.Fatal("claude agent not registered")
+	}
+	const hostSession = `{"session_id":"s1","hook_event_name":"PreToolUse",` +
+		`"cwd":"/Users/michel/projects/app/.claude/worktrees/feature-abc123",` +
+		`"transcript_path":"/Users/michel/.claude/projects/-Users-michel-projects-app/s1.jsonl"}`
+	tests := []struct {
+		name string
+		env  map[string]string
+		want string
+	}{
+		{"cowork host session", map[string]string{"CLAUDE_CODE_HOST_SESSION_ID": "local_9826bfca-2687"}, "cowork"},
+		{"no host session id", nil, "claude"},
+		{"empty host session id", map[string]string{"CLAUDE_CODE_HOST_SESSION_ID": ""}, "claude"},
+		{"non-cowork host session id", map[string]string{"CLAUDE_CODE_HOST_SESSION_ID": "remote_9826bfca"}, "claude"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stubEnv(t, tt.env)
+			event, err := (managedHookAgent{Agent: a}).DecodeHookInput([]byte(hostSession))
 			if err != nil {
 				t.Fatalf("DecodeHookInput() error = %v", err)
 			}

--- a/internal/agent/cowork/cowork.go
+++ b/internal/agent/cowork/cowork.go
@@ -1,9 +1,11 @@
 // Package cowork registers the Cowork agent adapter. Claude Cowork runs the same
-// bundled Claude Code CLI inside a per-session VM, so its hook payloads use the
-// identical Claude Code hook-input format. The adapter therefore reuses the
-// Claude decoder/encoder and only differs in its name, which is recorded as the
+// bundled Claude Code CLI — on the host when opened on a folder or repository,
+// and otherwise inside a per-session VM — so its hook payloads use the identical
+// Claude Code hook-input format. The adapter therefore reuses the Claude
+// decoder/encoder and only differs in its name, which is recorded as the
 // session's agent ("cowork") to distinguish Cowork activity from Claude Code in
-// the ledger and dashboard.
+// the ledger and dashboard. Only host-run sessions reach a hook at all; VM
+// sessions have no kontext binary in the guest.
 package cowork
 
 import (


### PR DESCRIPTION
## Problem

Cowork activity never appears under Cowork in the dashboard. On this machine the ledger holds 22 sessions and **zero** `cowork` rows, ever.

The cause is labeling, not lost data. Cowork opened on a folder or repository runs the bundled CLI **on the host**, so its hooks fire normally and the daemon records everything — but `isCoworkPath` only recognizes the retired layout `~/Library/Application Support/Claude/local-agent-mode-sessions/<acct>/<org>/local_*`. A modern host session looks like this instead:

- `cwd` → the user's own checkout, e.g. `…/kontext-cli/.claude/worktrees/<name>`
- `transcript_path` → `~/.claude/projects/<slug>/<uuid>.jsonl`

Neither matches, so `isCoworkHookContext` falls through and the session is stored as `claude_code`. Filter the dashboard for Cowork and you see nothing, which reads as a broken integration.

Observed live with desktop app 1.24012.9 / claude-code 2.1.219: Cowork session `local_9826bfca-…` landed in the ledger as `efb31c8c-…` with `agent = claude_code` and its Bash/Read actions attached.

## Fix

Identify host-run Cowork by environment rather than by path. The desktop app sets `CLAUDE_CODE_HOST_SESSION_ID` to the Cowork session id, which carries a `local_` prefix; hooks inherit it as child processes, and plain Claude Code leaves it unset. The existing path heuristic stays as a fallback so the older layout keeps working.

## Testing

- New table test covers the real host-session payload shape plus the unset, empty, and non-`local_` cases.
- Confirmed the new test fails on `main` (`agent = "claude"`) and passes here.
- Existing path-heuristic test still passes, pinned against a stubbed environment.
- `go build ./...`, `go test ./...`, `go vet ./...`, `gofmt -l` all clean.

Not covered: the full managed-observe path end-to-end. It has no state-directory override, so exercising it would write into the live ledger and stream to the real dashboard. The unit tests target `DecodeHookInput` directly, which is the function that was wrong.

## Scope

This fixes host-run Cowork only. Cowork sessions that execute in the per-session VM still bypass observation entirely — no kontext binary, managed-settings drop-in, or daemon socket exists in the guest, so no hook can fire. That is a separate gap and is untouched here.