### PR TITLE
feat(managed-observe): report a stable device key for endpoint reconciliation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kontext-security/kontext-cli
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/cedar-policy/cedar-go v1.8.0

--- a/internal/deviceid/deviceid.go
+++ b/internal/deviceid/deviceid.go
@@ -1,0 +1,77 @@
+// Package deviceid derives the stable device reconciliation key reported to
+// the hosted API alongside the random installation identity.
+//
+// The installation id (internal/installation) is deliberately random and dies
+// with its file: removing a profile or wiping Application Support mints a
+// fresh one, and the hosted inventory shows a duplicate endpoint whose stale
+// twin never disappears. The device key closes that gap without giving up the
+// properties the random id exists for. It is HMAC-SHA256 over the Mac's
+// IOPlatformUUID, keyed with the workspace's organization id:
+//
+//   - Stable where it matters: the same Mac re-enrolled in the same workspace
+//     derives the same key, so the hosted side can reconcile a fresh
+//     installation id with the stale instance it replaces.
+//   - Unlinkable where it must be: two workspaces derive different keys for
+//     one Mac, and the raw hardware identifier never leaves the machine.
+//   - A hint, never a credential: the endpoint reports the value about
+//     itself, so the hosted side may use it to fold inventory rows — never to
+//     authenticate, and never to destroy a superseded instance's history.
+package deviceid
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+// Test seam (repo convention, cf. setup's execCommand): PlatformUUID goes
+// through this so tests never depend on this machine's ioreg.
+var runCommand = func(ctx context.Context, name string, args ...string) (string, error) {
+	out, err := exec.CommandContext(ctx, name, args...).Output()
+	return string(out), err
+}
+
+var platformUUIDPattern = regexp.MustCompile(`"IOPlatformUUID"\s*=\s*"([0-9A-Fa-f-]{36})"`)
+
+// PlatformUUID reads this Mac's IOPlatformUUID. It is readable without
+// privileges, survives OS reinstalls, and changes only with a logic-board
+// repair — which is exactly when a machine should read as a new device. The
+// absolute ioreg path matters: under launchd the daemon runs with a minimal
+// PATH.
+func PlatformUUID(ctx context.Context) (string, error) {
+	out, err := runCommand(ctx, "/usr/sbin/ioreg", "-rd1", "-c", "IOPlatformExpertDevice")
+	if err != nil {
+		return "", fmt.Errorf("read IOPlatformUUID: %w", err)
+	}
+	match := platformUUIDPattern.FindStringSubmatch(out)
+	if match == nil {
+		return "", errors.New("IOPlatformUUID not present in ioreg output")
+	}
+	// Uppercase before hashing: the derivation must not depend on how a
+	// particular macOS build happens to case the value.
+	return strings.ToUpper(match[1]), nil
+}
+
+// Key derives the reconciliation key for one Mac in one workspace. The
+// organization id is the HMAC key, so the raw platform UUID is never sent and
+// two workspaces cannot correlate the same machine by comparing values.
+//
+// Both inputs are required: an unsalted or unkeyed digest would be linkable
+// across workspaces, which is the property the per-profile installation
+// identity deliberately refuses to give up.
+func Key(platformUUID, organizationID string) (string, error) {
+	uuid := strings.ToUpper(strings.TrimSpace(platformUUID))
+	org := strings.TrimSpace(organizationID)
+	if uuid == "" || org == "" {
+		return "", errors.New("device key requires both a platform UUID and an organization id")
+	}
+	mac := hmac.New(sha256.New, []byte(org))
+	mac.Write([]byte(uuid))
+	return "dk_" + base64.RawURLEncoding.EncodeToString(mac.Sum(nil)), nil
+}

