### PR TITLE
feat(policy): validate prompt policy bundles

### DIFF
--- a/internal/promptpolicy/client.go
+++ b/internal/promptpolicy/client.go
@@ -1,0 +1,93 @@
+package promptpolicy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Client struct {
+	baseURL *url.URL
+	http    *http.Client
+}
+
+type Request struct {
+	Token                    string
+	InstallationID           string
+	AuthorizationSessionID   string
+	PromptSequence           uint64
+	Prompt                   string
+	ParentDeploymentIdentity string
+}
+
+type HTTPError struct {
+	StatusCode int
+	Response   ErrorResponse
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("prompt-policy request failed: HTTP %d (%s)", e.StatusCode, e.Response.Code)
+}
+
+func NewClient(baseURL string, httpClient *http.Client) (*Client, error) {
+	parsed, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return nil, errors.New("invalid prompt-policy base URL")
+	}
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 60 * time.Second}
+	}
+	return &Client{baseURL: parsed, http: httpClient}, nil
+}
+
+func (c *Client) Put(ctx context.Context, input Request) (Bundle, error) {
+	if input.Token == "" || input.PromptSequence == 0 || len([]byte(input.Prompt)) == 0 || len([]byte(input.Prompt)) > MaxPromptBytes {
+		return Bundle{}, errors.New("invalid prompt-policy request")
+	}
+	body, err := json.Marshal(PutRequest{
+		RequestContractVersion:           RequestContractVersion,
+		Prompt:                           input.Prompt,
+		ExpectedParentDeploymentIdentity: input.ParentDeploymentIdentity,
+	})
+	if err != nil {
+		return Bundle{}, fmt.Errorf("encode prompt-policy request: %w", err)
+	}
+	path := "/api/v1/installations/" + url.PathEscape(input.InstallationID) +
+		"/authorization-sessions/" + url.PathEscape(input.AuthorizationSessionID) +
+		"/prompt-policies/" + strconv.FormatUint(input.PromptSequence, 10)
+	endpoint := c.baseURL.ResolveReference(&url.URL{Path: path})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, endpoint.String(), bytes.NewReader(body))
+	if err != nil {
+		return Bundle{}, fmt.Errorf("create prompt-policy request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+input.Token)
+	req.Header.Set("Content-Type", "application/json")
+	response, err := c.http.Do(req)
+	if err != nil {
+		return Bundle{}, fmt.Errorf("send prompt-policy request: %w", err)
+	}
+	defer response.Body.Close()
+	data, err := io.ReadAll(io.LimitReader(response.Body, maxPolicySetBytes+64*1024))
+	if err != nil {
+		return Bundle{}, fmt.Errorf("read prompt-policy response: %w", err)
+	}
+	if response.StatusCode != http.StatusOK {
+		var apiError ErrorResponse
+		if err := decodeStrict(data, &apiError); err != nil {
+			return Bundle{}, fmt.Errorf("decode prompt-policy error: %w", err)
+		}
+		if apiError.ResponseVersion != ResponseVersion || apiError.Code == "" {
+			return Bundle{}, errors.New("invalid prompt-policy error response")
+		}
+		return Bundle{}, &HTTPError{StatusCode: response.StatusCode, Response: apiError}
+	}
+	return DecodeBundle(data)
+}

--- a/internal/promptpolicy/client_test.go
+++ b/internal/promptpolicy/client_test.go
@@ -1,0 +1,65 @@
+package promptpolicy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestClientPutUsesSynchronousExactPromptResource(t *testing.T) {
+	bundle := testBundle(t, time.Now().UTC())
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/api/v1/installations/ins_12345678901234567890123456789012/authorization-sessions/codex-session-1/prompt-policies/3" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer install-token" {
+			t.Fatal("missing install token")
+		}
+		var request PutRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatal(err)
+		}
+		if request.Prompt != "email the report" || request.RequestContractVersion != RequestContractVersion {
+			t.Fatalf("unexpected body: %+v", request)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(bundle)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL, server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := client.Put(t.Context(), Request{
+		Token: "install-token", InstallationID: bundle.Audience.InstallationID,
+		AuthorizationSessionID: bundle.Audience.AuthorizationSessionID,
+		PromptSequence:         bundle.Audience.PromptSequence, Prompt: "email the report",
+		ParentDeploymentIdentity: bundle.Parent.DeploymentIdentity,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.DeploymentIdentity != bundle.DeploymentIdentity {
+		t.Fatal("returned wrong bundle")
+	}
+}
+
+func TestClientPutReturnsTypedError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(ErrorResponse{ResponseVersion: ResponseVersion, Code: "prompt_sequence_conflict"})
+	}))
+	defer server.Close()
+	client, err := NewClient(server.URL, server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.Put(t.Context(), Request{Token: "x", InstallationID: "ins_12345678901234567890123456789012", AuthorizationSessionID: "s", PromptSequence: 1, Prompt: "p", ParentDeploymentIdentity: "a"})
+	httpError, ok := err.(*HTTPError)
+	if !ok || httpError.Response.Code != "prompt_sequence_conflict" {
+		t.Fatalf("expected typed conflict, got %v", err)
+	}
+}

