### PR TITLE
docs: rewrite README around agent action control

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,91 +20,341 @@
 
 </div>
 
-Runtime governance for AI agents, with local policy decisions, pre-action
-enforcement, and an authorization ledger.
+# Stop risky AI-agent actions before they run
 
-Kontext runs alongside AI agents on developer machines and in cloud
-environments. It receives tool-use events through local hooks, evaluates
-policy before consequential actions execute, and records decisions and outcomes
-in an authorization ledger. The decision path stays local; managed deployments
-can export redacted records to the Kontext dashboard.
+AI agents do more than suggest code. They run shell commands, read files, call
+services, change infrastructure, and interact with production systems.
 
-[The agent support matrix](docs/coverage.md) is authoritative for each agent and event
-surface. Blocking is off by default and available only at supported synchronous
-pre-action hooks.
+**Kontext puts local policy between AI agents and the tools they call.** It
+observes supported actions, evaluates policy before consequential actions run,
+and records the decision and outcome in an authorization ledger.
+
+Start in observe mode. See what policy would stop. Move supported boundaries
+into enforcement when you are ready.
+
+- **Local decisions:** policy evaluation happens alongside the agent.
+- **Pre-action enforcement:** matching actions can be denied at supported
+  synchronous hooks.
+- **No wrapper command:** install Kontext once and continue using your agents
+  normally.
+- **Attributable evidence:** preserve the agent, session, action, policy
+  decision, and outcome.
+- **Managed rollout:** distribute policy and review redacted records across an
+  organization.
+
+Kontext currently supports **Claude Code, Claude Cowork, and Codex**. Exact
+event and enforcement coverage varies by agent—see the
+[agent support matrix](docs/coverage.md).
+
+---
 
 ## Quickstart
 
