### PR TITLE
fix: harden prompt policy activation

### DIFF
--- a/internal/cedarpolicy/cache.go
+++ b/internal/cedarpolicy/cache.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kontext-security/kontext/internal/cedareval"
 	"github.com/kontext-security/kontext/internal/diagnostic"
 )
 
@@ -32,8 +33,55 @@ type CacheStatus struct {
 type Snapshot struct {
 	Deployment    *Deployment
 	LastKnownGood *Deployment
-	State         State
-	Status        CacheStatus
+	// PolicySet is the runtime authorization shape for non-v1 sources such as
+	// session-derived bundles. Wire DTOs are converted at the boundary.
+	PolicySet *PolicySetSnapshot
+	State     State
+	Status    CacheStatus
+}
+
+type PolicySetSnapshot struct {
+	ResponseVersion        int
+	RequestContractVersion int
+	SourceHash             string
+	RolloutMode            string
+	EvaluationPrincipal    cedareval.EvaluationPrincipal
+	Source                 string
+	DeploymentIdentity     string
+	Evaluator              *cedareval.Evaluator
+}
+
+func (s Snapshot) ActivePolicySet() *PolicySetSnapshot {
+	if s.PolicySet != nil {
+		copy := *s.PolicySet
+		return &copy
+	}
+	if s.Deployment == nil {
+		return nil
+	}
+	return policySetFromDeployment(s.Deployment)
+}
+
+func (s Snapshot) BestKnownPolicySet() *PolicySetSnapshot {
+	if active := s.ActivePolicySet(); active != nil {
+		return active
+	}
+	if s.LastKnownGood == nil {
+		return nil
+	}
+	return policySetFromDeployment(s.LastKnownGood)
+}
+
+func policySetFromDeployment(deployment *Deployment) *PolicySetSnapshot {
+	return &PolicySetSnapshot{
+		ResponseVersion:        deployment.ResponseVersion,
+		RequestContractVersion: deployment.RequestContractVersion,
+		SourceHash:             deployment.PolicyHash,
+		RolloutMode:            string(deployment.RolloutMode),
+		EvaluationPrincipal:    deployment.EvaluationPrincipal,
+		Source:                 deployment.PolicyText,
+		DeploymentIdentity:     deployment.DeploymentIdentity,
+	}
 }
 
 // SnapshotProvider exposes validated in-memory policy state to the hook path.

--- a/internal/cedarpolicy/mode.go
+++ b/internal/cedarpolicy/mode.go
@@ -15,9 +15,6 @@ func DeploymentClaimsEnforce(snapshot Snapshot) bool {
 	if snapshot.State == StateDisabled || snapshot.State == StateNoActivePolicy {
 		return false
 	}
-	deployment := snapshot.Deployment
-	if deployment == nil {
-		deployment = snapshot.LastKnownGood
-	}
-	return deployment != nil && deployment.RolloutMode == cedareval.RolloutModeEnforce
+	policySet := snapshot.BestKnownPolicySet()
+	return policySet != nil && policySet.RolloutMode == string(cedareval.RolloutModeEnforce)
 }

--- a/internal/claudemanaged/settings.go
+++ b/internal/claudemanaged/settings.go
@@ -166,11 +166,17 @@ func IsManagedSettingsDropIn(data []byte) bool {
 	if err := json.Unmarshal(data, &settings); err != nil {
 		return false
 	}
-	if len(settings.Hooks) != len(SupportedEvents) {
+	// Upgrade compatibility: the previous Kontext-owned drop-in had the same
+	// exact shape minus UserPromptSubmit. Recognize it as ours so setup can
+	// replace it and uninstall can remove it safely.
+	if len(settings.Hooks) != len(SupportedEvents) && len(settings.Hooks) != len(SupportedEvents)-1 {
 		return false
 	}
 	for _, event := range SupportedEvents {
 		groups := settings.Hooks[event.Name.String()]
+		if event.Name == hook.HookUserPromptSubmit && len(groups) == 0 && len(settings.Hooks) == len(SupportedEvents)-1 {
+			continue
+		}
 		if len(groups) != 1 || groups[0].Matcher != "" || len(groups[0].Hooks) != 1 {
 			return false
 		}

--- a/internal/claudemanaged/settings_test.go
+++ b/internal/claudemanaged/settings_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/kontext-security/kontext/internal/hook"
 )
 
 func TestTemplateIncludesManagedKontextHooks(t *testing.T) {
@@ -113,6 +115,18 @@ func TestTemplateJSONOnlyMarksLifecycleHooksAsync(t *testing.T) {
 		} else if hasAsync {
 			t.Fatalf("%s async emitted, want omitted", event.Name)
 		}
+	}
+}
+
+func TestLegacyFiveHookDropInRemainsKontextOwned(t *testing.T) {
+	settings := Template("/usr/local/bin/kontext")
+	delete(settings.Hooks, hook.HookUserPromptSubmit.String())
+	data, err := json.Marshal(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !IsManagedSettingsDropIn(data) {
+		t.Fatal("legacy Kontext drop-in was not recognized for upgrade")
 	}
 }
 

--- a/internal/endpointconfig/cache.go
+++ b/internal/endpointconfig/cache.go
@@ -41,6 +41,9 @@ type Snapshot struct {
 	// explicit directive is remembered until an explicit one replaces it. Nil
 	// means the org has never set it, which resolves to enabled.
 	GuardrailLLMDirective *bool
+	// PromptPolicyDirective is remembered across transient refresh failures so
+	// an enabled authorization barrier cannot silently fail open.
+	PromptPolicyDirective *bool
 	ConfigIdentity        string
 	Confirmed             bool
 	FallbackReason        string
@@ -51,7 +54,7 @@ type Snapshot struct {
 // cacheFileVersion is written by this build. Version 1 files load fine and
 // simply carry no remembered directive; a version this build does not know is
 // rejected rather than guessed at.
-const cacheFileVersion = 2
+const cacheFileVersion = 3
 
 type cacheFile struct {
 	Version   int       `json:"version"`
@@ -61,18 +64,20 @@ type cacheFile struct {
 	// config, because the response's identity is verified against its config on
 	// load — editing the config to carry a remembered value would invalidate it.
 	GuardrailLLMDirective *bool `json:"guardrailLlmDirective,omitempty"`
+	PromptPolicyDirective *bool `json:"promptPolicyDirective,omitempty"`
 }
 
 type Cache struct {
 	path string
 	now  func() time.Time
 
-	mu        sync.RWMutex
-	fetched   time.Time
-	active    *Response
-	lastGood  *Response
-	status    Status
-	directive *bool
+	mu                    sync.RWMutex
+	fetched               time.Time
+	active                *Response
+	lastGood              *Response
+	status                Status
+	directive             *bool
+	promptPolicyDirective *bool
 }
 
 func NewCache(path string) *Cache {
@@ -112,6 +117,7 @@ func (c *Cache) Load() error {
 		if file.Response.ResponseVersion != ResponseVersion {
 			c.mu.Lock()
 			c.directive = cloneBool(file.GuardrailLLMDirective)
+			c.promptPolicyDirective = cloneBool(file.PromptPolicyDirective)
 			c.status = Status{Stale: true, LastError: "persisted configuration predates the current response version"}
 			c.mu.Unlock()
 			return nil
@@ -127,6 +133,7 @@ func (c *Cache) Load() error {
 	c.active = nil
 	c.lastGood = cloneResponse(file.Response)
 	c.directive = cloneBool(file.GuardrailLLMDirective)
+	c.promptPolicyDirective = cloneBool(file.PromptPolicyDirective)
 	c.status = Status{FetchedAt: fetchedAt, Stale: true, LastError: "persisted configuration not yet confirmed"}
 	c.mu.Unlock()
 	return nil
@@ -139,6 +146,7 @@ func (c *Cache) Apply(result FetchResult, fetchedAt time.Time) error {
 	c.mu.RLock()
 	lastGood := cloneResponse(c.lastGood)
 	directive := cloneBool(c.directive)
+	promptPolicyDirective := cloneBool(c.promptPolicyDirective)
 	c.mu.RUnlock()
 	var confirmed *Response
 	switch {
@@ -160,11 +168,15 @@ func (c *Cache) Apply(result FetchResult, fetchedAt time.Time) error {
 	if confirmed.Config.GuardrailLLMEnabled != nil {
 		directive = cloneBool(confirmed.Config.GuardrailLLMEnabled)
 	}
+	if confirmed.Config.PromptPolicyEnabled != nil {
+		promptPolicyDirective = cloneBool(confirmed.Config.PromptPolicyEnabled)
+	}
 	file := cacheFile{
 		Version:               cacheFileVersion,
 		FetchedAt:             fetchedAt.UTC().Format(time.RFC3339Nano),
 		Response:              cloneResponse(confirmed),
 		GuardrailLLMDirective: cloneBool(directive),
+		PromptPolicyDirective: cloneBool(promptPolicyDirective),
 	}
 	if err := c.persist(file); err != nil {
 		return err
@@ -174,6 +186,7 @@ func (c *Cache) Apply(result FetchResult, fetchedAt time.Time) error {
 	c.active = cloneResponse(confirmed)
 	c.lastGood = cloneResponse(confirmed)
 	c.directive = cloneBool(directive)
+	c.promptPolicyDirective = cloneBool(promptPolicyDirective)
 	c.status = Status{FetchedAt: fetchedAt, LastAttemptAt: fetchedAt}
 	c.mu.Unlock()
 	return nil
@@ -213,6 +226,7 @@ func (c *Cache) Current() Snapshot {
 	active := cloneResponse(c.active)
 	lastGood := cloneResponse(c.lastGood)
 	directive := cloneBool(c.directive)
+	promptPolicyDirective := cloneBool(c.promptPolicyDirective)
 	status := c.status
 	c.mu.RUnlock()
 	if active == nil {
@@ -234,6 +248,7 @@ func (c *Cache) Current() Snapshot {
 			Config:                defaultConfig,
 			Configured:            configured,
 			GuardrailLLMDirective: directive,
+			PromptPolicyDirective: promptPolicyDirective,
 			ConfigIdentity:        identity,
 			FallbackReason:        fallbackReason,
 			LastKnownGood:         lastGood,
@@ -244,6 +259,7 @@ func (c *Cache) Current() Snapshot {
 		Config:                active.Config,
 		Configured:            active.Config,
 		GuardrailLLMDirective: directive,
+		PromptPolicyDirective: promptPolicyDirective,
 		ConfigIdentity:        active.ConfigIdentity,
 		Confirmed:             true,
 		LastKnownGood:         lastGood,

--- a/internal/endpointconfig/client_test.go
+++ b/internal/endpointconfig/client_test.go
@@ -23,7 +23,7 @@ func TestClientFetchAndConditionalRefresh(t *testing.T) {
 			t.Fatalf("path = %q", request.URL.Path)
 		}
 		query := request.URL.Query()
-		if len(query) != 1 || query.Get("response_version") != "2" {
+		if len(query) != 1 || query.Get("response_version") != "3" {
 			t.Fatalf("query = %v", query)
 		}
 		if request.Header.Get("Authorization") != "Bearer token" {

--- a/internal/endpointconfig/contract.go
+++ b/internal/endpointconfig/contract.go
@@ -18,8 +18,8 @@ const (
 	// and v2 side by side and keys the response off the requested version, so
 	// moving here changes only what this build asks for; released binaries keep
 	// getting the v1 shape and the v1 identity hashes.
-	ResponseVersion  = 2
-	identityDomain   = "kontext:endpoint-config:v2"
+	ResponseVersion  = 3
+	identityDomain   = "kontext:endpoint-config:v3"
 	MaxResponseBytes = 64 * 1024
 )
 
@@ -42,6 +42,8 @@ type Config struct {
 	// "the server said false": the former is a contract violation Validate
 	// rejects, the latter is a directive to honour.
 	GuardrailLLMEnabled *bool `json:"guardrailLlmEnabled"`
+	// PromptPolicyEnabled is the single remotely managed runtime switch.
+	PromptPolicyEnabled *bool `json:"promptPolicyEnabled"`
 }
 
 func (c Config) Validate() error {
@@ -55,6 +57,9 @@ func (c Config) Validate() error {
 	// reject it as the contract violation it is.
 	if c.GuardrailLLMEnabled == nil {
 		return errors.New("endpoint configuration: guardrailLlmEnabled is required")
+	}
+	if c.PromptPolicyEnabled == nil {
+		return errors.New("endpoint configuration: promptPolicyEnabled is required")
 	}
 	return nil
 }
@@ -98,6 +103,7 @@ func ComputeIdentity(config Config) (string, error) {
 		ResponseVersion,
 		string(config.PayloadCaptureMode),
 		*config.GuardrailLLMEnabled,
+		*config.PromptPolicyEnabled,
 	})
 	if err != nil {
 		return "", fmt.Errorf("endpoint configuration: encode identity preimage: %w", err)

--- a/internal/endpointconfig/contract_test.go
+++ b/internal/endpointconfig/contract_test.go
@@ -17,9 +17,10 @@ func TestResponseValidate(t *testing.T) {
 		{name: "unsupported version", mutate: func(response *Response) { response.ResponseVersion = 1 }, wantErr: "version"},
 		{name: "unknown mode", mutate: func(response *Response) { response.Config.PayloadCaptureMode = "unknown" }, wantErr: "mode"},
 		{name: "identity mismatch", mutate: func(response *Response) { response.ConfigIdentity = strings.Repeat("f", 64) }, wantErr: "identity"},
-		// v2 always emits the guardrail flag. A response without it cannot be
+		// v3 always emits the runtime flags. A response without either cannot be
 		// identity-checked, since its preimage would differ from the server's.
 		{name: "missing guardrail flag", mutate: func(response *Response) { response.Config.GuardrailLLMEnabled = nil }, wantErr: "guardrailLlmEnabled"},
+		{name: "missing prompt policy flag", mutate: func(response *Response) { response.Config.PromptPolicyEnabled = nil }, wantErr: "promptPolicyEnabled"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -40,7 +41,7 @@ func TestResponseValidate(t *testing.T) {
 
 func TestDecodeStrictRejectsUnknownAndTrailingFields(t *testing.T) {
 	response := testResponse(t, payloadcapture.ModeFull)
-	valid := `{"responseVersion":2,"config":{"payloadCaptureMode":"full","guardrailLlmEnabled":true},"configIdentity":"` + response.ConfigIdentity + `"}`
+	valid := `{"responseVersion":3,"config":{"payloadCaptureMode":"full","guardrailLlmEnabled":true,"promptPolicyEnabled":false},"configIdentity":"` + response.ConfigIdentity + `"}`
 	for _, body := range []string{
 		strings.TrimSuffix(valid, "}") + `,"policyText":"permit();"}`,
 		valid + `{}`,

--- a/internal/endpointconfig/fixture_test.go
+++ b/internal/endpointconfig/fixture_test.go
@@ -1,77 +1,41 @@
 package endpointconfig
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
-	"os"
 	"testing"
+
+	"github.com/kontext-security/kontext/internal/payloadcapture"
 )
 
-const identityFixturePath = "testdata/portable/v2/identity-v2.json"
-
-// Update only when deliberately revising the portable fixture bytes.
-const identityFixtureSHA256 = "7dc694e9ecf0ef755ffeef6a49fe59a24d59db7451fc88bba55538d4f3898494"
-
-type identityFixture struct {
-	SchemaVersion  string                  `json:"schemaVersion"`
-	IdentityDomain string                  `json:"identityDomain"`
-	Vectors        []identityFixtureVector `json:"vectors"`
-}
-
-type identityFixtureVector struct {
-	Name            string `json:"name"`
-	ResponseVersion int    `json:"responseVersion"`
-	Config          Config `json:"config"`
-	Preimage        string `json:"preimage"`
-	ConfigIdentity  string `json:"configIdentity"`
-}
-
-func TestPortableIdentityFixture(t *testing.T) {
-	data, err := os.ReadFile(identityFixturePath)
+// This vector is mirrored by the TypeScript contract test. Keeping one small
+// explicit vector is easier to audit than a generated Cartesian-product file.
+func TestPortableV3IdentityVector(t *testing.T) {
+	enabled := true
+	config := Config{
+		PayloadCaptureMode:  payloadcapture.ModeSummary,
+		GuardrailLLMEnabled: &enabled,
+		PromptPolicyEnabled: &enabled,
+	}
+	preimage, err := json.Marshal([]any{
+		identityDomain,
+		ResponseVersion,
+		string(config.PayloadCaptureMode),
+		*config.GuardrailLLMEnabled,
+		*config.PromptPolicyEnabled,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	digest := sha256.Sum256(data)
-	if got := hex.EncodeToString(digest[:]); got != identityFixtureSHA256 {
-		t.Fatalf("fixture SHA-256 = %s, want %s", got, identityFixtureSHA256)
+	const expectedPreimage = `["kontext:endpoint-config:v3",3,"summary",true,true]`
+	if string(preimage) != expectedPreimage {
+		t.Fatalf("preimage = %s, want %s", preimage, expectedPreimage)
 	}
-	var fixture identityFixture
-	if err := json.Unmarshal(data, &fixture); err != nil {
+	identity, err := ComputeIdentity(config)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if fixture.SchemaVersion != "endpoint-config-identity-fixture-v2" || fixture.IdentityDomain != identityDomain {
-		t.Fatalf("fixture metadata = %#v", fixture)
-	}
-	// Six: three capture modes crossed with the guardrail flag, which is what
-	// makes the flag observably part of the identity.
-	if len(fixture.Vectors) != 6 {
-		t.Fatalf("fixture vector count = %d, want 6", len(fixture.Vectors))
-	}
-	for _, vector := range fixture.Vectors {
-		t.Run(vector.Name, func(t *testing.T) {
-			if vector.ResponseVersion != ResponseVersion {
-				t.Fatalf("responseVersion = %d", vector.ResponseVersion)
-			}
-			identity, err := ComputeIdentity(vector.Config)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if identity != vector.ConfigIdentity {
-				t.Fatalf("ComputeIdentity() = %s, want %s", identity, vector.ConfigIdentity)
-			}
-			preimage, err := json.Marshal([]any{
-				identityDomain,
-				ResponseVersion,
-				string(vector.Config.PayloadCaptureMode),
-				*vector.Config.GuardrailLLMEnabled,
-			})
-			if err != nil {
-				t.Fatal(err)
-			}
-			if string(preimage) != vector.Preimage {
-				t.Fatalf("preimage = %s, want %s", preimage, vector.Preimage)
-			}
-		})
+	const expectedIdentity = "445d27e4721a7c9ae886574397074813678e540c7924be75c44a58eb465e264f"
+	if identity != expectedIdentity {
+		t.Fatalf("identity = %s, want %s", identity, expectedIdentity)
 	}
 }

--- a/internal/endpointconfig/guardrail_directive_test.go
+++ b/internal/endpointconfig/guardrail_directive_test.go
@@ -2,6 +2,7 @@ package endpointconfig
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,7 +13,8 @@ import (
 
 func guardrailResponse(t *testing.T, mode payloadcapture.Mode, enabled *bool) Response {
 	t.Helper()
-	config := Config{PayloadCaptureMode: mode, GuardrailLLMEnabled: enabled}
+	promptPolicyEnabled := false
+	config := Config{PayloadCaptureMode: mode, GuardrailLLMEnabled: enabled, PromptPolicyEnabled: &promptPolicyEnabled}
 	identity, err := ComputeIdentity(config)
 	if err != nil {
 		t.Fatal(err)
@@ -21,6 +23,26 @@ func guardrailResponse(t *testing.T, mode payloadcapture.Mode, enabled *bool) Re
 }
 
 func boolPtr(value bool) *bool { return &value }
+
+func TestPromptPolicyDirectiveSurvivesRefreshFailure(t *testing.T) {
+	cache := NewCache(filepath.Join(t.TempDir(), "endpoint-config.json"))
+	now := time.Now().UTC()
+	response := guardrailResponse(t, payloadcapture.ModeSummary, boolPtr(true))
+	response.Config.PromptPolicyEnabled = boolPtr(true)
+	identity, err := ComputeIdentity(response.Config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.ConfigIdentity = identity
+	if err := cache.Apply(FetchResult{Response: &response, ETag: identity}, now); err != nil {
+		t.Fatal(err)
+	}
+	cache.MarkFailed(errors.New("offline"), now.Add(time.Minute))
+	directive := cache.Current().PromptPolicyDirective
+	if directive == nil || !*directive {
+		t.Fatalf("prompt-policy barrier failed open after refresh failure: %v", directive)
+	}
+}
 
 // Under v2 the flag is required, so the rollback case that motivated remembering
 // it cannot even reach the cache: a response without the flag is rejected rather

--- a/internal/endpointconfig/test_helpers_test.go
+++ b/internal/endpointconfig/test_helpers_test.go
@@ -8,10 +8,10 @@ import (
 
 func testResponse(t *testing.T, mode payloadcapture.Mode) Response {
 	t.Helper()
-	// The server always emits the guardrail flag under v2 and defaults it to
-	// enabled, so that is what a representative response looks like.
+	// The server always emits both runtime directives under v3.
 	enabled := true
-	config := Config{PayloadCaptureMode: mode, GuardrailLLMEnabled: &enabled}
+	disabled := false
+	config := Config{PayloadCaptureMode: mode, GuardrailLLMEnabled: &enabled, PromptPolicyEnabled: &disabled}
 	identity, err := ComputeIdentity(config)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/guard/app/server/cedar.go
+++ b/internal/guard/app/server/cedar.go
@@ -36,17 +36,23 @@ type cedarPolicyProvider struct {
 	snapshots   cedarpolicy.SnapshotProvider
 	enforcement CedarEnforcementSource
 
-	mu        sync.Mutex
-	identity  string
-	evaluator *cedareval.Evaluator
-	parseErr  error
+	mu             sync.Mutex
+	evaluators     map[string]cachedEvaluator
+	evaluatorOrder []string
 }
+
+type cachedEvaluator struct {
+	evaluator *cedareval.Evaluator
+	err       error
+}
+
+const maxCachedEvaluators = 32
 
 func newCedarPolicyProvider(current PolicyProvider, snapshots cedarpolicy.SnapshotProvider, enforcement CedarEnforcementSource) PolicyProvider {
 	if snapshots == nil {
 		return current
 	}
-	return &cedarPolicyProvider{current: current, snapshots: snapshots, enforcement: enforcement}
+	return &cedarPolicyProvider{current: current, snapshots: snapshots, enforcement: enforcement, evaluators: make(map[string]cachedEvaluator)}
 }
 
 func (p *cedarPolicyProvider) DecideHook(ctx context.Context, event risk.HookEvent) (risk.RiskDecision, error) {
@@ -90,18 +96,15 @@ func (p *cedarPolicyProvider) claimsAuthority(snapshot cedarpolicy.Snapshot) boo
 		if snapshot.Status.Invalid {
 			return true
 		}
-		deployment := snapshot.Deployment
-		if deployment == nil {
-			deployment = snapshot.LastKnownGood
-		}
-		if deployment == nil {
+		policySet := snapshot.BestKnownPolicySet()
+		if policySet == nil {
 			// Once the local cutover gate is enabled, absence and untrusted
 			// response states cannot silently restore the previous evaluator.
 			// Only explicit disabled/no-active-policy states relinquish Cedar
 			// authority.
 			return true
 		}
-		return deployment.RolloutMode == cedareval.RolloutModeEnforce
+		return policySet.RolloutMode == string(cedareval.RolloutModeEnforce)
 	case CedarEnforcementRemote:
 		return cedarpolicy.DeploymentClaimsEnforce(snapshot)
 	default:
@@ -123,23 +126,20 @@ func (p *cedarPolicyProvider) evaluate(snapshot cedarpolicy.Snapshot, event risk
 	outcome := cedareval.EvaluationOutcome{State: cedareval.EvaluationStateFailed, Reason: cedareval.ReasonPolicyMissing}
 	var principal *cedareval.EvaluationPrincipal
 
-	metadata := snapshot.Deployment
-	if metadata == nil {
-		metadata = snapshot.LastKnownGood
-	}
+	metadata := snapshot.BestKnownPolicySet()
 	if metadata != nil {
-		deployment := metadata
-		evidence.ResponseVersion = deployment.ResponseVersion
-		evidence.RequestContractVersion = deployment.RequestContractVersion
-		evidence.PolicyHash = deployment.PolicyHash
-		evidence.DeploymentIdentity = deployment.DeploymentIdentity
-		evidence.ConfiguredRolloutMode = deployment.RolloutMode
-		principalValue := deployment.EvaluationPrincipal
+		policySet := metadata
+		evidence.ResponseVersion = policySet.ResponseVersion
+		evidence.RequestContractVersion = policySet.RequestContractVersion
+		evidence.PolicyHash = policySet.SourceHash
+		evidence.DeploymentIdentity = policySet.DeploymentIdentity
+		evidence.ConfiguredRolloutMode = cedareval.RolloutMode(policySet.RolloutMode)
+		principalValue := policySet.EvaluationPrincipal
 		principal = &principalValue
 
-		if snapshot.Deployment == nil {
+		if snapshot.ActivePolicySet() == nil {
 			outcome.Reason = cedareval.ReasonStaleCachedPolicy
-		} else if evaluator, parseErr := p.evaluatorFor(deployment); parseErr != nil {
+		} else if evaluator, parseErr := p.evaluatorFor(policySet); parseErr != nil {
 			outcome.Reason = cedareval.ReasonInvalidCachedPolicy
 			evidence.EngineErrorCount = 1
 		} else {
@@ -187,7 +187,7 @@ func (p *cedarPolicyProvider) evaluate(snapshot cedarpolicy.Snapshot, event risk
 	currentAuthority := current
 	if claimsAuthority {
 		appliedMode = cedareval.RolloutModeEnforce
-		enforcementReady = snapshot.Deployment != nil && !snapshot.Status.Expired && !snapshot.Status.Invalid
+		enforcementReady = snapshot.ActivePolicySet() != nil && !snapshot.Status.Expired && !snapshot.Status.Invalid
 		currentAuthority = ""
 		if !enforcementReady {
 			outcome = cedareval.EvaluationOutcome{State: cedareval.EvaluationStateNotEvaluated, Reason: cedareval.ReasonEnforcementNotReady}
@@ -243,14 +243,32 @@ func (p *cedarPolicyProvider) evaluate(snapshot cedarpolicy.Snapshot, event risk
 	return evidence
 }
 
-func (p *cedarPolicyProvider) evaluatorFor(deployment *cedarpolicy.Deployment) (*cedareval.Evaluator, error) {
+func (p *cedarPolicyProvider) evaluatorFor(policySet *cedarpolicy.PolicySetSnapshot) (*cedareval.Evaluator, error) {
+	if policySet.Evaluator != nil {
+		return policySet.Evaluator, nil
+	}
+	p.mu.Lock()
+	if cached, ok := p.evaluators[policySet.DeploymentIdentity]; ok {
+		p.mu.Unlock()
+		return cached.evaluator, cached.err
+	}
+	p.mu.Unlock()
+
+	evaluator, err := cedareval.New(policySet.Source)
+
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if p.identity != deployment.DeploymentIdentity {
-		p.identity = deployment.DeploymentIdentity
-		p.evaluator, p.parseErr = cedareval.New(deployment.PolicyText)
+	if cached, ok := p.evaluators[policySet.DeploymentIdentity]; ok {
+		return cached.evaluator, cached.err
 	}
-	return p.evaluator, p.parseErr
+	p.evaluators[policySet.DeploymentIdentity] = cachedEvaluator{evaluator: evaluator, err: err}
+	p.evaluatorOrder = append(p.evaluatorOrder, policySet.DeploymentIdentity)
+	if len(p.evaluatorOrder) > maxCachedEvaluators {
+		oldest := p.evaluatorOrder[0]
+		p.evaluatorOrder = p.evaluatorOrder[1:]
+		delete(p.evaluators, oldest)
+	}
+	return evaluator, err
 }
 
 func executionAction(decision risk.Decision) cedareval.EffectiveExecutionAction {

--- a/internal/guard/app/server/cedar_test.go
+++ b/internal/guard/app/server/cedar_test.go
@@ -111,6 +111,41 @@ func TestCedarObserveRecordsUnresolvedPrincipal(t *testing.T) {
 	}
 }
 
+func TestSessionPolicyRemainsAdvisoryInObserveMode(t *testing.T) {
+	deployment := cedarTestDeployment(t, cedareval.RolloutModeObserve, `@id("permit-read") permit(principal, action, resource == Kontext::Tool::"Read");`)
+	current := &countingHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow}}
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{
+		Deployment: &deployment,
+		State:      cedarpolicy.StateSuccess,
+	}}, CedarEnforcementRemote)
+
+	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Write", ToolInput: map[string]any{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.calls != 1 || decision.Decision != risk.DecisionAllow || decision.Cedar.AppliedRolloutMode != cedareval.RolloutModeObserve || decision.Cedar.Mapping.EvaluationState != cedareval.EvaluationStateEvaluated {
+		t.Fatalf("calls = %d decision = %#v, want prompt policy to remain advisory", current.calls, decision)
+	}
+}
+
+func TestMissingSessionPolicyContinuesInObserveMode(t *testing.T) {
+	deployment := cedarTestDeployment(t, cedareval.RolloutModeObserve, `@id("permit-read") permit(principal, action, resource == Kontext::Tool::"Read");`)
+	current := &countingHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionAllow}}
+	provider := newCedarPolicyProvider(current, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{
+		LastKnownGood: &deployment,
+		State:         cedarpolicy.StateUnavailable,
+		Status:        cedarpolicy.CacheStatus{Invalid: true},
+	}}, CedarEnforcementRemote)
+
+	decision, err := provider.DecideHook(context.Background(), risk.HookEvent{HookEventName: "PreToolUse", ToolName: "Read", ToolInput: map[string]any{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.calls != 1 || decision.Decision != risk.DecisionAllow || decision.Cedar.AppliedRolloutMode != cedareval.RolloutModeObserve || decision.Cedar.Mapping.EvaluationState != cedareval.EvaluationStateFailed {
+		t.Fatalf("calls = %d decision = %#v, want missing prompt policy to continue with failure evidence", current.calls, decision)
+	}
+}
+
 func TestCedarEnforceIsSingularAuthority(t *testing.T) {
 	deployment := cedarTestDeployment(t, cedareval.RolloutModeEnforce, `@id("permit-read") permit(principal, action, resource == Kontext::Tool::"Read");`)
 	current := &countingHookPolicy{decision: risk.RiskDecision{Decision: risk.DecisionDeny, ReasonCode: "legacy_deny"}}

--- a/internal/guard/app/server/prompt_policy.go
+++ b/internal/guard/app/server/prompt_policy.go
@@ -3,9 +3,9 @@ package server
 import (
 	"context"
 
-	"github.com/kontext-security/kontext-cli/internal/guard/risk"
-	"github.com/kontext-security/kontext-cli/internal/hook"
-	"github.com/kontext-security/kontext-cli/internal/sessionpolicy"
+	"github.com/kontext-security/kontext/internal/guard/risk"
+	"github.com/kontext-security/kontext/internal/hook"
+	"github.com/kontext-security/kontext/internal/sessionpolicy"
 )
 
 type promptPolicyProvider struct {
@@ -24,12 +24,23 @@ func (p *promptPolicyProvider) DecideHook(ctx context.Context, event risk.HookEv
 	key := sessionpolicy.SessionKey{Provider: event.Agent, NativeSessionID: event.SessionID}
 	switch hook.HookName(event.HookEventName) {
 	case hook.HookUserPromptSubmit:
-		if _, err := p.policies.BeginPrompt(ctx, key, event.Prompt); err != nil {
-			return risk.RiskDecision{
-				Decision: risk.DecisionDeny, Reason: "The prompt policy could not be activated: " + err.Error(),
-				ReasonCode: "prompt_policy_activation_failed",
-			}, nil
+		snapshot, activationErr := p.policies.BeginPrompt(ctx, key, event.Prompt)
+		decision, err := p.current.DecideHook(ctx, event)
+		if err != nil {
+			decision = risk.RiskDecision{
+				Reason:     "Prompt accepted; downstream prompt evaluation was unavailable.",
+				ReasonCode: "prompt_evaluation_unavailable",
+			}
 		}
+		decision.Decision = risk.DecisionAllow
+		if activationErr != nil {
+			decision.Reason = "Prompt accepted; policy was not generated."
+			decision.ReasonCode = "prompt_policy_generation_failed"
+		} else if snapshot.State == sessionpolicy.SessionStateActive {
+			decision.Reason = "Prompt accepted; policy generated."
+			decision.ReasonCode = "prompt_policy_generated"
+		}
+		return decision, nil
 	case hook.HookSessionEnd:
 		p.policies.EndSession(key)
 	}

--- a/internal/guard/app/server/prompt_policy_test.go
+++ b/internal/guard/app/server/prompt_policy_test.go
@@ -1,0 +1,83 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kontext-security/kontext/internal/cedarpolicy"
+	"github.com/kontext-security/kontext/internal/guard/risk"
+	"github.com/kontext-security/kontext/internal/promptpolicy"
+	"github.com/kontext-security/kontext/internal/sessionpolicy"
+)
+
+type promptTestDeriver struct{}
+
+func (promptTestDeriver) Put(context.Context, promptpolicy.Request) (promptpolicy.Bundle, error) {
+	return promptpolicy.Bundle{}, errors.New("unexpected generation")
+}
+
+type promptTestParents struct{}
+
+func (promptTestParents) Current() cedarpolicy.Snapshot { return cedarpolicy.Snapshot{} }
+
+type denyPromptDelegate struct{}
+
+func (denyPromptDelegate) DecideHook(context.Context, risk.HookEvent) (risk.RiskDecision, error) {
+	return risk.RiskDecision{Decision: risk.DecisionDeny}, nil
+}
+
+func TestPromptGenerationFailurePublishesBarrierAndDelegates(t *testing.T) {
+	manager, err := sessionpolicy.NewManager(
+		promptTestDeriver{},
+		promptpolicy.NewActivationValidator(),
+		promptTestParents{},
+		func(context.Context) (string, error) { return "token", nil },
+		"ins_12345678901234567890123456789012",
+		time.Second,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager.SetEnabled(true)
+	provider := newPromptPolicyProvider(denyPromptDelegate{}, manager)
+	decision, err := provider.DecideHook(t.Context(), risk.HookEvent{
+		HookEventName: "UserPromptSubmit",
+		Agent:         "codex",
+		SessionID:     "session-1",
+		Prompt:        "read the report",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Decision != risk.DecisionAllow || decision.ReasonCode != "prompt_policy_generation_failed" || decision.Reason != "Prompt accepted; policy was not generated." {
+		t.Fatalf("prompt provider rejected the prompt or lost activation evidence: %+v", decision)
+	}
+	if snapshot := manager.SnapshotFor(sessionpolicy.SessionKey{Provider: "codex", NativeSessionID: "session-1"}); snapshot.State != sessionpolicy.SessionStateFailed {
+		t.Fatalf("generation failure did not publish a failed barrier: %+v", snapshot)
+	}
+
+	key := sessionpolicy.SessionKey{Provider: "codex", NativeSessionID: "session-1"}
+	if _, err := provider.DecideHook(t.Context(), risk.HookEvent{
+		HookEventName: "Stop",
+		Agent:         key.Provider,
+		SessionID:     key.NativeSessionID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if snapshot := manager.SnapshotFor(key); snapshot.State != sessionpolicy.SessionStateFailed {
+		t.Fatalf("turn-level Stop cleared prompt sequence state: %+v", snapshot)
+	}
+
+	if _, err := provider.DecideHook(t.Context(), risk.HookEvent{
+		HookEventName: "SessionEnd",
+		Agent:         key.Provider,
+		SessionID:     key.NativeSessionID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if snapshot := manager.SnapshotFor(key); snapshot.State != sessionpolicy.SessionStateIdle {
+		t.Fatalf("SessionEnd retained prompt sequence state: %+v", snapshot)
+	}
+}

--- a/internal/hookruntime/claude_test.go
+++ b/internal/hookruntime/claude_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kontext-security/kontext-cli/internal/hook"
+	"github.com/kontext-security/kontext/internal/hook"
 )
 
 func TestDecodeClaudeEventUserPromptSubmitPreservesPrompt(t *testing.T) {

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -29,8 +29,6 @@ import (
 	"github.com/kontext-security/kontext/internal/sessionpolicy"
 )
 
-const promptPolicyEnabledEnv = "KONTEXT_PROMPT_POLICY_ENABLED"
-
 type DaemonOptions struct {
 	SocketPath              string
 	DBPath                  string
@@ -170,28 +168,25 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 		return fmt.Errorf("configure cedar policy client: %w", err)
 	}
 	cedarSnapshots := cedarpolicy.SnapshotProvider(cedarCache)
-	var promptPolicies *sessionpolicy.Manager
-	if strings.EqualFold(strings.TrimSpace(os.Getenv(promptPolicyEnabledEnv)), "true") {
-		promptClient, clientErr := promptpolicy.NewClient(loadedConfig.Config.CloudURL, opts.PolicyHTTPClient)
-		if clientErr != nil {
-			return fmt.Errorf("configure prompt-policy client: %w", clientErr)
-		}
-		promptPolicies, clientErr = sessionpolicy.NewManager(
-			promptClient, promptpolicy.NewActivationValidator(), cedarCache,
-			func(tokenCtx context.Context) (string, error) {
-				loaded, loadErr := managedconfig.Load()
-				if loadErr != nil {
-					return "", loadErr
-				}
-				return managedconfig.ResolveInstallToken(tokenCtx, loaded.Config.Credentials.InstallTokenRef)
-			},
-			installationState.InstallationID, 60*time.Second,
-		)
-		if clientErr != nil {
-			return fmt.Errorf("configure prompt-policy manager: %w", clientErr)
-		}
-		cedarSnapshots = promptPolicies
+	promptClient, err := promptpolicy.NewClient(loadedConfig.Config.CloudURL, opts.PolicyHTTPClient)
+	if err != nil {
+		return fmt.Errorf("configure prompt-policy client: %w", err)
 	}
+	promptPolicies, err := sessionpolicy.NewManager(
+		promptClient, promptpolicy.NewActivationValidator(), cedarCache,
+		func(tokenCtx context.Context) (string, error) {
+			loaded, loadErr := managedconfig.Load()
+			if loadErr != nil {
+				return "", loadErr
+			}
+			return managedconfig.ResolveInstallToken(tokenCtx, loaded.Config.Credentials.InstallTokenRef)
+		},
+		installationState.InstallationID, 0,
+	)
+	if err != nil {
+		return fmt.Errorf("configure prompt-policy manager: %w", err)
+	}
+	cedarSnapshots = promptPolicies
 	endpointConfigCachePath := opts.EndpointConfigCachePath
 	if endpointConfigCachePath == "" {
 		endpointConfigCachePath = endpointconfig.DefaultCachePathForDB(dbPath)
@@ -201,6 +196,7 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 		endpointConfigCache.MarkInvalid(err)
 		opts.Diagnostic.Printf("endpoint configuration cache load: %v\n", err)
 	}
+	promptPolicies.SetEnabled(promptPolicyEnabled(endpointConfigCache.Current()))
 	endpointConfigClient, err := endpointconfig.NewClient(loadedConfig.Config.CloudURL, opts.EndpointConfigHTTPClient)
 	if err != nil {
 		return fmt.Errorf("configure endpoint configuration client: %w", err)
@@ -299,6 +295,7 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 		OnChanged: func(snapshot endpointconfig.Snapshot) {
 			host.SetPayloadCaptureConfiguration(captureConfiguration(snapshot))
 			host.SetGuardrailLLMEnabled(guardrailLLMEnabled(snapshot))
+			promptPolicies.SetEnabled(promptPolicyEnabled(snapshot))
 		},
 	}
 	go endpointConfigRefresher.Run(policyCtx)
@@ -395,6 +392,10 @@ func captureConfiguration(snapshot endpointconfig.Snapshot) payloadcapture.Runti
 // would clear a deliberate off. A kill switch has to survive both.
 func guardrailLLMEnabled(snapshot endpointconfig.Snapshot) bool {
 	return riskclassifier.ResolveLLMEnabled(snapshot.GuardrailLLMDirective)
+}
+
+func promptPolicyEnabled(snapshot endpointconfig.Snapshot) bool {
+	return snapshot.PromptPolicyDirective != nil && *snapshot.PromptPolicyDirective
 }
 
 func requireManagedHooksForLegacyCowork(cfg managedconfig.Config) error {

--- a/internal/managedobserve/lifecycle.go
+++ b/internal/managedobserve/lifecycle.go
@@ -175,6 +175,17 @@ func (l Lifecycle) processIfAvailable(ctx context.Context, event hook.Event, bud
 // stamped enforce — the daemon stamps those exactly when the fetched policy
 // deployment claims enforcement — and treats everything else as observe.
 func (l Lifecycle) finalize(event hook.Event, result hook.Result) hook.Result {
+	// Prompt submission is the policy boundary, never an authorization target.
+	// Generation may fail, but rejecting the user's prompt would prevent the
+	// agent from explaining or recovering. PreToolUse remains the fail-closed
+	// edge when no policy was activated.
+	if event.HookName == hook.HookUserPromptSubmit {
+		result.Decision = hook.DecisionAllow
+		if l.enforcing() {
+			result.Mode = managedconfig.ModeEnforce
+		}
+		return result
+	}
 	if l.enforcing() {
 		if !guardhookruntime.AuthoritativeEnforce(result) {
 			return l.daemonUnavailable(event)
@@ -198,6 +209,17 @@ func (l Lifecycle) finalize(event hook.Event, result hook.Result) hook.Result {
 // enforcement; otherwise it fails open like observe, so a fresh self-serve
 // install without an enforcing deployment never hard-blocks the agent.
 func (l Lifecycle) daemonUnavailable(event hook.Event) hook.Result {
+	if event.HookName == hook.HookUserPromptSubmit {
+		mode := managedconfig.Mode
+		if l.enforcing() || (l.remote() && l.RemoteEnforce != nil && l.RemoteEnforce()) {
+			mode = managedconfig.ModeEnforce
+		}
+		return hook.Result{
+			Decision: hook.DecisionAllow,
+			Mode:     mode,
+			Reason:   "Prompt accepted; tool use waits for authorization policy activation",
+		}
+	}
 	if l.remote() && l.RemoteEnforce != nil && l.RemoteEnforce() {
 		decision := hook.DecisionAllow
 		if event.HookName.CanBlock() {

--- a/internal/managedobserve/lifecycle_test.go
+++ b/internal/managedobserve/lifecycle_test.go
@@ -334,6 +334,23 @@ func TestLifecycleEnforceUnavailableNonBlockingHookDoesNotDeny(t *testing.T) {
 	}
 }
 
+func TestLifecycleNeverRejectsPromptSubmit(t *testing.T) {
+	lifecycle := Lifecycle{Mode: "enforce"}
+	event := hook.Event{HookName: hook.HookUserPromptSubmit}
+	for name, result := range map[string]hook.Result{
+		"unstamped daemon allow": {Decision: hook.DecisionAllow},
+		"daemon deny":            {Decision: hook.DecisionDeny},
+		"daemon unavailable":     lifecycle.daemonUnavailable(event),
+	} {
+		t.Run(name, func(t *testing.T) {
+			final := lifecycle.finalize(event, result)
+			if final.Decision != hook.DecisionAllow || final.Mode != "enforce" {
+				t.Fatalf("prompt result = %+v, want enforce-stamped allow", final)
+			}
+		})
+	}
+}
+
 func TestObserveResultFormatsBlockingPromptSubmit(t *testing.T) {
 	result := guardhookruntime.ObserveResult(hook.Event{HookName: hook.HookUserPromptSubmit}, hook.Result{
 		Decision: hook.DecisionDeny,

--- a/internal/promptpolicy/client.go
+++ b/internal/promptpolicy/client.go
@@ -31,11 +31,17 @@ type Request struct {
 type HTTPError struct {
 	StatusCode int
 	Response   ErrorResponse
+	RetryAfter time.Duration
 }
 
 func (e *HTTPError) Error() string {
 	return fmt.Sprintf("prompt-policy request failed: HTTP %d (%s)", e.StatusCode, e.Response.Code)
 }
+
+type TransportError struct{ Err error }
+
+func (e *TransportError) Error() string { return e.Err.Error() }
+func (e *TransportError) Unwrap() error { return e.Err }
 
 func NewClient(baseURL string, httpClient *http.Client) (*Client, error) {
 	parsed, err := url.Parse(strings.TrimSpace(baseURL))
@@ -53,7 +59,7 @@ func (c *Client) Put(ctx context.Context, input Request) (Bundle, error) {
 		return Bundle{}, errors.New("invalid prompt-policy request")
 	}
 	body, err := json.Marshal(PutRequest{
-		RequestContractVersion:           RequestContractVersion,
+		PromptPolicyContractVersion:      RequestContractVersion,
 		Prompt:                           input.Prompt,
 		ExpectedParentDeploymentIdentity: input.ParentDeploymentIdentity,
 	})
@@ -72,12 +78,16 @@ func (c *Client) Put(ctx context.Context, input Request) (Bundle, error) {
 	req.Header.Set("Content-Type", "application/json")
 	response, err := c.http.Do(req)
 	if err != nil {
-		return Bundle{}, fmt.Errorf("send prompt-policy request: %w", err)
+		return Bundle{}, &TransportError{Err: fmt.Errorf("send prompt-policy request: %w", err)}
 	}
 	defer response.Body.Close()
-	data, err := io.ReadAll(io.LimitReader(response.Body, maxPolicySetBytes+64*1024))
+	const maxResponseBytes = 6*maxPolicySetBytes + 64*1024
+	data, err := io.ReadAll(io.LimitReader(response.Body, maxResponseBytes+1))
 	if err != nil {
-		return Bundle{}, fmt.Errorf("read prompt-policy response: %w", err)
+		return Bundle{}, &TransportError{Err: fmt.Errorf("read prompt-policy response: %w", err)}
+	}
+	if len(data) > maxResponseBytes {
+		return Bundle{}, errors.New("prompt-policy response exceeds size limit")
 	}
 	if response.StatusCode != http.StatusOK {
 		var apiError ErrorResponse
@@ -87,7 +97,15 @@ func (c *Client) Put(ctx context.Context, input Request) (Bundle, error) {
 		if apiError.ResponseVersion != ResponseVersion || apiError.Code == "" {
 			return Bundle{}, errors.New("invalid prompt-policy error response")
 		}
-		return Bundle{}, &HTTPError{StatusCode: response.StatusCode, Response: apiError}
+		return Bundle{}, &HTTPError{StatusCode: response.StatusCode, Response: apiError, RetryAfter: retryAfter(response.Header.Get("Retry-After"))}
 	}
 	return DecodeBundle(data)
+}
+
+func retryAfter(value string) time.Duration {
+	seconds, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || seconds <= 0 || seconds > 5 {
+		return 500 * time.Millisecond
+	}
+	return time.Duration(seconds) * time.Second
 }

--- a/internal/promptpolicy/client_test.go
+++ b/internal/promptpolicy/client_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -21,7 +22,7 @@ func TestClientPutUsesSynchronousExactPromptResource(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 			t.Fatal(err)
 		}
-		if request.Prompt != "email the report" || request.RequestContractVersion != RequestContractVersion {
+		if request.Prompt != "email the report" || request.PromptPolicyContractVersion != RequestContractVersion {
 			t.Fatalf("unexpected body: %+v", request)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -44,6 +45,21 @@ func TestClientPutUsesSynchronousExactPromptResource(t *testing.T) {
 	}
 	if got.DeploymentIdentity != bundle.DeploymentIdentity {
 		t.Fatal("returned wrong bundle")
+	}
+}
+
+func TestClientRejectsOversizedResponseBeforeDecoding(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(strings.Repeat("x", 6*maxPolicySetBytes+64*1024+1)))
+	}))
+	defer server.Close()
+	client, err := NewClient(server.URL, server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.Put(t.Context(), Request{Token: "x", InstallationID: "ins_12345678901234567890123456789012", AuthorizationSessionID: "s", PromptSequence: 1, Prompt: "p", ParentDeploymentIdentity: "a"})
+	if err == nil || !strings.Contains(err.Error(), "exceeds size limit") {
+		t.Fatalf("expected size-limit error, got %v", err)
 	}
 }
 

--- a/internal/promptpolicy/contract.go
+++ b/internal/promptpolicy/contract.go
@@ -28,22 +28,22 @@ var (
 )
 
 type PutRequest struct {
-	RequestContractVersion           int    `json:"requestContractVersion"`
+	PromptPolicyContractVersion      int    `json:"promptPolicyContractVersion"`
 	Prompt                           string `json:"prompt"`
 	ExpectedParentDeploymentIdentity string `json:"expectedParentDeploymentIdentity"`
 }
 
 type Bundle struct {
-	ResponseVersion        int                 `json:"responseVersion"`
-	RequestContractVersion int                 `json:"requestContractVersion"`
-	DeploymentIdentity     string              `json:"deploymentIdentity"`
-	RolloutMode            string              `json:"rolloutMode"`
-	Audience               Audience            `json:"audience"`
-	Parent                 ParentPolicySet     `json:"parent"`
-	PolicySet              EffectivePolicySet  `json:"policySet"`
-	EvaluationPrincipal    EvaluationPrincipal `json:"evaluationPrincipal"`
-	ValidFrom              string              `json:"validFrom"`
-	ExpiresAt              string              `json:"expiresAt"`
+	ResponseVersion             int                 `json:"responseVersion"`
+	CedarRequestContractVersion int                 `json:"cedarRequestContractVersion"`
+	DeploymentIdentity          string              `json:"deploymentIdentity"`
+	RolloutMode                 string              `json:"rolloutMode"`
+	Audience                    Audience            `json:"audience"`
+	Parent                      ParentPolicySet     `json:"parent"`
+	PolicySet                   EffectivePolicySet  `json:"policySet"`
+	EvaluationPrincipal         EvaluationPrincipal `json:"evaluationPrincipal"`
+	ValidFrom                   string              `json:"validFrom"`
+	ExpiresAt                   string              `json:"expiresAt"`
 }
 
 type Audience struct {
@@ -89,7 +89,7 @@ func DecodeBundle(data []byte) (Bundle, error) {
 }
 
 func (b Bundle) Validate() error {
-	if b.ResponseVersion != ResponseVersion || b.RequestContractVersion != CedarRequestVersion {
+	if b.ResponseVersion != ResponseVersion || b.CedarRequestContractVersion != CedarRequestVersion {
 		return errors.New("unsupported prompt-policy bundle version")
 	}
 	if b.RolloutMode != "observe" && b.RolloutMode != "enforce" {
@@ -131,7 +131,7 @@ func (b Bundle) ComputeDeploymentIdentity() (string, error) {
 	preimage, err := json.Marshal([]any{
 		bundleIdentityDomain,
 		b.ResponseVersion,
-		b.RequestContractVersion,
+		b.CedarRequestContractVersion,
 		b.RolloutMode,
 		b.Audience.OrganizationID,
 		b.Audience.InstallationID,

--- a/internal/promptpolicy/contract_test.go
+++ b/internal/promptpolicy/contract_test.go
@@ -14,6 +14,7 @@ func TestActivationValidatorAcceptsExactBundleAndRejectsTampering(t *testing.T) 
 		OrganizationID: "org-1", InstallationID: "ins_12345678901234567890123456789012",
 		AuthorizationSessionID: "codex-session-1", PromptSequence: 3,
 		ParentDeploymentIdentity: bundle.Parent.DeploymentIdentity,
+		RolloutMode:              bundle.RolloutMode,
 	}
 	if err := validator.Validate(bundle, expected); err != nil {
 		t.Fatalf("validate bundle: %v", err)
@@ -29,6 +30,11 @@ func TestActivationValidatorAcceptsExactBundleAndRejectsTampering(t *testing.T) 
 	if err := validator.Validate(bundle, wrongSession); err == nil {
 		t.Fatal("expected audience mismatch to be rejected")
 	}
+	wrongRollout := expected
+	wrongRollout.RolloutMode = "observe"
+	if err := validator.Validate(bundle, wrongRollout); err == nil {
+		t.Fatal("expected rollout mismatch to be rejected")
+	}
 }
 
 func TestDecodeBundleRejectsUnknownAndTrailingJSON(t *testing.T) {
@@ -42,11 +48,33 @@ func TestDecodeBundleRejectsUnknownAndTrailingJSON(t *testing.T) {
 	}
 }
 
+func TestDeploymentIdentityMatchesTypeScriptFixture(t *testing.T) {
+	source := `@id("kontext.generated.fixture") forbid(principal, action, resource);`
+	digest := sourceHash(source)
+	bundle := Bundle{
+		ResponseVersion: ResponseVersion, CedarRequestContractVersion: CedarRequestVersion,
+		RolloutMode:         "enforce",
+		Audience:            Audience{OrganizationID: "org_fixture", InstallationID: "ins_0123456789abcdefghijklmnopqrstuv", AuthorizationSessionID: "codex:session:epoch", PromptSequence: 1},
+		Parent:              ParentPolicySet{PolicySetVersionID: "11111111-1111-4111-8111-111111111111", PolicySetSourceHash: digest, DeploymentIdentity: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		PolicySet:           EffectivePolicySet{PolicySetVersionID: "22222222-2222-4222-8222-222222222222", Source: source, SourceHash: digest, StaticPolicyCount: 1},
+		EvaluationPrincipal: EvaluationPrincipal{EntityType: "Kontext::User", EntityID: "user-fixture"},
+		ValidFrom:           "2026-08-15T10:00:00.000Z", ExpiresAt: "2026-08-15T11:00:00.000Z",
+	}
+	identity, err := bundle.ComputeDeploymentIdentity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const expected = "817e35fb0e6018c6bf9e50e143be55df2ae23e1a07a5786e9aa2b1bc3e353e31"
+	if identity != expected {
+		t.Fatalf("identity = %s, want %s", identity, expected)
+	}
+}
+
 func testBundle(t *testing.T, now time.Time) Bundle {
 	t.Helper()
 	source := `permit(principal, action, resource);`
 	bundle := Bundle{
-		ResponseVersion: ResponseVersion, RequestContractVersion: CedarRequestVersion,
+		ResponseVersion: ResponseVersion, CedarRequestContractVersion: CedarRequestVersion,
 		RolloutMode:         "enforce",
 		Audience:            Audience{OrganizationID: "org-1", InstallationID: "ins_12345678901234567890123456789012", AuthorizationSessionID: "codex-session-1", PromptSequence: 3},
 		Parent:              ParentPolicySet{PolicySetVersionID: "11111111-1111-4111-8111-111111111111", PolicySetSourceHash: sourceHash(source), DeploymentIdentity: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},

--- a/internal/promptpolicy/validator.go
+++ b/internal/promptpolicy/validator.go
@@ -11,6 +11,7 @@ type ExpectedAudience struct {
 	AuthorizationSessionID   string
 	PromptSequence           uint64
 	ParentDeploymentIdentity string
+	RolloutMode              string
 }
 
 // ActivationValidator checks that a decoded bundle is the exact, current
@@ -31,7 +32,8 @@ func (v *ActivationValidator) Validate(bundle Bundle, expected ExpectedAudience)
 		bundle.Audience.InstallationID != expected.InstallationID ||
 		bundle.Audience.AuthorizationSessionID != expected.AuthorizationSessionID ||
 		bundle.Audience.PromptSequence != expected.PromptSequence ||
-		bundle.Parent.DeploymentIdentity != expected.ParentDeploymentIdentity {
+		bundle.Parent.DeploymentIdentity != expected.ParentDeploymentIdentity ||
+		(expected.RolloutMode != "" && bundle.RolloutMode != expected.RolloutMode) {
 		return errors.New("prompt-policy audience or parent mismatch")
 	}
 	validFrom, _ := time.Parse(time.RFC3339Nano, bundle.ValidFrom)

--- a/internal/sessionpolicy/manager.go
+++ b/internal/sessionpolicy/manager.go
@@ -2,21 +2,20 @@ package sessionpolicy
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"sync"
 	"time"
 
-	"github.com/kontext-security/kontext-cli/internal/cedareval"
-	"github.com/kontext-security/kontext-cli/internal/cedarpolicy"
-	"github.com/kontext-security/kontext-cli/internal/promptpolicy"
+	"github.com/kontext-security/kontext/internal/cedareval"
+	"github.com/kontext-security/kontext/internal/cedarpolicy"
+	"github.com/kontext-security/kontext/internal/promptpolicy"
 )
 
-const defaultDerivationTimeout = 60 * time.Second
+const defaultDerivationTimeout = 58 * time.Second
 
-// SessionKey is the authority-bearing identity of one agent session. The
-// installation is configured on Manager; Provider prevents native session IDs
-// from different adapters sharing an authorization boundary.
 type SessionKey struct {
 	Provider        string
 	NativeSessionID string
@@ -39,15 +38,22 @@ type ParentSource interface {
 	Current() cedarpolicy.Snapshot
 }
 
-// Snapshot is the single effective PolicySet selected for a session. Required
-// with Ready=false is an explicit fail-closed barrier, not a fallback request.
+type SessionState string
+
+const (
+	SessionStateIdle    SessionState = ""
+	SessionStatePending SessionState = "pending"
+	SessionStateActive  SessionState = "active"
+	SessionStateFailed  SessionState = "failed"
+)
+
 type Snapshot struct {
-	Required       bool
-	Ready          bool
-	PromptSequence uint64
-	Deployment     *cedarpolicy.Deployment
-	Failure        error
-	ExpiresAt      time.Time
+	State                    SessionState
+	PromptSequence           uint64
+	PolicySet                *cedarpolicy.PolicySetSnapshot
+	ParentDeploymentIdentity string
+	Failure                  error
+	ExpiresAt                time.Time
 }
 
 type Manager struct {
@@ -57,15 +63,19 @@ type Manager struct {
 	tokenSource    TokenSource
 	installationID string
 	timeout        time.Duration
+	daemonEpoch    string
+	configMu       sync.RWMutex
+	enabled        bool
 
 	mu       sync.Mutex
 	sessions map[SessionKey]*session
 }
 
 type session struct {
-	mu       sync.Mutex
-	sequence uint64
-	snapshot Snapshot
+	operationMu sync.Mutex
+	mu          sync.RWMutex
+	sequence    uint64
+	snapshot    Snapshot
 }
 
 func NewManager(deriver Deriver, validator *promptpolicy.ActivationValidator, parents ParentSource, tokenSource TokenSource, installationID string, timeout time.Duration) (*Manager, error) {
@@ -75,88 +85,149 @@ func NewManager(deriver Deriver, validator *promptpolicy.ActivationValidator, pa
 	if timeout <= 0 {
 		timeout = defaultDerivationTimeout
 	}
-	return &Manager{deriver: deriver, validator: validator, parents: parents, tokenSource: tokenSource, installationID: installationID, timeout: timeout, sessions: make(map[SessionKey]*session)}, nil
+	epoch, err := newDaemonEpoch()
+	if err != nil {
+		return nil, fmt.Errorf("create prompt-policy daemon epoch: %w", err)
+	}
+	return &Manager{deriver: deriver, validator: validator, parents: parents, tokenSource: tokenSource, installationID: installationID, timeout: timeout, daemonEpoch: epoch, sessions: make(map[SessionKey]*session)}, nil
 }
 
-// BeginPrompt is the synchronous policy barrier. It returns only after a new
-// complete PolicySet has been verified, parsed, and atomically selected.
+// BeginPrompt synchronously establishes the policy barrier. Snapshot readers
+// never wait on its network work: they immediately see required/not-ready.
 func (m *Manager) BeginPrompt(ctx context.Context, key SessionKey, prompt string) (Snapshot, error) {
-	authorizationSessionID, err := key.AuthorizationSessionID()
+	baseSessionID, err := key.AuthorizationSessionID()
 	if err != nil {
 		return Snapshot{}, err
 	}
 	if prompt == "" {
 		return Snapshot{}, errors.New("prompt policy requires a prompt")
 	}
+	m.configMu.RLock()
+	if !m.enabled {
+		m.configMu.RUnlock()
+		return Snapshot{}, nil
+	}
 	state := m.sessionFor(key)
 	state.mu.Lock()
-	defer state.mu.Unlock()
-
 	state.sequence++
 	sequence := state.sequence
-	state.snapshot = Snapshot{Required: true, PromptSequence: sequence}
+	state.snapshot = Snapshot{State: SessionStatePending, PromptSequence: sequence}
+	state.mu.Unlock()
+	m.configMu.RUnlock()
 
-	parent := m.parents.Current().Deployment
-	if parent == nil {
-		err := errors.New("prompt policy parent is not ready")
-		state.snapshot.Failure = err
-		return state.snapshot, err
+	state.operationMu.Lock()
+	defer state.operationMu.Unlock()
+	state.mu.RLock()
+	if state.sequence != sequence {
+		snapshot := cloneSnapshot(state.snapshot)
+		state.mu.RUnlock()
+		return snapshot, nil
+	}
+	state.mu.RUnlock()
+
+	parentSnapshot := m.parents.Current()
+	parent := parentSnapshot.ActivePolicySet()
+	if parentSnapshot.State != cedarpolicy.StateSuccess || parent == nil {
+		failure := errors.New("prompt policy parent is not ready")
+		return m.failIfCurrent(state, sequence, failure), failure
 	}
 	token, err := m.tokenSource(ctx)
 	if err != nil {
-		state.snapshot.Failure = fmt.Errorf("resolve prompt-policy token: %w", err)
-		return state.snapshot, state.snapshot.Failure
+		failure := fmt.Errorf("resolve prompt-policy token: %w", err)
+		return m.failIfCurrent(state, sequence, failure), failure
 	}
+	authorizationSessionID := baseSessionID + ":" + m.daemonEpoch
 	requestCtx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
-	bundle, err := m.deriver.Put(requestCtx, promptpolicy.Request{
+	request := promptpolicy.Request{
 		Token: token, InstallationID: m.installationID,
 		AuthorizationSessionID: authorizationSessionID, PromptSequence: sequence,
 		Prompt: prompt, ParentDeploymentIdentity: parent.DeploymentIdentity,
-	})
+	}
+	bundle, err := m.deriveWithRetry(requestCtx, request)
 	if err != nil {
-		state.snapshot.Failure = err
-		return state.snapshot, err
+		return m.failIfCurrent(state, sequence, err), err
 	}
 	if err := m.validator.Validate(bundle, promptpolicy.ExpectedAudience{
 		InstallationID: m.installationID, AuthorizationSessionID: authorizationSessionID,
 		PromptSequence: sequence, ParentDeploymentIdentity: parent.DeploymentIdentity,
+		RolloutMode: parent.RolloutMode,
 	}); err != nil {
-		state.snapshot.Failure = err
-		return state.snapshot, err
+		return m.failIfCurrent(state, sequence, err), err
 	}
-	if _, err := cedareval.New(bundle.PolicySet.Source); err != nil {
-		state.snapshot.Failure = fmt.Errorf("parse effective prompt policy set: %w", err)
-		return state.snapshot, state.snapshot.Failure
+	evaluator, err := cedareval.New(bundle.PolicySet.Source)
+	if err != nil {
+		failure := fmt.Errorf("parse effective prompt policy set: %w", err)
+		return m.failIfCurrent(state, sequence, failure), failure
 	}
-	deployment := deploymentFromBundle(bundle)
+	policySet := policySetFromBundle(bundle, evaluator)
 	expiresAt, _ := time.Parse(time.RFC3339Nano, bundle.ExpiresAt)
-	state.snapshot = Snapshot{Required: true, Ready: true, PromptSequence: sequence, Deployment: &deployment, ExpiresAt: expiresAt}
-	return cloneSnapshot(state.snapshot), nil
+	state.mu.Lock()
+	if state.sequence == sequence {
+		state.snapshot = Snapshot{State: SessionStateActive, PromptSequence: sequence, PolicySet: &policySet, ParentDeploymentIdentity: bundle.Parent.DeploymentIdentity, ExpiresAt: expiresAt}
+	}
+	snapshot := cloneSnapshot(state.snapshot)
+	state.mu.Unlock()
+	return snapshot, nil
 }
 
-// Current preserves the existing organization policy API.
-func (m *Manager) Current() cedarpolicy.Snapshot { return m.parents.Current() }
-
-// CurrentFor returns exactly one selected complete policy set. Once a prompt
-// requires a derived set, absence/failure never falls back to the broader
-// parent in enforce mode.
-func (m *Manager) CurrentFor(sessionID, agent string) cedarpolicy.Snapshot {
-	base := m.parents.Current()
-	selected := m.SnapshotFor(SessionKey{Provider: agent, NativeSessionID: sessionID})
-	if !selected.Required {
-		return base
-	}
-	if selected.Ready && selected.Deployment != nil && time.Now().Before(selected.ExpiresAt) {
-		return cedarpolicy.Snapshot{
-			Deployment: selected.Deployment, LastKnownGood: selected.Deployment,
-			State:  cedarpolicy.StateSuccess,
-			Status: cedarpolicy.CacheStatus{State: cedarpolicy.StateSuccess, FetchedAt: time.Now()},
+func (m *Manager) deriveWithRetry(ctx context.Context, request promptpolicy.Request) (promptpolicy.Bundle, error) {
+	for attempt := 0; ; attempt++ {
+		bundle, err := m.deriver.Put(ctx, request)
+		if err == nil || attempt >= 2 {
+			return bundle, err
+		}
+		var httpError *promptpolicy.HTTPError
+		var transportError *promptpolicy.TransportError
+		retryDelay := 100 * time.Millisecond
+		if errors.As(err, &httpError) {
+			if !httpError.Response.Retryable {
+				return promptpolicy.Bundle{}, err
+			}
+			retryDelay = httpError.RetryAfter
+		} else if !errors.As(err, &transportError) {
+			return promptpolicy.Bundle{}, err
+		}
+		timer := time.NewTimer(retryDelay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return promptpolicy.Bundle{}, ctx.Err()
+		case <-timer.C:
 		}
 	}
-	return cedarpolicy.Snapshot{
-		LastKnownGood: base.Deployment, State: cedarpolicy.StateUnavailable,
-		Status: cedarpolicy.CacheStatus{State: cedarpolicy.StateUnavailable, Invalid: true, LastError: "required prompt policy is not ready"},
+}
+
+func (m *Manager) Current() cedarpolicy.Snapshot { return m.parents.Current() }
+
+func (m *Manager) CurrentFor(sessionID, agent string) cedarpolicy.Snapshot {
+	base := m.parents.Current()
+	m.configMu.RLock()
+	defer m.configMu.RUnlock()
+	if !m.enabled {
+		return base
+	}
+	selected := m.SnapshotFor(SessionKey{Provider: agent, NativeSessionID: sessionID})
+	if selected.State == SessionStateIdle {
+		return unavailableSnapshot(base, "no prompt policy is active for this session")
+	}
+	parent := base.ActivePolicySet()
+	parentMatches := parent != nil && parent.DeploymentIdentity == selected.ParentDeploymentIdentity
+	parentEligible := base.State == cedarpolicy.StateSuccess && !base.Status.Invalid && !base.Status.Expired
+	if selected.State == SessionStateActive && selected.PolicySet != nil && parentMatches && parentEligible && time.Now().Before(selected.ExpiresAt) {
+		return cedarpolicy.Snapshot{PolicySet: selected.PolicySet, State: cedarpolicy.StateSuccess, Status: cedarpolicy.CacheStatus{State: cedarpolicy.StateSuccess, FetchedAt: time.Now()}}
+	}
+	return unavailableSnapshot(base, "required prompt policy is not ready or its parent changed")
+}
+
+func (m *Manager) SetEnabled(enabled bool) {
+	m.configMu.Lock()
+	defer m.configMu.Unlock()
+	m.enabled = enabled
+	if !enabled {
+		m.mu.Lock()
+		m.sessions = make(map[SessionKey]*session)
+		m.mu.Unlock()
 	}
 }
 
@@ -167,8 +238,8 @@ func (m *Manager) SnapshotFor(key SessionKey) Snapshot {
 	if state == nil {
 		return Snapshot{}
 	}
-	state.mu.Lock()
-	defer state.mu.Unlock()
+	state.mu.RLock()
+	defer state.mu.RUnlock()
 	return cloneSnapshot(state.snapshot)
 }
 
@@ -189,19 +260,39 @@ func (m *Manager) sessionFor(key SessionKey) *session {
 	return created
 }
 
-func deploymentFromBundle(bundle promptpolicy.Bundle) cedarpolicy.Deployment {
-	return cedarpolicy.Deployment{
-		ResponseVersion: bundle.ResponseVersion, RequestContractVersion: bundle.RequestContractVersion,
-		PolicyHash: bundle.PolicySet.SourceHash, RolloutMode: cedareval.RolloutMode(bundle.RolloutMode),
-		EvaluationPrincipal: cedareval.EvaluationPrincipal{EntityType: bundle.EvaluationPrincipal.EntityType, EntityID: bundle.EvaluationPrincipal.EntityID},
-		PolicyText:          bundle.PolicySet.Source, DeploymentIdentity: bundle.DeploymentIdentity,
+func (m *Manager) failIfCurrent(state *session, sequence uint64, failure error) Snapshot {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.sequence == sequence {
+		state.snapshot = Snapshot{State: SessionStateFailed, PromptSequence: sequence, Failure: failure}
 	}
+	return cloneSnapshot(state.snapshot)
+}
+
+func policySetFromBundle(bundle promptpolicy.Bundle, evaluator *cedareval.Evaluator) cedarpolicy.PolicySetSnapshot {
+	return cedarpolicy.PolicySetSnapshot{ResponseVersion: bundle.ResponseVersion, RequestContractVersion: bundle.CedarRequestContractVersion, SourceHash: bundle.PolicySet.SourceHash, RolloutMode: bundle.RolloutMode, EvaluationPrincipal: cedareval.EvaluationPrincipal{EntityType: bundle.EvaluationPrincipal.EntityType, EntityID: bundle.EvaluationPrincipal.EntityID}, Source: bundle.PolicySet.Source, DeploymentIdentity: bundle.DeploymentIdentity, Evaluator: evaluator}
+}
+
+func unavailableSnapshot(base cedarpolicy.Snapshot, reason string) cedarpolicy.Snapshot {
+	lastKnownParent := base.Deployment
+	if lastKnownParent == nil {
+		lastKnownParent = base.LastKnownGood
+	}
+	return cedarpolicy.Snapshot{LastKnownGood: lastKnownParent, State: cedarpolicy.StateUnavailable, Status: cedarpolicy.CacheStatus{State: cedarpolicy.StateUnavailable, Invalid: true, LastError: reason}}
 }
 
 func cloneSnapshot(snapshot Snapshot) Snapshot {
-	if snapshot.Deployment != nil {
-		deployment := *snapshot.Deployment
-		snapshot.Deployment = &deployment
+	if snapshot.PolicySet != nil {
+		policySet := *snapshot.PolicySet
+		snapshot.PolicySet = &policySet
 	}
 	return snapshot
+}
+
+func newDaemonEpoch() (string, error) {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(value[:]), nil
 }

--- a/internal/sessionpolicy/manager_test.go
+++ b/internal/sessionpolicy/manager_test.go
@@ -3,12 +3,13 @@ package sessionpolicy
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/kontext-security/kontext-cli/internal/cedareval"
-	"github.com/kontext-security/kontext-cli/internal/cedarpolicy"
-	"github.com/kontext-security/kontext-cli/internal/promptpolicy"
+	"github.com/kontext-security/kontext/internal/cedareval"
+	"github.com/kontext-security/kontext/internal/cedarpolicy"
+	"github.com/kontext-security/kontext/internal/promptpolicy"
 )
 
 type fakeDeriver struct {
@@ -26,24 +27,116 @@ type fakeParents struct{ snapshot cedarpolicy.Snapshot }
 
 func (f fakeParents) Current() cedarpolicy.Snapshot { return f.snapshot }
 
+type mutableParents struct{ snapshot cedarpolicy.Snapshot }
+
+func (f *mutableParents) Current() cedarpolicy.Snapshot { return f.snapshot }
+
+type firstBlockingDeriver struct {
+	started chan struct{}
+	release chan struct{}
+	calls   atomic.Int32
+}
+
+type blockingBundleDeriver struct {
+	bundle  promptpolicy.Bundle
+	started chan struct{}
+	release chan struct{}
+}
+
+func (d *blockingBundleDeriver) Put(context.Context, promptpolicy.Request) (promptpolicy.Bundle, error) {
+	close(d.started)
+	<-d.release
+	return d.bundle, nil
+}
+
+type flakyTransportDeriver struct {
+	bundle promptpolicy.Bundle
+	calls  int
+}
+
+func (d *flakyTransportDeriver) Put(context.Context, promptpolicy.Request) (promptpolicy.Bundle, error) {
+	d.calls++
+	if d.calls < 3 {
+		return promptpolicy.Bundle{}, &promptpolicy.TransportError{Err: errors.New("connection reset")}
+	}
+	return d.bundle, nil
+}
+
+func (d *firstBlockingDeriver) Put(context.Context, promptpolicy.Request) (promptpolicy.Bundle, error) {
+	if d.calls.Add(1) == 1 {
+		close(d.started)
+		<-d.release
+	}
+	return promptpolicy.Bundle{}, errors.New("generation unavailable")
+}
+
 func TestBeginPromptSynchronouslyActivatesVerifiedPolicySet(t *testing.T) {
 	parent := cedarpolicy.Deployment{DeploymentIdentity: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
 	bundle := validBundle(t, parent.DeploymentIdentity, 1)
 	deriver := &fakeDeriver{bundle: bundle}
-	manager, err := NewManager(deriver, promptpolicy.NewActivationValidator(), fakeParents{cedarpolicy.Snapshot{Deployment: &parent}}, func(context.Context) (string, error) { return "token", nil }, bundle.Audience.InstallationID, time.Second)
+	manager, err := NewManager(deriver, promptpolicy.NewActivationValidator(), fakeParents{cedarpolicy.Snapshot{Deployment: &parent, State: cedarpolicy.StateSuccess}}, func(context.Context) (string, error) { return "token", nil }, bundle.Audience.InstallationID, time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
+	manager.SetEnabled(true)
+	manager.daemonEpoch = "test"
+	bundle.Audience.AuthorizationSessionID = "codex:s1:test"
+	refreshIdentity(t, &bundle)
+	deriver.bundle = bundle
 	key := SessionKey{Provider: "codex", NativeSessionID: "s1"}
 	snapshot, err := manager.BeginPrompt(t.Context(), key, "read the report")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !snapshot.Required || !snapshot.Ready || snapshot.Deployment == nil || snapshot.Deployment.PolicyText != bundle.PolicySet.Source {
+	if snapshot.State != SessionStateActive || snapshot.PolicySet == nil || snapshot.PolicySet.Source != bundle.PolicySet.Source {
 		t.Fatalf("unexpected snapshot: %+v", snapshot)
 	}
-	if deriver.requests[0].AuthorizationSessionID != "codex:s1" {
+	if deriver.requests[0].AuthorizationSessionID != "codex:s1:test" {
 		t.Fatalf("unexpected authorization session: %s", deriver.requests[0].AuthorizationSessionID)
+	}
+}
+
+func TestSessionPolicyFollowsGeneratedRolloutMode(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		rolloutMode cedareval.RolloutMode
+		wantEnforce bool
+	}{
+		{name: "observe", rolloutMode: cedareval.RolloutModeObserve},
+		{name: "enforce", rolloutMode: cedareval.RolloutModeEnforce, wantEnforce: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			parent := cedarpolicy.Deployment{
+				DeploymentIdentity: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				RolloutMode:        test.rolloutMode,
+			}
+			bundle := validBundle(t, parent.DeploymentIdentity, 1)
+			bundle.RolloutMode = string(test.rolloutMode)
+			bundle.Audience.AuthorizationSessionID = "codex:s1:test"
+			refreshIdentity(t, &bundle)
+			manager, err := NewManager(
+				&fakeDeriver{bundle: bundle},
+				promptpolicy.NewActivationValidator(),
+				fakeParents{snapshot: cedarpolicy.Snapshot{Deployment: &parent, State: cedarpolicy.StateSuccess}},
+				func(context.Context) (string, error) { return "token", nil },
+				bundle.Audience.InstallationID,
+				time.Second,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			manager.SetEnabled(true)
+			manager.daemonEpoch = "test"
+			key := SessionKey{Provider: "codex", NativeSessionID: "s1"}
+			if _, err := manager.BeginPrompt(t.Context(), key, "read"); err != nil {
+				t.Fatal(err)
+			}
+
+			current := manager.CurrentFor(key.NativeSessionID, key.Provider)
+			if got := cedarpolicy.DeploymentClaimsEnforce(current); got != test.wantEnforce {
+				t.Fatalf("DeploymentClaimsEnforce() = %t, want %t; snapshot = %+v", got, test.wantEnforce, current)
+			}
+		})
 	}
 }
 
@@ -51,7 +144,12 @@ func TestNewPromptInvalidatesPriorPolicyOnFailure(t *testing.T) {
 	parent := cedarpolicy.Deployment{DeploymentIdentity: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
 	bundle := validBundle(t, parent.DeploymentIdentity, 1)
 	deriver := &fakeDeriver{bundle: bundle}
-	manager, _ := NewManager(deriver, promptpolicy.NewActivationValidator(), fakeParents{cedarpolicy.Snapshot{Deployment: &parent}}, func(context.Context) (string, error) { return "token", nil }, bundle.Audience.InstallationID, time.Second)
+	manager, _ := NewManager(deriver, promptpolicy.NewActivationValidator(), fakeParents{cedarpolicy.Snapshot{Deployment: &parent, State: cedarpolicy.StateSuccess}}, func(context.Context) (string, error) { return "token", nil }, bundle.Audience.InstallationID, time.Second)
+	manager.SetEnabled(true)
+	manager.daemonEpoch = "test"
+	bundle.Audience.AuthorizationSessionID = "codex:s1:test"
+	refreshIdentity(t, &bundle)
+	deriver.bundle = bundle
 	key := SessionKey{Provider: "codex", NativeSessionID: "s1"}
 	if _, err := manager.BeginPrompt(t.Context(), key, "first"); err != nil {
 		t.Fatal(err)
@@ -61,8 +159,189 @@ func TestNewPromptInvalidatesPriorPolicyOnFailure(t *testing.T) {
 		t.Fatal("expected second prompt failure")
 	}
 	snapshot := manager.SnapshotFor(key)
-	if snapshot.PromptSequence != 2 || snapshot.Ready || snapshot.Deployment != nil {
+	if snapshot.PromptSequence != 2 || snapshot.State != SessionStateFailed || snapshot.PolicySet != nil {
 		t.Fatalf("old policy remained eligible: %+v", snapshot)
+	}
+}
+
+func TestBeginPromptRetriesIdempotentTransportFailures(t *testing.T) {
+	parent := cedarpolicy.Deployment{DeploymentIdentity: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+	bundle := validBundle(t, parent.DeploymentIdentity, 1)
+	bundle.Audience.AuthorizationSessionID = "codex:s1:test"
+	refreshIdentity(t, &bundle)
+	deriver := &flakyTransportDeriver{bundle: bundle}
+	manager, _ := NewManager(deriver, promptpolicy.NewActivationValidator(), fakeParents{cedarpolicy.Snapshot{Deployment: &parent, State: cedarpolicy.StateSuccess}}, func(context.Context) (string, error) { return "token", nil }, bundle.Audience.InstallationID, time.Second)
+	manager.SetEnabled(true)
+	manager.daemonEpoch = "test"
+
+	snapshot, err := manager.BeginPrompt(t.Context(), SessionKey{Provider: "codex", NativeSessionID: "s1"}, "read")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deriver.calls != 3 || snapshot.State != SessionStateActive {
+		t.Fatalf("calls = %d snapshot = %+v", deriver.calls, snapshot)
+	}
+}
+
+func TestOrganizationDeploymentChangeInvalidatesSessionPolicy(t *testing.T) {
+	parent := cedarpolicy.Deployment{DeploymentIdentity: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+	parents := &mutableParents{snapshot: cedarpolicy.Snapshot{Deployment: &parent, State: cedarpolicy.StateSuccess}}
+	bundle := validBundle(t, parent.DeploymentIdentity, 1)
+	manager, _ := NewManager(&fakeDeriver{bundle: bundle}, promptpolicy.NewActivationValidator(), parents, func(context.Context) (string, error) { return "token", nil }, bundle.Audience.InstallationID, time.Second)
+	manager.SetEnabled(true)
+	manager.daemonEpoch = "test"
+	bundle.Audience.AuthorizationSessionID = "codex:s1:test"
+	refreshIdentity(t, &bundle)
+	manager.deriver = &fakeDeriver{bundle: bundle}
+	key := SessionKey{Provider: "codex", NativeSessionID: "s1"}
+	if _, err := manager.BeginPrompt(t.Context(), key, "first"); err != nil {
+		t.Fatal(err)
+	}
+	replacement := parent
+	replacement.DeploymentIdentity = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	parents.snapshot = cedarpolicy.Snapshot{Deployment: &replacement, State: cedarpolicy.StateSuccess}
+	if snapshot := manager.CurrentFor(key.NativeSessionID, key.Provider); snapshot.Deployment != nil || !snapshot.Status.Invalid {
+		t.Fatalf("session policy survived parent replacement: %+v", snapshot)
+	}
+}
+
+func TestNonSuccessParentCannotReactivateLastKnownSessionPolicy(t *testing.T) {
+	parent := cedarpolicy.Deployment{DeploymentIdentity: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+	parents := &mutableParents{snapshot: cedarpolicy.Snapshot{Deployment: &parent, State: cedarpolicy.StateSuccess}}
+	bundle := validBundle(t, parent.DeploymentIdentity, 1)
+	manager, _ := NewManager(&fakeDeriver{bundle: bundle}, promptpolicy.NewActivationValidator(), parents, func(context.Context) (string, error) { return "token", nil }, bundle.Audience.InstallationID, time.Second)
+	manager.SetEnabled(true)
+	manager.daemonEpoch = "test"
+	bundle.Audience.AuthorizationSessionID = "codex:s1:test"
+	refreshIdentity(t, &bundle)
+	manager.deriver = &fakeDeriver{bundle: bundle}
+	key := SessionKey{Provider: "codex", NativeSessionID: "s1"}
+	if _, err := manager.BeginPrompt(t.Context(), key, "first"); err != nil {
+		t.Fatal(err)
+	}
+	parents.snapshot = cedarpolicy.Snapshot{LastKnownGood: &parent, State: cedarpolicy.StatePrincipalUnavailable}
+	snapshot := manager.CurrentFor(key.NativeSessionID, key.Provider)
+	if !snapshot.Status.Invalid || snapshot.PolicySet != nil || snapshot.ActivePolicySet() != nil {
+		t.Fatalf("non-success parent reactivated a stale session policy: %+v", snapshot)
+	}
+}
+
+func TestNewPromptPublishesBarrierBeforePriorGenerationFinishes(t *testing.T) {
+	parent := cedarpolicy.Deployment{DeploymentIdentity: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", RolloutMode: cedareval.RolloutModeObserve}
+	deriver := &firstBlockingDeriver{started: make(chan struct{}), release: make(chan struct{})}
+	manager, _ := NewManager(deriver, promptpolicy.NewActivationValidator(), fakeParents{cedarpolicy.Snapshot{Deployment: &parent, State: cedarpolicy.StateSuccess}}, func(context.Context) (string, error) { return "token", nil }, "ins_12345678901234567890123456789012", time.Second)
+	manager.SetEnabled(true)
+	key := SessionKey{Provider: "codex", NativeSessionID: "s1"}
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		_, _ = manager.BeginPrompt(t.Context(), key, "first")
+	}()
+	<-deriver.started
+	secondDone := make(chan struct{})
+	go func() {
+		defer close(secondDone)
+		_, _ = manager.BeginPrompt(t.Context(), key, "second")
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for manager.SnapshotFor(key).PromptSequence != 2 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	snapshot := manager.SnapshotFor(key)
+	if snapshot.PromptSequence != 2 || snapshot.State != SessionStatePending {
+		t.Fatalf("second prompt did not publish its barrier: %+v", snapshot)
+	}
+	if current := manager.CurrentFor(key.NativeSessionID, key.Provider); !current.Status.Invalid || cedarpolicy.DeploymentClaimsEnforce(current) {
+		t.Fatalf("pending observe policy became authoritative: %+v", current)
+	}
+	close(deriver.release)
+	<-firstDone
+	<-secondDone
+}
+
+func TestMissingRequiredPolicyPreservesParentEnforcementClaim(t *testing.T) {
+	parent := cedarpolicy.Deployment{
+		DeploymentIdentity: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		RolloutMode:        cedareval.RolloutModeEnforce,
+	}
+	manager, _ := NewManager(
+		&fakeDeriver{err: errors.New("unavailable")},
+		promptpolicy.NewActivationValidator(),
+		&mutableParents{snapshot: cedarpolicy.Snapshot{LastKnownGood: &parent, State: cedarpolicy.StateUnavailable}},
+		func(context.Context) (string, error) { return "token", nil },
+		"ins_12345678901234567890123456789012",
+		time.Second,
+	)
+	manager.SetEnabled(true)
+	key := SessionKey{Provider: "codex", NativeSessionID: "s1"}
+	state := manager.sessionFor(key)
+	state.snapshot = Snapshot{State: SessionStatePending, PromptSequence: 1}
+	snapshot := manager.CurrentFor(key.NativeSessionID, key.Provider)
+	if snapshot.LastKnownGood == nil || !cedarpolicy.DeploymentClaimsEnforce(snapshot) {
+		t.Fatalf("parent enforce claim was lost: %+v", snapshot)
+	}
+}
+
+func TestExplicitOrganizationDisableKeepsPromptBarrierClosed(t *testing.T) {
+	parent := cedarpolicy.Deployment{
+		DeploymentIdentity: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		RolloutMode:        cedareval.RolloutModeEnforce,
+	}
+	parents := &mutableParents{snapshot: cedarpolicy.Snapshot{State: cedarpolicy.StateDisabled, LastKnownGood: &parent}}
+	manager, _ := NewManager(
+		&fakeDeriver{}, promptpolicy.NewActivationValidator(), parents,
+		func(context.Context) (string, error) { return "token", nil },
+		"ins_12345678901234567890123456789012", time.Second,
+	)
+	manager.SetEnabled(true)
+	key := SessionKey{Provider: "codex", NativeSessionID: "s1"}
+	state := manager.sessionFor(key)
+	state.snapshot = Snapshot{
+		State: SessionStateActive, PromptSequence: 1,
+		PolicySet:                &cedarpolicy.PolicySetSnapshot{RolloutMode: "enforce"},
+		ParentDeploymentIdentity: parent.DeploymentIdentity,
+		ExpiresAt:                time.Now().Add(time.Hour),
+	}
+	snapshot := manager.CurrentFor(key.NativeSessionID, key.Provider)
+	if !snapshot.Status.Invalid || !cedarpolicy.DeploymentClaimsEnforce(snapshot) {
+		t.Fatalf("explicit disable opened the prompt barrier: %+v", snapshot)
+	}
+}
+
+func TestDisableDiscardsAnInFlightPromptPolicy(t *testing.T) {
+	parent := cedarpolicy.Deployment{DeploymentIdentity: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+	bundle := validBundle(t, parent.DeploymentIdentity, 1)
+	bundle.Audience.AuthorizationSessionID = "codex:s1:test"
+	refreshIdentity(t, &bundle)
+	deriver := &blockingBundleDeriver{bundle: bundle, started: make(chan struct{}), release: make(chan struct{})}
+	manager, _ := NewManager(
+		deriver,
+		promptpolicy.NewActivationValidator(),
+		fakeParents{snapshot: cedarpolicy.Snapshot{Deployment: &parent, State: cedarpolicy.StateSuccess}},
+		func(context.Context) (string, error) { return "token", nil },
+		bundle.Audience.InstallationID,
+		time.Second,
+	)
+	manager.daemonEpoch = "test"
+	manager.SetEnabled(true)
+	key := SessionKey{Provider: "codex", NativeSessionID: "s1"}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = manager.BeginPrompt(t.Context(), key, "read")
+	}()
+	<-deriver.started
+	manager.SetEnabled(false)
+	close(deriver.release)
+	<-done
+	manager.SetEnabled(true)
+
+	if snapshot := manager.SnapshotFor(key); snapshot.State != SessionStateIdle {
+		t.Fatalf("disabled in-flight policy was resurrected: %+v", snapshot)
+	}
+	if current := manager.CurrentFor(key.NativeSessionID, key.Provider); !current.Status.Invalid || cedarpolicy.DeploymentClaimsEnforce(current) {
+		t.Fatalf("re-enabled session did not require a fresh prompt: %+v", current)
 	}
 }
 
@@ -72,17 +351,22 @@ func validBundle(t *testing.T, parentIdentity string, sequence uint64) promptpol
 	source := `@id("kontext.generated.test") forbid(principal, action, resource);`
 	digest := cedareval.ComputePolicyHash(source)
 	bundle := promptpolicy.Bundle{
-		ResponseVersion: 2, RequestContractVersion: 1, RolloutMode: "enforce",
+		ResponseVersion: 2, CedarRequestContractVersion: 1, RolloutMode: "enforce",
 		Audience:            promptpolicy.Audience{OrganizationID: "org-1", InstallationID: "ins_12345678901234567890123456789012", AuthorizationSessionID: "codex:s1", PromptSequence: sequence},
 		Parent:              promptpolicy.ParentPolicySet{PolicySetVersionID: "11111111-1111-4111-8111-111111111111", PolicySetSourceHash: digest, DeploymentIdentity: parentIdentity},
 		PolicySet:           promptpolicy.EffectivePolicySet{PolicySetVersionID: "22222222-2222-4222-8222-222222222222", Source: source, SourceHash: digest, StaticPolicyCount: 1},
 		EvaluationPrincipal: promptpolicy.EvaluationPrincipal{EntityType: cedareval.PrincipalEntityType, EntityID: "user-1"},
 		ValidFrom:           now.Add(-time.Minute).Format(time.RFC3339Nano), ExpiresAt: now.Add(time.Hour).Format(time.RFC3339Nano),
 	}
+	refreshIdentity(t, &bundle)
+	return bundle
+}
+
+func refreshIdentity(t *testing.T, bundle *promptpolicy.Bundle) {
+	t.Helper()
 	identity, err := bundle.ComputeDeploymentIdentity()
 	if err != nil {
 		t.Fatal(err)
 	}
 	bundle.DeploymentIdentity = identity
-	return bundle
 }


### PR DESCRIPTION
## Summary

- always accept prompt submission while gating every subsequent tool use until the new session PolicySet is active
- publish the new prompt barrier before network work, serialize runtime enable/disable with session creation, and invalidate derived policy immediately when its organization parent or principal changes
- consume endpoint-config v3 as the single live per-installation switch
- retry idempotent transport failures, discard superseded concurrent prompts, prevent daemon-restart identity collisions, and keep generation outside snapshot locks
- validate live bundles through source hash, deployment identity, audience, parent, prompt sequence, validity window, and Cedar parsing without signing-key configuration
- separate V1/V2 wire DTOs from the runtime PolicySet snapshot, with bounded evaluator caching, response sizes, clock skew, and portable TypeScript/Go identity tests

Part of ENG-624. This is stack 6/6 and the review-remediation tip.

## Verification

- [x] go test ./...
- [x] go test -race ./internal/promptpolicy ./internal/sessionpolicy ./internal/managedobserve ./internal/guard/app/server
- [x] go vet ./...

## Deferred

- Bash and incomplete tool-catalog semantics are intentionally deferred for a separate architecture decision.