--- a/internal/promptpolicy/contract.go
+++ b/internal/promptpolicy/contract.go
@@ -1,0 +1,176 @@
+package promptpolicy
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"time"
+)
+
+const (
+	RequestContractVersion = 2
+	ResponseVersion        = 2
+	CedarRequestVersion    = 1
+	MaxPromptBytes         = 65_536
+	maxPolicySetBytes      = 1_048_576
+	policySetHashDomain    = "kontext:cedar-policy:v1\x00"
+	bundleIdentityDomain   = "kontext:effective-authorization-bundle:v2"
+)
+
+var (
+	sha256HexPattern      = regexp.MustCompile(`^[a-f0-9]{64}$`)
+	installationIDPattern = regexp.MustCompile(`^ins_[A-Za-z0-9_-]{32}$`)
+)
+
+type PutRequest struct {
+	RequestContractVersion           int    `json:"requestContractVersion"`
+	Prompt                           string `json:"prompt"`
+	ExpectedParentDeploymentIdentity string `json:"expectedParentDeploymentIdentity"`
+}
+
+type Bundle struct {
+	ResponseVersion        int                 `json:"responseVersion"`
+	RequestContractVersion int                 `json:"requestContractVersion"`
+	DeploymentIdentity     string              `json:"deploymentIdentity"`
+	RolloutMode            string              `json:"rolloutMode"`
+	Audience               Audience            `json:"audience"`
+	Parent                 ParentPolicySet     `json:"parent"`
+	PolicySet              EffectivePolicySet  `json:"policySet"`
+	EvaluationPrincipal    EvaluationPrincipal `json:"evaluationPrincipal"`
+	ValidFrom              string              `json:"validFrom"`
+	ExpiresAt              string              `json:"expiresAt"`
+}
+
+type Audience struct {
+	OrganizationID         string `json:"organizationId"`
+	InstallationID         string `json:"installationId"`
+	AuthorizationSessionID string `json:"authorizationSessionId"`
+	PromptSequence         uint64 `json:"promptSequence"`
+}
+
+type ParentPolicySet struct {
+	PolicySetVersionID  string `json:"policySetVersionId"`
+	PolicySetSourceHash string `json:"policySetSourceHash"`
+	DeploymentIdentity  string `json:"deploymentIdentity"`
+}
+
+type EffectivePolicySet struct {
+	PolicySetVersionID string `json:"policySetVersionId"`
+	Source             string `json:"source"`
+	SourceHash         string `json:"sourceHash"`
+	StaticPolicyCount  int    `json:"staticPolicyCount"`
+}
+
+type EvaluationPrincipal struct {
+	EntityType string `json:"entityType"`
+	EntityID   string `json:"entityId"`
+}
+
+type ErrorResponse struct {
+	ResponseVersion int    `json:"responseVersion"`
+	Code            string `json:"code"`
+	Retryable       bool   `json:"retryable"`
+}
+
+func DecodeBundle(data []byte) (Bundle, error) {
+	var bundle Bundle
+	if err := decodeStrict(data, &bundle); err != nil {
+		return Bundle{}, fmt.Errorf("decode prompt-policy bundle: %w", err)
+	}
+	if err := bundle.Validate(); err != nil {
+		return Bundle{}, err
+	}
+	return bundle, nil
+}
+
+func (b Bundle) Validate() error {
+	if b.ResponseVersion != ResponseVersion || b.RequestContractVersion != CedarRequestVersion {
+		return errors.New("unsupported prompt-policy bundle version")
+	}
+	if b.RolloutMode != "observe" && b.RolloutMode != "enforce" {
+		return errors.New("invalid prompt-policy rollout mode")
+	}
+	if b.Audience.OrganizationID == "" || !installationIDPattern.MatchString(b.Audience.InstallationID) || b.Audience.AuthorizationSessionID == "" || b.Audience.PromptSequence == 0 {
+		return errors.New("invalid prompt-policy audience")
+	}
+	if len([]byte(b.PolicySet.Source)) > maxPolicySetBytes || b.PolicySet.StaticPolicyCount < 0 {
+		return errors.New("invalid prompt-policy policy set")
+	}
+	if sourceHash(b.PolicySet.Source) != b.PolicySet.SourceHash {
+		return errors.New("prompt-policy source hash mismatch")
+	}
+	for _, value := range []string{b.DeploymentIdentity, b.Parent.PolicySetSourceHash, b.Parent.DeploymentIdentity, b.PolicySet.SourceHash} {
+		if !sha256HexPattern.MatchString(value) {
+			return errors.New("invalid prompt-policy hash")
+		}
+	}
+	validFrom, err := time.Parse(time.RFC3339Nano, b.ValidFrom)
+	if err != nil {
+		return errors.New("invalid prompt-policy validFrom")
+	}
+	expiresAt, err := time.Parse(time.RFC3339Nano, b.ExpiresAt)
+	if err != nil || !expiresAt.After(validFrom) {
+		return errors.New("invalid prompt-policy expiry")
+	}
+	identity, err := b.ComputeDeploymentIdentity()
+	if err != nil {
+		return err
+	}
+	if identity != b.DeploymentIdentity {
+		return errors.New("prompt-policy deployment identity mismatch")
+	}
+	return nil
+}
+
+func (b Bundle) ComputeDeploymentIdentity() (string, error) {
+	preimage, err := json.Marshal([]any{
+		bundleIdentityDomain,
+		b.ResponseVersion,
+		b.RequestContractVersion,
+		b.RolloutMode,
+		b.Audience.OrganizationID,
+		b.Audience.InstallationID,
+		b.Audience.AuthorizationSessionID,
+		b.Audience.PromptSequence,
+		b.Parent.PolicySetVersionID,
+		b.Parent.PolicySetSourceHash,
+		b.Parent.DeploymentIdentity,
+		b.PolicySet.PolicySetVersionID,
+		b.PolicySet.SourceHash,
+		b.PolicySet.StaticPolicyCount,
+		b.EvaluationPrincipal.EntityType,
+		b.EvaluationPrincipal.EntityID,
+		b.ValidFrom,
+		b.ExpiresAt,
+	})
+	if err != nil {
+		return "", fmt.Errorf("encode deployment identity: %w", err)
+	}
+	digest := sha256.Sum256(preimage)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func sourceHash(source string) string {
+	digest := sha256.Sum256([]byte(policySetHashDomain + source))
+	return hex.EncodeToString(digest[:])
+}
+
+func decodeStrict(data []byte, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("unexpected trailing JSON value")
+		}
+		return fmt.Errorf("decode trailing JSON: %w", err)
+	}
+	return nil
+}

