### PR TITLE
Enforce GitHub presets in Codex hooks

### DIFF
--- a/internal/cedareval/v2.go
+++ b/internal/cedareval/v2.go
@@ -38,6 +38,11 @@ type ToolUseInputV2 struct {
 }
 
 func BuildRequestV2(input ToolUseInputV2) (cedar.Request, cedar.EntityMap, error) {
+	if input.ToolInput == nil {
+		// A call without arguments is still a call; evaluate it against an
+		// empty object instead of failing the request.
+		input.ToolInput = map[string]any{}
+	}
 	if err := validateInputV2(input); err != nil {
 		return cedar.Request{}, nil, newConversionError("invalid_v2_request", "", err.Error())
 	}
@@ -135,9 +140,6 @@ func validateInputV2(input ToolUseInputV2) error {
 	}
 	if !validText(input.ToolID, 4096) {
 		return fmt.Errorf("cedareval: tool id must contain 1 to 4096 characters")
-	}
-	if input.ToolInput == nil {
-		return fmt.Errorf("cedareval: tool input must be a JSON object")
 	}
 	if (input.ToolID == ToolShellV2) != (input.Shell != nil) {
 		return fmt.Errorf("cedareval: shell projection must be present only for the shell tool")

--- a/internal/cedareval/v2_test.go
+++ b/internal/cedareval/v2_test.go
@@ -144,3 +144,23 @@ func assertUID(t *testing.T, actual interface{ String() string }, expected entit
 		t.Fatalf("uid = %s, want %s", actual.String(), want)
 	}
 }
+
+func TestBuildRequestV2DefaultsMissingToolInput(t *testing.T) {
+	request, _, err := cedareval.BuildRequestV2(cedareval.ToolUseInputV2{
+		Version:    cedareval.RequestContractVersionV2,
+		EndpointID: "endpoint-1",
+		AgentID:    cedareval.AgentCodexV2,
+		SessionID:  "session-1",
+		ToolID:     cedareval.ToolUnknownV2,
+	})
+	if err != nil {
+		t.Fatalf("BuildRequestV2() error = %v, want nil tool input to evaluate as an empty object", err)
+	}
+	actualContext, err := json.Marshal(request.Context)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(actualContext, []byte(`"inputJson":"{}"`)) {
+		t.Fatalf("context = %s, want empty inputJson", actualContext)
+	}
+}

--- a/internal/guard/app/server/cedar.go
+++ b/internal/guard/app/server/cedar.go
@@ -319,7 +319,7 @@ func legacyDeployment(snapshot cedarpolicy.Snapshot) *cedarpolicy.LegacyDeployme
 // projected into one entry per call; every other tool is either a pinned
 // GitHub MCP tool or unknown.
 func resolveTool(event risk.HookEvent) (string, []cedareval.ShellProjectionV2) {
-	if event.ToolName == "Bash" {
+	if risk.IsShellTool(event.ToolName) {
 		return cedareval.ToolShellV2, shellprojection.Project(risk.CommandFromInput(event.ToolInput))
 	}
 	if toolID, github := toolcatalog.Resolve(event.ToolName, event.ToolInput); github {

--- a/internal/guard/app/server/cedar_test.go
+++ b/internal/guard/app/server/cedar_test.go
@@ -831,3 +831,102 @@ func TestCedarRemoteDisabledStateRelinquishesAuthority(t *testing.T) {
 		t.Fatalf("calls = %d decision = %#v, want current authority after explicit disable", current.calls, decision)
 	}
 }
+
+func codexHookEvent(tool string, input map[string]any) risk.HookEvent {
+	return risk.HookEvent{SessionID: "codex-session-1", Agent: "codex", HookEventName: "PreToolUse", ToolName: tool, ToolInput: input}
+}
+
+// TestCedarForcePushProbeCorpusCodex runs the probe corpus the way Codex
+// delivers it: argv arrays under its shell tool names, usually wrapped in
+// bash -lc and sometimes as plain argv. Every bypass must deny exactly as it
+// does for Claude Code.
+func TestCedarForcePushProbeCorpusCodex(t *testing.T) {
+	deployment := cedarTestDeployment(t, cedareval.RolloutModeEnforce, githubForcePushPolicy)
+	provider := newCedarPolicyProvider(staticHookPolicy{}, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, LastKnownGood: &deployment, State: cedarpolicy.StateSuccess}}, CedarEnforcementRemote)
+	shellTools := []string{"shell", "unified_exec", "exec_command", "local_shell"}
+
+	denied := []map[string]any{
+		{"command": []any{"bash", "-lc", "git push --force origin main"}, "workdir": "/tmp/repo"},
+		{"command": []any{"bash", "-lc", "git push -f origin main"}},
+		{"command": []any{"/bin/zsh", "-lc", "git status; git push -f origin main"}},
+		{"command": []any{"sh", "-c", "exec git push -f origin main"}},
+		{"command": []any{"bash", "-lc", "bash -c 'git push -f origin main'"}},
+		{"command": []any{"bash", "-lc", "git push origin +HEAD:main"}},
+		{"command": []any{"git", "push", "--force", "origin", "main"}},
+		{"command": []any{"git", "push", "-fu", "origin", "main"}},
+		{"command": []any{"git", "push", "origin", "+main"}},
+		{"command": []any{"timeout", "30", "git", "push", "-f", "origin", "main"}},
+		{"command": []any{"git", "-c", "alias.x=y", "push", "-f", "origin", "main"}},
+		{"command": "git push -f origin main"},
+	}
+	for _, tool := range shellTools {
+		for _, input := range denied {
+			decision, err := provider.DecideHook(context.Background(), codexHookEvent(tool, input))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if decision.Decision != risk.DecisionDeny || decision.Reason != "Blocked by rule github-block-force-push" {
+				t.Errorf("%s %v: decision = %#v, want deny by the force-push rule", tool, input["command"], decision)
+			}
+			if decision.Cedar.ToolID != cedareval.ToolShellV2 {
+				t.Errorf("%s %v: tool id = %q, want shell", tool, input["command"], decision.Cedar.ToolID)
+			}
+		}
+	}
+
+	allowed := []map[string]any{
+		{"command": []any{"bash", "-lc", "git status"}},
+		{"command": []any{"bash", "-lc", "git push --force-with-lease origin main"}},
+		{"command": []any{"git", "push", "origin", "main"}},
+		{"command": []any{"git", "push", "--force-with-lease", "origin", "main"}},
+		{"command": []any{"git", "commit", "-m", "force push origin main later"}},
+		{"command": []any{"gh", "pr", "view", "42"}},
+		{"command": []any{"bash", "-lc", "command -v git"}},
+	}
+	for _, tool := range shellTools {
+		for _, input := range allowed {
+			decision, err := provider.DecideHook(context.Background(), codexHookEvent(tool, input))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if decision.Decision != risk.DecisionAllow {
+				t.Errorf("%s %v: decision = %#v, want allow", tool, input["command"], decision)
+			}
+		}
+	}
+}
+
+// TestCedarCodexNonShellAndEmptyInputs keeps Codex's other shapes out of the
+// engine-error path: apply_patch is never a shell however its input looks, a
+// missing tool_input evaluates as an empty object, and GitHub MCP tools
+// resolve to the same pinned ids as under Claude Code.
+func TestCedarCodexNonShellAndEmptyInputs(t *testing.T) {
+	deployment := cedarTestDeployment(t, cedareval.RolloutModeEnforce, githubForcePushPolicy)
+	provider := newCedarPolicyProvider(staticHookPolicy{}, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{Deployment: &deployment, LastKnownGood: &deployment, State: cedarpolicy.StateSuccess}}, CedarEnforcementRemote)
+
+	patch, err := provider.DecideHook(context.Background(), codexHookEvent("apply_patch", map[string]any{"command": "git push -f origin main", "patch": "*** Begin Patch"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if patch.Decision != risk.DecisionAllow || patch.Cedar.ToolID != cedareval.ToolUnknownV2 || patch.Cedar.Shell != nil {
+		t.Fatalf("apply_patch decision = %#v, want allow as a non-shell tool", patch)
+	}
+
+	for _, tool := range []string{"shell", "view_image", "Read"} {
+		decision, err := provider.DecideHook(context.Background(), codexHookEvent(tool, nil))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if decision.Decision != risk.DecisionAllow || decision.Cedar.EngineErrorCount != 0 || decision.Cedar.Mapping.DerivedCedarAction != cedareval.DerivedCedarActionAllow {
+			t.Fatalf("%s with nil input: decision = %#v, want policy-decided allow without engine error", tool, decision)
+		}
+	}
+
+	mcp, err := provider.DecideHook(context.Background(), codexHookEvent("mcp__github__get_me", map[string]any{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mcp.Cedar.ToolID != "github-mcp/get_me" {
+		t.Fatalf("Cedar evidence = %#v, want pinned GitHub tool id", mcp.Cedar)
+	}
+}

--- a/internal/guard/risk/normalizer.go
+++ b/internal/guard/risk/normalizer.go
@@ -2,6 +2,7 @@ package risk
 
 import (
 	"fmt"
+	"mvdan.cc/sh/v3/syntax"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -75,7 +76,7 @@ func NormalizeHookEvent(event HookEvent) RiskEvent {
 		riskEvent.Type = EventManagedToolCall
 		addSignal(&riskEvent, signalSet, "managed_tool")
 	}
-	if lowerTool == "bash" || strings.Contains(lowerTool, "bash") || strings.Contains(lowerTool, "shell") {
+	if IsShellTool(lowerTool) {
 		classifySourceControl(&riskEvent, signalSet, lowerCommand)
 	}
 	if isReadTool(lowerTool) && isCredentialPath(path) {
@@ -85,7 +86,7 @@ func NormalizeHookEvent(event HookEvent) RiskEvent {
 		riskEvent.PathClass = pathClass(path)
 		addSignal(&riskEvent, signalSet, "credential_path")
 	}
-	if lowerTool == "bash" || strings.Contains(lowerTool, "bash") || strings.Contains(lowerTool, "shell") {
+	if IsShellTool(lowerTool) {
 		classifyBash(&riskEvent, signalSet, lowerCommand, commandSignalText)
 	}
 	if strings.Contains(lowerCommand, "curl") {
@@ -207,8 +208,13 @@ func classifyProvider(event *RiskEvent, signalSet map[string]struct{}, text stri
 
 func commandFromInput(input map[string]any) string {
 	for _, key := range []string{"command", "cmd", "script"} {
-		if value, ok := input[key].(string); ok {
+		switch value := input[key].(type) {
+		case string:
 			return value
+		case []any:
+			if command := commandFromArgv(value); command != "" {
+				return command
+			}
 		}
 	}
 	return ""
@@ -217,8 +223,98 @@ func commandFromInput(input map[string]any) string {
 // CommandFromInput extracts the raw shell command from a tool input payload,
 // using the same keys the normalizer recognizes. Empty when the input carries
 // no command.
+//
+// Claude Code sends the command as one string. Codex sends an argv array
+// ({"command":["bash","-lc","git push -f origin main"]}); a `<shell> -c
+// <script>` wrapper yields the script itself and any other argv is joined
+// with POSIX quoting, so the result parses like a command a person typed.
 func CommandFromInput(input map[string]any) string {
 	return commandFromInput(input)
+}
+
+// IsShellTool reports whether a hook tool name is the agent's shell. Claude
+// Code calls it Bash; Codex has used shell, unified_exec, exec_command and
+// local_shell across versions. apply_patch and MCP tools are never shells,
+// whatever their input carries.
+func IsShellTool(toolName string) bool {
+	switch strings.ToLower(strings.TrimSpace(toolName)) {
+	case "bash", "shell", "shell_command", "unified_exec", "exec_command", "local_shell":
+		return true
+	default:
+		return false
+	}
+}
+
+var shellWrapperPrograms = map[string]bool{"bash": true, "sh": true, "zsh": true, "dash": true, "ksh": true}
+
+// commandFromArgv turns an argv array into shell text. Non-string elements
+// leave the array unrecognized.
+func commandFromArgv(values []any) string {
+	argv := make([]string, 0, len(values))
+	for _, value := range values {
+		switch v := value.(type) {
+		case string:
+			argv = append(argv, v)
+		case interface{ String() string }:
+			argv = append(argv, v.String())
+		default:
+			return ""
+		}
+	}
+	if len(argv) == 0 {
+		return ""
+	}
+	if script, ok := shellWrapperScript(argv); ok {
+		return script
+	}
+	quoted := make([]string, len(argv))
+	for i, word := range argv {
+		quoted[i] = quoteShellWord(word)
+	}
+	return strings.Join(quoted, " ")
+}
+
+// shellWrapperScript unwraps `bash -lc <script>` and its siblings: a shell
+// program, short options that include -c (long options and -o/+o pairs are
+// skipped), then the script. Anything after the script is $0 and positional
+// parameters, which never change what runs.
+func shellWrapperScript(argv []string) (string, bool) {
+	if len(argv) < 3 || !shellWrapperPrograms[filepath.Base(argv[0])] {
+		return "", false
+	}
+	commandFlag := false
+	i := 1
+	for ; i < len(argv); i++ {
+		arg := argv[i]
+		if arg == "--" || arg == "-" {
+			i++
+			break
+		}
+		if !strings.HasPrefix(arg, "-") && !strings.HasPrefix(arg, "+") {
+			break
+		}
+		if arg == "-o" || arg == "+o" || arg == "-O" || arg == "+O" || arg == "--rcfile" || arg == "--init-file" {
+			i++
+			continue
+		}
+		if strings.HasPrefix(arg, "--") {
+			continue
+		}
+		if strings.Contains(arg, "c") {
+			commandFlag = true
+		}
+	}
+	if !commandFlag || i >= len(argv) {
+		return "", false
+	}
+	return argv[i], true
+}
+
+func quoteShellWord(word string) string {
+	if quoted, err := syntax.Quote(word, syntax.LangBash); err == nil {
+		return quoted
+	}
+	return "'" + strings.ReplaceAll(word, "'", "'\\''") + "'"
 }
 
 func pathFromInput(input map[string]any) string {

--- a/internal/guard/risk/normalizer_test.go
+++ b/internal/guard/risk/normalizer_test.go
@@ -1,0 +1,16 @@
+package risk
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestNormalizeHookEventClassifiesEveryCodexShellLikeBash(t *testing.T) {
+	want := NormalizeHookEvent(HookEvent{Agent: "claude", ToolName: "Bash", ToolInput: map[string]any{"command": "git push --force origin main"}})
+	for _, name := range []string{"shell", "unified_exec", "exec_command", "local_shell"} {
+		got := NormalizeHookEvent(HookEvent{Agent: "codex", ToolName: name, ToolInput: map[string]any{"command": []any{"bash", "-lc", "git push --force origin main"}}})
+		if got.Type != want.Type || fmt.Sprint(got.Signals) != fmt.Sprint(want.Signals) {
+			t.Errorf("%s: type=%s signals=%v, want type=%s signals=%v", name, got.Type, got.Signals, want.Type, want.Signals)
+		}
+	}
+}

--- a/internal/guard/risk/risk_test.go
+++ b/internal/guard/risk/risk_test.go
@@ -352,3 +352,51 @@ func TestAddSignalPreservesFirstSeenOrderAndSkipsDuplicates(t *testing.T) {
 		t.Fatalf("signals = %#v, want %#v", event.Signals, want)
 	}
 }
+
+func TestCommandFromInputArgv(t *testing.T) {
+	tests := []struct {
+		name  string
+		input map[string]any
+		want  string
+	}{
+		{"string", map[string]any{"command": "git status"}, "git status"},
+		{"bash -lc wrapper", map[string]any{"command": []any{"bash", "-lc", "git push --force origin main"}, "workdir": "/tmp/repo"}, "git push --force origin main"},
+		{"sh -c with positional params", map[string]any{"command": []any{"sh", "-c", "git push -f origin main", "sh", "x"}}, "git push -f origin main"},
+		{"absolute shell with long option", map[string]any{"command": []any{"/bin/zsh", "--login", "-c", "git status"}}, "git status"},
+		{"-o pair before -c", map[string]any{"command": []any{"bash", "-o", "pipefail", "-c", "git status"}}, "git status"},
+		{"plain argv", map[string]any{"command": []any{"git", "push", "--force", "origin", "main"}}, "git push --force origin main"},
+		{"argv needing quotes", map[string]any{"command": []any{"git", "commit", "-m", "fix it's broken"}}, `git commit -m "fix it's broken"`},
+		{"shell without -c", map[string]any{"command": []any{"bash", "-l"}}, "bash -l"},
+		{"shell -c without script", map[string]any{"command": []any{"bash", "-c"}}, "bash -c"},
+		{"non-string element", map[string]any{"command": []any{"git", true}}, ""},
+		{"empty argv", map[string]any{"command": []any{}}, ""},
+		{"nil input", nil, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CommandFromInput(tt.input); got != tt.want {
+				t.Fatalf("CommandFromInput() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeHookEventReadsCodexArgv(t *testing.T) {
+	event := NormalizeHookEvent(HookEvent{Agent: "codex", ToolName: "shell", ToolInput: map[string]any{"command": []any{"bash", "-lc", "git push --force origin main"}}})
+	if event.CommandSummary != "git push --force origin main" {
+		t.Fatalf("command summary = %q, want the unwrapped script", event.CommandSummary)
+	}
+}
+
+func TestIsShellTool(t *testing.T) {
+	for _, name := range []string{"Bash", "shell", "unified_exec", "exec_command", "local_shell", "shell_command"} {
+		if !IsShellTool(name) {
+			t.Errorf("IsShellTool(%q) = false, want true", name)
+		}
+	}
+	for _, name := range []string{"apply_patch", "Read", "mcp__github__push_files", "", "shell-ish"} {
+		if IsShellTool(name) {
+			t.Errorf("IsShellTool(%q) = true, want false", name)
+		}
+	}
+}

--- a/internal/hookruntime/codex.go
+++ b/internal/hookruntime/codex.go
@@ -169,16 +169,15 @@ func normalizeCodexToolInput(h codexHookInput) (map[string]any, error) {
 	if err != nil {
 		return nil, err
 	}
+	if toolInput == nil {
+		// Codex omits tool_input (or sends null) for calls without
+		// arguments; policy evaluation needs a JSON object either way.
+		toolInput = map[string]any{}
+	}
 	if h.HookEventName == hook.HookUserPromptSubmit.String() && h.Prompt != nil {
-		if toolInput == nil {
-			toolInput = map[string]any{}
-		}
 		toolInput["prompt"] = *h.Prompt
 	}
 	if h.HookEventName == hook.HookSessionStart.String() && h.Source != nil {
-		if toolInput == nil {
-			toolInput = map[string]any{}
-		}
 		toolInput["source"] = *h.Source
 	}
 	return toolInput, nil

--- a/internal/hookruntime/codex_test.go
+++ b/internal/hookruntime/codex_test.go
@@ -298,3 +298,17 @@ func TestEncodeCodexRejectsUnsupportedEvent(t *testing.T) {
 		t.Fatal("EncodeCodexResult() error = nil, want unsupported event error")
 	}
 }
+
+func TestDecodeCodexEventMissingToolInputIsEmptyObject(t *testing.T) {
+	t.Parallel()
+
+	for _, toolInput := range []string{`"tool_input":null,`, ``} {
+		event, err := DecodeCodexEvent([]byte(`{"session_id":"abc","hook_event_name":"PreToolUse","tool_name":"shell",`+toolInput+`"cwd":"/tmp"}`), "codex")
+		if err != nil {
+			t.Fatalf("DecodeCodexEvent() error = %v", err)
+		}
+		if event.ToolInput == nil || len(event.ToolInput) != 0 {
+			t.Fatalf("ToolInput = %#v, want empty object for %q", event.ToolInput, toolInput)
+		}
+	}
+}


### PR DESCRIPTION
Stacked on #481. Makes the Cedar v2 GitHub presets enforce for OpenAI Codex CLI the way they already do for Claude Code.

## Why

Cedar v2 only treated Claude Code's `Bash` tool as the shell. Codex sends `shell` / `unified_exec` / `exec_command` / `local_shell` with an argv array (`{"command":["bash","-lc","git push --force origin main"],"workdir":...}`), so every Codex call resolved to `Kontext::Tool::"unknown"` with no shell projection and the force-push preset never fired. Argument-less Codex calls with `tool_input: null` went further and failed request conversion, which under enforce is a deny.

## What changed

- `internal/guard/app/server/cedar.go`: `resolveTool` uses a shell tool-name set (`risk.IsShellTool`: `Bash`, `shell`, `shell_command`, `unified_exec`, `exec_command`, `local_shell`) instead of `== "Bash"`. The resource id stays `Kontext::Tool::"shell"`, so existing presets apply unchanged. `apply_patch` and MCP tools are not shells whatever their input carries.
- `internal/guard/risk/normalizer.go`: `CommandFromInput` accepts `[]any` argv. A `<shell> -c <script>` wrapper (`bash -lc`, `/bin/zsh --login -c`, `-o` pairs skipped) yields the script; any other argv is joined with `mvdan.cc/sh` POSIX quoting so the projection parses it as typed. This also fixes the risk normalizer's command summary and the classifier's command text for Codex.
- `internal/hookruntime/codex.go` + `internal/cedareval/v2.go`: missing/`null` `tool_input` decodes as `{}`, and `BuildRequestV2` defaults nil input the same way instead of returning a conversion error.

## Tests

- `TestCedarForcePushProbeCorpusCodex`: the force-push probe corpus in Codex shape (bash -lc wrappers, nested shells, plain argv, `+HEAD:main`, `timeout`, `git -c alias`) across all four Codex shell tool names, every case denied by `github-block-force-push`; allowed list stays allowed.
- `TestCedarCodexNonShellAndEmptyInputs`: `apply_patch` with a command-shaped field is not projected; nil `tool_input` on shell/non-shell tools is a policy-decided allow with zero engine errors; `mcp__github__get_me` resolves to the pinned id under the Codex agent.
- `TestCommandFromInputArgv`, `TestNormalizeHookEventReadsCodexArgv`, `TestIsShellTool`, `TestDecodeCodexEventMissingToolInputIsEmptyObject`, `TestBuildRequestV2DefaultsMissingToolInput`.

`gofmt -l`, `go vet ./...`, `go test ./...` clean.

## Known limitation (not addressed here)

Codex can be configured with `non_prefixed_mcp_tool_names`, in which case GitHub MCP tools arrive as bare `get_me` / `push_files` instead of `mcp__<server>__<tool>`. Those still resolve to `Kontext::Tool::"unknown"`; only the `mcp__<server>__tool` form (default) is catalogued (#481). Mapping bare names would need the server identity from the Codex config, which the hook payload does not carry.

Live check: a Codex-shaped PreToolUse for `git push --force origin main` piped to `kontext hook --agent codex pre-tool-use` now returns `hookSpecificOutput` with a Cedar decision instead of `{}`.
