### PR TITLE
feat(hooks): add synchronous prompt submission plumbing

### DIFF
--- a/internal/codexmanaged/hooks.go
+++ b/internal/codexmanaged/hooks.go
@@ -15,6 +15,7 @@ import (
 const (
 	DefaultKontextBinary = "/usr/local/bin/kontext"
 	DefaultHookTimeout   = 20
+	PromptHookTimeout    = 65
 )
 
 var SupportedEvents = []hook.EventAlias{
@@ -88,11 +89,18 @@ func Template(kontextBinary string) Settings {
 			Hooks: []Handler{{
 				Type:    "command",
 				Command: hookCommand(kontextBinary, event.Alias),
-				Timeout: DefaultHookTimeout,
+				Timeout: hookTimeout(event.Name),
 			}},
 		}}
 	}
 	return settings
+}
+
+func hookTimeout(name hook.HookName) int {
+	if name == hook.HookUserPromptSubmit {
+		return PromptHookTimeout
+	}
+	return DefaultHookTimeout
 }
 
 func TemplateJSON(kontextBinary string) ([]byte, error) {
@@ -219,7 +227,7 @@ func managedHookPlan(kontextBinary string) agenthooks.Plan {
 			},
 			Command: agenthooks.CommandHook{
 				Command: hookCommand(kontextBinary, event.Alias),
-				Timeout: DefaultHookTimeout,
+				Timeout: hookTimeout(event.Name),
 			},
 			Placement: agenthooks.PlacementAppend,
 		}