--- a/internal/promptpolicy/contract_test.go
+++ b/internal/promptpolicy/contract_test.go
@@ -1,0 +1,63 @@
+package promptpolicy
+
+import (
+	"testing"
+	"time"
+)
+
+func TestActivationValidatorAcceptsExactBundleAndRejectsTampering(t *testing.T) {
+	now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+	bundle := testBundle(t, now)
+	validator := NewActivationValidator()
+	validator.now = func() time.Time { return now }
+	expected := ExpectedAudience{
+		OrganizationID: "org-1", InstallationID: "ins_12345678901234567890123456789012",
+		AuthorizationSessionID: "codex-session-1", PromptSequence: 3,
+		ParentDeploymentIdentity: bundle.Parent.DeploymentIdentity,
+	}
+	if err := validator.Validate(bundle, expected); err != nil {
+		t.Fatalf("validate bundle: %v", err)
+	}
+
+	tampered := bundle
+	tampered.PolicySet.Source += "\nforbid(principal, action, resource);"
+	if err := validator.Validate(tampered, expected); err == nil {
+		t.Fatal("expected tampered source to be rejected")
+	}
+	wrongSession := expected
+	wrongSession.AuthorizationSessionID = "codex-session-2"
+	if err := validator.Validate(bundle, wrongSession); err == nil {
+		t.Fatal("expected audience mismatch to be rejected")
+	}
+}
+
+func TestDecodeBundleRejectsUnknownAndTrailingJSON(t *testing.T) {
+	for _, input := range []string{
+		`{"unknown":true}`,
+		`{} {}`,
+	} {
+		if _, err := DecodeBundle([]byte(input)); err == nil {
+			t.Fatalf("expected strict decode failure for %q", input)
+		}
+	}
+}
+
+func testBundle(t *testing.T, now time.Time) Bundle {
+	t.Helper()
+	source := `permit(principal, action, resource);`
+	bundle := Bundle{
+		ResponseVersion: ResponseVersion, RequestContractVersion: CedarRequestVersion,
+		RolloutMode:         "enforce",
+		Audience:            Audience{OrganizationID: "org-1", InstallationID: "ins_12345678901234567890123456789012", AuthorizationSessionID: "codex-session-1", PromptSequence: 3},
+		Parent:              ParentPolicySet{PolicySetVersionID: "11111111-1111-4111-8111-111111111111", PolicySetSourceHash: sourceHash(source), DeploymentIdentity: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		PolicySet:           EffectivePolicySet{PolicySetVersionID: "22222222-2222-4222-8222-222222222222", Source: source, SourceHash: sourceHash(source), StaticPolicyCount: 1},
+		EvaluationPrincipal: EvaluationPrincipal{EntityType: "Kontext::User", EntityID: "user-1"},
+		ValidFrom:           now.Add(-time.Minute).Format(time.RFC3339Nano), ExpiresAt: now.Add(time.Hour).Format(time.RFC3339Nano),
+	}
+	identity, err := bundle.ComputeDeploymentIdentity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle.DeploymentIdentity = identity
+	return bundle
+}

--- a/internal/promptpolicy/validator.go
+++ b/internal/promptpolicy/validator.go
@@ -1,0 +1,44 @@
+package promptpolicy
+
+import (
+	"errors"
+	"time"
+)
+
+type ExpectedAudience struct {
+	OrganizationID           string
+	InstallationID           string
+	AuthorizationSessionID   string
+	PromptSequence           uint64
+	ParentDeploymentIdentity string
+}
+
+// ActivationValidator checks that a decoded bundle is the exact, current
+// response requested for one prompt before the session manager activates it.
+type ActivationValidator struct {
+	now func() time.Time
+}
+
+func NewActivationValidator() *ActivationValidator {
+	return &ActivationValidator{now: time.Now}
+}
+
+func (v *ActivationValidator) Validate(bundle Bundle, expected ExpectedAudience) error {
+	if err := bundle.Validate(); err != nil {
+		return err
+	}
+	if bundle.Audience.OrganizationID != expected.OrganizationID ||
+		bundle.Audience.InstallationID != expected.InstallationID ||
+		bundle.Audience.AuthorizationSessionID != expected.AuthorizationSessionID ||
+		bundle.Audience.PromptSequence != expected.PromptSequence ||
+		bundle.Parent.DeploymentIdentity != expected.ParentDeploymentIdentity {
+		return errors.New("prompt-policy audience or parent mismatch")
+	}
+	validFrom, _ := time.Parse(time.RFC3339Nano, bundle.ValidFrom)
+	expiresAt, _ := time.Parse(time.RFC3339Nano, bundle.ExpiresAt)
+	now := v.now()
+	if now.Before(validFrom) || !now.Before(expiresAt) {
+		return errors.New("prompt-policy bundle is outside its validity window")
+	}
+	return nil
+}


### PR DESCRIPTION
ENG-624 CLI stack 2/6; stacked on #466.

Adds the strict V2 synchronous prompt-policy client, portable deployment-identity calculation, source-hash checks, audience/parent/TTL validation, bounded response sizes, and typed HTTP failures.

Bundles are validated as live HTTPS responses and activated only after their complete authority-bearing identity is recomputed. No signing keys or policy-signature configuration are required.