### PR TITLE
fix(ci): bump Go to 1.25.13 so govulncheck passes again

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kontext-security/kontext-cli
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/cedar-policy/cedar-go v1.8.0


### PR DESCRIPTION
Four stdlib vulnerabilities published since the last main build (net/url, crypto/tls, net/http, encoding/asn1 — all fixed in go1.25.13) fail the `verify` job's govulncheck on every PR right now, including [#463](https://github.com/kontext-security/kontext-cli/pull/463). CI resolves the toolchain from go.mod (`go-version-file`), so the directive bump is the whole fix.

Verified locally with CI's exact invocation (`govulncheck -mode=binary` on a `GOTOOLCHAIN=go1.25.13` build): **0 affected vulnerabilities**. The one remaining finding is in an imported package on an uncalled path, which govulncheck does not fail on.

Unblocks every open PR once merged; #463 will pick it up via a rebase/merge from main.