### PR TITLE
fix(setup): let `kontext setup` re-run against the active profile

### DIFF
--- a/internal/setup/inventory.go
+++ b/internal/setup/inventory.go
@@ -238,36 +238,10 @@ func orDash(value string) string {
 //
 // `exclude` is the profile being written, so re-running setup for an existing
 // profile — rotating its token — is never mistaken for a duplicate of itself.
-// rewriteTarget names the profile this run will write to, when that is knowable
-// before the workspace is. It is what the duplicate check must EXCLUDE:
-// rewriting a profile in place is the documented way to rotate its token, and
-// counting the profile you are about to write as a duplicate of itself refuses
-// the re-run that `kontext setup` promises is safe.
-//
-// Empty means "exclude nothing", which is correct in the two cases it returns
-// it for: a derived name (`profile add` with no name) creates a NEW profile, so
-// every existing one is a real candidate; and a legacy install with no active
-// profile is not a profile, so nothing can collide with it.
-func rewriteTarget(opts Options) (string, error) {
-	if opts.Profile != "" {
-		return opts.Profile, nil
-	}
-	if opts.DeriveProfileName {
-		return "", nil
-	}
-	// Plain `kontext setup`: resolveTarget falls back to the active profile, so
-	// that is the profile being rewritten.
-	active, err := profile.ActiveName()
-	switch {
-	case err == nil:
-		return active, nil
-	case errors.Is(err, profile.ErrNoActive):
-		return "", nil
-	default:
-		return "", err
-	}
-}
-
+// profileBoundToWorkspace names an existing profile already bound to this
+// workspace on this backend, or "" if none is. exclude is the profile the
+// caller is about to write to — rewriting a profile in place is how a token is
+// rotated, so it must never count as a duplicate of itself.
 func profileBoundToWorkspace(organizationID, cloudURL, exclude string) (string, error) {
 	if strings.TrimSpace(organizationID) == "" {
 		// Nothing to compare. The legacy env-fallback org reports an empty id, and

--- a/internal/setup/inventory.go
+++ b/internal/setup/inventory.go
@@ -238,6 +238,36 @@ func orDash(value string) string {
 //
 // `exclude` is the profile being written, so re-running setup for an existing
 // profile — rotating its token — is never mistaken for a duplicate of itself.
+// rewriteTarget names the profile this run will write to, when that is knowable
+// before the workspace is. It is what the duplicate check must EXCLUDE:
+// rewriting a profile in place is the documented way to rotate its token, and
+// counting the profile you are about to write as a duplicate of itself refuses
+// the re-run that `kontext setup` promises is safe.
+//
+// Empty means "exclude nothing", which is correct in the two cases it returns
+// it for: a derived name (`profile add` with no name) creates a NEW profile, so
+// every existing one is a real candidate; and a legacy install with no active
+// profile is not a profile, so nothing can collide with it.
+func rewriteTarget(opts Options) (string, error) {
+	if opts.Profile != "" {
+		return opts.Profile, nil
+	}
+	if opts.DeriveProfileName {
+		return "", nil
+	}
+	// Plain `kontext setup`: resolveTarget falls back to the active profile, so
+	// that is the profile being rewritten.
+	active, err := profile.ActiveName()
+	switch {
+	case err == nil:
+		return active, nil
+	case errors.Is(err, profile.ErrNoActive):
+		return "", nil
+	default:
+		return "", err
+	}
+}
+
 func profileBoundToWorkspace(organizationID, cloudURL, exclude string) (string, error) {
 	if strings.TrimSpace(organizationID) == "" {
 		// Nothing to compare. The legacy env-fallback org reports an empty id, and

--- a/internal/setup/recovery_test.go
+++ b/internal/setup/recovery_test.go
@@ -443,6 +443,49 @@ func TestSetupRerunWithoutAProfileNameRotatesTheActiveProfile(t *testing.T) {
 	}
 }
 
+// The profile excluded from duplicate detection and the profile written to must
+// be the SAME one. When the active pointer was read twice — once to exclude,
+// once to write — a `kontext profile use` landing between the two reads sent
+// the write to a profile the guard had never cleared. The menu bar app switches
+// profiles on one click, so the window is reachable.
+//
+// The seam fires at exactly that instant.
+func TestSetupWritesToTheProfileItCleared(t *testing.T) {
+	h := profileHarness(t)
+	server := pingServer(t, "kt_same")
+	first := h.options("kt_same", server)
+	first.Profile = "work"
+	if err := Run(context.Background(), first); err != nil {
+		t.Fatal(err)
+	}
+	other := h.options("kt_other", multiWorkspacePingServer(t, map[string]string{"kt_other": "org_other"}))
+	other.Profile = "other"
+	if err := Run(context.Background(), other); err != nil {
+		t.Fatal(err)
+	}
+	if err := profile.SetActive("work"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Switch the active profile the moment the guard runs.
+	overrideVar(t, &boundProfileLookup, func(orgID, cloudURL, exclude string) (string, error) {
+		if err := profile.SetActive("other"); err != nil {
+			t.Fatal(err)
+		}
+		return profileBoundToWorkspace(orgID, cloudURL, exclude)
+	})
+
+	rerun := h.options("kt_same", server)
+	var wrote string
+	rerun.OnProfileResolved = func(name string) { wrote = name }
+	if err := Run(context.Background(), rerun); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if wrote != "work" {
+		t.Errorf("setup wrote to profile %q, but cleared %q past the guard", wrote, "work")
+	}
+}
+
 // The fix must not blunt the guard: a run that DERIVES its name is creating a
 // new profile, so every existing profile stays a candidate duplicate — even
 // though this run has an active profile that a plain setup would have excluded.

--- a/internal/setup/recovery_test.go
+++ b/internal/setup/recovery_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -478,11 +479,100 @@ func TestSetupWritesToTheProfileItCleared(t *testing.T) {
 	rerun := h.options("kt_same", server)
 	var wrote string
 	rerun.OnProfileResolved = func(name string) { wrote = name }
-	if err := Run(context.Background(), rerun); err != nil {
-		t.Fatalf("Run() error = %v", err)
+	err := Run(context.Background(), rerun)
+
+	// The invariant is that the write never lands on a profile the guard did not
+	// clear. Refusing satisfies it more strongly than writing to "work" would,
+	// and refusing is what the target snapshot now does — but "other" must never
+	// be the target either way.
+	if wrote == "other" {
+		t.Errorf("setup targeted %q, which the guard never cleared", wrote)
 	}
-	if wrote != "work" {
-		t.Errorf("setup wrote to profile %q, but cleared %q past the guard", wrote, "work")
+	if err == nil {
+		t.Fatal("Run() = nil, want a refusal after the active pointer moved")
+	}
+	if !strings.Contains(err.Error(), "while setup was running") {
+		t.Fatalf("error = %v, want it to name the concurrent change", err)
+	}
+}
+
+// Resolving the target once is not enough on its own: `profile rename` moves
+// the directory the resolved paths name, so writing afterwards would recreate a
+// profile under the name the user just renamed away. Refuse instead.
+func TestSetupRefusesWhenTheTargetIsRenamedMidRun(t *testing.T) {
+	h := profileHarness(t)
+	server := pingServer(t, "kt_same")
+	first := h.options("kt_same", server)
+	first.Profile = "work"
+	if err := Run(context.Background(), first); err != nil {
+		t.Fatal(err)
+	}
+	if err := profile.SetActive("work"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Rename the target the moment the guard runs — after resolution, before the
+	// first write.
+	overrideVar(t, &boundProfileLookup, func(orgID, cloudURL, exclude string) (string, error) {
+		// Renaming AFTER the real lookup, so the guard sees the world as it was
+		// and the run proceeds to the write it must now refuse.
+		duplicate, err := profileBoundToWorkspace(orgID, cloudURL, exclude)
+		if err != nil {
+			return "", err
+		}
+		if renameErr := RenameProfile(context.Background(), "work", "renamed", io.Discard); renameErr != nil {
+			t.Fatal(renameErr)
+		}
+		return duplicate, nil
+	})
+
+	err := Run(context.Background(), h.options("kt_same", server))
+	if err == nil {
+		t.Fatal("Run() = nil, want a refusal after the target moved")
+	}
+	if !strings.Contains(err.Error(), "while setup was running") {
+		t.Fatalf("error = %v, want it to name the concurrent change", err)
+	}
+	// The refusal must be clean: no profile resurrected under the old name.
+	if exists, _ := profile.Exists("work"); exists {
+		t.Error("a refused setup recreated the renamed-away profile")
+	}
+}
+
+// `profile rm` refuses the ACTIVE profile, but an explicitly named target need
+// not be active — so removal mid-run is reachable there.
+func TestSetupRefusesWhenTheTargetIsRemovedMidRun(t *testing.T) {
+	h := profileHarness(t)
+	server := pingServer(t, "kt_same")
+	first := h.options("kt_same", server)
+	first.Profile = "work"
+	if err := Run(context.Background(), first); err != nil {
+		t.Fatal(err)
+	}
+	other := h.options("kt_other", multiWorkspacePingServer(t, map[string]string{"kt_other": "org_other"}))
+	other.Profile = "other"
+	if err := Run(context.Background(), other); err != nil {
+		t.Fatal(err)
+	}
+	if err := profile.SetActive("other"); err != nil {
+		t.Fatal(err)
+	}
+
+	overrideVar(t, &boundProfileLookup, func(orgID, cloudURL, exclude string) (string, error) {
+		if err := profile.Remove("work"); err != nil {
+			t.Fatal(err)
+		}
+		return profileBoundToWorkspace(orgID, cloudURL, exclude)
+	})
+
+	rerun := h.options("kt_same", server)
+	rerun.Profile = "work"
+	err := Run(context.Background(), rerun)
+	if err == nil {
+		t.Fatal("Run() = nil, want a refusal after the target was removed")
+	}
+	if !strings.Contains(err.Error(), "while setup was running") {
+		t.Fatalf("error = %v, want it to name the concurrent change", err)
 	}
 }
 

--- a/internal/setup/recovery_test.go
+++ b/internal/setup/recovery_test.go
@@ -411,6 +411,64 @@ func TestSetupRerunForTheSameProfileIsNotADuplicate(t *testing.T) {
 	}
 }
 
+// Plain `kontext setup` — no profile name — rewrites the ACTIVE profile, which
+// is how a token is rotated on a machine that already has profiles. So the
+// duplicate check has to exclude the active profile, not only an explicitly
+// named one: excluding just opts.Profile made the re-run find the very profile
+// it was about to write and refuse itself, breaking the documented promise that
+// re-running setup is safe.
+func TestSetupRerunWithoutAProfileNameRotatesTheActiveProfile(t *testing.T) {
+	h := profileHarness(t)
+	server := pingServer(t, "kt_same")
+	first := h.options("kt_same", server)
+	first.Profile = "work"
+	if err := Run(context.Background(), first); err != nil {
+		t.Fatal(err)
+	}
+	if err := profile.SetActive("work"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Profile deliberately unset: resolveTarget falls back to the active one.
+	rerun := h.options("kt_same", server)
+	if err := Run(context.Background(), rerun); err != nil {
+		t.Fatalf("plain `kontext setup` against the active profile was refused: %v", err)
+	}
+	names, err := profile.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(names) != 1 || names[0] != "work" {
+		t.Errorf("profiles = %v, want the re-run to rewrite \"work\" rather than add another", names)
+	}
+}
+
+// The fix must not blunt the guard: a run that DERIVES its name is creating a
+// new profile, so every existing profile stays a candidate duplicate — even
+// though this run has an active profile that a plain setup would have excluded.
+func TestSetupStillRefusesADuplicateWhenTheNameIsDerived(t *testing.T) {
+	h := profileHarness(t)
+	server := pingServer(t, "kt_same")
+	first := h.options("kt_same", server)
+	first.Profile = "work"
+	if err := Run(context.Background(), first); err != nil {
+		t.Fatal(err)
+	}
+	if err := profile.SetActive("work"); err != nil {
+		t.Fatal(err)
+	}
+
+	added := h.options("kt_same", server)
+	added.DeriveProfileName = true
+	err := Run(context.Background(), added)
+	if err == nil {
+		t.Fatal("Run() = nil, want a duplicate-workspace refusal")
+	}
+	if !strings.Contains(err.Error(), "already set up as profile \"work\"") {
+		t.Fatalf("error = %v, want it to name the existing profile", err)
+	}
+}
+
 // Several workspaces on ONE backend is exactly what workspaces are for — the
 // rule is per workspace, not per environment.
 func TestSetupAllowsASecondWorkspaceOnTheSameBackend(t *testing.T) {

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -87,6 +87,9 @@ var (
 		}
 		return conn.Close()
 	}
+	// Seam so a test can move the active profile at the one instant that used to
+	// matter: between the duplicate check and the write.
+	boundProfileLookup  = profileBoundToWorkspace
 	systemConfigPath    = managedconfig.DefaultPath
 	orgInstallTokenPath = "/Library/Application Support/Kontext/install-token"
 	managedSettingsPath = claudemanaged.ManagedSettingsDropInPath
@@ -227,11 +230,31 @@ func Run(ctx context.Context, opts Options) error {
 	// the hosted API answers, so nothing earlier can tell two tokens apart. It is
 	// deliberately NOT "one profile per environment" — several workspaces on one
 	// backend is exactly what workspaces are for.
-	rewriting, err := rewriteTarget(opts)
-	if err != nil {
-		return err
+	// The target is resolved BEFORE the guard, and exactly once: the profile
+	// excluded from duplicate detection and the profile written to must be the
+	// same one. Resolving the active pointer twice — once to exclude, once to
+	// write — leaves a window in which a concurrent `kontext profile use` moves
+	// it in between, so the guard clears profile A while the write lands on B.
+	// The menu bar app switches profiles on a single click, which makes that
+	// window reachable rather than theoretical.
+	//
+	// Resolving early writes nothing: a target is path arithmetic, and every
+	// failure below still leaves the profile untouched.
+	//
+	// The derived case is the exception, and cannot be resolved yet: its name
+	// comes from the workspace, which nothing knows until the hosted API answers.
+	// It also needs no exclusion — that run creates a NEW profile, so every
+	// existing one is a real candidate duplicate.
+	var slot target
+	deriving := opts.DeriveProfileName && opts.Profile == ""
+	if !deriving {
+		slot, err = resolveTarget(opts.Profile)
+		if err != nil {
+			return err
+		}
 	}
-	if duplicate, err := profileBoundToWorkspace(ping.OrganizationID, cloudURL, rewriting); err != nil {
+
+	if duplicate, err := boundProfileLookup(ping.OrganizationID, cloudURL, slot.Profile); err != nil {
 		return err
 	} else if duplicate != "" {
 		return fmt.Errorf(
@@ -239,21 +262,16 @@ func Run(ctx context.Context, opts Options) error {
 			orgLabel, duplicate, cloudURL, duplicate)
 	}
 
-	// The target is resolved HERE, not before the token: with DeriveProfileName
-	// the name comes from the workspace, which nothing knows until the hosted API
-	// answers. Nothing above this point writes anything, so the ordering costs
-	// nothing and removes the need to invent a name up front.
-	profileName := opts.Profile
-	if opts.DeriveProfileName && profileName == "" {
-		profileName, err = DeriveProfileName(cloudURL, ping.OrganizationName, ping.OrganizationID)
+	if deriving {
+		profileName, err := DeriveProfileName(cloudURL, ping.OrganizationName, ping.OrganizationID)
 		if err != nil {
 			return err
 		}
 		fmt.Fprintf(opts.Stdout, "  ✓ Profile name: %s\n", profileName)
-	}
-	slot, err := resolveTarget(profileName)
-	if err != nil {
-		return err
+		slot, err = resolveTarget(profileName)
+		if err != nil {
+			return err
+		}
 	}
 	if opts.OnProfileResolved != nil {
 		opts.OnProfileResolved(slot.Profile)

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -246,9 +246,14 @@ func Run(ctx context.Context, opts Options) error {
 	// It also needs no exclusion — that run creates a NEW profile, so every
 	// existing one is a real candidate duplicate.
 	var slot target
+	var snapshot targetSnapshot
 	deriving := opts.DeriveProfileName && opts.Profile == ""
 	if !deriving {
 		slot, err = resolveTarget(opts.Profile)
+		if err != nil {
+			return err
+		}
+		snapshot, err = snapshotTarget(slot.Profile, opts.Profile == "")
 		if err != nil {
 			return err
 		}
@@ -272,9 +277,19 @@ func Run(ctx context.Context, opts Options) error {
 		if err != nil {
 			return err
 		}
+		snapshot, err = snapshotTarget(slot.Profile, false)
+		if err != nil {
+			return err
+		}
 	}
 	if opts.OnProfileResolved != nil {
 		opts.OnProfileResolved(slot.Profile)
+	}
+
+	// Last point at which nothing has been written. Past here the target's
+	// meaning is assumed, so a concurrent rename or removal must be caught now.
+	if err := snapshot.confirm(); err != nil {
+		return err
 	}
 
 	if err := writeKeychainToken(ctx, slot.KeychainItem, token); err != nil {

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -227,7 +227,11 @@ func Run(ctx context.Context, opts Options) error {
 	// the hosted API answers, so nothing earlier can tell two tokens apart. It is
 	// deliberately NOT "one profile per environment" — several workspaces on one
 	// backend is exactly what workspaces are for.
-	if duplicate, err := profileBoundToWorkspace(ping.OrganizationID, cloudURL, opts.Profile); err != nil {
+	rewriting, err := rewriteTarget(opts)
+	if err != nil {
+		return err
+	}
+	if duplicate, err := profileBoundToWorkspace(ping.OrganizationID, cloudURL, rewriting); err != nil {
 		return err
 	} else if duplicate != "" {
 		return fmt.Errorf(

--- a/internal/setup/target.go
+++ b/internal/setup/target.go
@@ -59,6 +59,82 @@ func resolveTarget(name string) (target, error) {
 	}
 }
 
+// targetSnapshot records what was true about the write target when it was
+// resolved, so that a concurrent `kontext profile` command moving that state is
+// caught BEFORE this run writes through it.
+//
+// Resolving the target once removes the divergence between the duplicate guard
+// and the write, but a target is only a set of paths: `profile rename` can move
+// the directory those paths name, and `profile rm` can delete it. Writing
+// afterwards would recreate a profile under a name the user had just renamed
+// away, and rotate a token into a keychain item nothing points at.
+//
+// There is no lock between kontext invocations — an interactive setup holds the
+// terminal across a token prompt and a sudo prompt, so holding one would block
+// the menu bar app's `profile use` for as long as someone leaves the prompt
+// sitting there. This is optimistic instead: it does not prevent the
+// interleaving, it refuses to write through it. A refusal that says what
+// happened and can be retried beats a stray profile nobody notices.
+type targetSnapshot struct {
+	profile    string
+	fromActive bool
+	active     string
+	existed    bool
+}
+
+func snapshotTarget(profileName string, fromActive bool) (targetSnapshot, error) {
+	snapshot := targetSnapshot{profile: profileName, fromActive: fromActive}
+	if profileName == "" {
+		// The legacy unprofiled slot: no profile state exists to be moved.
+		return snapshot, nil
+	}
+	exists, err := profile.Exists(profileName)
+	if err != nil {
+		return snapshot, err
+	}
+	snapshot.existed = exists
+	if fromActive {
+		active, err := profile.ActiveName()
+		if err != nil && !errors.Is(err, profile.ErrNoActive) {
+			return snapshot, err
+		}
+		snapshot.active = active
+	}
+	return snapshot, nil
+}
+
+// confirm reports whether the target still means what it did when resolved.
+func (s targetSnapshot) confirm() error {
+	if s.profile == "" {
+		return nil
+	}
+	if s.fromActive {
+		active, err := profile.ActiveName()
+		if err != nil && !errors.Is(err, profile.ErrNoActive) {
+			return err
+		}
+		if active != s.active {
+			return fmt.Errorf(
+				"the active profile changed from %q to %q while setup was running, so nothing was written; re-run the command",
+				s.active, active)
+		}
+	}
+	// Only meaningful when it existed at resolution: a run that is CREATING a
+	// profile legitimately finds nothing here.
+	if s.existed {
+		exists, err := profile.Exists(s.profile)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf(
+				"profile %q was renamed or removed while setup was running, so nothing was written; re-run the command",
+				s.profile)
+		}
+	}
+	return nil
+}
+
 func profileTarget(name string) (target, error) {
 	if _, err := profile.Dir(name); err != nil {
 		return target{}, err


### PR DESCRIPTION
`kontext setup` refuses to re-run on any Mac that has profiles, including the
plain production case it was meant to serve:

```
workspace Acme (org_...) is already set up as profile "prod" on https://api.kontext.security

Switch to it with `kontext profile use prod`, or remove it first to re-create it.
```

Rotating an install token is the documented reason to re-run setup, so this
blocks the supported path. There is no way around it from the command line —
the guard fires before the target profile is resolved.

## Cause

The duplicate-workspace guard (added in #446) excluded `opts.Profile` — the
profile the *caller named*. A plain `kontext setup` leaves that empty and
resolves its target to the **active** profile, so the scan skipped nothing,
found the very profile the run was about to write, and reported it as a
duplicate of itself.

## Fix

Exclude the profile the run will actually write to, not the one the caller
happened to name. That is knowable before the workspace is in exactly the cases
that need it:

| Call | Writes to | Excluded |
| --- | --- | --- |
| `setup` / `profile add <name>` | that name | that name |
| `setup` (no name) | the active profile | the active profile |
| `profile add` (derived name) | a new profile | nothing |

The derived-name case is why this is not simply "always exclude the active
profile": that run creates a new profile, so every existing one stays a real
candidate.

## Tests

- `TestSetupRerunWithoutAProfileNameRotatesTheActiveProfile` — the regression.
  Verified it fails without the fix, with the refusal quoted above.
- `TestSetupStillRefusesADuplicateWhenTheNameIsDerived` — the guard is not
  blunted: a derived name is still refused even when an active profile exists
  that a plain setup would have excluded. Verified it passes under the revert.

Full suite green.