--- a/internal/deviceid/deviceid_test.go
+++ b/internal/deviceid/deviceid_test.go
@@ -1,0 +1,121 @@
+package deviceid
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+const sampleIoregOutput = `+-o MacBookAir10,1  <class IOPlatformExpertDevice, id 0x100000112, registered, matched, active, busy 0 (2 ms), retain 40>
+    {
+      "IOPlatformSerialNumber" = "C02XXXXXXXXX"
+      "IOPlatformUUID" = "0f3a45b2-1c4d-4e5f-8a9b-0c1d2e3f4a5b"
+      "board-id" = <"Mac-XXXX">
+    }
+`
+
+func stubRunCommand(t *testing.T, fn func(ctx context.Context, name string, args ...string) (string, error)) {
+	t.Helper()
+	previous := runCommand
+	runCommand = fn
+	t.Cleanup(func() { runCommand = previous })
+}
+
+func TestPlatformUUIDParsesAndUppercasesIoregOutput(t *testing.T) {
+	stubRunCommand(t, func(_ context.Context, name string, args ...string) (string, error) {
+		if name != "/usr/sbin/ioreg" {
+			t.Fatalf("command = %q, want absolute ioreg path (launchd has a minimal PATH)", name)
+		}
+		return sampleIoregOutput, nil
+	})
+
+	uuid, err := PlatformUUID(context.Background())
+	if err != nil {
+		t.Fatalf("PlatformUUID() error = %v", err)
+	}
+	if uuid != "0F3A45B2-1C4D-4E5F-8A9B-0C1D2E3F4A5B" {
+		t.Fatalf("PlatformUUID() = %q, want uppercased UUID", uuid)
+	}
+}
+
+func TestPlatformUUIDErrors(t *testing.T) {
+	t.Run("command failure", func(t *testing.T) {
+		stubRunCommand(t, func(context.Context, string, ...string) (string, error) {
+			return "", errors.New("exec: not found")
+		})
+		if _, err := PlatformUUID(context.Background()); err == nil {
+			t.Fatal("PlatformUUID() error = nil, want command failure surfaced")
+		}
+	})
+
+	t.Run("uuid absent", func(t *testing.T) {
+		stubRunCommand(t, func(context.Context, string, ...string) (string, error) {
+			return `{"IOPlatformSerialNumber" = "C02XXXXXXXXX"}`, nil
+		})
+		if _, err := PlatformUUID(context.Background()); err == nil {
+			t.Fatal("PlatformUUID() error = nil, want parse failure")
+		}
+	})
+}
+
+// The expected values are fixed vectors, computed independently. If this test
+// fails after touching Key, the derivation changed — which silently detaches
+// every already-reported device key from the machines that reported them. Do
+// not update the vectors without a hosted-side migration plan.
+func TestKeyMatchesFixedVectors(t *testing.T) {
+	key, err := Key("0F3A45B2-1C4D-4E5F-8A9B-0C1D2E3F4A5B", "org_katana")
+	if err != nil {
+		t.Fatalf("Key() error = %v", err)
+	}
+	if key != "dk_r9NpM1vh94fxqPIcsnx6DalBNVfubPTNYHUBLGUoUcc" {
+		t.Fatalf("Key() = %q, want pinned vector", key)
+	}
+
+	other, err := Key("0F3A45B2-1C4D-4E5F-8A9B-0C1D2E3F4A5B", "org_other")
+	if err != nil {
+		t.Fatalf("Key() error = %v", err)
+	}
+	if other != "dk_wOHaCumCEoXxMGJTl7KiZ-AranWDM3LpSgC8zass4UQ" {
+		t.Fatalf("Key() = %q, want pinned vector", other)
+	}
+	if key == other {
+		t.Fatal("same machine in two workspaces derived one key; workspaces must be unlinkable")
+	}
+}
+
+func TestKeyNormalizesInputCase(t *testing.T) {
+	upper, err := Key("0F3A45B2-1C4D-4E5F-8A9B-0C1D2E3F4A5B", "org_katana")
+	if err != nil {
+		t.Fatalf("Key() error = %v", err)
+	}
+	lower, err := Key(" 0f3a45b2-1c4d-4e5f-8a9b-0c1d2e3f4a5b ", "org_katana")
+	if err != nil {
+		t.Fatalf("Key() error = %v", err)
+	}
+	if upper != lower {
+		t.Fatalf("Key() case-sensitive: %q != %q; the same hardware must derive one key", upper, lower)
+	}
+}
+
+func TestKeyRequiresBothInputs(t *testing.T) {
+	if _, err := Key("", "org_katana"); err == nil {
+		t.Fatal("Key() with blank UUID = nil error, want refusal")
+	}
+	if _, err := Key("0F3A45B2-1C4D-4E5F-8A9B-0C1D2E3F4A5B", " "); err == nil {
+		t.Fatal("Key() with blank organization id = nil error, want refusal (unkeyed digests are linkable)")
+	}
+}
+
+func TestKeyShape(t *testing.T) {
+	key, err := Key("0F3A45B2-1C4D-4E5F-8A9B-0C1D2E3F4A5B", "org_katana")
+	if err != nil {
+		t.Fatalf("Key() error = %v", err)
+	}
+	if !strings.HasPrefix(key, "dk_") {
+		t.Fatalf("Key() = %q, want dk_ prefix", key)
+	}
+	if len(key) != len("dk_")+43 {
+		t.Fatalf("len(Key()) = %d, want 3+43 (raw-url base64 of 32 bytes)", len(key))
+	}
+}

--- a/internal/ledgerping/ledgerping.go
+++ b/internal/ledgerping/ledgerping.go
@@ -1,0 +1,76 @@
+// Package ledgerping resolves an install token to the workspace that owns it,
+// via the hosted ledger API's ping endpoint. Setup uses it to validate a
+// pasted token before anything is written; the daemon uses it to learn the
+// organization id that keys the device reconciliation key. It is the one
+// place the CLI answers "whose token is this", so the two callers cannot
+// drift apart.
+package ledgerping
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const Path = "/api/v1/authorization-ledger/ping"
+
+// ErrUnauthorized reports a 401/403: the token itself was rejected. Callers
+// own the user-facing copy — setup tells a human where to mint a new token,
+// the daemon just logs — so this stays a bare sentinel.
+var ErrUnauthorized = errors.New("install token rejected")
+
+// StatusError reports any other non-2xx answer, preserving the code so
+// callers can phrase their own message around it.
+type StatusError struct {
+	StatusCode int
+}
+
+func (e *StatusError) Error() string {
+	return fmt.Sprintf("ping returned HTTP %d", e.StatusCode)
+}
+
+type Response struct {
+	OrganizationID string `json:"organization_id"`
+	// JSON null (the legacy env-fallback org) decodes to "".
+	OrganizationName string `json:"organization_name"`
+}
+
+// Ping resolves token against cloudURL. A nil client gets a 10s-timeout
+// default, matching what setup has always used.
+func Ping(ctx context.Context, client *http.Client, cloudURL, token string) (Response, error) {
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(cloudURL, "/")+Path, nil)
+	if err != nil {
+		return Response{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return Response{}, fmt.Errorf("cannot reach %s: %w", cloudURL, err)
+	}
+	defer resp.Body.Close()
+
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		return Response{}, ErrUnauthorized
+	case resp.StatusCode < 200 || resp.StatusCode >= 300:
+		return Response{}, &StatusError{StatusCode: resp.StatusCode}
+	}
+
+	var ping Response
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&ping); err != nil {
+		return Response{}, fmt.Errorf("parse ping response: %w", err)
+	}
+	if strings.TrimSpace(ping.OrganizationID) == "" {
+		return Response{}, errors.New("server did not return an organization id for this token")
+	}
+	return ping, nil
+}

