### PR TITLE
Project GitHub operations into Cedar facts

### DIFF
--- a/internal/shellprojection/github_operations.go
+++ b/internal/shellprojection/github_operations.go
@@ -1,0 +1,594 @@
+package shellprojection
+
+import (
+	"encoding/json"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// GitHub operation facts name the verb-object effect a shell call has on
+// GitHub so a Cedar preset can forbid one effect with a single
+// facts.contains. A call can carry several (`gh pr merge --delete-branch`
+// merges and deletes a ref). The values are shared with the cloud templates;
+// renaming one is a contract change.
+const (
+	factOperationPrefix = "github/operation="
+
+	OperationForcePush            = "force-push"
+	OperationForcePushWithLease   = "force-push-with-lease"
+	OperationDeleteRef            = "delete-ref"
+	OperationMoveTag              = "move-tag"
+	OperationUpdateRef            = "update-ref"
+	OperationMergePullRequest     = "merge-pull-request"
+	OperationEnableAutoMerge      = "enable-auto-merge"
+	OperationDisableAutoMerge     = "disable-auto-merge"
+	OperationMergeBranch          = "merge-branch"
+	OperationApprovePullRequest   = "approve-pull-request"
+	OperationCreateRelease        = "create-release"
+	OperationEditRelease          = "edit-release"
+	OperationDeleteRelease        = "delete-release"
+	OperationUploadReleaseAsset   = "upload-release-asset"
+	OperationRunWorkflow          = "run-workflow"
+	OperationRerunWorkflowRun     = "rerun-workflow-run"
+	OperationCancelWorkflowRun    = "cancel-workflow-run"
+	OperationApproveWorkflowRun   = "approve-workflow-run"
+	OperationDeleteWorkflowRun    = "delete-workflow-run"
+	OperationEnableWorkflow       = "enable-workflow"
+	OperationDisableWorkflow      = "disable-workflow"
+	OperationEditRepository       = "edit-repository"
+	OperationDeleteRepository     = "delete-repository"
+	OperationTransferRepository   = "transfer-repository"
+	OperationEditBranchProtection = "edit-branch-protection"
+	OperationEditEnvironment      = "edit-environment"
+	OperationEditCollaborators    = "edit-collaborators"
+	OperationEditWebhooks         = "edit-webhooks"
+	OperationEditDeployKeys       = "edit-deploy-keys"
+	OperationEditSecrets          = "edit-secrets"
+	// OperationOtherWrite marks a catalogued GitHub write no row above
+	// names, so a strict custom policy can deny "every other write" without
+	// the read-only preset.
+	OperationOtherWrite = "other-write"
+
+	// FeatureOperationFromRoute marks operations derived from a REST
+	// method and path; FeatureOperationFromGraphQL from a literal GraphQL
+	// mutation; FeatureGraphQLNotLiteral a GraphQL call whose query text
+	// could not be read (file, variable, --input).
+	FeatureOperationFromRoute   = "github-operation-from-route"
+	FeatureOperationFromGraphQL = "github-operation-from-graphql"
+	FeatureGraphQLNotLiteral    = "graphql-query-not-literal"
+
+	hostGitHubAPI     = "api.github.com"
+	hostGitHubUploads = "uploads.github.com"
+)
+
+// OperationFact renders an operation as the fact string Cedar matches.
+func OperationFact(operation string) string {
+	return factOperationPrefix + operation
+}
+
+func operationFacts(operations []string) []string {
+	facts := make([]string, 0, len(operations))
+	for _, operation := range operations {
+		facts = append(facts, OperationFact(operation))
+	}
+	return facts
+}
+
+// ghCommandOperations maps a gh command key (see classifyGH) to the
+// operations it always performs. Flag-sensitive commands are refined by
+// ghOperations. A write key absent here is other-write.
+var ghCommandOperations = map[string][]string{
+	"pr/merge":               {OperationMergePullRequest},
+	"release/create":         {OperationCreateRelease},
+	"release/edit":           {OperationEditRelease},
+	"release/delete":         {OperationDeleteRelease},
+	"release/delete-asset":   {OperationDeleteRelease},
+	"release/upload":         {OperationUploadReleaseAsset},
+	"workflow/run":           {OperationRunWorkflow},
+	"workflow/enable":        {OperationEnableWorkflow},
+	"workflow/disable":       {OperationDisableWorkflow},
+	"run/rerun":              {OperationRerunWorkflowRun},
+	"run/cancel":             {OperationCancelWorkflowRun},
+	"run/delete":             {OperationDeleteWorkflowRun},
+	"repo/edit":              {OperationEditRepository},
+	"repo/rename":            {OperationEditRepository},
+	"repo/archive":           {OperationEditRepository},
+	"repo/unarchive":         {OperationEditRepository},
+	"repo/autolink/create":   {OperationEditRepository},
+	"repo/autolink/delete":   {OperationEditRepository},
+	"repo/delete":            {OperationDeleteRepository},
+	"repo/deploy-key/add":    {OperationEditDeployKeys},
+	"repo/deploy-key/delete": {OperationEditDeployKeys},
+	"secret/set":             {OperationEditSecrets},
+	"secret/delete":          {OperationEditSecrets},
+	"variable/set":           {OperationEditSecrets},
+	"variable/delete":        {OperationEditSecrets},
+}
+
+// ghOperations classifies a non-api gh write command from its key and the
+// literal arguments after the key words.
+func ghOperations(key string, rest []string) []string {
+	flags := ghFlags(rest)
+	var operations []string
+	switch key {
+	case "pr/merge":
+		switch {
+		case flags["--auto"]:
+			operations = append(operations, OperationEnableAutoMerge)
+		case flags["--disable-auto"]:
+			operations = append(operations, OperationDisableAutoMerge)
+		default:
+			operations = append(operations, OperationMergePullRequest)
+		}
+		if flags["-d"] || flags["--delete-branch"] {
+			operations = append(operations, OperationDeleteRef)
+		}
+	case "pr/review":
+		if flags["-a"] || flags["--approve"] {
+			operations = append(operations, OperationApprovePullRequest)
+		}
+	case "release/delete":
+		operations = append(operations, OperationDeleteRelease)
+		if flags["--cleanup-tag"] {
+			operations = append(operations, OperationDeleteRef)
+		}
+	case "repo/sync":
+		if flags["--force"] {
+			operations = append(operations, OperationForcePush)
+		}
+	default:
+		operations = append(operations, ghCommandOperations[key]...)
+	}
+	if len(operations) == 0 {
+		operations = append(operations, OperationOtherWrite)
+	}
+	return operations
+}
+
+// ghFlags collects the option words of a gh command, expanding clustered
+// short flags (`-ds` is `-d -s`) and dropping `--option=value` values, so
+// flag-sensitive operations can test presence. Option values that happen
+// to look like flags are counted too; the projection prefers to over-report
+// an effect rather than miss one.
+func ghFlags(args []string) map[string]bool {
+	flags := make(map[string]bool, len(args))
+	for _, arg := range args {
+		if arg == "--" {
+			break
+		}
+		switch {
+		case strings.HasPrefix(arg, "--"):
+			name, _, _ := strings.Cut(arg, "=")
+			flags[name] = true
+		case shortFlagCluster.MatchString(arg):
+			for _, flag := range arg[1:] {
+				flags["-"+string(flag)] = true
+			}
+		case strings.HasPrefix(arg, "-") && arg != "-":
+			flags[arg] = true
+		}
+	}
+	return flags
+}
+
+// hasDeleteRefspec reports a push refspec with an empty source (`:branch`,
+// `+:refs/tags/v1`): git deletes the destination. A bare `:` pushes matching
+// branches and is not a deletion.
+func hasDeleteRefspec(refspecs []string) bool {
+	for _, refspec := range refspecs {
+		trimmed := strings.TrimPrefix(refspec, "+")
+		if strings.HasPrefix(trimmed, ":") && len(trimmed) > 1 {
+			return true
+		}
+	}
+	return false
+}
+
+func hasForceWithLease(options []string) bool {
+	return hasArg(options, "--force-with-lease", "--force-if-includes") || hasPrefixArg(options, "--force-with-lease=")
+}
+
+func hasPrefixArg(args []string, prefix string) bool {
+	for _, arg := range args {
+		if strings.HasPrefix(arg, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// githubRoute is one row of the REST route table. `*` matches exactly one
+// non-empty path segment, `**` one or more trailing segments; every other
+// segment must match literally, so `pulls/x/merge-ish` never matches
+// `pulls/*/merge`. Host "" is api.github.com.
+type githubRoute struct {
+	host      string
+	methods   []string
+	pattern   []string
+	operation string
+}
+
+func route(methods, pattern, operation string) githubRoute {
+	return githubRoute{methods: strings.Fields(methods), pattern: strings.Split(pattern, "/"), operation: operation}
+}
+
+func uploadsRoute(methods, pattern, operation string) githubRoute {
+	r := route(methods, pattern, operation)
+	r.host = hostGitHubUploads
+	return r
+}
+
+var githubRoutes = []githubRoute{
+	// Git refs. PATCH is handled in githubRouteOperations because force and
+	// tag detection decide between several operations.
+	route("DELETE", "repos/*/*/git/refs/**", OperationDeleteRef),
+
+	// Merging.
+	route("PUT", "repos/*/*/pulls/*/merge", OperationMergePullRequest),
+	route("POST", "repos/*/*/merges", OperationMergeBranch),
+	route("POST", "repos/*/*/merge-upstream", OperationMergeBranch),
+
+	// Releases. `curl -T` sends PUT to the uploads host, so both verbs count.
+	route("POST", "repos/*/*/releases", OperationCreateRelease),
+	route("PATCH", "repos/*/*/releases/*", OperationEditRelease),
+	route("PATCH", "repos/*/*/releases/assets/*", OperationEditRelease),
+	route("DELETE", "repos/*/*/releases/*", OperationDeleteRelease),
+	route("DELETE", "repos/*/*/releases/assets/*", OperationDeleteRelease),
+	uploadsRoute("POST PUT", "repos/*/*/releases/*/assets", OperationUploadReleaseAsset),
+
+	// Actions.
+	route("POST", "repos/*/*/actions/workflows/*/dispatches", OperationRunWorkflow),
+	route("POST", "repos/*/*/dispatches", OperationRunWorkflow),
+	route("POST", "repos/*/*/actions/runs/*/rerun", OperationRerunWorkflowRun),
+	route("POST", "repos/*/*/actions/runs/*/rerun-failed-jobs", OperationRerunWorkflowRun),
+	route("POST", "repos/*/*/actions/jobs/*/rerun", OperationRerunWorkflowRun),
+	route("POST", "repos/*/*/actions/runs/*/cancel", OperationCancelWorkflowRun),
+	route("POST", "repos/*/*/actions/runs/*/force-cancel", OperationCancelWorkflowRun),
+	route("POST", "repos/*/*/actions/runs/*/approve", OperationApproveWorkflowRun),
+	route("POST", "repos/*/*/actions/runs/*/pending_deployments", OperationApproveWorkflowRun),
+	route("POST", "repos/*/*/actions/runs/*/deployment_protection_rule", OperationApproveWorkflowRun),
+	route("DELETE", "repos/*/*/actions/runs/*", OperationDeleteWorkflowRun),
+	route("DELETE", "repos/*/*/actions/runs/*/logs", OperationDeleteWorkflowRun),
+	route("DELETE", "repos/*/*/actions/artifacts/*", OperationDeleteWorkflowRun),
+	route("PUT", "repos/*/*/actions/workflows/*/enable", OperationEnableWorkflow),
+	route("PUT", "repos/*/*/actions/workflows/*/disable", OperationDisableWorkflow),
+
+	// Repository settings.
+	route("PATCH", "repos/*/*", OperationEditRepository),
+	route("PUT", "repos/*/*/topics", OperationEditRepository),
+	route("PUT DELETE", "repos/*/*/automated-security-fixes", OperationEditRepository),
+	route("PUT DELETE", "repos/*/*/vulnerability-alerts", OperationEditRepository),
+	route("PUT DELETE", "repos/*/*/private-vulnerability-reporting", OperationEditRepository),
+	route("PUT", "repos/*/*/actions/permissions", OperationEditRepository),
+	route("PUT", "repos/*/*/actions/permissions/**", OperationEditRepository),
+	route("PUT DELETE", "repos/*/*/interaction-limits", OperationEditRepository),
+	route("POST PUT DELETE", "repos/*/*/pages", OperationEditRepository),
+	route("POST PUT DELETE", "repos/*/*/pages/**", OperationEditRepository),
+	route("PUT", "repos/*/*/actions/oidc/**", OperationEditRepository),
+	route("POST PATCH DELETE", "repos/*/*/autolinks", OperationEditRepository),
+	route("POST PATCH DELETE", "repos/*/*/autolinks/**", OperationEditRepository),
+	route("PATCH", "repos/*/*/code-scanning/default-setup", OperationEditRepository),
+	route("DELETE", "repos/*/*", OperationDeleteRepository),
+	route("POST", "repos/*/*/transfer", OperationTransferRepository),
+
+	// Branch protection and rulesets.
+	route("PUT PATCH POST DELETE", "repos/*/*/branches/*/protection", OperationEditBranchProtection),
+	route("PUT PATCH POST DELETE", "repos/*/*/branches/*/protection/**", OperationEditBranchProtection),
+	route("POST PUT DELETE", "repos/*/*/rulesets", OperationEditBranchProtection),
+	route("POST PUT DELETE", "repos/*/*/rulesets/**", OperationEditBranchProtection),
+	route("POST", "repos/*/*/branches/*/rename", OperationEditBranchProtection),
+
+	// Environments.
+	route("PUT DELETE", "repos/*/*/environments/*", OperationEditEnvironment),
+	route("POST PUT DELETE", "repos/*/*/environments/*/deployment-branch-policies", OperationEditEnvironment),
+	route("POST PUT DELETE", "repos/*/*/environments/*/deployment-branch-policies/**", OperationEditEnvironment),
+	route("POST DELETE", "repos/*/*/environments/*/deployment_protection_rules", OperationEditEnvironment),
+	route("POST DELETE", "repos/*/*/environments/*/deployment_protection_rules/**", OperationEditEnvironment),
+
+	// Access.
+	route("PUT DELETE", "repos/*/*/collaborators/*", OperationEditCollaborators),
+	route("PATCH DELETE", "repos/*/*/invitations/*", OperationEditCollaborators),
+	route("PUT DELETE", "orgs/*/teams/*/repos/*/*", OperationEditCollaborators),
+	route("PUT DELETE", "user/installations/*/repositories/*", OperationEditCollaborators),
+
+	// Integrations.
+	route("POST PATCH DELETE", "repos/*/*/hooks", OperationEditWebhooks),
+	route("POST PATCH DELETE", "repos/*/*/hooks/**", OperationEditWebhooks),
+	route("POST DELETE", "repos/*/*/keys", OperationEditDeployKeys),
+	route("POST DELETE", "repos/*/*/keys/**", OperationEditDeployKeys),
+
+	// Secrets and variables.
+	route("PUT DELETE", "repos/*/*/actions/secrets/**", OperationEditSecrets),
+	route("POST PATCH DELETE", "repos/*/*/actions/variables", OperationEditSecrets),
+	route("POST PATCH DELETE", "repos/*/*/actions/variables/**", OperationEditSecrets),
+	route("PUT DELETE", "repos/*/*/dependabot/secrets/**", OperationEditSecrets),
+	route("PUT DELETE", "repos/*/*/codespaces/secrets/**", OperationEditSecrets),
+	route("PUT DELETE", "repos/*/*/environments/*/secrets/**", OperationEditSecrets),
+	route("POST PATCH DELETE", "repos/*/*/environments/*/variables", OperationEditSecrets),
+	route("POST PATCH DELETE", "repos/*/*/environments/*/variables/**", OperationEditSecrets),
+	route("PUT DELETE", "orgs/*/actions/secrets/**", OperationEditSecrets),
+	route("POST PATCH DELETE", "orgs/*/actions/variables", OperationEditSecrets),
+	route("POST PATCH DELETE", "orgs/*/actions/variables/**", OperationEditSecrets),
+	route("PUT DELETE", "orgs/*/dependabot/secrets/**", OperationEditSecrets),
+	route("PUT DELETE", "orgs/*/codespaces/secrets/**", OperationEditSecrets),
+	route("PUT DELETE", "user/codespaces/secrets/**", OperationEditSecrets),
+}
+
+func (r githubRoute) matches(host, method string, segments []string) bool {
+	routeHost := r.host
+	if routeHost == "" {
+		routeHost = hostGitHubAPI
+	}
+	if routeHost != host || !hasArg(r.methods, method) {
+		return false
+	}
+	return matchSegments(r.pattern, segments)
+}
+
+func matchSegments(pattern, segments []string) bool {
+	for i, part := range pattern {
+		if part == "**" {
+			return len(segments) > i
+		}
+		if i >= len(segments) || segments[i] == "" {
+			return false
+		}
+		if part != "*" && part != segments[i] {
+			return false
+		}
+	}
+	return len(segments) == len(pattern)
+}
+
+var gitRefsPattern = []string{"repos", "*", "*", "git", "refs", "**"}
+var pullReviewPatterns = [][]string{
+	{"repos", "*", "*", "pulls", "*", "reviews"},
+	{"repos", "*", "*", "pulls", "*", "reviews", "*", "events"},
+}
+
+// githubRouteOperations classifies a REST call to api.github.com or
+// uploads.github.com. force is the caller's existing force-push detection;
+// approve reports a literal event=APPROVE in the request body.
+func githubRouteOperations(host, method string, segments []string, force, approve bool) []string {
+	var operations []string
+	matched := false
+	if force {
+		operations = append(operations, OperationForcePush)
+		matched = true
+	}
+	if host == hostGitHubAPI && method == "PATCH" && matchSegments(gitRefsPattern, segments) {
+		switch segments[5] {
+		case "tags":
+			operations = append(operations, OperationMoveTag)
+			matched = true
+		case "heads":
+			if !force {
+				operations = append(operations, OperationUpdateRef)
+			}
+			matched = true
+		}
+	}
+	if host == hostGitHubAPI && method == "POST" && approve {
+		for _, pattern := range pullReviewPatterns {
+			if matchSegments(pattern, segments) {
+				operations = append(operations, OperationApprovePullRequest)
+				matched = true
+			}
+		}
+	}
+	for _, r := range githubRoutes {
+		if r.matches(host, method, segments) {
+			operations = append(operations, r.operation)
+			matched = true
+		}
+	}
+	if !matched && isWriteMethod(method) {
+		operations = append(operations, OperationOtherWrite)
+	}
+	return operations
+}
+
+// githubAPISegments normalises a `gh api` path or a full GitHub URL into
+// host and path segments. A full URL on another host is not a GitHub API
+// call the route table can classify.
+func githubAPISegments(path string) (host string, segments []string, ok bool) {
+	host = hostGitHubAPI
+	if strings.HasPrefix(path, "https://") || strings.HasPrefix(path, "http://") {
+		parsed, err := url.Parse(path)
+		if err != nil {
+			return "", nil, false
+		}
+		host = strings.ToLower(parsed.Hostname())
+		if host != hostGitHubAPI && host != hostGitHubUploads {
+			return "", nil, false
+		}
+		path = parsed.EscapedPath()
+	}
+	path, _, _ = strings.Cut(path, "?")
+	path, _, _ = strings.Cut(path, "#")
+	return host, pathSegments(path), true
+}
+
+func pathSegments(path string) []string {
+	path = strings.Trim(path, "/")
+	if path == "" {
+		return nil
+	}
+	return strings.Split(path, "/")
+}
+
+// graphqlMutationOperations maps GraphQL mutation names to operations. Names
+// that need the query body (updateRef, review submissions) are handled in
+// graphqlOperations.
+var graphqlMutationOperations = map[string]string{
+	"deleteRef":                   OperationDeleteRef,
+	"mergePullRequest":            OperationMergePullRequest,
+	"enqueuePullRequest":          OperationMergePullRequest,
+	"enablePullRequestAutoMerge":  OperationEnableAutoMerge,
+	"disablePullRequestAutoMerge": OperationDisableAutoMerge,
+	"createRelease":               OperationCreateRelease,
+	"updateRepository":            OperationEditRepository,
+	"archiveRepository":           OperationEditRepository,
+	"unarchiveRepository":         OperationEditRepository,
+	"transferRepository":          OperationTransferRepository,
+	"createBranchProtectionRule":  OperationEditBranchProtection,
+	"updateBranchProtectionRule":  OperationEditBranchProtection,
+	"deleteBranchProtectionRule":  OperationEditBranchProtection,
+	"createRepositoryRuleset":     OperationEditBranchProtection,
+	"updateRepositoryRuleset":     OperationEditBranchProtection,
+	"deleteRepositoryRuleset":     OperationEditBranchProtection,
+}
+
+var (
+	graphqlMutationKeyword = regexp.MustCompile(`\bmutation\b`)
+	graphqlFieldCall       = regexp.MustCompile(`([A-Za-z_][A-Za-z0-9_]*)\s*\(`)
+	graphqlForceLiteral    = regexp.MustCompile(`\bforce\s*:\s*true\b`)
+	graphqlApproveLiteral  = regexp.MustCompile(`\bevent\s*:\s*APPROVE\b`)
+)
+
+// graphqlOperations classifies a literal GraphQL document. Only the
+// top-level fields of each `mutation { … }` body count; a document without
+// a mutation is a read and yields nothing.
+func graphqlOperations(query string) []string {
+	names := graphqlMutationFields(query)
+	if len(names) == 0 {
+		return nil
+	}
+	force := graphqlForceLiteral.MatchString(query)
+	approve := graphqlApproveLiteral.MatchString(query)
+	tag := strings.Contains(query, "refs/tags/")
+	var operations []string
+	for _, name := range names {
+		switch name {
+		case "updateRef":
+			switch {
+			case force:
+				operations = append(operations, OperationForcePush)
+				if tag {
+					operations = append(operations, OperationMoveTag)
+				}
+			case tag:
+				operations = append(operations, OperationMoveTag)
+			default:
+				operations = append(operations, OperationUpdateRef)
+			}
+		case "addPullRequestReview", "submitPullRequestReview":
+			if approve {
+				operations = append(operations, OperationApprovePullRequest)
+			} else {
+				operations = append(operations, OperationOtherWrite)
+			}
+		default:
+			if operation, ok := graphqlMutationOperations[name]; ok {
+				operations = append(operations, operation)
+			} else {
+				operations = append(operations, OperationOtherWrite)
+			}
+		}
+	}
+	return operations
+}
+
+// graphqlMutationFields returns the field names called at the top level of
+// every mutation body in the document, in order.
+func graphqlMutationFields(query string) []string {
+	var names []string
+	rest := query
+	for {
+		loc := graphqlMutationKeyword.FindStringIndex(rest)
+		if loc == nil {
+			return names
+		}
+		rest = rest[loc[1]:]
+		open := strings.Index(rest, "{")
+		if open < 0 {
+			return names
+		}
+		body, end := topLevelBody(rest[open:])
+		for _, match := range graphqlFieldCall.FindAllStringSubmatch(body, -1) {
+			names = append(names, match[1])
+		}
+		rest = rest[open+end:]
+	}
+}
+
+// topLevelBody returns the text at brace depth one of the block that starts
+// at text[0] == '{', with nested blocks and string literals blanked out, and
+// the offset just past the closing brace.
+func topLevelBody(text string) (string, int) {
+	var out strings.Builder
+	depth := 0
+	inString := false
+	for i := 0; i < len(text); i++ {
+		ch := text[i]
+		if inString {
+			if ch == '\\' && i+1 < len(text) {
+				i++
+			} else if ch == '"' {
+				inString = false
+			}
+			out.WriteByte(' ')
+			continue
+		}
+		switch ch {
+		case '"':
+			inString = true
+			out.WriteByte(' ')
+		case '{':
+			depth++
+			out.WriteByte(' ')
+		case '}':
+			depth--
+			out.WriteByte(' ')
+			if depth == 0 {
+				return out.String(), i + 1
+			}
+		default:
+			if depth == 1 {
+				out.WriteByte(ch)
+			} else {
+				out.WriteByte(' ')
+			}
+		}
+	}
+	return out.String(), len(text)
+}
+
+// graphqlQueryText finds the literal query in gh api fields (`query=…`) or
+// curl bodies (`{"query": "…"}`, `query=…`). ok is false when no literal
+// query is present: a file reference, a variable, or an --input body.
+func graphqlQueryText(values []string) (string, bool) {
+	for _, value := range values {
+		if query, found := strings.CutPrefix(value, "query="); found {
+			if query == "" || strings.HasPrefix(query, "@") {
+				return "", false
+			}
+			return query, true
+		}
+		var body map[string]any
+		if json.Unmarshal([]byte(value), &body) == nil {
+			if query, isString := body["query"].(string); isString && query != "" {
+				return query, true
+			}
+		}
+	}
+	return "", false
+}
+
+// bodyHasField reports a request field with a literal string value, in gh
+// `key=value` form or inside a JSON body.
+func bodyHasField(values []string, key, want string) bool {
+	for _, value := range values {
+		if value == key+"="+want {
+			return true
+		}
+		var body map[string]any
+		if json.Unmarshal([]byte(value), &body) == nil {
+			if got, isString := body[key].(string); isString && got == want {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/shellprojection/github_operations_test.go
+++ b/internal/shellprojection/github_operations_test.go
@@ -1,0 +1,306 @@
+package shellprojection
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kontext-security/kontext/internal/toolcatalog"
+)
+
+func op(operation string) string { return OperationFact(operation) }
+
+// TestOperationVocabulary pins the exact fact strings the cloud presets
+// match. A rename here is a contract change for every template.
+func TestOperationVocabulary(t *testing.T) {
+	want := []string{
+		"github/operation=force-push", "github/operation=force-push-with-lease", "github/operation=delete-ref",
+		"github/operation=move-tag", "github/operation=update-ref", "github/operation=merge-pull-request",
+		"github/operation=enable-auto-merge", "github/operation=disable-auto-merge", "github/operation=merge-branch",
+		"github/operation=approve-pull-request", "github/operation=create-release", "github/operation=edit-release",
+		"github/operation=delete-release", "github/operation=upload-release-asset", "github/operation=run-workflow",
+		"github/operation=rerun-workflow-run", "github/operation=cancel-workflow-run", "github/operation=approve-workflow-run",
+		"github/operation=delete-workflow-run", "github/operation=enable-workflow", "github/operation=disable-workflow",
+		"github/operation=edit-repository", "github/operation=delete-repository", "github/operation=transfer-repository",
+		"github/operation=edit-branch-protection", "github/operation=edit-environment", "github/operation=edit-collaborators",
+		"github/operation=edit-webhooks", "github/operation=edit-deploy-keys", "github/operation=edit-secrets",
+		"github/operation=other-write",
+	}
+	got := operationFacts([]string{
+		OperationForcePush, OperationForcePushWithLease, OperationDeleteRef, OperationMoveTag, OperationUpdateRef,
+		OperationMergePullRequest, OperationEnableAutoMerge, OperationDisableAutoMerge, OperationMergeBranch,
+		OperationApprovePullRequest, OperationCreateRelease, OperationEditRelease, OperationDeleteRelease,
+		OperationUploadReleaseAsset, OperationRunWorkflow, OperationRerunWorkflowRun, OperationCancelWorkflowRun,
+		OperationApproveWorkflowRun, OperationDeleteWorkflowRun, OperationEnableWorkflow, OperationDisableWorkflow,
+		OperationEditRepository, OperationDeleteRepository, OperationTransferRepository, OperationEditBranchProtection,
+		OperationEditEnvironment, OperationEditCollaborators, OperationEditWebhooks, OperationEditDeployKeys,
+		OperationEditSecrets, OperationOtherWrite,
+	})
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("vocabulary = %v, want %v", got, want)
+	}
+	if got := toolcatalog.Operations(toolcatalog.GitHubToolPrefix + "merge_pull_request"); !reflect.DeepEqual(got, []string{OperationMergePullRequest}) {
+		t.Fatalf("toolcatalog merge operations = %v", got)
+	}
+}
+
+// TestGitHistoryOperations covers the protect-git-history vocabulary.
+func TestGitHistoryOperations(t *testing.T) {
+	deleteRef, forceOp, lease, moveTag, updateRef := op(OperationDeleteRef), op(OperationForcePush), op(OperationForcePushWithLease), op(OperationMoveTag), op(OperationUpdateRef)
+	runCorpus(t, []corpusCase{
+		{name: "plain push", command: "git push origin main", programs: []string{"git"}, facts: []string{write}, absentFacts: []string{deleteRef, forceOp, lease}, complete: true},
+		{name: "push tags", command: "git push --tags origin", programs: []string{"git"}, facts: []string{write}, absentFacts: []string{deleteRef, forceOp}, complete: true},
+		{name: "push feature branch", command: "git push origin feature", programs: []string{"git"}, facts: []string{write}, absentFacts: []string{deleteRef}, complete: true},
+		{name: "force short", command: "git push -f origin main", programs: []string{"git"}, facts: []string{forcePush, forceOp}, absentFacts: []string{lease, deleteRef}, complete: true},
+		{name: "force refspec", command: "git push origin +main:main", programs: []string{"git"}, facts: []string{forcePush, forceOp}, absentFacts: []string{deleteRef}, complete: true},
+		{name: "force with lease", command: "git push --force-with-lease origin main", programs: []string{"git"}, facts: []string{write, lease}, absentFacts: []string{forcePush, forceOp}, complete: true},
+		{name: "force with lease value", command: "git push --force-with-lease=main:abc origin main", programs: []string{"git"}, facts: []string{lease}, absentFacts: []string{forcePush}, complete: true},
+		{name: "force if includes", command: "git push --force-if-includes --force-with-lease origin main", programs: []string{"git"}, facts: []string{lease}, absentFacts: []string{forcePush}, complete: true},
+		{name: "delete long", command: "git push origin --delete feature", programs: []string{"git"}, facts: []string{write, deleteRef}, absentFacts: []string{forceOp}, complete: true},
+		{name: "delete short", command: "git push -d origin feature", programs: []string{"git"}, facts: []string{deleteRef}, complete: true},
+		{name: "delete in cluster", command: "git push -fd origin feature", programs: []string{"git"}, facts: []string{deleteRef, forceOp, forcePush}, complete: true},
+		{name: "empty source refspec", command: "git push origin :feature", programs: []string{"git"}, facts: []string{deleteRef}, absentFacts: []string{forceOp}, complete: true},
+		{name: "empty source tag refspec", command: "git push origin :refs/tags/v1.0", programs: []string{"git"}, facts: []string{deleteRef}, complete: true},
+		{name: "forced empty source refspec", command: "git push origin +:refs/tags/v1", programs: []string{"git"}, facts: []string{deleteRef, forceOp}, complete: true},
+		{name: "bare colon pushes matching", command: "git push origin :", programs: []string{"git"}, facts: []string{write}, absentFacts: []string{deleteRef}, complete: true},
+		{name: "prune", command: "git push --prune origin", programs: []string{"git"}, facts: []string{deleteRef}, absentFacts: []string{forceOp}, complete: true},
+		{name: "mirror", command: "git push --mirror origin", programs: []string{"git"}, facts: []string{deleteRef, forceOp, forcePush}, complete: true},
+		{name: "dry run delete", command: "git push -n --delete origin feature", programs: []string{"git"}, facts: []string{"github/dry-run=true"}, absentFacts: []string{deleteRef, write}, complete: true},
+		{name: "dry run lease", command: "git push --dry-run --force-with-lease origin main", programs: []string{"git"}, absentFacts: []string{lease, forceOp}, complete: true},
+		{name: "gh merge delete branch", command: "gh pr merge 42 --delete-branch", programs: []string{"gh"}, facts: []string{op(OperationMergePullRequest), deleteRef}, complete: true},
+		{name: "gh merge -d cluster", command: "gh pr merge 42 -sd", programs: []string{"gh"}, facts: []string{op(OperationMergePullRequest), deleteRef}, complete: true},
+		{name: "gh release delete cleanup tag", command: "gh release delete v1.2.0 --cleanup-tag", programs: []string{"gh"}, facts: []string{op(OperationDeleteRelease), deleteRef}, complete: true},
+		{name: "gh release delete keeps tag", command: "gh release delete v1.2.0 -y", programs: []string{"gh"}, facts: []string{op(OperationDeleteRelease)}, absentFacts: []string{deleteRef}, complete: true},
+		{name: "gh repo sync force", command: "gh repo sync --force", programs: []string{"gh"}, facts: []string{forceOp}, absentFacts: []string{forcePush}, complete: true},
+		{name: "gh repo sync", command: "gh repo sync", programs: []string{"gh"}, facts: []string{op(OperationOtherWrite)}, absentFacts: []string{forceOp}, complete: true},
+		{name: "api delete ref", command: "gh api -X DELETE repos/acme/api/git/refs/heads/old", programs: []string{"gh"}, facts: []string{deleteRef, catalogued}, features: []string{FeatureOperationFromRoute}, complete: true},
+		{name: "api delete ref full url", command: "gh api -X DELETE https://api.github.com/repos/acme/api/git/refs/heads/old", programs: []string{"gh"}, facts: []string{deleteRef}, complete: true},
+		{name: "api delete ref placeholders", command: "gh api -X DELETE repos/{owner}/{repo}/git/refs/heads/old", programs: []string{"gh"}, facts: []string{deleteRef}, complete: true},
+		{name: "api get ref", command: "gh api repos/acme/api/git/refs/heads/old", programs: []string{"gh"}, absentFacts: []string{deleteRef, write, op(OperationOtherWrite)}, complete: true},
+		{name: "api move tag", command: "gh api -X PATCH repos/acme/api/git/refs/tags/v1 -f sha=abc", programs: []string{"gh"}, facts: []string{moveTag}, absentFacts: []string{forceOp, updateRef}, complete: true},
+		{name: "api forced move tag", command: "gh api -X PATCH repos/acme/api/git/refs/tags/v1 -f sha=abc -f force=true", programs: []string{"gh"}, facts: []string{moveTag, forceOp, forcePush}, complete: true},
+		{name: "api fast forward ref", command: "gh api -X PATCH repos/acme/api/git/refs/heads/main -f sha=abc", programs: []string{"gh"}, facts: []string{updateRef}, absentFacts: []string{forceOp, moveTag, op(OperationOtherWrite)}, complete: true},
+		{name: "api forced ref", command: "gh api repos/acme/api/git/refs/heads/main -X PATCH -f force=true", programs: []string{"gh"}, facts: []string{forceOp, forcePush}, absentFacts: []string{updateRef}, complete: true},
+		{name: "api delete ref-ish segment", command: "gh api -X DELETE repos/acme/api/git/refs-archive/heads/old", programs: []string{"gh"}, facts: []string{op(OperationOtherWrite)}, absentFacts: []string{deleteRef}, complete: true},
+		{name: "curl delete ref", command: "curl -X DELETE https://api.github.com/repos/acme/api/git/refs/heads/x", programs: []string{"curl"}, facts: []string{deleteRef}, features: []string{FeatureOperationFromRoute}, complete: true},
+		{name: "curl force", command: `curl -X PATCH -d '{"force":true}' https://api.github.com/repos/acme/api/git/refs/heads/main`, programs: []string{"curl"}, facts: []string{forcePush, forceOp}, absentFacts: []string{updateRef}, complete: true},
+		{name: "graphql delete ref", command: `gh api graphql -f query='mutation { deleteRef(input: {refId: "R_1"}) { clientMutationId } }'`, programs: []string{"gh"}, facts: []string{deleteRef, catalogued}, features: []string{FeatureOperationFromGraphQL}, complete: true},
+		{name: "graphql forced update ref", command: `gh api graphql -f query='mutation { updateRef(input: {refId: "R_1", oid: "abc", force: true}) { clientMutationId } }'`, programs: []string{"gh"}, facts: []string{forceOp}, absentFacts: []string{updateRef, forcePush}, complete: true},
+		{name: "graphql tag move", command: `gh api graphql -f query='mutation { updateRef(input: {refId: "refs/tags/v1", oid: "abc"}) { clientMutationId } }'`, programs: []string{"gh"}, facts: []string{moveTag}, absentFacts: []string{forceOp}, complete: true},
+		{name: "graphql fast forward", command: `gh api graphql -f query='mutation { updateRef(input: {refId: "R_1", oid: "abc"}) { clientMutationId } }'`, programs: []string{"gh"}, facts: []string{updateRef}, absentFacts: []string{forceOp, moveTag}, complete: true},
+	})
+}
+
+// TestHumanMergeOperations covers the require-human-merge vocabulary.
+func TestHumanMergeOperations(t *testing.T) {
+	merge, auto, disableAuto, mergeBranch, approve, other := op(OperationMergePullRequest), op(OperationEnableAutoMerge), op(OperationDisableAutoMerge), op(OperationMergeBranch), op(OperationApprovePullRequest), op(OperationOtherWrite)
+	runCorpus(t, []corpusCase{
+		{name: "pr merge", command: "gh pr merge 42", programs: []string{"gh"}, facts: []string{"gh/command=pr/merge", write, merge}, absentFacts: []string{auto, other}, complete: true},
+		{name: "pr merge squash", command: "gh pr merge 42 --squash", programs: []string{"gh"}, facts: []string{merge}, complete: true},
+		{name: "pr merge via repo flag", command: "gh --repo acme/api pr merge 42", programs: []string{"gh"}, facts: []string{merge}, complete: true},
+		{name: "pr merge auto", command: "gh pr merge 42 --auto --squash", programs: []string{"gh"}, facts: []string{auto}, absentFacts: []string{merge}, complete: true},
+		{name: "pr merge disable auto", command: "gh pr merge 42 --disable-auto", programs: []string{"gh"}, facts: []string{disableAuto}, absentFacts: []string{merge, auto}, complete: true},
+		{name: "pr view", command: "gh pr view 42", programs: []string{"gh"}, facts: []string{"gh/command=pr/view"}, absentFacts: []string{merge, write, other}, complete: true},
+		{name: "pr create", command: "gh pr create --title x --body y", programs: []string{"gh"}, facts: []string{"gh/command=pr/create", write, other}, absentFacts: []string{merge}, complete: true},
+		{name: "pr edit", command: "gh pr edit 42 --add-label ready", programs: []string{"gh"}, facts: []string{other}, absentFacts: []string{merge}, complete: true},
+		{name: "pr review approve", command: "gh pr review 42 --approve", programs: []string{"gh"}, facts: []string{approve}, absentFacts: []string{merge, other}, complete: true},
+		{name: "pr review approve short", command: "gh pr review 42 -a", programs: []string{"gh"}, facts: []string{approve}, complete: true},
+		{name: "pr review comment", command: "gh pr review 42 --comment -b lgtm", programs: []string{"gh"}, facts: []string{other}, absentFacts: []string{approve}, complete: true},
+		{name: "api merge", command: "gh api -X PUT repos/o/r/pulls/42/merge", programs: []string{"gh"}, facts: []string{merge, catalogued}, complete: true},
+		{name: "api merge with input body", command: "gh api -X PUT repos/acme/api/pulls/42/merge --input body.json", programs: []string{"gh"}, facts: []string{merge, unrecognized}, complete: false},
+		{name: "api get pull", command: "gh api repos/o/r/pulls/42", programs: []string{"gh"}, absentFacts: []string{merge, write, other}, complete: true},
+		{name: "api merge-ish segment", command: "gh api -X PUT repos/o/r/pulls/42/merge-ish", programs: []string{"gh"}, facts: []string{other}, absentFacts: []string{merge}, complete: true},
+		{name: "api update branch", command: "gh api -X PUT repos/acme/api/pulls/42/update-branch", programs: []string{"gh"}, facts: []string{write, other}, absentFacts: []string{merge}, complete: true},
+		{name: "api edit pull", command: "gh api -X PATCH repos/acme/api/pulls/42 -f title=x", programs: []string{"gh"}, facts: []string{write, other}, absentFacts: []string{merge}, complete: true},
+		{name: "api merge branch", command: "gh api -X POST repos/acme/api/merges -f base=main -f head=feat", programs: []string{"gh"}, facts: []string{mergeBranch}, complete: true},
+		{name: "api merge upstream", command: "gh api repos/acme/api/merge-upstream -f branch=main", programs: []string{"gh"}, facts: []string{mergeBranch}, complete: true},
+		{name: "api approve review", command: "gh api repos/acme/api/pulls/42/reviews -f event=APPROVE", programs: []string{"gh"}, facts: []string{approve}, absentFacts: []string{other}, complete: true},
+		{name: "api comment review", command: "gh api repos/acme/api/pulls/42/reviews -f event=COMMENT", programs: []string{"gh"}, facts: []string{other}, absentFacts: []string{approve}, complete: true},
+		{name: "api submit approve event", command: "gh api repos/acme/api/pulls/42/reviews/7/events -f event=APPROVE", programs: []string{"gh"}, facts: []string{approve}, complete: true},
+		{name: "curl merge", command: `curl -X PUT -d '{"merge_method":"squash"}' https://api.github.com/repos/acme/api/pulls/42/merge`, programs: []string{"curl"}, facts: []string{merge}, complete: true},
+		{name: "curl approve", command: `curl -d '{"event":"APPROVE"}' https://api.github.com/repos/acme/api/pulls/42/reviews`, programs: []string{"curl"}, facts: []string{approve}, complete: true},
+		{name: "curl read pull", command: "curl https://api.github.com/repos/acme/api/pulls/42", programs: []string{"curl"}, absentFacts: []string{merge, other}, complete: true},
+		{name: "graphql merge", command: `gh api graphql -f query='mutation { mergePullRequest(input: {pullRequestId: "PR_1"}) { clientMutationId } }'`, programs: []string{"gh"}, facts: []string{merge}, complete: true},
+		{name: "graphql enqueue", command: `gh api graphql --raw-field query='mutation Enqueue($id: ID!) { enqueuePullRequest(input: {pullRequestId: $id}) { clientMutationId } }'`, programs: []string{"gh"}, facts: []string{merge}, absentFacts: []string{other}, complete: true},
+		{name: "graphql enable auto merge", command: `gh api graphql -f query='mutation { enablePullRequestAutoMerge(input:{pullRequestId:"X"}) { clientMutationId } }'`, programs: []string{"gh"}, facts: []string{auto}, complete: true},
+		{name: "graphql disable auto merge", command: `gh api graphql -f query='mutation { disablePullRequestAutoMerge(input:{pullRequestId:"X"}) { clientMutationId } }'`, programs: []string{"gh"}, facts: []string{disableAuto}, absentFacts: []string{auto, merge}, complete: true},
+		{name: "graphql approve review", command: `gh api graphql -f query='mutation { addPullRequestReview(input: {pullRequestId: "X", event: APPROVE}) { clientMutationId } }'`, programs: []string{"gh"}, facts: []string{approve}, complete: true},
+		{name: "graphql comment review", command: `gh api graphql -f query='mutation { addPullRequestReview(input: {pullRequestId: "X", event: COMMENT}) { clientMutationId } }'`, programs: []string{"gh"}, facts: []string{other}, absentFacts: []string{approve}, complete: true},
+		{name: "graphql query is a read", command: `gh api graphql -f query='query { viewer { login } }'`, programs: []string{"gh"}, facts: []string{write, catalogued}, absentFacts: []string{merge, other}, complete: true},
+		{name: "graphql query from file", command: "gh api graphql -f query=@m.graphql", programs: []string{"gh"}, facts: []string{unrecognized}, absentFacts: []string{merge, other}, features: []string{FeatureGraphQLNotLiteral}, complete: false},
+		{name: "graphql query from variable", command: `gh api graphql -f query="$Q"`, programs: []string{"gh"}, facts: []string{unrecognized}, absentFacts: []string{merge}, features: []string{FeatureGraphQLNotLiteral}, complete: false},
+		{name: "graphql input body", command: "gh api graphql --input body.json", programs: []string{"gh"}, facts: []string{unrecognized}, absentFacts: []string{merge}, complete: false},
+		{name: "graphql unknown mutation", command: `gh api graphql -f query='mutation { addComment(input: {subjectId: "X", body: "hi"}) { clientMutationId } }'`, programs: []string{"gh"}, facts: []string{other}, absentFacts: []string{merge}, complete: true},
+		{name: "curl graphql merge", command: `curl -X POST -d '{"query":"mutation { mergePullRequest(input: {pullRequestId: \"PR_1\"}) { clientMutationId } }"}' https://api.github.com/graphql`, programs: []string{"curl"}, facts: []string{merge}, complete: true},
+		{name: "curl graphql from file", command: "curl -d @m.json https://api.github.com/graphql", programs: []string{"curl"}, facts: []string{unrecognized}, absentFacts: []string{merge, other}, features: []string{FeatureGraphQLNotLiteral}, complete: false},
+	})
+}
+
+// TestReleaseAndWorkflowOperations covers protect-releases-and-workflows.
+func TestReleaseAndWorkflowOperations(t *testing.T) {
+	other := op(OperationOtherWrite)
+	runCorpus(t, []corpusCase{
+		{name: "release list", command: "gh release list", programs: []string{"gh"}, facts: []string{"gh/command=release/list", catalogued}, absentFacts: []string{write, op(OperationCreateRelease)}, complete: true},
+		{name: "release create", command: "gh release create v1", programs: []string{"gh"}, facts: []string{op(OperationCreateRelease)}, absentFacts: []string{other}, complete: true},
+		{name: "release create notes", command: "gh release create v1.2.0 --notes x", programs: []string{"gh"}, facts: []string{op(OperationCreateRelease)}, complete: true},
+		{name: "release edit", command: "gh release edit v1.2.0 --draft=false", programs: []string{"gh"}, facts: []string{op(OperationEditRelease)}, complete: true},
+		{name: "release upload", command: "gh release upload v1.2.0 dist.zip", programs: []string{"gh"}, facts: []string{op(OperationUploadReleaseAsset)}, complete: true},
+		{name: "release delete asset", command: "gh release delete-asset v1.2.0 dist.zip", programs: []string{"gh"}, facts: []string{op(OperationDeleteRelease)}, complete: true},
+		{name: "release download", command: "gh release download v1.2.0", programs: []string{"gh"}, absentFacts: []string{write, op(OperationDeleteRelease)}, complete: true},
+		{name: "api create release", command: "gh api repos/acme/api/releases -f tag_name=v1", programs: []string{"gh"}, facts: []string{op(OperationCreateRelease), "http/method=POST"}, complete: true},
+		{name: "api list releases", command: "gh api repos/acme/api/releases", programs: []string{"gh"}, absentFacts: []string{op(OperationCreateRelease), other}, complete: true},
+		{name: "api generate notes", command: "gh api -X POST repos/acme/api/releases/generate-notes -f tag_name=v1", programs: []string{"gh"}, facts: []string{other}, absentFacts: []string{op(OperationCreateRelease), op(OperationEditRelease)}, complete: true},
+		{name: "api edit release", command: "gh api -X PATCH repos/acme/api/releases/1 -f name=x", programs: []string{"gh"}, facts: []string{op(OperationEditRelease)}, complete: true},
+		{name: "api edit release asset", command: "gh api -X PATCH repos/acme/api/releases/assets/9 -f name=x", programs: []string{"gh"}, facts: []string{op(OperationEditRelease)}, complete: true},
+		{name: "api delete release", command: "gh api -X DELETE repos/acme/api/releases/1", programs: []string{"gh"}, facts: []string{op(OperationDeleteRelease)}, complete: true},
+		{name: "api delete release asset", command: "gh api -X DELETE repos/acme/api/releases/assets/9", programs: []string{"gh"}, facts: []string{op(OperationDeleteRelease)}, complete: true},
+		{name: "curl upload asset", command: "curl -sS -T asset.zip https://uploads.github.com/repos/acme/api/releases/1/assets", programs: []string{"curl"}, facts: []string{op(OperationUploadReleaseAsset), "http/method=PUT"}, complete: true},
+		{name: "curl post asset", command: "curl -X POST --data-binary @asset.zip https://uploads.github.com/repos/acme/api/releases/1/assets?name=x", programs: []string{"curl"}, facts: []string{op(OperationUploadReleaseAsset)}, complete: false},
+		{name: "api host asset path is not upload", command: "gh api -X POST repos/acme/api/releases/1/assets", programs: []string{"gh"}, facts: []string{other}, absentFacts: []string{op(OperationUploadReleaseAsset)}, complete: true},
+		{name: "workflow run", command: "gh workflow run ci.yml", programs: []string{"gh"}, facts: []string{op(OperationRunWorkflow)}, absentFacts: []string{other}, complete: true},
+		{name: "workflow run inputs", command: "gh workflow run ci.yml -f env=prod", programs: []string{"gh"}, facts: []string{op(OperationRunWorkflow)}, complete: true},
+		{name: "workflow list", command: "gh workflow list", programs: []string{"gh"}, absentFacts: []string{op(OperationRunWorkflow), write}, complete: true},
+		{name: "workflow enable", command: "gh workflow enable ci.yml", programs: []string{"gh"}, facts: []string{op(OperationEnableWorkflow)}, complete: true},
+		{name: "workflow disable", command: "gh workflow disable ci.yml", programs: []string{"gh"}, facts: []string{op(OperationDisableWorkflow)}, complete: true},
+		{name: "run rerun", command: "gh run rerun 123 --failed", programs: []string{"gh"}, facts: []string{op(OperationRerunWorkflowRun)}, complete: true},
+		{name: "run cancel", command: "gh run cancel 123", programs: []string{"gh"}, facts: []string{op(OperationCancelWorkflowRun)}, complete: true},
+		{name: "run delete", command: "gh run delete 123", programs: []string{"gh"}, facts: []string{op(OperationDeleteWorkflowRun)}, complete: true},
+		{name: "run view", command: "gh run view 123 --log", programs: []string{"gh"}, facts: []string{"gh/command=run/view"}, absentFacts: []string{write, op(OperationRerunWorkflowRun)}, complete: true},
+		{name: "api dispatch workflow", command: "gh api -X POST repos/acme/api/actions/workflows/ci.yml/dispatches -f ref=main", programs: []string{"gh"}, facts: []string{op(OperationRunWorkflow)}, complete: true},
+		{name: "api repository dispatch", command: "gh api -X POST repos/acme/api/dispatches -f event_type=deploy", programs: []string{"gh"}, facts: []string{op(OperationRunWorkflow)}, complete: true},
+		{name: "api get workflow", command: "gh api repos/acme/api/actions/workflows/ci.yml", programs: []string{"gh"}, absentFacts: []string{op(OperationRunWorkflow), other}, complete: true},
+		{name: "api rerun", command: "gh api -X POST repos/acme/api/actions/runs/123/rerun", programs: []string{"gh"}, facts: []string{op(OperationRerunWorkflowRun)}, complete: true},
+		{name: "api rerun failed jobs", command: "gh api -X POST repos/acme/api/actions/runs/123/rerun-failed-jobs", programs: []string{"gh"}, facts: []string{op(OperationRerunWorkflowRun)}, complete: true},
+		{name: "api rerun job", command: "gh api -X POST repos/acme/api/actions/jobs/9/rerun", programs: []string{"gh"}, facts: []string{op(OperationRerunWorkflowRun)}, complete: true},
+		{name: "api cancel", command: "gh api -X POST repos/acme/api/actions/runs/123/cancel", programs: []string{"gh"}, facts: []string{op(OperationCancelWorkflowRun)}, complete: true},
+		{name: "api force cancel", command: "gh api -X POST repos/acme/api/actions/runs/123/force-cancel", programs: []string{"gh"}, facts: []string{op(OperationCancelWorkflowRun)}, complete: true},
+		{name: "api approve run", command: "gh api -X POST repos/acme/api/actions/runs/123/approve", programs: []string{"gh"}, facts: []string{op(OperationApproveWorkflowRun)}, complete: true},
+		{name: "api approve pending deployment", command: "gh api -X POST repos/acme/api/actions/runs/123/pending_deployments -f state=approved", programs: []string{"gh"}, facts: []string{op(OperationApproveWorkflowRun)}, complete: true},
+		{name: "api deployment protection rule", command: "gh api -X POST repos/acme/api/actions/runs/123/deployment_protection_rule -f state=approved", programs: []string{"gh"}, facts: []string{op(OperationApproveWorkflowRun)}, complete: true},
+		{name: "api delete run", command: "gh api -X DELETE repos/acme/api/actions/runs/123", programs: []string{"gh"}, facts: []string{op(OperationDeleteWorkflowRun)}, complete: true},
+		{name: "api delete run logs", command: "gh api -X DELETE repos/acme/api/actions/runs/123/logs", programs: []string{"gh"}, facts: []string{op(OperationDeleteWorkflowRun)}, complete: true},
+		{name: "api delete artifact", command: "gh api -X DELETE repos/acme/api/actions/artifacts/5", programs: []string{"gh"}, facts: []string{op(OperationDeleteWorkflowRun)}, complete: true},
+		{name: "api get run", command: "gh api repos/acme/api/actions/runs/123", programs: []string{"gh"}, absentFacts: []string{op(OperationDeleteWorkflowRun), other}, complete: true},
+		{name: "api enable workflow", command: "gh api -X PUT repos/acme/api/actions/workflows/ci.yml/enable", programs: []string{"gh"}, facts: []string{op(OperationEnableWorkflow)}, absentFacts: []string{op(OperationDisableWorkflow)}, complete: true},
+		{name: "api disable workflow", command: "gh api -X PUT repos/acme/api/actions/workflows/7/disable", programs: []string{"gh"}, facts: []string{op(OperationDisableWorkflow)}, complete: true},
+		{name: "curl rerun", command: "curl -X POST https://api.github.com/repos/acme/api/actions/runs/123/rerun", programs: []string{"curl"}, facts: []string{op(OperationRerunWorkflowRun)}, complete: true},
+		{name: "push tag", command: "git push origin v1.2.0", programs: []string{"git"}, facts: []string{write}, absentFacts: []string{op(OperationCreateRelease)}, complete: true},
+	})
+}
+
+// TestRepositorySettingsOperations covers protect-repository-settings.
+func TestRepositorySettingsOperations(t *testing.T) {
+	other := op(OperationOtherWrite)
+	runCorpus(t, []corpusCase{
+		{name: "repo view", command: "gh repo view acme/api", programs: []string{"gh"}, facts: []string{"gh/command=repo/view"}, absentFacts: []string{write, op(OperationEditRepository)}, complete: true},
+		{name: "repo edit", command: "gh repo edit --visibility private", programs: []string{"gh"}, facts: []string{op(OperationEditRepository)}, absentFacts: []string{other}, complete: true},
+		{name: "repo edit default branch", command: "gh repo edit --default-branch main", programs: []string{"gh"}, facts: []string{op(OperationEditRepository)}, complete: true},
+		{name: "repo rename", command: "gh repo rename new-name", programs: []string{"gh"}, facts: []string{op(OperationEditRepository)}, complete: true},
+		{name: "repo archive", command: "gh repo archive acme/api -y", programs: []string{"gh"}, facts: []string{op(OperationEditRepository)}, complete: true},
+		{name: "repo unarchive", command: "gh repo unarchive acme/api -y", programs: []string{"gh"}, facts: []string{"gh/command=repo/unarchive", write, op(OperationEditRepository)}, absentFacts: []string{unrecognized}, complete: true},
+		{name: "repo delete", command: "gh repo delete acme/api --yes", programs: []string{"gh"}, facts: []string{op(OperationDeleteRepository)}, absentFacts: []string{op(OperationEditRepository)}, complete: true},
+		{name: "repo create", command: "gh repo create acme/new --private", programs: []string{"gh"}, facts: []string{"gh/command=repo/create", other}, absentFacts: []string{op(OperationEditRepository)}, complete: true},
+		{name: "deploy key add", command: "gh repo deploy-key add key.pub", programs: []string{"gh"}, facts: []string{"gh/command=repo/deploy-key/add", write, op(OperationEditDeployKeys)}, complete: true},
+		{name: "deploy key delete", command: "gh repo deploy-key delete 123", programs: []string{"gh"}, facts: []string{op(OperationEditDeployKeys)}, complete: true},
+		{name: "deploy key list", command: "gh repo deploy-key list", programs: []string{"gh"}, facts: []string{"gh/command=repo/deploy-key/list", catalogued}, absentFacts: []string{write, op(OperationEditDeployKeys)}, complete: true},
+		{name: "autolink create", command: "gh repo autolink create TICKET- 'https://x/<num>'", programs: []string{"gh"}, facts: []string{"gh/command=repo/autolink/create", op(OperationEditRepository)}, complete: true},
+		{name: "autolink list", command: "gh repo autolink list", programs: []string{"gh"}, facts: []string{catalogued}, absentFacts: []string{write}, complete: true},
+		{name: "secret set", command: "gh secret set X", programs: []string{"gh"}, facts: []string{op(OperationEditSecrets)}, complete: true},
+		{name: "secret set body", command: "gh secret set NPM_TOKEN --body x", programs: []string{"gh"}, facts: []string{op(OperationEditSecrets)}, complete: true},
+		{name: "secret delete", command: "gh secret delete NPM_TOKEN", programs: []string{"gh"}, facts: []string{op(OperationEditSecrets)}, complete: true},
+		{name: "secret list", command: "gh secret list", programs: []string{"gh"}, facts: []string{"gh/command=secret/list"}, absentFacts: []string{write, op(OperationEditSecrets)}, complete: true},
+		{name: "variable set env", command: "gh variable set FOO --env prod --body bar", programs: []string{"gh"}, facts: []string{op(OperationEditSecrets)}, complete: true},
+		{name: "variable delete", command: "gh variable delete FOO", programs: []string{"gh"}, facts: []string{op(OperationEditSecrets)}, complete: true},
+		{name: "api edit repo", command: "gh api -X PATCH repos/acme/api -f allow_force_pushes=true", programs: []string{"gh"}, facts: []string{op(OperationEditRepository)}, absentFacts: []string{op(OperationDeleteRepository), forcePush}, complete: true},
+		{name: "api get repo", command: "gh api repos/acme/api", programs: []string{"gh"}, absentFacts: []string{op(OperationEditRepository), other}, complete: true},
+		{name: "api delete repo", command: "gh api -X DELETE repos/acme/api", programs: []string{"gh"}, facts: []string{op(OperationDeleteRepository)}, absentFacts: []string{op(OperationEditRepository)}, complete: true},
+		{name: "api delete deeper path is not repo", command: "gh api -X DELETE repos/acme/api/issues/1/labels/bug", programs: []string{"gh"}, facts: []string{other}, absentFacts: []string{op(OperationDeleteRepository)}, complete: true},
+		{name: "api transfer", command: "gh api -X POST repos/acme/api/transfer -f new_owner=x", programs: []string{"gh"}, facts: []string{op(OperationTransferRepository)}, complete: true},
+		{name: "api topics", command: "gh api -X PUT repos/acme/api/topics -f names[]=x", programs: []string{"gh"}, facts: []string{op(OperationEditRepository)}, complete: true},
+		{name: "api pages", command: "gh api -X POST repos/acme/api/pages -f build_type=workflow", programs: []string{"gh"}, facts: []string{op(OperationEditRepository)}, complete: true},
+		{name: "api actions permissions", command: "gh api -X PUT repos/acme/api/actions/permissions/workflow -f default_workflow_permissions=read", programs: []string{"gh"}, facts: []string{op(OperationEditRepository)}, complete: true},
+		{name: "api vulnerability alerts", command: "gh api -X DELETE repos/acme/api/vulnerability-alerts", programs: []string{"gh"}, facts: []string{op(OperationEditRepository)}, complete: true},
+		{name: "api branch protection input", command: "gh api -X PUT repos/acme/api/branches/main/protection --input p.json", programs: []string{"gh"}, facts: []string{op(OperationEditBranchProtection), unrecognized}, complete: false},
+		{name: "api delete branch protection", command: "gh api -X DELETE repos/acme/api/branches/main/protection", programs: []string{"gh"}, facts: []string{op(OperationEditBranchProtection)}, complete: true},
+		{name: "api required reviews", command: "gh api -X PATCH repos/acme/api/branches/main/protection/required_pull_request_reviews -f required_approving_review_count=2", programs: []string{"gh"}, facts: []string{op(OperationEditBranchProtection)}, complete: true},
+		{name: "api get branch protection", command: "gh api repos/acme/api/branches/main/protection", programs: []string{"gh"}, absentFacts: []string{op(OperationEditBranchProtection), other}, complete: true},
+		{name: "api create ruleset", command: "gh api repos/acme/api/rulesets -f name=x", programs: []string{"gh"}, facts: []string{op(OperationEditBranchProtection)}, complete: true},
+		{name: "api delete ruleset", command: "gh api -X DELETE repos/acme/api/rulesets/5", programs: []string{"gh"}, facts: []string{op(OperationEditBranchProtection)}, complete: true},
+		{name: "api rename branch", command: "gh api -X POST repos/acme/api/branches/main/rename -f new_name=trunk", programs: []string{"gh"}, facts: []string{op(OperationEditBranchProtection)}, complete: true},
+		{name: "api environment", command: "gh api -X PUT repos/acme/api/environments/prod", programs: []string{"gh"}, facts: []string{op(OperationEditEnvironment)}, complete: true},
+		{name: "api deployment branch policy", command: "gh api -X POST repos/acme/api/environments/prod/deployment-branch-policies -f name=main", programs: []string{"gh"}, facts: []string{op(OperationEditEnvironment)}, complete: true},
+		{name: "api environment secret", command: "gh api -X PUT repos/acme/api/environments/prod/secrets/TOKEN -f encrypted_value=x", programs: []string{"gh"}, facts: []string{op(OperationEditSecrets)}, absentFacts: []string{op(OperationEditEnvironment)}, complete: true},
+		{name: "api collaborator", command: "gh api -X PUT repos/acme/api/collaborators/bob -f permission=admin", programs: []string{"gh"}, facts: []string{op(OperationEditCollaborators)}, complete: true},
+		{name: "api remove collaborator", command: "gh api -X DELETE repos/acme/api/collaborators/bob", programs: []string{"gh"}, facts: []string{op(OperationEditCollaborators)}, complete: true},
+		{name: "api invitation", command: "gh api -X PATCH repos/acme/api/invitations/3 -f permissions=write", programs: []string{"gh"}, facts: []string{op(OperationEditCollaborators)}, complete: true},
+		{name: "api team repo", command: "gh api -X PUT orgs/acme/teams/core/repos/acme/api -f permission=push", programs: []string{"gh"}, facts: []string{op(OperationEditCollaborators)}, complete: true},
+		{name: "api webhook", command: "gh api repos/acme/api/hooks -f config[url]=https://x", programs: []string{"gh"}, facts: []string{op(OperationEditWebhooks)}, complete: true},
+		{name: "api webhook config", command: "gh api -X PATCH repos/acme/api/hooks/7/config -f url=https://y", programs: []string{"gh"}, facts: []string{op(OperationEditWebhooks)}, complete: true},
+		{name: "api list webhooks", command: "gh api repos/acme/api/hooks", programs: []string{"gh"}, absentFacts: []string{op(OperationEditWebhooks), other}, complete: true},
+		{name: "api deploy key", command: "gh api repos/acme/api/keys -f key=ssh-ed25519...", programs: []string{"gh"}, facts: []string{op(OperationEditDeployKeys)}, complete: true},
+		{name: "api delete deploy key", command: "gh api -X DELETE repos/acme/api/keys/12", programs: []string{"gh"}, facts: []string{op(OperationEditDeployKeys)}, complete: true},
+		{name: "api repo secret", command: "gh api -X PUT repos/acme/api/actions/secrets/TOKEN -f encrypted_value=x", programs: []string{"gh"}, facts: []string{op(OperationEditSecrets)}, complete: true},
+		{name: "api repo variable", command: "gh api repos/acme/api/actions/variables -f name=FOO -f value=bar", programs: []string{"gh"}, facts: []string{op(OperationEditSecrets)}, complete: true},
+		{name: "api dependabot secret", command: "gh api -X DELETE repos/acme/api/dependabot/secrets/TOKEN", programs: []string{"gh"}, facts: []string{op(OperationEditSecrets)}, complete: true},
+		{name: "api org secret", command: "gh api -X PUT orgs/acme/actions/secrets/TOKEN -f encrypted_value=x", programs: []string{"gh"}, facts: []string{op(OperationEditSecrets)}, complete: true},
+		{name: "api org variable", command: "gh api -X PATCH orgs/acme/actions/variables/FOO -f value=x", programs: []string{"gh"}, facts: []string{op(OperationEditSecrets)}, complete: true},
+		{name: "api user codespaces secret", command: "gh api -X PUT user/codespaces/secrets/TOKEN -f encrypted_value=x", programs: []string{"gh"}, facts: []string{op(OperationEditSecrets)}, complete: true},
+		{name: "api list secrets", command: "gh api repos/acme/api/actions/secrets", programs: []string{"gh"}, absentFacts: []string{op(OperationEditSecrets), other}, complete: true},
+		{name: "api create issue", command: "gh api repos/acme/api/issues -f title=x", programs: []string{"gh"}, facts: []string{other}, absentFacts: []string{op(OperationEditRepository)}, complete: true},
+		{name: "api edit org", command: "gh api -X PATCH orgs/acme -f description=x", programs: []string{"gh"}, facts: []string{other}, absentFacts: []string{op(OperationEditRepository)}, complete: true},
+		{name: "api enterprise host", command: "gh api -X DELETE https://ghe.example.com/api/v3/repos/acme/api", programs: []string{"gh"}, facts: []string{write}, absentFacts: []string{op(OperationDeleteRepository), other}, complete: true},
+		{name: "curl delete repo", command: "curl -X DELETE https://api.github.com/repos/o/r", programs: []string{"curl"}, facts: []string{op(OperationDeleteRepository)}, complete: true},
+		{name: "curl edit repo", command: `curl -X PATCH -d '{"private":true}' https://api.github.com/repos/acme/api`, programs: []string{"curl"}, facts: []string{op(OperationEditRepository)}, complete: true},
+		{name: "curl edit repo with query", command: `curl -X PATCH -d '{"private":true}' "https://api.github.com/repos/acme/api?x=1"`, programs: []string{"curl"}, facts: []string{op(OperationEditRepository)}, complete: true},
+		{name: "curl read repo", command: "curl https://api.github.com/repos/acme/api", programs: []string{"curl"}, absentFacts: []string{op(OperationEditRepository), other}, complete: true},
+		{name: "curl other host", command: `curl -X DELETE https://example.com/repos/o/r`, programs: []string{"curl"}, absentFacts: []string{op(OperationDeleteRepository), other, write}, complete: true},
+		{name: "graphql update repository", command: `gh api graphql -f query='mutation { updateRepository(input: {repositoryId: "R", hasWikiEnabled: false}) { clientMutationId } }'`, programs: []string{"gh"}, facts: []string{op(OperationEditRepository)}, complete: true},
+		{name: "graphql archive repository", command: `gh api graphql -f query='mutation { archiveRepository(input: {repositoryId: "R"}) { clientMutationId } }'`, programs: []string{"gh"}, facts: []string{op(OperationEditRepository)}, complete: true},
+		{name: "graphql branch protection rule", command: `gh api graphql -f query='mutation { createBranchProtectionRule(input: {repositoryId: "R", pattern: "main"}) { clientMutationId } }'`, programs: []string{"gh"}, facts: []string{op(OperationEditBranchProtection)}, complete: true},
+		{name: "graphql ruleset", command: `gh api graphql -f query='mutation { deleteRepositoryRuleset(input: {repositoryRulesetId: "X"}) { clientMutationId } }'`, programs: []string{"gh"}, facts: []string{op(OperationEditBranchProtection)}, complete: true},
+		{name: "graphql two mutations", command: `gh api graphql -f query='mutation { a: mergePullRequest(input: {pullRequestId: "P"}) { clientMutationId } b: deleteRef(input: {refId: "R"}) { clientMutationId } }'`, programs: []string{"gh"}, facts: []string{op(OperationMergePullRequest), op(OperationDeleteRef)}, complete: true},
+	})
+}
+
+func TestGraphQLMutationFields(t *testing.T) {
+	tests := []struct {
+		query string
+		want  []string
+	}{
+		{`mutation { mergePullRequest(input: {pullRequestId: "X"}) { clientMutationId } }`, []string{"mergePullRequest"}},
+		{`mutation M($id: ID!) { deleteRef(input: {refId: $id}) { clientMutationId } }`, []string{"deleteRef"}},
+		{`mutation { a: updateRef(input: {refId: "x", oid: "y"}) { ref { name } } b: deleteRef(input: {refId: "z"}) { clientMutationId } }`, []string{"updateRef", "deleteRef"}},
+		{`query { repository(owner: "o", name: "r") { id } }`, nil},
+		{`mutation { updateRef(input: {refId: "a", oid: "b"}) { ref { target { ... on Commit { history(first: 1) { totalCount } } } } } }`, []string{"updateRef"}},
+		{`mutation { x(input: {body: "mutation { deleteRef(input: {refId: \"a\"}) }"}) { id } }`, []string{"x"}},
+		{`mutation {`, nil},
+	}
+	for _, test := range tests {
+		if got := graphqlMutationFields(test.query); !reflect.DeepEqual(got, test.want) {
+			t.Errorf("graphqlMutationFields(%q) = %v, want %v", test.query, got, test.want)
+		}
+	}
+}
+
+func TestMatchSegments(t *testing.T) {
+	tests := []struct {
+		pattern, path string
+		want          bool
+	}{
+		{"repos/*/*", "repos/o/r", true},
+		{"repos/*/*", "repos/o/r/hooks", false},
+		{"repos/*/*", "repos//r", false},
+		{"repos/*/*/pulls/*/merge", "repos/o/r/pulls/42/merge", true},
+		{"repos/*/*/pulls/*/merge", "repos/o/r/pulls/42/merge-ish", false},
+		{"repos/*/*/pulls/*/merge", "repos/o/r/pulls/42/merge/x", false},
+		{"repos/*/*/git/refs/**", "repos/o/r/git/refs", false},
+		{"repos/*/*/git/refs/**", "repos/o/r/git/refs/heads", true},
+		{"repos/*/*/git/refs/**", "repos/o/r/git/refs/heads/feature/x", true},
+		{"repos/*/*/hooks", "repos/{owner}/{repo}/hooks", true},
+	}
+	for _, test := range tests {
+		got := matchSegments(pathSegments(test.pattern), pathSegments(test.path))
+		if got != test.want {
+			t.Errorf("matchSegments(%q, %q) = %t, want %t", test.pattern, test.path, got, test.want)
+		}
+	}
+}

--- a/internal/shellprojection/project.go
+++ b/internal/shellprojection/project.go
@@ -502,7 +502,15 @@ func classifyGit(args []string, complete bool) cedareval.ShellProjectionV2 {
 	if !dryRun {
 		force := hasArg(options, "-f", "--force", "--mirror") || hasForceRefspec(refspecs)
 		if force {
-			facts = append(facts, "github/force-push=true", "git/force=true")
+			facts = append(facts, "github/force-push=true", "git/force=true", OperationFact(OperationForcePush))
+		}
+		// Lease pushes are a separate operation: block-github-force-push
+		// promises to allow them, protect-git-history forbids them.
+		if hasForceWithLease(options) {
+			facts = append(facts, OperationFact(OperationForcePushWithLease))
+		}
+		if hasArg(options, "-d", "--delete", "--prune", "--mirror") || hasDeleteRefspec(refspecs) {
+			facts = append(facts, OperationFact(OperationDeleteRef))
 		}
 	}
 	return projection("git", facts, features, complete)
@@ -605,11 +613,21 @@ func classifyGH(args []string, complete bool) cedareval.ShellProjectionV2 {
 		return classifyGHAPI(args[1:], complete)
 	}
 	key := args[0]
-	if len(args) > 1 && !strings.HasPrefix(args[1], "-") {
-		key += "/" + args[1]
+	rest := args[1:]
+	if len(rest) > 0 && !strings.HasPrefix(rest[0], "-") {
+		key += "/" + rest[0]
+		rest = rest[1:]
+		// `repo deploy-key add` and `repo autolink create` carry their verb
+		// in a third word.
+		if ghNestedCommands[key] && len(rest) > 0 && !strings.HasPrefix(rest[0], "-") {
+			key += "/" + rest[0]
+			rest = rest[1:]
+		}
 	}
 	if ghWriteCommands[key] {
-		return projection("gh", []string{"gh/command=" + key, "github/route=catalogued", "github/write=true"}, nil, complete)
+		facts := []string{"gh/command=" + key, "github/route=catalogued", "github/write=true"}
+		facts = append(facts, operationFacts(ghOperations(key, rest))...)
+		return projection("gh", facts, nil, complete)
 	}
 	if ghReadCommands[key] || ghReadCommands[args[0]] {
 		return projection("gh", []string{"gh/command=" + key, "github/route=catalogued"}, nil, complete)
@@ -709,13 +727,49 @@ func classifyGHAPI(args []string, complete bool) cedareval.ShellProjectionV2 {
 	if isWriteMethod(method) {
 		facts = append(facts, "github/write=true")
 	}
-	if method == "PATCH" && strings.Contains(path, "/git/refs") && containsForceField(fields) {
+	force := method == "PATCH" && strings.Contains(path, "/git/refs") && containsForceField(fields)
+	if force {
 		facts = append(facts, "github/force-push=true")
 	}
+	operations, features, literal := githubOperations(path, method, fields, force)
+	facts = append(facts, operationFacts(operations)...)
+	complete = complete && literal
 	if !complete {
 		facts = replaceFact(facts, "github/route=catalogued", FactRouteUnrecognized)
 	}
-	return projection("gh", facts, nil, complete)
+	return projection("gh", facts, features, complete)
+}
+
+// githubOperations derives operation facts for a literal REST or GraphQL
+// call from its route (see githubRouteOperations) or its literal mutation
+// text. Route matching runs even for an incomplete call: the path is known
+// even when the body is not. literal is false when the call is GraphQL and
+// its query text cannot be read, which makes the route unrecognized.
+func githubOperations(path, method string, bodies []string, force bool) (operations, features []string, literal bool) {
+	literal = true
+	if path == "" {
+		return nil, nil, literal
+	}
+	host, segments, ok := githubAPISegments(path)
+	if !ok {
+		return nil, nil, literal
+	}
+	if host == hostGitHubAPI && len(segments) == 1 && segments[0] == "graphql" {
+		query, found := graphqlQueryText(bodies)
+		if !found {
+			return nil, []string{FeatureGraphQLNotLiteral}, false
+		}
+		operations = graphqlOperations(query)
+		if len(operations) > 0 {
+			features = append(features, FeatureOperationFromGraphQL)
+		}
+		return operations, features, literal
+	}
+	operations = githubRouteOperations(host, method, segments, force, bodyHasField(bodies, "event", "APPROVE"))
+	if len(operations) > 0 {
+		features = append(features, FeatureOperationFromRoute)
+	}
+	return operations, features, literal
 }
 
 // gh api flags that only affect output or transport; they never change what
@@ -826,10 +880,17 @@ func classifyCurl(args []string, complete bool) cedareval.ShellProjectionV2 {
 	if isWriteMethod(method) {
 		facts = append(facts, "github/write=true")
 	}
-	if method == "PATCH" && strings.Contains(parsed.Path, "/git/refs") && containsForceBody(bodies) {
+	force := method == "PATCH" && strings.Contains(parsed.Path, "/git/refs") && containsForceBody(bodies)
+	if force {
 		facts = append(facts, "github/force-push=true")
 	}
-	return projection("curl", facts, nil, complete)
+	operations, features, literal := githubOperations("https://"+host+parsed.EscapedPath(), method, bodies, force)
+	facts = append(facts, operationFacts(operations)...)
+	if !literal && complete {
+		complete = false
+		facts = replaceFact(facts, "github/route=catalogued", FactRouteUnrecognized)
+	}
+	return projection("curl", facts, features, complete)
 }
 
 var curlDataFlags = map[string]bool{"-d": true, "--data": true, "--data-raw": true, "--data-binary": true, "--data-urlencode": true, "--data-ascii": true, "--json": true, "-F": true, "--form": true, "--form-string": true}
@@ -957,7 +1018,8 @@ var ghWriteCommands = map[string]bool{
 	"label/clone": true, "label/create": true, "label/delete": true, "label/edit": true,
 	"pr/close": true, "pr/comment": true, "pr/create": true, "pr/edit": true, "pr/merge": true, "pr/ready": true, "pr/reopen": true, "pr/review": true,
 	"release/create": true, "release/delete": true, "release/delete-asset": true, "release/edit": true, "release/upload": true,
-	"repo/archive": true, "repo/create": true, "repo/delete": true, "repo/edit": true, "repo/fork": true, "repo/rename": true, "repo/sync": true,
+	"repo/archive": true, "repo/create": true, "repo/delete": true, "repo/edit": true, "repo/fork": true, "repo/rename": true, "repo/sync": true, "repo/unarchive": true,
+	"repo/autolink/create": true, "repo/autolink/delete": true, "repo/deploy-key/add": true, "repo/deploy-key/delete": true,
 	"run/cancel": true, "run/delete": true, "run/rerun": true,
 	"secret/delete": true, "secret/set": true, "variable/delete": true, "variable/set": true,
 	"workflow/disable": true, "workflow/enable": true, "workflow/run": true,
@@ -969,6 +1031,10 @@ var ghReadCommands = map[string]bool{
 	"pr/checks": true, "pr/diff": true, "pr/list": true, "pr/status": true, "pr/view": true,
 	"release/download": true, "release/list": true, "release/view": true,
 	"repo/clone": true, "repo/list": true, "repo/view": true,
+	"repo/autolink/list": true, "repo/autolink/view": true, "repo/deploy-key/list": true,
 	"run/list": true, "run/view": true, "run/watch": true, "search": true,
 	"secret/list": true, "status": true, "variable/list": true, "workflow/list": true, "workflow/view": true,
 }
+
+// ghNestedCommands take their verb as a third word (`repo deploy-key add`).
+var ghNestedCommands = map[string]bool{"repo/autolink": true, "repo/deploy-key": true}

--- a/internal/toolcatalog/github.go
+++ b/internal/toolcatalog/github.go
@@ -171,3 +171,24 @@ func validType(kind string, value any) bool {
 	}
 	return false
 }
+
+// githubOperations is the crosswalk from catalogued GitHub MCP write tools
+// to the github/operation vocabulary the shell projection emits for git, gh
+// and curl. Cedar matches MCP calls by resource id, so the presets list the
+// tool ids directly; this table keeps the two surfaces named consistently
+// for trace display and template authors. The pinned catalog has no
+// ref-deleting, release, workflow or settings tool, so merge is the only
+// row until it is re-pinned.
+var githubOperations = map[string][]string{
+	GitHubToolPrefix + "merge_pull_request": {"merge-pull-request"},
+}
+
+// Operations returns the github/operation values a resolved GitHub MCP tool
+// id performs, or nil for reads, unrecognized and non-GitHub tools.
+func Operations(toolID string) []string {
+	operations := githubOperations[toolID]
+	if len(operations) == 0 {
+		return nil
+	}
+	return append([]string(nil), operations...)
+}

--- a/internal/toolcatalog/github_test.go
+++ b/internal/toolcatalog/github_test.go
@@ -56,3 +56,14 @@ func TestCatalogDigestIsStable(t *testing.T) {
 		t.Fatalf("Digest() = %q, want %q", got, want)
 	}
 }
+
+func TestOperations(t *testing.T) {
+	if got := Operations(GitHubToolPrefix + "merge_pull_request"); len(got) != 1 || got[0] != "merge-pull-request" {
+		t.Fatalf("Operations(merge_pull_request) = %v", got)
+	}
+	for _, toolID := range []string{GitHubToolPrefix + "update_pull_request", GitHubToolPrefix + "create_branch", GitHubUnrecognizedTool, "shell", ""} {
+		if got := Operations(toolID); got != nil {
+			t.Errorf("Operations(%q) = %v, want nil", toolID, got)
+		}
+	}
+}


### PR DESCRIPTION
## What

CLI half of the four GitHub write-guard presets. The shell projection now emits `github/operation=<verb-object>` facts from git, gh and curl so a Cedar template can forbid one effect with a single `facts.contains`. A call can carry several (`gh pr merge --delete-branch` emits `merge-pull-request` and `delete-ref`).

`github/write=true`, `github/route=*` and `github/force-push=true` keep their current meaning; the new facts sit beside them.

Stacked on `feat/cedar-codex-hooks`. Does not rebuild the daemon binary.

## Fact vocabulary

| `github/operation=` | git | gh | REST (`gh api`, `curl` to api.github.com / uploads.github.com) | GraphQL (literal `query=` only) | Preset |
|---|---|---|---|---|---|
| `force-push` | `-f`, `--force`, `--mirror`, `+refspec` | `repo sync --force` | `PATCH repos/*/*/git/refs/**` with `force=true` | `updateRef` with `force: true` | history |
| `force-push-with-lease` | `--force-with-lease[=…]`, `--force-if-includes` (no `github/force-push=true`) | | | | history |
| `delete-ref` | `-d`, `--delete`, `--prune`, `--mirror`, `:ref`, `+:ref` | `pr merge -d/--delete-branch`, `release delete --cleanup-tag` | `DELETE repos/*/*/git/refs/**` | `deleteRef` | history |
| `move-tag` | | | `PATCH repos/*/*/git/refs/tags/**` (with or without force) | `updateRef` naming `refs/tags/` | history |
| `update-ref` | | | `PATCH repos/*/*/git/refs/heads/**` without force | `updateRef` non-force, non-tag | none |
| `merge-pull-request` | | `pr merge` (not `--auto`/`--disable-auto`) | `PUT repos/*/*/pulls/*/merge` | `mergePullRequest`, `enqueuePullRequest` | merge |
| `enable-auto-merge` | | `pr merge --auto` | | `enablePullRequestAutoMerge` | merge |
| `disable-auto-merge` | | `pr merge --disable-auto` | | `disablePullRequestAutoMerge` | none |
| `merge-branch` | | | `POST repos/*/*/merges`, `POST repos/*/*/merge-upstream` | | merge |
| `approve-pull-request` | | `pr review -a/--approve` | `POST …/pulls/*/reviews[/*/events]` with `event=APPROVE` | `addPullRequestReview` / `submitPullRequestReview` with `event: APPROVE` | optional |
| `create-release` | | `release create` | `POST repos/*/*/releases` | `createRelease` | releases |
| `edit-release` | | `release edit` | `PATCH repos/*/*/releases/*`, `PATCH …/releases/assets/*` | | releases |
| `delete-release` | | `release delete`, `release delete-asset` | `DELETE repos/*/*/releases/*`, `DELETE …/releases/assets/*` | | releases |
| `upload-release-asset` | | `release upload` | `POST\|PUT uploads.github.com/repos/*/*/releases/*/assets` | | releases |
| `run-workflow` | | `workflow run` | `POST …/actions/workflows/*/dispatches`, `POST repos/*/*/dispatches` | | releases |
| `rerun-workflow-run` | | `run rerun` | `POST …/actions/runs/*/rerun`, `…/rerun-failed-jobs`, `…/actions/jobs/*/rerun` | | releases |
| `cancel-workflow-run` | | `run cancel` | `POST …/actions/runs/*/cancel`, `…/force-cancel` | | releases |
| `approve-workflow-run` | | | `POST …/actions/runs/*/approve`, `…/pending_deployments`, `…/deployment_protection_rule` | | releases |
| `delete-workflow-run` | | `run delete` | `DELETE …/actions/runs/*`, `…/runs/*/logs`, `…/actions/artifacts/*` | | releases |
| `enable-workflow` | | `workflow enable` | `PUT …/actions/workflows/*/enable` | | releases |
| `disable-workflow` | | `workflow disable` | `PUT …/actions/workflows/*/disable` | | releases |
| `edit-repository` | | `repo edit\|rename\|archive\|unarchive`, `repo autolink create\|delete` | `PATCH repos/*/*`; topics, security fixes, vulnerability alerts, private reporting, actions permissions, interaction limits, pages, oidc, autolinks, code-scanning default-setup | `updateRepository`, `archiveRepository`, `unarchiveRepository` | settings |
| `delete-repository` | | `repo delete` | `DELETE repos/*/*` | | settings |
| `transfer-repository` | | | `POST repos/*/*/transfer` | `transferRepository` | settings |
| `edit-branch-protection` | | | `PUT\|PATCH\|POST\|DELETE …/branches/*/protection[/**]`, `POST\|PUT\|DELETE …/rulesets[/**]`, `POST …/branches/*/rename` | `create\|update\|deleteBranchProtectionRule`, `create\|update\|deleteRepositoryRuleset` | settings |
| `edit-environment` | | | `PUT\|DELETE …/environments/*`, deployment-branch-policies, deployment_protection_rules | | settings |
| `edit-collaborators` | | | `PUT\|DELETE …/collaborators/*`, `PATCH\|DELETE …/invitations/*`, `PUT\|DELETE orgs/*/teams/*/repos/*/*`, `PUT\|DELETE user/installations/*/repositories/*` | | settings |
| `edit-webhooks` | | | `POST\|PATCH\|DELETE …/hooks[/**]` | | settings |
| `edit-deploy-keys` | | `repo deploy-key add\|delete` | `POST\|DELETE …/keys[/**]` | | settings |
| `edit-secrets` | | `secret set\|delete`, `variable set\|delete` | actions/dependabot/codespaces/environment secrets and variables under `repos/*/*`, `orgs/*`, `user` | | settings |
| `other-write` | | any other `ghWriteCommands` key | any other write method on a literal GitHub path | any other literal mutation | none (sentinel) |

MCP: `toolcatalog.Operations("github-mcp/merge_pull_request")` returns `["merge-pull-request"]`; Cedar keeps matching MCP by resource id.

## Matching rules

- Route table is exact-segment: `*` is one non-empty segment, `**` one or more trailing segments, everything else literal. `pulls/42/merge-ish` and `refs-archive/...` do not match. `{owner}`/`{repo}` placeholders satisfy `*`.
- Path normalisation strips an `https://api.github.com` / `https://uploads.github.com` prefix, `?query`, and slashes. A full URL on another host (GHE) gets no operation.
- Routes classify even when the body is opaque (`--input`): `gh api -X PUT repos/o/r/pulls/42/merge --input body.json` emits `merge-pull-request` and keeps `github/route=unrecognized`.
- GraphQL only for path `graphql` with a literal query; top-level fields of each `mutation { … }` body are mapped by name. `-f query=@file`, `"$Q"`, `--input` and `curl -d @file` emit no operation, feature `graphql-query-not-literal`, and make the route unrecognized.
- New `gh/command=` keys: `repo/deploy-key/{add,delete,list}`, `repo/autolink/{create,delete,list,view}`, `repo/unarchive`.
- Features: `github-operation-from-route`, `github-operation-from-graphql`, `graphql-query-not-literal`.

## Tests

`internal/shellprojection/github_operations_test.go`: one corpus per preset (history 39 cases, merge 38, releases/workflows 45, settings 68) with positives and negatives per operation, plus vocabulary pin, GraphQL body extraction and segment-matching unit tests. `internal/toolcatalog/github_test.go` covers `Operations`. Existing corpora (force-push bypass, unrecognized-route contract) unchanged and green.

`gofmt -l` empty, `go vet ./...` clean, `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