--- a/internal/hook/domain.go
+++ b/internal/hook/domain.go
@@ -84,9 +84,12 @@ func NormalizeDecision(value string) (Decision, bool) {
 }
 
 type Event struct {
-	SessionID      string
-	Agent          string
-	HookName       HookName
+	SessionID string
+	Agent     string
+	HookName  HookName
+	// Prompt is first-class task input. ToolInput temporarily retains a mirror
+	// for older classifier consumers; new prompt-policy code uses this field.
+	Prompt         string
 	ToolName       string
 	ToolInput      map[string]any
 	ToolResponse   map[string]any

--- a/internal/hookruntime/claude.go
+++ b/internal/hookruntime/claude.go
@@ -37,6 +37,8 @@ type claudeHookInput struct {
 type claudeHookOutput struct {
 	HookSpecificOutput *claudeHookSpecificOutput `json:"hookSpecificOutput,omitempty"`
 	SuppressOutput     bool                      `json:"suppressOutput,omitempty"`
+	Decision           string                    `json:"decision,omitempty"`
+	Reason             string                    `json:"reason,omitempty"`
 }
 
 type claudeHookSpecificOutput struct {
@@ -60,6 +62,7 @@ func DecodeClaudeEvent(input []byte, agentName string) (hook.Event, error) {
 		SessionID:      firstString(h.SessionID, h.SessionIDAlt),
 		Agent:          agentName,
 		HookName:       hook.HookName(hookName),
+		Prompt:         stringPtrValue(h.Prompt),
 		ToolName:       firstString(h.ToolName, h.ToolNameAlt),
 		ToolInput:      normalizeClaudeToolInput(hookName, h),
 		ToolResponse:   normalizeToolResponse(h.ToolResponse, h.ToolResponseAlt),
@@ -147,7 +150,26 @@ func decodeUseNumber(data []byte, dst any) error {
 }
 
 func EncodeClaudeResult(hookEventName string, result hook.Result) ([]byte, error) {
-	if hook.HookName(hookEventName) != hook.HookPreToolUse {
+	hookName := hook.HookName(hookEventName)
+	if hookName == hook.HookUserPromptSubmit {
+		if result.Decision == hook.DecisionDeny {
+			return json.Marshal(claudeHookOutput{
+				Decision: "block",
+				Reason:   result.ClaudeReason(),
+			})
+		}
+		reason := strings.TrimSpace(result.Reason)
+		if reason == "" || strings.EqualFold(reason, "allowed") {
+			return json.Marshal(claudeHookOutput{})
+		}
+		return json.Marshal(claudeHookOutput{
+			HookSpecificOutput: &claudeHookSpecificOutput{
+				HookEventName:     hookEventName,
+				AdditionalContext: reason,
+			},
+		})
+	}
+	if hookName != hook.HookPreToolUse {
 		return json.Marshal(claudeHookOutput{SuppressOutput: true})
 	}
 

--- a/internal/hookruntime/claude_test.go
+++ b/internal/hookruntime/claude_test.go
@@ -2,8 +2,33 @@ package hookruntime
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
+
+	"github.com/kontext-security/kontext-cli/internal/hook"
 )
+
+func TestDecodeClaudeEventUserPromptSubmitPreservesPrompt(t *testing.T) {
+	t.Parallel()
+	event, err := DecodeClaudeEvent([]byte(`{"session_id":"s1","hook_event_name":"UserPromptSubmit","prompt":"ship it"}`), "claude")
+	if err != nil {
+		t.Fatalf("DecodeClaudeEvent() error = %v", err)
+	}
+	if event.Prompt != "ship it" || event.ToolInput["prompt"] != "ship it" {
+		t.Fatalf("event = %+v, want first-class prompt and compatibility mirror", event)
+	}
+}
+
+func TestEncodeClaudeUserPromptSubmitDenyBlocks(t *testing.T) {
+	t.Parallel()
+	out, err := EncodeClaudeResult("UserPromptSubmit", hook.Result{Decision: hook.DecisionDeny, Reason: "policy unavailable"})
+	if err != nil {
+		t.Fatalf("EncodeClaudeResult() error = %v", err)
+	}
+	if text := string(out); !strings.Contains(text, `"decision":"block"`) || !strings.Contains(text, "policy unavailable") {
+		t.Fatalf("EncodeClaudeResult() = %s, want top-level block", text)
+	}
+}
 
 func TestDecodeClaudeEventToolResponseObject(t *testing.T) {
 	t.Parallel()

--- a/internal/hookruntime/codex.go
+++ b/internal/hookruntime/codex.go
@@ -62,6 +62,7 @@ func DecodeCodexEvent(input []byte, agentName string) (hook.Event, error) {
 		SessionID:      codexSessionID(h.SessionID),
 		Agent:          agentName,
 		HookName:       hookName,
+		Prompt:         stringPtrValue(h.Prompt),
 		ToolName:       h.ToolName,
 		ToolInput:      toolInput,
 		ToolResponse:   normalizeToolResponse(h.ToolResponse),

--- a/internal/hookruntime/codex_test.go
+++ b/internal/hookruntime/codex_test.go
@@ -92,6 +92,9 @@ func TestDecodeCodexEventUserPromptSubmitPreservesPrompt(t *testing.T) {
 	if event.HookName != hook.HookUserPromptSubmit {
 		t.Fatalf("HookName = %q, want UserPromptSubmit", event.HookName)
 	}
+	if event.Prompt != "ship it" {
+		t.Fatalf("Prompt = %q, want ship it", event.Prompt)
+	}
 	if event.ToolInput["prompt"] != "ship it" {
 		t.Fatalf("ToolInput[prompt] = %v, want prompt", event.ToolInput["prompt"])
 	}

--- a/internal/localruntime/conversions.go
+++ b/internal/localruntime/conversions.go
@@ -12,17 +12,19 @@ import (
 
 func EvaluateRequestFromEvent(event hook.Event) (EvaluateRequest, error) {
 	req := EvaluateRequest{
-		Type:           "evaluate",
-		SessionID:      event.SessionID,
-		Agent:          event.Agent,
-		HookEvent:      event.HookName.String(),
-		ToolName:       event.ToolName,
-		ToolUseID:      event.ToolUseID,
-		CWD:            event.CWD,
-		PermissionMode: event.PermissionMode,
-		DurationMs:     event.DurationMs,
-		Error:          event.Error,
-		IsInterrupt:    event.IsInterrupt,
+		ProtocolVersion: 2,
+		Type:            "evaluate",
+		SessionID:       event.SessionID,
+		Agent:           event.Agent,
+		HookEvent:       event.HookName.String(),
+		Prompt:          event.Prompt,
+		ToolName:        event.ToolName,
+		ToolUseID:       event.ToolUseID,
+		CWD:             event.CWD,
+		PermissionMode:  event.PermissionMode,
+		DurationMs:      event.DurationMs,
+		Error:           event.Error,
+		IsInterrupt:     event.IsInterrupt,
 	}
 
 	if event.ToolInput != nil {
@@ -64,6 +66,7 @@ func EventFromEvaluateRequest(sessionID, fallbackAgent string, req *EvaluateRequ
 		SessionID:      sessionID,
 		Agent:          agent,
 		HookName:       hookName,
+		Prompt:         req.Prompt,
 		ToolName:       req.ToolName,
 		ToolUseID:      req.ToolUseID,
 		CWD:            req.CWD,
@@ -87,16 +90,17 @@ func EventFromEvaluateRequest(sessionID, fallbackAgent string, req *EvaluateRequ
 
 func EvaluateResultFromResult(result hook.Result) EvaluateResult {
 	return EvaluateResult{
-		Type:         "result",
-		Decision:     string(result.Decision),
-		Allowed:      result.Allowed(),
-		Reason:       result.Reason,
-		ReasonCode:   result.ReasonCode,
-		RequestID:    result.RequestID,
-		Mode:         result.Mode,
-		Epoch:        result.Epoch,
-		EventID:      result.EventID,
-		UpdatedInput: result.UpdatedInput,
+		ProtocolVersion: 2,
+		Type:            "result",
+		Decision:        string(result.Decision),
+		Allowed:         result.Allowed(),
+		Reason:          result.Reason,
+		ReasonCode:      result.ReasonCode,
+		RequestID:       result.RequestID,
+		Mode:            result.Mode,
+		Epoch:           result.Epoch,
+		EventID:         result.EventID,
+		UpdatedInput:    result.UpdatedInput,
 	}
 }
 

--- a/internal/localruntime/conversions_test.go
+++ b/internal/localruntime/conversions_test.go
@@ -15,6 +15,7 @@ func TestEvaluateRequestFromEventPreservesHookFields(t *testing.T) {
 	req, err := EvaluateRequestFromEvent(hook.Event{
 		Agent:          "claude",
 		HookName:       hook.HookPostToolUseFailed,
+		Prompt:         "ship it",
 		ToolName:       "Bash",
 		ToolInput:      map[string]any{"command": "npm test"},
 		ToolResponse:   map[string]any{"stderr": "failed"},
@@ -30,8 +31,10 @@ func TestEvaluateRequestFromEventPreservesHookFields(t *testing.T) {
 	}
 
 	if req.Type != "evaluate" ||
+		req.ProtocolVersion != 2 ||
 		req.Agent != "claude" ||
 		req.HookEvent != "PostToolUseFailure" ||
+		req.Prompt != "ship it" ||
 		req.ToolName != "Bash" ||
 		req.ToolUseID != "toolu_123" ||
 		req.CWD != "/tmp/project" ||
@@ -56,6 +59,7 @@ func TestEventFromEvaluateRequestPreservesHookFields(t *testing.T) {
 	event, err := EventFromEvaluateRequest("session-123", "fallback-agent", &EvaluateRequest{
 		Agent:          "claude",
 		HookEvent:      "PostToolUseFailure",
+		Prompt:         "ship it",
 		ToolName:       "Bash",
 		ToolInput:      json.RawMessage(`{"command":"npm test"}`),
 		ToolResponse:   json.RawMessage(`{"stderr":"failed"}`),
@@ -73,6 +77,7 @@ func TestEventFromEvaluateRequestPreservesHookFields(t *testing.T) {
 	if event.SessionID != "session-123" ||
 		event.Agent != "claude" ||
 		event.HookName != hook.HookPostToolUseFailed ||
+		event.Prompt != "ship it" ||
 		event.ToolName != "Bash" ||
 		event.ToolInput["command"] != "npm test" ||
 		event.ToolResponse["stderr"] != "failed" ||

--- a/internal/localruntime/protocol.go
+++ b/internal/localruntime/protocol.go
@@ -9,30 +9,33 @@ import (
 )
 
 type EvaluateRequest struct {
-	Type           string          `json:"type"`
-	SessionID      string          `json:"session_id,omitempty"`
-	Agent          string          `json:"agent"`
-	HookEvent      string          `json:"hook_event"`
-	ToolName       string          `json:"tool_name"`
-	ToolInput      json.RawMessage `json:"tool_input,omitempty"`
-	ToolResponse   json.RawMessage `json:"tool_response,omitempty"`
-	ToolUseID      string          `json:"tool_use_id"`
-	CWD            string          `json:"cwd"`
-	PermissionMode string          `json:"permission_mode,omitempty"`
-	DurationMs     *int64          `json:"duration_ms,omitempty"`
-	Error          string          `json:"error,omitempty"`
-	IsInterrupt    *bool           `json:"is_interrupt,omitempty"`
+	ProtocolVersion int             `json:"protocol_version,omitempty"`
+	Type            string          `json:"type"`
+	SessionID       string          `json:"session_id,omitempty"`
+	Agent           string          `json:"agent"`
+	HookEvent       string          `json:"hook_event"`
+	Prompt          string          `json:"prompt,omitempty"`
+	ToolName        string          `json:"tool_name"`
+	ToolInput       json.RawMessage `json:"tool_input,omitempty"`
+	ToolResponse    json.RawMessage `json:"tool_response,omitempty"`
+	ToolUseID       string          `json:"tool_use_id"`
+	CWD             string          `json:"cwd"`
+	PermissionMode  string          `json:"permission_mode,omitempty"`
+	DurationMs      *int64          `json:"duration_ms,omitempty"`
+	Error           string          `json:"error,omitempty"`
+	IsInterrupt     *bool           `json:"is_interrupt,omitempty"`
 }
 
 type EvaluateResult struct {
-	Type       string `json:"type"`
-	Decision   string `json:"decision,omitempty"`
-	Allowed    bool   `json:"allowed"`
-	Reason     string `json:"reason"`
-	ReasonCode string `json:"reason_code,omitempty"`
-	RequestID  string `json:"request_id,omitempty"`
-	Mode       string `json:"mode,omitempty"`
-	Epoch      string `json:"epoch,omitempty"`
+	ProtocolVersion int    `json:"protocol_version,omitempty"`
+	Type            string `json:"type"`
+	Decision        string `json:"decision,omitempty"`
+	Allowed         bool   `json:"allowed"`
+	Reason          string `json:"reason"`
+	ReasonCode      string `json:"reason_code,omitempty"`
+	RequestID       string `json:"request_id,omitempty"`
+	Mode            string `json:"mode,omitempty"`
+	Epoch           string `json:"epoch,omitempty"`
 	// EventID is the persisted decision row's ID — pre-minted when the
 	// runtime answers before persisting — so a hook client can correlate
 	// its response with the eventual record.

--- a/internal/managedobserve/lifecycle.go
+++ b/internal/managedobserve/lifecycle.go
@@ -19,10 +19,11 @@ import (
 )
 
 const (
-	sessionStartWait = 400 * time.Millisecond
-	preToolUseWait   = 250 * time.Millisecond
-	asyncHookWait    = 120 * time.Millisecond
-	probeTimeout     = 60 * time.Millisecond
+	sessionStartWait     = 400 * time.Millisecond
+	preToolUseWait       = 250 * time.Millisecond
+	userPromptSubmitWait = 60 * time.Second
+	asyncHookWait        = 120 * time.Millisecond
+	probeTimeout         = 60 * time.Millisecond
 )
 
 var launchdMu sync.Mutex
@@ -123,6 +124,8 @@ func (l Lifecycle) Process(ctx context.Context, event hook.Event) hook.Result {
 		return l.processWithKickstart(ctx, event, sessionStartWait)
 	case hook.HookPreToolUse:
 		return l.processWithKickstart(ctx, event, preToolUseWait)
+	case hook.HookUserPromptSubmit:
+		return l.processWithKickstart(ctx, event, userPromptSubmitWait)
 	default:
 		return l.processIfAvailable(ctx, event, asyncHookWait)
 	}


### PR DESCRIPTION
ENG-624 CLI stack 1/6.

Makes UserPromptSubmit a first-class synchronous hook event across the domain and local wire, preserves compatibility mirrors, and gives prompt processing a 65-second budget while keeping normal tool-call budgets unchanged.

The prompt itself is always accepted. Subsequent tool use waits for the corresponding session policy set.