--- a/internal/ledgerping/ledgerping_test.go
+++ b/internal/ledgerping/ledgerping_test.go
@@ -1,0 +1,84 @@
+package ledgerping
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func pingServer(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != Path {
+			t.Errorf("path = %q, want %q", r.URL.Path, Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("authorization = %q, want bearer token", got)
+		}
+		w.WriteHeader(status)
+		w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestPingResolvesWorkspace(t *testing.T) {
+	server := pingServer(t, http.StatusOK, `{"organization_id":"org_katana","organization_name":"Katana"}`)
+
+	got, err := Ping(context.Background(), server.Client(), server.URL+"/", "test-token")
+	if err != nil {
+		t.Fatalf("Ping() error = %v", err)
+	}
+	if got.OrganizationID != "org_katana" || got.OrganizationName != "Katana" {
+		t.Fatalf("Ping() = %+v", got)
+	}
+}
+
+func TestPingTreatsNullOrganizationNameAsEmpty(t *testing.T) {
+	server := pingServer(t, http.StatusOK, `{"organization_id":"org_katana","organization_name":null}`)
+
+	got, err := Ping(context.Background(), server.Client(), server.URL, "test-token")
+	if err != nil {
+		t.Fatalf("Ping() error = %v", err)
+	}
+	if got.OrganizationName != "" {
+		t.Fatalf("organization_name = %q, want empty for JSON null", got.OrganizationName)
+	}
+}
+
+func TestPingReportsRejectedToken(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		server := pingServer(t, status, "")
+		if _, err := Ping(context.Background(), server.Client(), server.URL, "test-token"); !errors.Is(err, ErrUnauthorized) {
+			t.Fatalf("Ping() with HTTP %d error = %v, want ErrUnauthorized", status, err)
+		}
+	}
+}
+
+func TestPingReportsOtherStatuses(t *testing.T) {
+	server := pingServer(t, http.StatusBadGateway, "")
+
+	_, err := Ping(context.Background(), server.Client(), server.URL, "test-token")
+	var statusErr *StatusError
+	if !errors.As(err, &statusErr) || statusErr.StatusCode != http.StatusBadGateway {
+		t.Fatalf("Ping() error = %v, want StatusError{502}", err)
+	}
+}
+
+func TestPingRejectsMissingOrganizationID(t *testing.T) {
+	server := pingServer(t, http.StatusOK, `{"organization_id":"  "}`)
+
+	if _, err := Ping(context.Background(), server.Client(), server.URL, "test-token"); err == nil {
+		t.Fatal("Ping() error = nil, want refusal on blank organization id")
+	}
+}
+
+func TestPingRejectsMalformedBody(t *testing.T) {
+	server := pingServer(t, http.StatusOK, `not json`)
+
+	if _, err := Ping(context.Background(), server.Client(), server.URL, "test-token"); err == nil {
+		t.Fatal("Ping() error = nil, want parse failure")
+	}
+}

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kontext-security/kontext-cli/internal/cedarpolicy"
 	"github.com/kontext-security/kontext-cli/internal/claudemanaged"
+	"github.com/kontext-security/kontext-cli/internal/deviceid"
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 	"github.com/kontext-security/kontext-cli/internal/endpointconfig"
 	"github.com/kontext-security/kontext-cli/internal/guard/app/server"
@@ -19,6 +20,7 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/guard/riskclassifier"
 	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
 	"github.com/kontext-security/kontext-cli/internal/installation"
+	"github.com/kontext-security/kontext-cli/internal/ledgerping"
 	"github.com/kontext-security/kontext-cli/internal/managedconfig"
 	"github.com/kontext-security/kontext-cli/internal/managedstream"
 	"github.com/kontext-security/kontext-cli/internal/payloadcapture"
@@ -481,14 +483,78 @@ func loadManagedConfig(ctx context.Context) (managedconfig.LoadedConfig, string,
 	return loadedConfig, installToken, nil
 }
 
+// envNoDeviceKey switches off device-key reporting entirely — the escape
+// hatch for a backend that rejects the field before its ingest side deploys.
+const envNoDeviceKey = "KONTEXT_NO_DEVICE_KEY"
+
+// deviceKeyPingTimeout bounds the workspace ping inside a flush. The flush
+// interval is ~10s; a hung ping must not eat the whole cycle.
+const deviceKeyPingTimeout = 10 * time.Second
+
+// Test seams (repo convention, cf. updater.go's runCommand) so device-key
+// resolution never touches this machine's ioreg or a hosted backend.
+var (
+	platformUUIDFn  = deviceid.PlatformUUID
+	workspacePingFn = ledgerping.Ping
+)
+
+// deviceKeySource resolves the device reconciliation key once and caches it
+// for the daemon's lifetime. Confined to the managed-stream goroutine, so no
+// locking. Both ingredients are stable while the daemon runs: the hardware
+// UUID by definition, and the organization id because a re-enrollment
+// rewrites the config and restarts the agent.
+type deviceKeySource struct {
+	key      string
+	resolved bool
+}
+
+// get returns the cached key, resolving it on first use. Empty means "no key
+// this flush" and the batch's device envelope simply omits the field. The
+// failure modes deliberately differ: a machine that cannot answer ioreg now
+// will not answer it in ten seconds either, so that failure is cached; an
+// unreachable workspace is retried on the next flush, because the first
+// flushes after login race the network coming up.
+func (s *deviceKeySource) get(ctx context.Context, cloudURL, token string, client *http.Client, diag diagnostic.Logger) string {
+	if s.resolved {
+		return s.key
+	}
+	if strings.TrimSpace(os.Getenv(envNoDeviceKey)) != "" {
+		s.resolved = true
+		return ""
+	}
+	uuid, err := platformUUIDFn(ctx)
+	if err != nil {
+		diag.Printf("device key: %v\n", err)
+		s.resolved = true
+		return ""
+	}
+	pingCtx, cancel := context.WithTimeout(ctx, deviceKeyPingTimeout)
+	defer cancel()
+	ping, err := workspacePingFn(pingCtx, client, cloudURL, token)
+	if err != nil {
+		diag.Printf("device key: workspace ping: %v\n", err)
+		return ""
+	}
+	key, err := deviceid.Key(uuid, ping.OrganizationID)
+	if err != nil {
+		diag.Printf("device key: %v\n", err)
+		s.resolved = true
+		return ""
+	}
+	s.key = key
+	s.resolved = true
+	return s.key
+}
+
 func runManagedStream(ctx context.Context, opts DaemonOptions, dbPath, installationID string) error {
 	interval := opts.StreamInterval
 	if interval == 0 {
 		interval = managedstream.DefaultIntervalFromEnv()
 	}
+	deviceKeys := &deviceKeySource{}
 	var consecutiveAuthFailures, consecutiveFlushFailures int
 	flush := func() {
-		err := flushManagedStream(ctx, opts, dbPath, installationID)
+		err := flushManagedStream(ctx, opts, dbPath, installationID, deviceKeys)
 		if err == nil {
 			consecutiveAuthFailures = 0
 			consecutiveFlushFailures = 0
@@ -523,7 +589,7 @@ func runManagedStream(ctx context.Context, opts DaemonOptions, dbPath, installat
 	}
 }
 
-func flushManagedStream(ctx context.Context, opts DaemonOptions, dbPath, installationID string) error {
+func flushManagedStream(ctx context.Context, opts DaemonOptions, dbPath, installationID string, deviceKeys *deviceKeySource) error {
 	loadedConfig, installToken, err := loadManagedConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("managed stream config reload: %w", err)
@@ -538,8 +604,11 @@ func flushManagedStream(ctx context.Context, opts DaemonOptions, dbPath, install
 		UserEmail:         loadedConfig.Config.Device.UserEmail,
 		DeploymentVersion: deploymentVersionWithFallback(opts.FallbackDeploymentVersion),
 		HooksFact:         managedObserveHooksFact,
-		HTTPClient:        opts.StreamHTTPClient,
-		Diagnostic:        opts.Diagnostic,
+		DeviceKey: func() string {
+			return deviceKeys.get(ctx, loadedConfig.Config.CloudURL, installToken, opts.StreamHTTPClient, opts.Diagnostic)
+		},
+		HTTPClient: opts.StreamHTTPClient,
+		Diagnostic: opts.Diagnostic,
 		OnFlushSuccess: func() {
 			if err := ClearAuthError(dbPath); err != nil {
 				opts.Diagnostic.Printf("clear auth-error breadcrumb: %v\n", err)

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -498,34 +498,41 @@ var (
 	workspacePingFn = ledgerping.Ping
 )
 
-// deviceKeySource resolves the device reconciliation key once and caches it
-// for the daemon's lifetime. Confined to the managed-stream goroutine, so no
-// locking. Both ingredients are stable while the daemon runs: the hardware
-// UUID by definition, and the organization id because a re-enrollment
-// rewrites the config and restarts the agent.
+// deviceKeySource resolves the device reconciliation key and caches it per
+// config identity. Confined to the managed-stream goroutine, so no locking.
+//
+// The cache is keyed by (cloudURL, token), not held for the daemon's
+// lifetime: a system-scope config can be rewritten in place to a DIFFERENT
+// workspace under a running daemon (MDM re-enrollment does not restart this
+// agent), and serving that workspace the key derived for the previous one
+// would hand it the previous workspace's stable pseudonym — precisely the
+// cross-workspace linkability the per-organization HMAC exists to prevent.
+// A token rotation within one workspace also invalidates and merely costs
+// one extra ping; the re-derived key is identical.
 type deviceKeySource struct {
 	key      string
+	cloudURL string
+	token    string
 	resolved bool
 }
 
-// get returns the cached key, resolving it on first use. Empty means "no key
-// this flush" and the batch's device envelope simply omits the field. The
-// failure modes deliberately differ: a machine that cannot answer ioreg now
-// will not answer it in ten seconds either, so that failure is cached; an
-// unreachable workspace is retried on the next flush, because the first
-// flushes after login race the network coming up.
-func (s *deviceKeySource) get(ctx context.Context, cloudURL, token string, client *http.Client, diag diagnostic.Logger) string {
-	if s.resolved {
-		return s.key
-	}
+// resolve returns the key for this flush's config identity, deriving it on
+// first use or whenever the identity changed. Empty means "no key this
+// flush" and the batch's device envelope simply omits the field. Every
+// failure is retried on a later flush — the first flushes after login race
+// the network coming up, and even the local ioreg read can fail transiently
+// under resource pressure — so nothing short of the kill switch disables
+// reporting for the daemon's lifetime.
+func (s *deviceKeySource) resolve(ctx context.Context, cloudURL, token string, client *http.Client, diag diagnostic.Logger) string {
 	if strings.TrimSpace(os.Getenv(envNoDeviceKey)) != "" {
-		s.resolved = true
 		return ""
+	}
+	if s.resolved && s.cloudURL == cloudURL && s.token == token {
+		return s.key
 	}
 	uuid, err := platformUUIDFn(ctx)
 	if err != nil {
 		diag.Printf("device key: %v\n", err)
-		s.resolved = true
 		return ""
 	}
 	pingCtx, cancel := context.WithTimeout(ctx, deviceKeyPingTimeout)
@@ -538,10 +545,11 @@ func (s *deviceKeySource) get(ctx context.Context, cloudURL, token string, clien
 	key, err := deviceid.Key(uuid, ping.OrganizationID)
 	if err != nil {
 		diag.Printf("device key: %v\n", err)
-		s.resolved = true
 		return ""
 	}
 	s.key = key
+	s.cloudURL = cloudURL
+	s.token = token
 	s.resolved = true
 	return s.key
 }
@@ -594,6 +602,10 @@ func flushManagedStream(ctx context.Context, opts DaemonOptions, dbPath, install
 	if err != nil {
 		return fmt.Errorf("managed stream config reload: %w", err)
 	}
+	// Resolved once per flush, not per payload: a Flush drains the backlog in
+	// pages and builds a payload for each, and a hung ping retried per page
+	// would stack its timeout onto every page of the drain.
+	deviceKey := deviceKeys.resolve(ctx, loadedConfig.Config.CloudURL, installToken, opts.StreamHTTPClient, opts.Diagnostic)
 	if err := managedstream.Flush(ctx, managedstream.Options{
 		DBPath:            dbPath,
 		StatePath:         opts.StreamStatePath,
@@ -604,11 +616,9 @@ func flushManagedStream(ctx context.Context, opts DaemonOptions, dbPath, install
 		UserEmail:         loadedConfig.Config.Device.UserEmail,
 		DeploymentVersion: deploymentVersionWithFallback(opts.FallbackDeploymentVersion),
 		HooksFact:         managedObserveHooksFact,
-		DeviceKey: func() string {
-			return deviceKeys.get(ctx, loadedConfig.Config.CloudURL, installToken, opts.StreamHTTPClient, opts.Diagnostic)
-		},
-		HTTPClient: opts.StreamHTTPClient,
-		Diagnostic: opts.Diagnostic,
+		DeviceKey:         func() string { return deviceKey },
+		HTTPClient:        opts.StreamHTTPClient,
+		Diagnostic:        opts.Diagnostic,
 		OnFlushSuccess: func() {
 			if err := ClearAuthError(dbPath); err != nil {
 				opts.Diagnostic.Printf("clear auth-error breadcrumb: %v\n", err)

--- a/internal/managedobserve/daemon_test.go
+++ b/internal/managedobserve/daemon_test.go
@@ -978,7 +978,7 @@ func TestDeviceKeySource(t *testing.T) {
 	const testUUID = "0F3A45B2-1C4D-4E5F-8A9B-0C1D2E3F4A5B"
 	quiet := diagnostic.Logger{}
 
-	t.Run("resolves once and caches", func(t *testing.T) {
+	t.Run("resolves once per config identity and caches", func(t *testing.T) {
 		pings := 0
 		stubDeviceKeyResolution(t,
 			func(context.Context) (string, error) { return testUUID, nil },
@@ -988,15 +988,46 @@ func TestDeviceKeySource(t *testing.T) {
 			})
 
 		source := &deviceKeySource{}
-		key := source.get(context.Background(), "https://api.test", "token", nil, quiet)
+		key := source.resolve(context.Background(), "https://api.test", "token", nil, quiet)
 		if key != "dk_r9NpM1vh94fxqPIcsnx6DalBNVfubPTNYHUBLGUoUcc" {
-			t.Fatalf("get() = %q, want the pinned deviceid vector", key)
+			t.Fatalf("resolve() = %q, want the pinned deviceid vector", key)
 		}
-		if again := source.get(context.Background(), "https://api.test", "token", nil, quiet); again != key {
-			t.Fatalf("second get() = %q, want cached %q", again, key)
+		if again := source.resolve(context.Background(), "https://api.test", "token", nil, quiet); again != key {
+			t.Fatalf("second resolve() = %q, want cached %q", again, key)
 		}
 		if pings != 1 {
 			t.Fatalf("workspace pings = %d, want the resolution cached after one", pings)
+		}
+	})
+
+	t.Run("re-derives when the config identity changes", func(t *testing.T) {
+		// A system-scope config rewritten in place to another workspace does
+		// NOT restart the daemon. Serving the old cached key there would hand
+		// the new workspace the previous workspace's stable pseudonym, so an
+		// identity change must invalidate the cache and derive fresh.
+		org := "org_katana"
+		pings := 0
+		stubDeviceKeyResolution(t,
+			func(context.Context) (string, error) { return testUUID, nil },
+			func(context.Context, *http.Client, string, string) (ledgerping.Response, error) {
+				pings++
+				return ledgerping.Response{OrganizationID: org}, nil
+			})
+
+		source := &deviceKeySource{}
+		first := source.resolve(context.Background(), "https://api.test", "token-a", nil, quiet)
+		org = "org_other"
+		second := source.resolve(context.Background(), "https://api.test", "token-b", nil, quiet)
+		if pings != 2 {
+			t.Fatalf("workspace pings = %d, want a fresh derivation after the token changed", pings)
+		}
+		if first == second || second != "dk_wOHaCumCEoXxMGJTl7KiZ-AranWDM3LpSgC8zass4UQ" {
+			t.Fatalf("resolve() after workspace change = %q, want the other workspace's pinned vector (first was %q)", second, first)
+		}
+		// A rotation back within one workspace re-pings but derives the same key.
+		org = "org_katana"
+		if rotated := source.resolve(context.Background(), "https://api.test", "token-c", nil, quiet); rotated != first {
+			t.Fatalf("resolve() after rotation = %q, want %q re-derived", rotated, first)
 		}
 	})
 
@@ -1010,38 +1041,38 @@ func TestDeviceKeySource(t *testing.T) {
 			})
 
 		source := &deviceKeySource{}
-		if key := source.get(context.Background(), "https://api.test", "token", nil, quiet); key != "" {
-			t.Fatalf("get() = %q, want empty while the workspace is unreachable", key)
+		if key := source.resolve(context.Background(), "https://api.test", "token", nil, quiet); key != "" {
+			t.Fatalf("resolve() = %q, want empty while the workspace is unreachable", key)
 		}
 		pingErr = nil
-		if key := source.get(context.Background(), "https://api.test", "token", nil, quiet); key == "" {
-			t.Fatal("get() after the network came up = empty, want the key resolved on retry")
+		if key := source.resolve(context.Background(), "https://api.test", "token", nil, quiet); key == "" {
+			t.Fatal("resolve() after the network came up = empty, want the key resolved on retry")
 		}
 	})
 
-	t.Run("gives up for good without a platform UUID", func(t *testing.T) {
-		uuidReads, pings := 0, 0
+	t.Run("retries after a failed platform UUID read", func(t *testing.T) {
+		// Even the local ioreg exec can fail transiently (resource pressure);
+		// caching that failure would silently disable the key until an
+		// unrelated daemon restart.
+		uuidErr := errors.New("fork: resource temporarily unavailable")
 		stubDeviceKeyResolution(t,
 			func(context.Context) (string, error) {
-				uuidReads++
-				return "", errors.New("ioreg unavailable")
+				if uuidErr != nil {
+					return "", uuidErr
+				}
+				return testUUID, nil
 			},
 			func(context.Context, *http.Client, string, string) (ledgerping.Response, error) {
-				pings++
 				return ledgerping.Response{OrganizationID: "org_katana"}, nil
 			})
 
 		source := &deviceKeySource{}
-		for range 2 {
-			if key := source.get(context.Background(), "https://api.test", "token", nil, quiet); key != "" {
-				t.Fatalf("get() = %q, want empty when the UUID is unreadable", key)
-			}
+		if key := source.resolve(context.Background(), "https://api.test", "token", nil, quiet); key != "" {
+			t.Fatalf("resolve() = %q, want empty while the UUID is unreadable", key)
 		}
-		if uuidReads != 1 {
-			t.Fatalf("uuid reads = %d, want the local deterministic failure cached", uuidReads)
-		}
-		if pings != 0 {
-			t.Fatal("workspace was pinged despite having no UUID to derive from")
+		uuidErr = nil
+		if key := source.resolve(context.Background(), "https://api.test", "token", nil, quiet); key == "" {
+			t.Fatal("resolve() after ioreg recovered = empty, want the key resolved on retry")
 		}
 	})
 
@@ -1058,8 +1089,8 @@ func TestDeviceKeySource(t *testing.T) {
 		t.Setenv(envNoDeviceKey, "1")
 
 		source := &deviceKeySource{}
-		if key := source.get(context.Background(), "https://api.test", "token", nil, quiet); key != "" {
-			t.Fatalf("get() = %q, want empty under %s", key, envNoDeviceKey)
+		if key := source.resolve(context.Background(), "https://api.test", "token", nil, quiet); key != "" {
+			t.Fatalf("resolve() = %q, want empty under %s", key, envNoDeviceKey)
 		}
 	})
 }

--- a/internal/managedobserve/daemon_test.go
+++ b/internal/managedobserve/daemon_test.go
@@ -3,6 +3,7 @@ package managedobserve
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -17,6 +18,7 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/diagnostic"
 	"github.com/kontext-security/kontext-cli/internal/guard/store/sqlite"
 	"github.com/kontext-security/kontext-cli/internal/hook"
+	"github.com/kontext-security/kontext-cli/internal/ledgerping"
 	"github.com/kontext-security/kontext-cli/internal/localruntime"
 	"github.com/kontext-security/kontext-cli/internal/managedconfig"
 )
@@ -113,6 +115,12 @@ func TestDaemonStreamsLedgerBatches(t *testing.T) {
 
 	requests := make(chan ledgerBatchRequest, 1)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == ledgerping.Path {
+			// The daemon resolves its device key against the same backend;
+			// answer so the flush keeps exercising the full path.
+			w.Write([]byte(`{"organization_id":"org_test"}`))
+			return
+		}
 		if r.URL.Path != "/api/v1/authorization-ledger/batches" {
 			t.Fatalf("path = %q", r.URL.Path)
 		}
@@ -208,7 +216,20 @@ func TestDaemonStreamsLedgerBatches(t *testing.T) {
 	}
 }
 
+// disableDeviceKeyResolution keeps a daemon test's strict fake backend from
+// seeing workspace pings it never expected: without a platform UUID the
+// resolver gives up before its first ping.
+func disableDeviceKeyResolution(t *testing.T) {
+	t.Helper()
+	stubDeviceKeyResolution(t,
+		func(context.Context) (string, error) { return "", errors.New("device key disabled in this test") },
+		func(context.Context, *http.Client, string, string) (ledgerping.Response, error) {
+			return ledgerping.Response{}, errors.New("device key disabled in this test")
+		})
+}
+
 func TestDaemonRefreshesStreamInstallToken(t *testing.T) {
+	disableDeviceKeyResolution(t)
 	streamTokens := make(chan string, 8)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v1/authorization-ledger/batches" {
@@ -295,6 +316,7 @@ func TestDaemonRefreshesStreamInstallToken(t *testing.T) {
 }
 
 func TestDaemonWritesAuthErrorAfterConsecutiveStreamAuthFailures(t *testing.T) {
+	disableDeviceKeyResolution(t)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v1/authorization-ledger/batches" {
 			t.Fatalf("path = %q", r.URL.Path)
@@ -933,6 +955,111 @@ func TestMigrateSelfServeModeToRemote(t *testing.T) {
 					t.Fatalf("on-disk mode = %q, want untouched %q", onDisk.Config.Mode, tc.mode)
 				}
 			})
+		}
+	})
+}
+
+func stubDeviceKeyResolution(
+	t *testing.T,
+	uuidFn func(context.Context) (string, error),
+	pingFn func(context.Context, *http.Client, string, string) (ledgerping.Response, error),
+) {
+	t.Helper()
+	previousUUID, previousPing := platformUUIDFn, workspacePingFn
+	platformUUIDFn = uuidFn
+	workspacePingFn = pingFn
+	t.Cleanup(func() {
+		platformUUIDFn = previousUUID
+		workspacePingFn = previousPing
+	})
+}
+
+func TestDeviceKeySource(t *testing.T) {
+	const testUUID = "0F3A45B2-1C4D-4E5F-8A9B-0C1D2E3F4A5B"
+	quiet := diagnostic.Logger{}
+
+	t.Run("resolves once and caches", func(t *testing.T) {
+		pings := 0
+		stubDeviceKeyResolution(t,
+			func(context.Context) (string, error) { return testUUID, nil },
+			func(context.Context, *http.Client, string, string) (ledgerping.Response, error) {
+				pings++
+				return ledgerping.Response{OrganizationID: "org_katana"}, nil
+			})
+
+		source := &deviceKeySource{}
+		key := source.get(context.Background(), "https://api.test", "token", nil, quiet)
+		if key != "dk_r9NpM1vh94fxqPIcsnx6DalBNVfubPTNYHUBLGUoUcc" {
+			t.Fatalf("get() = %q, want the pinned deviceid vector", key)
+		}
+		if again := source.get(context.Background(), "https://api.test", "token", nil, quiet); again != key {
+			t.Fatalf("second get() = %q, want cached %q", again, key)
+		}
+		if pings != 1 {
+			t.Fatalf("workspace pings = %d, want the resolution cached after one", pings)
+		}
+	})
+
+	t.Run("retries after a failed workspace ping", func(t *testing.T) {
+		pingErr := errors.New("cannot reach backend")
+		stubDeviceKeyResolution(t,
+			func(context.Context) (string, error) { return testUUID, nil },
+			func(context.Context, *http.Client, string, string) (ledgerping.Response, error) {
+				err := pingErr
+				return ledgerping.Response{OrganizationID: "org_katana"}, err
+			})
+
+		source := &deviceKeySource{}
+		if key := source.get(context.Background(), "https://api.test", "token", nil, quiet); key != "" {
+			t.Fatalf("get() = %q, want empty while the workspace is unreachable", key)
+		}
+		pingErr = nil
+		if key := source.get(context.Background(), "https://api.test", "token", nil, quiet); key == "" {
+			t.Fatal("get() after the network came up = empty, want the key resolved on retry")
+		}
+	})
+
+	t.Run("gives up for good without a platform UUID", func(t *testing.T) {
+		uuidReads, pings := 0, 0
+		stubDeviceKeyResolution(t,
+			func(context.Context) (string, error) {
+				uuidReads++
+				return "", errors.New("ioreg unavailable")
+			},
+			func(context.Context, *http.Client, string, string) (ledgerping.Response, error) {
+				pings++
+				return ledgerping.Response{OrganizationID: "org_katana"}, nil
+			})
+
+		source := &deviceKeySource{}
+		for range 2 {
+			if key := source.get(context.Background(), "https://api.test", "token", nil, quiet); key != "" {
+				t.Fatalf("get() = %q, want empty when the UUID is unreadable", key)
+			}
+		}
+		if uuidReads != 1 {
+			t.Fatalf("uuid reads = %d, want the local deterministic failure cached", uuidReads)
+		}
+		if pings != 0 {
+			t.Fatal("workspace was pinged despite having no UUID to derive from")
+		}
+	})
+
+	t.Run("kill switch reports nothing", func(t *testing.T) {
+		stubDeviceKeyResolution(t,
+			func(context.Context) (string, error) {
+				t.Fatal("platform UUID read despite kill switch")
+				return "", nil
+			},
+			func(context.Context, *http.Client, string, string) (ledgerping.Response, error) {
+				t.Fatal("workspace pinged despite kill switch")
+				return ledgerping.Response{}, nil
+			})
+		t.Setenv(envNoDeviceKey, "1")
+
+		source := &deviceKeySource{}
+		if key := source.get(context.Background(), "https://api.test", "token", nil, quiet); key != "" {
+			t.Fatalf("get() = %q, want empty under %s", key, envNoDeviceKey)
 		}
 	})
 }

--- a/internal/managedstream/stream.go
+++ b/internal/managedstream/stream.go
@@ -67,7 +67,12 @@ type Options struct {
 	// false second return means the state could not be determined (e.g. the
 	// settings file is unreadable) — the fact is then omitted entirely, which
 	// the hosted side reads as "unknown", never as "missing".
-	HooksFact         func() (HooksFact, bool)
+	HooksFact func() (HooksFact, bool)
+	// DeviceKey resolves the endpoint's stable reconciliation key per flush.
+	// Empty means unknown — the field is omitted, and the hosted side must
+	// read absence as "no key reported", never as "a different device":
+	// every CLI that predates the field omits it forever.
+	DeviceKey         func() string
 	Interval          time.Duration
 	HeartbeatInterval time.Duration
 	BatchLimit        int
@@ -115,6 +120,13 @@ type Device struct {
 	// ledger stays empty either way.
 	HooksPresent     *bool `json:"hooks_present,omitempty"`
 	DisabledAllHooks *bool `json:"disabled_all_hooks,omitempty"`
+	// DeviceKey is HMAC-SHA256 over the Mac's IOPlatformUUID, keyed with the
+	// organization id (internal/deviceid) — stable when the same Mac
+	// re-enrolls in the same workspace, unlinkable across workspaces, never
+	// the raw hardware identifier. The hosted side uses it to reconcile a
+	// fresh installation_id with the stale instance it replaces. It is
+	// self-reported: a reconciliation hint, never an authentication input.
+	DeviceKey string `json:"device_key,omitempty"`
 }
 
 // HooksFact is the per-flush answer to "are the Claude Code managed hooks for
@@ -368,13 +380,21 @@ func newPayload(
 			disabledAllHooks = &fact.DisabledAllHooks
 		}
 	}
-	if label != "" || deploymentVersion != "" || userEmail != "" || hooksPresent != nil {
+	// The device key resolves per flush as well, because its ingredients
+	// arrive late: the first flushes after login can race networking, and the
+	// resolver reports empty until the workspace answers.
+	deviceKey := ""
+	if opts.DeviceKey != nil {
+		deviceKey = strings.TrimSpace(opts.DeviceKey())
+	}
+	if label != "" || deploymentVersion != "" || userEmail != "" || hooksPresent != nil || deviceKey != "" {
 		payload.Device = &Device{
 			Label:             label,
 			DeploymentVersion: deploymentVersion,
 			UserEmail:         userEmail,
 			HooksPresent:      hooksPresent,
 			DisabledAllHooks:  disabledAllHooks,
+			DeviceKey:         deviceKey,
 		}
 	}
 	return payload

--- a/internal/managedstream/stream_test.go
+++ b/internal/managedstream/stream_test.go
@@ -237,6 +237,48 @@ func TestFlushReportsHooksFactPerFlush(t *testing.T) {
 	}
 }
 
+func TestFlushReportsDeviceKeyPerFlush(t *testing.T) {
+	_, dbPath := testStore(t)
+
+	var got Payload
+	server := capturePayloadServer(t, &got)
+	t.Cleanup(server.Close)
+
+	// Starts unresolved, as it does on a real boot when the workspace ping
+	// races login-time networking; a later flush picks the key up without
+	// rebuilding the daemon's options.
+	deviceKey := ""
+	flushOpts := func() Options {
+		return Options{
+			DBPath:         dbPath,
+			StatePath:      filepath.Join(t.TempDir(), "stream-state.json"),
+			CloudURL:       server.URL,
+			InstallationID: "ins_0123456789abcdefghijklmnopqrstuv",
+			InstallToken:   "test-install-token",
+			DeviceKey:      func() string { return deviceKey },
+			HTTPClient:     server.Client(),
+		}
+	}
+
+	// Empty ledger: this flush is a heartbeat, which must omit the whole
+	// device envelope while the key is still unknown and nothing else is set.
+	if err := Flush(context.Background(), flushOpts()); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if got.Device != nil {
+		t.Fatalf("device = %+v, want omitted while the key is unresolved", got.Device)
+	}
+
+	deviceKey = " dk_r9NpM1vh94fxqPIcsnx6DalBNVfubPTNYHUBLGUoUcc "
+	got = Payload{}
+	if err := Flush(context.Background(), flushOpts()); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if got.Device == nil || got.Device.DeviceKey != "dk_r9NpM1vh94fxqPIcsnx6DalBNVfubPTNYHUBLGUoUcc" {
+		t.Fatalf("device = %+v, want trimmed device_key on the heartbeat", got.Device)
+	}
+}
+
 func TestFlushDoesNotAdvanceCursorWhenHostedBackendFails(t *testing.T) {
 	store, dbPath := testStore(t)
 	saveTestDecision(t, store, "session-1", "toolu_1")

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kontext-security/kontext-cli/internal/claudemanaged"
 	"github.com/kontext-security/kontext-cli/internal/codexmanaged"
 	"github.com/kontext-security/kontext-cli/internal/installation"
+	"github.com/kontext-security/kontext-cli/internal/ledgerping"
 	"github.com/kontext-security/kontext-cli/internal/managedconfig"
 	"github.com/kontext-security/kontext-cli/internal/managedobserve"
 	"github.com/kontext-security/kontext-cli/internal/profile"
@@ -43,8 +44,6 @@ const (
 	// token with `security find-generic-password -s <name> -w`.
 	KeychainItemName = "kontext-install-token"
 	keychainAccount  = "kontext"
-
-	pingPath = "/api/v1/authorization-ledger/ping"
 
 	settingsBackupLabel = "kontext-setup"
 )
@@ -628,37 +627,23 @@ func validateTokenShape(token string) error {
 	return nil
 }
 
+// validateToken delegates the wire work to ledgerping — the daemon resolves
+// tokens through the same call, so the two cannot drift — and keeps only the
+// setup-specific copy: this is the one caller with a human at a terminal who
+// can go mint a fresh token.
 func validateToken(ctx context.Context, client *http.Client, cloudURL, token string) (pingResponse, error) {
-	if client == nil {
-		client = &http.Client{Timeout: 10 * time.Second}
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(cloudURL, "/")+pingPath, nil)
+	ping, err := ledgerping.Ping(ctx, client, cloudURL, token)
 	if err != nil {
+		if errors.Is(err, ledgerping.ErrUnauthorized) {
+			return pingResponse{}, errors.New("install token was rejected — it may be revoked or mistyped; create a new one in the dashboard (Deployments page)")
+		}
+		var status *ledgerping.StatusError
+		if errors.As(err, &status) {
+			return pingResponse{}, fmt.Errorf("token validation failed: %s returned HTTP %d", cloudURL, status.StatusCode)
+		}
 		return pingResponse{}, err
 	}
-	req.Header.Set("Authorization", "Bearer "+token)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return pingResponse{}, fmt.Errorf("cannot reach %s: %w", cloudURL, err)
-	}
-	defer resp.Body.Close()
-
-	switch {
-	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
-		return pingResponse{}, errors.New("install token was rejected — it may be revoked or mistyped; create a new one in the dashboard (Deployments page)")
-	case resp.StatusCode < 200 || resp.StatusCode >= 300:
-		return pingResponse{}, fmt.Errorf("token validation failed: %s returned HTTP %d", cloudURL, resp.StatusCode)
-	}
-
-	var ping pingResponse
-	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&ping); err != nil {
-		return pingResponse{}, fmt.Errorf("parse token validation response: %w", err)
-	}
-	if strings.TrimSpace(ping.OrganizationID) == "" {
-		return pingResponse{}, errors.New("server did not return an organization id for this token")
-	}
-	return ping, nil
+	return pingResponse{OrganizationID: ping.OrganizationID, OrganizationName: ping.OrganizationName}, nil
 }
 
 func deviceLabel(ctx context.Context) string {


### PR DESCRIPTION
## Why

Duplicate endpoint rows in the hosted inventory (one Active, one Stale, same Mac, same user) whenever an installation identity is legitimately re-minted: a removed profile, a wiped `~/Library/Application Support/Kontext`, or an MDM ↔ self-serve switch. The `installation_id` is deliberately random and dies with its file, so the backend cannot tell "new machine" from "same machine, new install" — nothing stable crosses the wire.

## What

Report `device.device_key` in every ledger batch and heartbeat: **HMAC-SHA256 over the Mac's `IOPlatformUUID`, keyed with the workspace's organization id** (`dk_` + raw-url base64).

- **Stable where it matters** — the same Mac re-enrolled in the same workspace derives the same key, giving ingest the join key to reconcile a fresh `installation_id` with the stale instance it replaces.
- **Unlinkable where it must be** — two workspaces derive different keys for one Mac; the raw hardware identifier never leaves the machine. The per-profile unlinkability the random id exists for is preserved.
- **A hint, never a credential** — the key is self-reported. Ingest may use it to fold inventory rows; it must never authenticate anything or destroy a superseded instance's history (receipt chains stand alone).

### How it lands

- `internal/deviceid` (new): reads `IOPlatformUUID` via `ioreg` (absolute path — launchd PATH is minimal), derives the key. Derivation is pinned by fixed test vectors: **do not update the vectors without a hosted-side migration plan**, changing them silently detaches every reported key.
- `internal/ledgerping` (new): the ledger ping extracted from setup's token validation and shared with the daemon, so the one place that answers "whose token is this" cannot drift. `setup.validateToken` delegates to it; user-facing copy unchanged.
- `internal/managedobserve`: lazy, cached resolution in the stream loop. Unreachable workspace → retried next flush (first flushes after login race the network). No readable UUID → gives up for the daemon's lifetime. `KONTEXT_NO_DEVICE_KEY` switches reporting off entirely (escape hatch if ingest rejects the field).
- `internal/managedstream`: `device_key,omitempty` on the device envelope, resolved per flush like `hooks_present` (#460).

## Deploy order

⚠️ **Hosted API first** (same as #460's device fields, strict schema): [kontext#842](https://github.com/kontext-security/kontext/pull/842) must deploy before this ships, and must read absence as "no key reported" forever — pre-field CLIs never send it.

## Suggested backend follow-up (not in this PR)

- Phase 1: dashboard-only reconciliation — collapse stale rows sharing a `device_key` behind the active one; mutate nothing.
- Same key + different `user_email` is a device handover, not a supersede — do not merge silently.
- Two *live* installations sharing a key (cloned VMs) must not flap-supersede each other.

## Testing

- `internal/deviceid`: pinned HMAC vectors, ioreg parsing/casing, input refusal.
- `internal/ledgerping`: happy path, 401/403 sentinel, status errors, malformed bodies.
- `internal/managedstream`: key emitted on heartbeats, trimmed, envelope omitted while unresolved.
- `internal/managedobserve`: resolution caching, ping retry, permanent give-up, kill switch; the daemon integration test's fake backend now answers the ping.
- Full suite green locally (37 packages).
