### PR TITLE
feat(managed-observe): report Claude Code hook health with every heartbeat

### DIFF
--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -390,6 +390,34 @@ func requireManagedHooksForLegacyCowork(cfg managedconfig.Config) error {
 	return fmt.Errorf("cowork_enabled is set but Claude Code managed hooks are missing at %s or %s; run `kontext setup` or install the managed-settings drop-in before starting managed observe", managedSettingsDropInPath, managedSettingsFilePath)
 }
 
+// managedObserveHooksFact reduces the two managed-settings locations to the
+// device fact reported with every heartbeat batch. Present requires the full
+// Kontext hook set in at least one location and no disableAllHooks anywhere:
+// Claude Code merges drop-ins into the managed settings, so a disable in
+// either file switches off hooks the other file declares. A read error yields
+// ok=false — the fact is omitted from the batch rather than reported as
+// missing, so a daemon that cannot read /Library (sandboxing, permissions)
+// never files a false "hooks deleted" alarm.
+func managedObserveHooksFact() (managedstream.HooksFact, bool) {
+	var hasHooks, disabled bool
+	for _, path := range []string{managedSettingsDropInPath, managedSettingsFilePath} {
+		state, err := managedObserveHooksState(path)
+		if err != nil {
+			return managedstream.HooksFact{}, false
+		}
+		if state.disabled {
+			disabled = true
+		}
+		if state.hasHooks {
+			hasHooks = true
+		}
+	}
+	return managedstream.HooksFact{
+		Present:          hasHooks && !disabled,
+		DisabledAllHooks: disabled,
+	}, true
+}
+
 type managedObserveHooksStatus struct {
 	disabled bool
 	hasHooks bool
@@ -509,6 +537,7 @@ func flushManagedStream(ctx context.Context, opts DaemonOptions, dbPath, install
 		DeviceLabel:       loadedConfig.Config.Device.Label,
 		UserEmail:         loadedConfig.Config.Device.UserEmail,
 		DeploymentVersion: deploymentVersionWithFallback(opts.FallbackDeploymentVersion),
+		HooksFact:         managedObserveHooksFact,
 		HTTPClient:        opts.StreamHTTPClient,
 		Diagnostic:        opts.Diagnostic,
 		OnFlushSuccess: func() {

--- a/internal/managedobserve/daemon_test.go
+++ b/internal/managedobserve/daemon_test.go
@@ -535,6 +535,84 @@ func TestLegacyCoworkRejectsDisabledManagedSettingsSource(t *testing.T) {
 	}
 }
 
+func TestManagedObserveHooksFact(t *testing.T) {
+	template, err := claudemanaged.TemplateJSON("/opt/homebrew/bin/kontext")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("drop-in installed", func(t *testing.T) {
+		dir := t.TempDir()
+		dropIn := filepath.Join(dir, "20-kontext.json")
+		if err := os.WriteFile(dropIn, template, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		swapManagedSettingsPaths(t, dropIn, filepath.Join(dir, "missing", "managed-settings.json"))
+
+		fact, ok := managedObserveHooksFact()
+		if !ok || !fact.Present || fact.DisabledAllHooks {
+			t.Fatalf("managedObserveHooksFact() = %+v, %v; want present", fact, ok)
+		}
+	})
+
+	t.Run("hooks deleted", func(t *testing.T) {
+		dir := t.TempDir()
+		swapManagedSettingsPaths(t,
+			filepath.Join(dir, "missing", "20-kontext.json"),
+			filepath.Join(dir, "missing", "managed-settings.json"))
+
+		fact, ok := managedObserveHooksFact()
+		if !ok || fact.Present || fact.DisabledAllHooks {
+			t.Fatalf("managedObserveHooksFact() = %+v, %v; want known-missing", fact, ok)
+		}
+	})
+
+	t.Run("disableAllHooks overrides drop-in", func(t *testing.T) {
+		dir := t.TempDir()
+		dropIn := filepath.Join(dir, "20-kontext.json")
+		if err := os.WriteFile(dropIn, template, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		root := filepath.Join(dir, "managed-settings.json")
+		if err := os.WriteFile(root, []byte(`{"disableAllHooks":true}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		swapManagedSettingsPaths(t, dropIn, root)
+
+		fact, ok := managedObserveHooksFact()
+		if !ok || fact.Present || !fact.DisabledAllHooks {
+			t.Fatalf("managedObserveHooksFact() = %+v, %v; want disabled", fact, ok)
+		}
+	})
+
+	t.Run("unreadable settings report unknown", func(t *testing.T) {
+		dir := t.TempDir()
+		// A directory where the drop-in file should be makes ReadFile fail
+		// without depending on permission semantics (root ignores 0o000).
+		dropIn := filepath.Join(dir, "20-kontext.json")
+		if err := os.Mkdir(dropIn, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		swapManagedSettingsPaths(t, dropIn, filepath.Join(dir, "missing", "managed-settings.json"))
+
+		if _, ok := managedObserveHooksFact(); ok {
+			t.Fatal("managedObserveHooksFact() ok = true, want unknown on read error")
+		}
+	})
+}
+
+func swapManagedSettingsPaths(t *testing.T, dropIn, root string) {
+	t.Helper()
+	previousDropIn := managedSettingsDropInPath
+	previousRoot := managedSettingsFilePath
+	managedSettingsDropInPath = dropIn
+	managedSettingsFilePath = root
+	t.Cleanup(func() {
+		managedSettingsDropInPath = previousDropIn
+		managedSettingsFilePath = previousRoot
+	})
+}
+
 func TestCleanupIntervalNeverReturnsZero(t *testing.T) {
 	if got := cleanupInterval(time.Nanosecond); got != time.Nanosecond {
 		t.Fatalf("cleanupInterval(1ns) = %s, want 1ns", got)

--- a/internal/managedstream/stream.go
+++ b/internal/managedstream/stream.go
@@ -62,6 +62,12 @@ type Options struct {
 	DeviceLabel       string
 	UserEmail         string
 	DeploymentVersion func() string
+	// HooksFact resolves the endpoint's Claude Code hook health per flush, so a
+	// drop-in deleted under a running daemon is reported on the next batch. A
+	// false second return means the state could not be determined (e.g. the
+	// settings file is unreadable) — the fact is then omitted entirely, which
+	// the hosted side reads as "unknown", never as "missing".
+	HooksFact         func() (HooksFact, bool)
 	Interval          time.Duration
 	HeartbeatInterval time.Duration
 	BatchLimit        int
@@ -102,6 +108,23 @@ type Device struct {
 	Label             string `json:"label,omitempty"`
 	DeploymentVersion string `json:"deployment_version,omitempty"`
 	UserEmail         string `json:"user_email,omitempty"`
+	// Hook health, pointers so an endpoint that cannot determine the state
+	// omits the fields instead of asserting false. Without this fact a device
+	// whose managed hooks were deleted is indistinguishable server-side from
+	// one where the agent simply isn't used: heartbeats keep flowing and the
+	// ledger stays empty either way.
+	HooksPresent     *bool `json:"hooks_present,omitempty"`
+	DisabledAllHooks *bool `json:"disabled_all_hooks,omitempty"`
+}
+
+// HooksFact is the per-flush answer to "are the Claude Code managed hooks for
+// Kontext actually in effect on this device". Present means the managed
+// settings (drop-in or file) carry the full Kontext hook set AND no settings
+// file disables all hooks; DisabledAllHooks distinguishes "hooks removed" from
+// "hooks present but switched off via disableAllHooks".
+type HooksFact struct {
+	Present          bool
+	DisabledAllHooks bool
 }
 
 type State struct {
@@ -336,8 +359,23 @@ func newPayload(
 	if opts.DeploymentVersion != nil {
 		deploymentVersion = strings.TrimSpace(opts.DeploymentVersion())
 	}
-	if label != "" || deploymentVersion != "" || userEmail != "" {
-		payload.Device = &Device{Label: label, DeploymentVersion: deploymentVersion, UserEmail: userEmail}
+	// Hook health resolves per flush too: it is exactly the fact that must not
+	// go stale when someone deletes the drop-in under a running daemon.
+	var hooksPresent, disabledAllHooks *bool
+	if opts.HooksFact != nil {
+		if fact, ok := opts.HooksFact(); ok {
+			hooksPresent = &fact.Present
+			disabledAllHooks = &fact.DisabledAllHooks
+		}
+	}
+	if label != "" || deploymentVersion != "" || userEmail != "" || hooksPresent != nil {
+		payload.Device = &Device{
+			Label:             label,
+			DeploymentVersion: deploymentVersion,
+			UserEmail:         userEmail,
+			HooksPresent:      hooksPresent,
+			DisabledAllHooks:  disabledAllHooks,
+		}
 	}
 	return payload
 }

--- a/internal/managedstream/stream_test.go
+++ b/internal/managedstream/stream_test.go
@@ -182,6 +182,61 @@ func TestFlushResolvesDeploymentVersionPerFlush(t *testing.T) {
 	}
 }
 
+func TestFlushReportsHooksFactPerFlush(t *testing.T) {
+	store, dbPath := testStore(t)
+	saveTestDecision(t, store, "session-1", "toolu_1")
+
+	var got Payload
+	server := capturePayloadServer(t, &got)
+	t.Cleanup(server.Close)
+
+	fact := HooksFact{Present: true}
+	known := true
+	flushOpts := func() Options {
+		return Options{
+			DBPath:         dbPath,
+			StatePath:      filepath.Join(t.TempDir(), "stream-state.json"),
+			CloudURL:       server.URL,
+			InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
+			InstallToken:   "test-install-token",
+			HooksFact:      func() (HooksFact, bool) { return fact, known },
+			HTTPClient:     server.Client(),
+		}
+	}
+
+	if err := Flush(context.Background(), flushOpts()); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if got.Device == nil || got.Device.HooksPresent == nil || !*got.Device.HooksPresent {
+		t.Fatalf("device = %+v, want hooks_present true", got.Device)
+	}
+	if got.Device.DisabledAllHooks == nil || *got.Device.DisabledAllHooks {
+		t.Fatalf("device = %+v, want disabled_all_hooks false", got.Device)
+	}
+
+	// A drop-in deleted under the running daemon flips the fact on the next
+	// flush, without rebuilding the daemon's options.
+	fact = HooksFact{Present: false}
+	if err := Flush(context.Background(), flushOpts()); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if got.Device == nil || got.Device.HooksPresent == nil || *got.Device.HooksPresent {
+		t.Fatalf("device = %+v, want hooks_present false", got.Device)
+	}
+
+	// An undetermined state omits the fields entirely: the hosted side must
+	// read "unknown", never "missing". Reset the capture first — decoding a
+	// payload without a device key would otherwise keep the previous one.
+	known = false
+	got = Payload{}
+	if err := Flush(context.Background(), flushOpts()); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if got.Device != nil {
+		t.Fatalf("device = %+v, want omitted when hooks state is unknown", got.Device)
+	}
+}
+
 func TestFlushDoesNotAdvanceCursorWhenHostedBackendFails(t *testing.T) {
 	store, dbPath := testStore(t)
 	saveTestDecision(t, store, "session-1", "toolu_1")


### PR DESCRIPTION
## Summary

- A device whose managed hooks were deleted is indistinguishable server-side from one where the agent simply isn't used: heartbeats keep flowing, the ledger stays empty, no failures. The daemon now checks the managed-settings drop-in and the managed settings file on every flush (reusing `managedObserveHooksState`) and reports `hooks_present` + `disabled_all_hooks` in the batch's device envelope.
- `hooks_present` means the full Kontext hook set is installed **and** no settings file sets `disableAllHooks` (Claude Code merges drop-ins, so a disable in either file switches off hooks the other declares); `disabled_all_hooks` distinguishes "switched off" from "deleted".
- Both fields are `*bool` and omitted entirely when the state cannot be determined (e.g. `/Library` unreadable under sandboxing), so the hosted side reads absence as **unknown**, never as missing — no false "hooks deleted" alarms, and older CLIs stay compatible.
- Resolved per flush like `DeploymentVersion`, so a drop-in deleted under a running daemon flips the fact on the next batch without a restart. Heartbeat-only payloads carry it too — a device with deleted hooks produces nothing *but* heartbeats.

Server side: kontext-security/kontext#834 ingests the fact, stores it on `hosted_ledger_installations`, and surfaces a warning in the Inventory tab. **That PR must deploy first** — the hosted device schema is strict, so a CLI emitting the new fields against an older API would have its batches rejected as `validation_failed`.

## Verification

- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] `go vet ./...`

New tests: `TestManagedObserveHooksFact` (installed / deleted / disableAllHooks-overrides-drop-in / unreadable→unknown) and `TestFlushReportsHooksFactPerFlush` (per-flush resolution, unknown omits the fields).

## Release notes

- [x] conventional commit title matches semver intent