### PR TITLE
feat(policy): activate prompt policy sets per session

### DIFF
--- a/internal/promptpolicy/validator.go
+++ b/internal/promptpolicy/validator.go
@@ -27,7 +27,7 @@ func (v *ActivationValidator) Validate(bundle Bundle, expected ExpectedAudience)
 	if err := bundle.Validate(); err != nil {
 		return err
 	}
-	if bundle.Audience.OrganizationID != expected.OrganizationID ||
+	if (expected.OrganizationID != "" && bundle.Audience.OrganizationID != expected.OrganizationID) ||
 		bundle.Audience.InstallationID != expected.InstallationID ||
 		bundle.Audience.AuthorizationSessionID != expected.AuthorizationSessionID ||
 		bundle.Audience.PromptSequence != expected.PromptSequence ||

--- a/internal/sessionpolicy/manager.go
+++ b/internal/sessionpolicy/manager.go
@@ -1,0 +1,180 @@
+package sessionpolicy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/cedareval"
+	"github.com/kontext-security/kontext-cli/internal/cedarpolicy"
+	"github.com/kontext-security/kontext-cli/internal/promptpolicy"
+)
+
+const defaultDerivationTimeout = 60 * time.Second
+
+// SessionKey is the authority-bearing identity of one agent session. The
+// installation is configured on Manager; Provider prevents native session IDs
+// from different adapters sharing an authorization boundary.
+type SessionKey struct {
+	Provider        string
+	NativeSessionID string
+}
+
+func (k SessionKey) AuthorizationSessionID() (string, error) {
+	if k.Provider == "" || k.NativeSessionID == "" {
+		return "", errors.New("prompt policy requires provider and native session id")
+	}
+	return k.Provider + ":" + k.NativeSessionID, nil
+}
+
+type Deriver interface {
+	Put(context.Context, promptpolicy.Request) (promptpolicy.Bundle, error)
+}
+
+type TokenSource func(context.Context) (string, error)
+
+type ParentSource interface {
+	Current() cedarpolicy.Snapshot
+}
+
+// Snapshot is the single effective PolicySet selected for a session. Required
+// with Ready=false is an explicit fail-closed barrier, not a fallback request.
+type Snapshot struct {
+	Required       bool
+	Ready          bool
+	PromptSequence uint64
+	Deployment     *cedarpolicy.Deployment
+	Failure        error
+}
+
+type Manager struct {
+	deriver        Deriver
+	validator      *promptpolicy.ActivationValidator
+	parents        ParentSource
+	tokenSource    TokenSource
+	installationID string
+	timeout        time.Duration
+
+	mu       sync.Mutex
+	sessions map[SessionKey]*session
+}
+
+type session struct {
+	mu       sync.Mutex
+	sequence uint64
+	snapshot Snapshot
+}
+
+func NewManager(deriver Deriver, validator *promptpolicy.ActivationValidator, parents ParentSource, tokenSource TokenSource, installationID string, timeout time.Duration) (*Manager, error) {
+	if deriver == nil || validator == nil || parents == nil || tokenSource == nil || installationID == "" {
+		return nil, errors.New("prompt policy manager dependencies are incomplete")
+	}
+	if timeout <= 0 {
+		timeout = defaultDerivationTimeout
+	}
+	return &Manager{deriver: deriver, validator: validator, parents: parents, tokenSource: tokenSource, installationID: installationID, timeout: timeout, sessions: make(map[SessionKey]*session)}, nil
+}
+
+// BeginPrompt is the synchronous policy barrier. It returns only after a new
+// complete PolicySet has been verified, parsed, and atomically selected.
+func (m *Manager) BeginPrompt(ctx context.Context, key SessionKey, prompt string) (Snapshot, error) {
+	authorizationSessionID, err := key.AuthorizationSessionID()
+	if err != nil {
+		return Snapshot{}, err
+	}
+	if prompt == "" {
+		return Snapshot{}, errors.New("prompt policy requires a prompt")
+	}
+	state := m.sessionFor(key)
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	state.sequence++
+	sequence := state.sequence
+	state.snapshot = Snapshot{Required: true, PromptSequence: sequence}
+
+	parent := m.parents.Current().Deployment
+	if parent == nil {
+		err := errors.New("prompt policy parent is not ready")
+		state.snapshot.Failure = err
+		return state.snapshot, err
+	}
+	token, err := m.tokenSource(ctx)
+	if err != nil {
+		state.snapshot.Failure = fmt.Errorf("resolve prompt-policy token: %w", err)
+		return state.snapshot, state.snapshot.Failure
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, m.timeout)
+	defer cancel()
+	bundle, err := m.deriver.Put(requestCtx, promptpolicy.Request{
+		Token: token, InstallationID: m.installationID,
+		AuthorizationSessionID: authorizationSessionID, PromptSequence: sequence,
+		Prompt: prompt, ParentDeploymentIdentity: parent.DeploymentIdentity,
+	})
+	if err != nil {
+		state.snapshot.Failure = err
+		return state.snapshot, err
+	}
+	if err := m.validator.Validate(bundle, promptpolicy.ExpectedAudience{
+		InstallationID: m.installationID, AuthorizationSessionID: authorizationSessionID,
+		PromptSequence: sequence, ParentDeploymentIdentity: parent.DeploymentIdentity,
+	}); err != nil {
+		state.snapshot.Failure = err
+		return state.snapshot, err
+	}
+	if _, err := cedareval.New(bundle.PolicySet.Source); err != nil {
+		state.snapshot.Failure = fmt.Errorf("parse effective prompt policy set: %w", err)
+		return state.snapshot, state.snapshot.Failure
+	}
+	deployment := deploymentFromBundle(bundle)
+	state.snapshot = Snapshot{Required: true, Ready: true, PromptSequence: sequence, Deployment: &deployment}
+	return cloneSnapshot(state.snapshot), nil
+}
+
+func (m *Manager) SnapshotFor(key SessionKey) Snapshot {
+	m.mu.Lock()
+	state := m.sessions[key]
+	m.mu.Unlock()
+	if state == nil {
+		return Snapshot{}
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	return cloneSnapshot(state.snapshot)
+}
+
+func (m *Manager) EndSession(key SessionKey) {
+	m.mu.Lock()
+	delete(m.sessions, key)
+	m.mu.Unlock()
+}
+
+func (m *Manager) sessionFor(key SessionKey) *session {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if current := m.sessions[key]; current != nil {
+		return current
+	}
+	created := &session{}
+	m.sessions[key] = created
+	return created
+}
+
+func deploymentFromBundle(bundle promptpolicy.Bundle) cedarpolicy.Deployment {
+	return cedarpolicy.Deployment{
+		ResponseVersion: bundle.ResponseVersion, RequestContractVersion: bundle.RequestContractVersion,
+		PolicyHash: bundle.PolicySet.SourceHash, RolloutMode: cedareval.RolloutMode(bundle.RolloutMode),
+		EvaluationPrincipal: cedareval.EvaluationPrincipal{EntityType: bundle.EvaluationPrincipal.EntityType, EntityID: bundle.EvaluationPrincipal.EntityID},
+		PolicyText:          bundle.PolicySet.Source, DeploymentIdentity: bundle.DeploymentIdentity,
+	}
+}
+
+func cloneSnapshot(snapshot Snapshot) Snapshot {
+	if snapshot.Deployment != nil {
+		deployment := *snapshot.Deployment
+		snapshot.Deployment = &deployment
+	}
+	return snapshot
+}

--- a/internal/sessionpolicy/manager_test.go
+++ b/internal/sessionpolicy/manager_test.go
@@ -1,0 +1,88 @@
+package sessionpolicy
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kontext-security/kontext-cli/internal/cedareval"
+	"github.com/kontext-security/kontext-cli/internal/cedarpolicy"
+	"github.com/kontext-security/kontext-cli/internal/promptpolicy"
+)
+
+type fakeDeriver struct {
+	bundle   promptpolicy.Bundle
+	err      error
+	requests []promptpolicy.Request
+}
+
+func (f *fakeDeriver) Put(_ context.Context, request promptpolicy.Request) (promptpolicy.Bundle, error) {
+	f.requests = append(f.requests, request)
+	return f.bundle, f.err
+}
+
+type fakeParents struct{ snapshot cedarpolicy.Snapshot }
+
+func (f fakeParents) Current() cedarpolicy.Snapshot { return f.snapshot }
+
+func TestBeginPromptSynchronouslyActivatesVerifiedPolicySet(t *testing.T) {
+	parent := cedarpolicy.Deployment{DeploymentIdentity: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+	bundle := validBundle(t, parent.DeploymentIdentity, 1)
+	deriver := &fakeDeriver{bundle: bundle}
+	manager, err := NewManager(deriver, promptpolicy.NewActivationValidator(), fakeParents{cedarpolicy.Snapshot{Deployment: &parent}}, func(context.Context) (string, error) { return "token", nil }, bundle.Audience.InstallationID, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := SessionKey{Provider: "codex", NativeSessionID: "s1"}
+	snapshot, err := manager.BeginPrompt(t.Context(), key, "read the report")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !snapshot.Required || !snapshot.Ready || snapshot.Deployment == nil || snapshot.Deployment.PolicyText != bundle.PolicySet.Source {
+		t.Fatalf("unexpected snapshot: %+v", snapshot)
+	}
+	if deriver.requests[0].AuthorizationSessionID != "codex:s1" {
+		t.Fatalf("unexpected authorization session: %s", deriver.requests[0].AuthorizationSessionID)
+	}
+}
+
+func TestNewPromptInvalidatesPriorPolicyOnFailure(t *testing.T) {
+	parent := cedarpolicy.Deployment{DeploymentIdentity: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+	bundle := validBundle(t, parent.DeploymentIdentity, 1)
+	deriver := &fakeDeriver{bundle: bundle}
+	manager, _ := NewManager(deriver, promptpolicy.NewActivationValidator(), fakeParents{cedarpolicy.Snapshot{Deployment: &parent}}, func(context.Context) (string, error) { return "token", nil }, bundle.Audience.InstallationID, time.Second)
+	key := SessionKey{Provider: "codex", NativeSessionID: "s1"}
+	if _, err := manager.BeginPrompt(t.Context(), key, "first"); err != nil {
+		t.Fatal(err)
+	}
+	deriver.err = errors.New("generator unavailable")
+	if _, err := manager.BeginPrompt(t.Context(), key, "second"); err == nil {
+		t.Fatal("expected second prompt failure")
+	}
+	snapshot := manager.SnapshotFor(key)
+	if snapshot.PromptSequence != 2 || snapshot.Ready || snapshot.Deployment != nil {
+		t.Fatalf("old policy remained eligible: %+v", snapshot)
+	}
+}
+
+func validBundle(t *testing.T, parentIdentity string, sequence uint64) promptpolicy.Bundle {
+	t.Helper()
+	now := time.Now().UTC()
+	source := `@id("kontext.generated.test") forbid(principal, action, resource);`
+	digest := cedareval.ComputePolicyHash(source)
+	bundle := promptpolicy.Bundle{
+		ResponseVersion: 2, RequestContractVersion: 1, RolloutMode: "enforce",
+		Audience:            promptpolicy.Audience{OrganizationID: "org-1", InstallationID: "ins_12345678901234567890123456789012", AuthorizationSessionID: "codex:s1", PromptSequence: sequence},
+		Parent:              promptpolicy.ParentPolicySet{PolicySetVersionID: "11111111-1111-4111-8111-111111111111", PolicySetSourceHash: digest, DeploymentIdentity: parentIdentity},
+		PolicySet:           promptpolicy.EffectivePolicySet{PolicySetVersionID: "22222222-2222-4222-8222-222222222222", Source: source, SourceHash: digest, StaticPolicyCount: 1},
+		EvaluationPrincipal: promptpolicy.EvaluationPrincipal{EntityType: cedareval.PrincipalEntityType, EntityID: "user-1"},
+		ValidFrom:           now.Add(-time.Minute).Format(time.RFC3339Nano), ExpiresAt: now.Add(time.Hour).Format(time.RFC3339Nano),
+	}
+	identity, err := bundle.ComputeDeploymentIdentity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle.DeploymentIdentity = identity
+	return bundle
+}


### PR DESCRIPTION
ENG-624 CLI stack 3/6; stacked on #467.

Adds the small session policy manager. For each prompt it synchronously derives, validates, parses, and atomically activates one complete PolicySet. Prompt sequence is ordering only; a failed newer prompt makes the older set ineligible rather than falling back to broader authority.

Policy generation happens once per prompt, never once per tool call.