+### Install Kontext
+
 ```bash
 brew install kontext-security/tap/kontext
+```
+
+### Connect this Mac
+
+Create an install token in the
+[Kontext dashboard](https://app.kontext.security), then run:
+
+```bash
 kontext setup
 ```
 
-Create an install token in the Kontext dashboard when setup asks for one.
-Setup stores the token in the login keychain, installs hooks for supported
-agents, and starts a background daemon.
+Setup:
+
+- stores the install token in the macOS login keychain;
+- installs hooks for supported agents;
+- starts the local Kontext daemon;
+- connects the installation to your Kontext organization.
+
+Verify the installation:
 
 ```bash
 kontext doctor
 ```
 
-Use `doctor` to check self-serve hook status, daemon health, and the managed
-export backlog. It exits non-zero when a configured installation is unhealthy.
-For a self-serve stale daemon, `kontext doctor --fix` performs the verified
-restart; other findings include their manual remediation. Re-run `kontext
-setup` to rotate the token. Run `kontext setup --uninstall` to remove the
-self-serve installation. Self-serve setup currently supports macOS.
+Then keep using Claude Code or Codex normally. You do not need to launch the
+agent through a separate wrapper.
 
-## How it works
+> Self-serve setup currently supports macOS. Managed and cloud environments can
+> run the same local runtime when they provide a supported hook contract,
+> storage, and daemon lifecycle.
+
+---
+
+## What changes after setup?
+
+Without pre-action policy, an agent action executes before a security team can
+review its logs:
 
 ```text
-agent asks to use a tool
+agent requests an action
         |
         v
-Kontext receives the action through a hook
+action executes
         |
         v
-local policy allows, denies, or records a would-decision
-        |
-        v
-the decision is written to the local authorization ledger
+activity appears in a log
 ```
 
-The decision path is local. A managed deployment adds configuration and record
-export; it does not require a hosted service to answer every tool call.
+With Kontext:
 
-## Core features
+```text
+agent requests an action
+        |
+        v
+Kontext receives it through a supported hook
+        |
+        v
+local policy evaluates the action
+        |
+        +---- allow ----------> action continues
+        |
+        +---- would deny -----> action continues and evidence is recorded
+        |                       (observe mode)
+        |
+        +---- deny -----------> action is stopped before execution
+                                (enforce mode)
+        |
+        v
+decision and outcome enter the authorization ledger
+```
 
-Kontext balances security and utility for AI agents: low-risk actions keep moving, and unsafe actions can be blocked before they execute.
+This creates a decision point before the action, not only a record after it.
 
-- **Observe agent actions.** Record supported tool calls, policy decisions, and
-  outcomes in a local authorization ledger.
-- **Apply policy before actions run.** Use deterministic rules for boundaries
-  such as destructive commands, sensitive files, production systems, data
-  exports, and credential access.
-- **Roll out safely.** Observe mode shows what policy would deny without
-  interrupting work. Enforce mode returns a real denial for matching rules.
-- **Keep evidence.** Store redacted records locally and, for managed
-  deployments, send them to the Kontext dashboard for review.
-- **Run where the agent runs.** Use Kontext on a developer machine, in a cloud
-  sandbox, or in another managed agent environment with a supported hook.
+---
 
-## Managed deployments
+## Observe first. Enforce when ready.
 
-For enterprise identity, audit retention, organization controls, deployment planning, custom usage volume, and onboarding for security and platform teams, contact [michel@kontext.security](mailto:michel@kontext.security) or [book here](https://calendar.superhuman.com/book/11W5Y8b5JsB8dOzQbd/YECs9).
+Blocking every unfamiliar action on day one creates noise and interrupts
+developers. Allowing every action indefinitely leaves policy as passive
+monitoring.
 
-## Agent support matrix
+Kontext separates rollout into two modes:
 
-[See the agent support matrix](docs/coverage.md) for the exact events, enforcement
-points, installation scope, and known gaps for each agent. It is the source of
-truth for what “supported” means; an integration is not treated as fully
-covered merely because Kontext can receive an event from it.
+### Observe mode
+
+Observe mode records the policy decision without interrupting the agent.
+
+Use it to answer:
+
+- Which tools are agents calling?
+- Which actions would current policy deny?
+- Which repositories, files, and systems are involved?
+- Where would enforcement interrupt legitimate work?
+- Which event surfaces can actually stop the action?
+
+### Enforce mode
+
+Enforce mode returns a real denial when a deterministic policy matches at a
+supported synchronous pre-action hook.
+
+Policies can define boundaries around actions such as:
+
+- destructive commands;
+- sensitive-file access;
+- production-system operations;
+- credential access;
+- data exports.
+
+Enforcement is intentionally limited to event surfaces where the agent waits
+for Kontext before continuing. Kontext does not claim that receiving an event
+means it can stop every action from that agent.
+
+---
+
+## Know what happened—and why
+
+Every supported event that reaches Kontext can contribute evidence to the local
+authorization ledger.
+
+A record can include:
+
+- the agent and session;
+- the lifecycle or tool event;
+- the tool name and available input;
+- the local policy decision;
+- the policy responsible for that decision;
+- the available action outcome;
+- redacted evidence for later review.
+
+Kontext records tool activity and decision evidence. It does not capture model
+reasoning or reconstruct full conversation history.
+
+Managed deployments can export redacted records to the Kontext dashboard for
+organization-wide review, retention, and investigation.
+
+---
+
+## Policy where the agent runs
+
+The decision path stays local:
+
+```text
+Claude Code / Cowork / Codex
+              |
+              v
+        supported hook
+              |
+              v
+     local Kontext runtime
+              |
+        +-----+------+
+        |            |
+        v            v
+  policy decision   local ledger
+        |
+        v
+ allow / would deny / deny
+```
+
+A hosted service does not need to answer every tool call.
+
+Managed deployments add organization configuration, policy rollout, record
+export, identity, and retention. They do not move the synchronous decision path
+out of the agent environment.
+
+---
+
+## Supported agents
+
+“Supported” means more than accepting an event. Kontext documents which events
+it receives, which events can block, and how each integration is installed.
+
+| Agent | What Kontext records | Pre-action blocking | Installation |
+| --- | --- | --- | --- |
+| **Claude Code** | Session lifecycle, pre-tool-use, successful and failed post-tool-use | Pre-tool-use | Installed by `kontext setup` |
+| **Codex** | Session start, pre-tool-use, post-tool-use, prompt submission, stop | Pre-tool-use | Installed by `kontext setup`; hooks must be trusted in Codex |
+| **Claude Cowork** | Claude Code-compatible session and tool events | Pre-tool-use | Configure the hook inside the Cowork environment |
+
+See the [agent support matrix](docs/coverage.md) for exact behavior, deployment
+scope, and known gaps. It is the authoritative source for enforcement coverage.
+
+---
+
+## Kontext and sandboxes solve different problems
+
+A process sandbox asks:
+
+> Which files, network destinations, credentials, and operating-system
+> resources can this process access?
+
+Kontext asks:
+
+> Which agent is attempting which action, what policy applies, should the
+> action proceed, and what evidence proves the decision?
+
+Kernel sandboxes are strong containment boundaries. Kontext provides semantic
+policy and attribution at supported agent and tool hooks.
+
+They are complementary:
+
+```text
+Kontext
+  decides whether the action is authorized
+              |
+              v
+sandbox
+  constrains what the process can physically access
+```
+
+Kontext does not claim kernel-level isolation. Use an appropriate sandbox when
+the threat model requires process, filesystem, or network containment.
+
+---
+
+## Why not just collect agent logs?
+
+Logs tell you what an agent reported after an event.
+
+Kontext creates an authorization decision before supported consequential
+actions execute, then links that decision to the available outcome.
+
+That distinction matters during:
+
+- policy rollout;
+- incident investigation;
+- production-access review;
+- developer exception handling;
+- compliance and audit review.
+
+The result is not only “the agent called a tool.” It is evidence of what was
+requested, which policy applied, whether it was allowed, and what happened
+next.
+
+---
+
+## Run Kontext across your organization
+
+Managed deployments add:
+
+- centrally managed deterministic policy;
+- enterprise identity and organization controls;
+- observe-to-enforce rollout;
+- managed agent and cloud deployment support;
+- redacted evidence export;
+- audit retention;
+- deployment health and backlog monitoring;
+- onboarding for security and platform teams.
+
+For deployment planning and organization onboarding, contact
+[michel@kontext.security](mailto:michel@kontext.security) or
+[book a conversation](https://calendar.superhuman.com/book/11W5Y8b5JsB8dOzQbd/YECs9).
+
+---
+
+## Diagnose an installation
+
+```bash
+kontext doctor
+```
+
+`doctor` checks:
+
+- installed agent hooks;
+- daemon health and version;
+- managed export health;
+- pending export backlog.
+
+It exits non-zero when a configured installation is unhealthy.
+
+When a self-serve daemon is stale:
+
+```bash
+kontext doctor --fix
+```
+
+Rotate the installation token by running setup again:
+
+```bash
+kontext setup
+```
+
+Remove the self-serve installation:
+
+```bash
+kontext setup --uninstall
+```
+
+---
 
 ## Data handling
 
-Kontext stores tool activity and decision evidence, not model reasoning or full
-conversation history. Sensitive values are redacted before local storage and
-managed export.
+- Policy decisions happen locally.
+- Tool activity and decision evidence are stored locally.
+- Sensitive values are redacted before local storage and managed export.
+- Kontext does not store model reasoning or full conversation history.
+- Managed deployments can export redacted records to the organization
+  dashboard.
+
+See the [Guard documentation](docs/guard.md) for the runtime and data boundary.
+
+---
 
 ## Development
 
@@ -119,4 +369,5 @@ go vet ./...
 
 - Read [SUPPORT.md](SUPPORT.md) for support channels.
 - Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a contribution.
+- Report vulnerabilities through our [Security Policy](SECURITY.md).
 - Kontext is released under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary

Reframe the README around the concrete developer and security outcome: stopping risky AI-agent actions before they run.

- lead with the problem, outcome, and supported agents instead of internal runtime terminology
- make the current `kontext setup` flow explicit without referring to the retired `kontext start`
- explain the before/after decision path and the difference between observe and enforce modes
- describe the authorization ledger in terms of the evidence users receive
- bring the supported-agent matrix into the README while keeping `docs/coverage.md` authoritative
- clarify how Kontext differs from—and complements—kernel sandboxes
- move operational diagnostics and data-handling details after the primary value story

## Positioning rationale

The previous README accurately described the architecture, but required readers to understand runtime governance, hooks, policy modes, managed export, and the authorization ledger before seeing a concrete security outcome. This rewrite follows a problem → promise → activation → proof → differentiation sequence while preserving the actual enforcement boundary.

## Accuracy constraints

- no reference to the removed `kontext start` command
- no claim of kernel-level isolation
- no claim that every received event can block
- enforcement remains limited to supported synchronous pre-action hooks
- self-serve setup remains documented as macOS-only
- `docs/coverage.md` remains the source of truth for integration coverage

## Verification

- ran `git diff --check`
- verified all relative documentation links exist
- cross-checked supported-agent and enforcement claims against `docs/coverage.md`

Documentation-only change; no runtime tests required.