### PR TITLE
Ignore GraphQL comments and strings when classifying mutations

### DIFF
--- a/internal/shellprojection/github_operations.go
+++ b/internal/shellprojection/github_operations.go
@@ -494,7 +494,7 @@ func graphqlOperations(query string) []string {
 // every mutation body in the document, in order.
 func graphqlMutationFields(query string) []string {
 	var names []string
-	rest := query
+	rest := blankGraphqlNoise(query)
 	for {
 		loc := graphqlMutationKeyword.FindStringIndex(rest)
 		if loc == nil {
@@ -511,6 +511,49 @@ func graphqlMutationFields(query string) []string {
 		}
 		rest = rest[open+end:]
 	}
+}
+
+// blankGraphqlNoise replaces comments (# to end of line), string literals and
+// block strings with spaces, so neither a `# mutation {` comment nor a string
+// argument can pose as an operation or open a brace the parser then follows.
+func blankGraphqlNoise(query string) string {
+	out := []byte(query)
+	for i := 0; i < len(out); {
+		switch {
+		case out[i] == '#':
+			for i < len(out) && out[i] != '\n' {
+				out[i] = ' '
+				i++
+			}
+		case strings.HasPrefix(string(out[i:]), `"""`):
+			end := strings.Index(string(out[i+3:]), `"""`)
+			stop := len(out)
+			if end >= 0 {
+				stop = i + 3 + end + 3
+			}
+			for ; i < stop; i++ {
+				out[i] = ' '
+			}
+		case out[i] == '"':
+			out[i] = ' '
+			i++
+			for i < len(out) && out[i] != '"' {
+				if out[i] == '\\' && i+1 < len(out) {
+					out[i] = ' '
+					i++
+				}
+				out[i] = ' '
+				i++
+			}
+			if i < len(out) {
+				out[i] = ' '
+				i++
+			}
+		default:
+			i++
+		}
+	}
+	return string(out)
 }
 
 // topLevelBody returns the text at brace depth one of the block that starts

--- a/internal/shellprojection/github_operations.go
+++ b/internal/shellprojection/github_operations.go
@@ -526,10 +526,13 @@ func blankGraphqlNoise(query string) string {
 				i++
 			}
 		case strings.HasPrefix(string(out[i:]), `"""`):
-			end := strings.Index(string(out[i+3:]), `"""`)
+			// A block string ends at the first """ that is not escaped as \""".
 			stop := len(out)
-			if end >= 0 {
-				stop = i + 3 + end + 3
+			for j := i + 3; j+3 <= len(out); j++ {
+				if string(out[j:j+3]) == `"""` && out[j-1] != '\\' {
+					stop = j + 3
+					break
+				}
 			}
 			for ; i < stop; i++ {
 				out[i] = ' '

--- a/internal/shellprojection/github_operations_test.go
+++ b/internal/shellprojection/github_operations_test.go
@@ -1,6 +1,7 @@
 package shellprojection
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -301,6 +302,20 @@ func TestMatchSegments(t *testing.T) {
 		got := matchSegments(pathSegments(test.pattern), pathSegments(test.path))
 		if got != test.want {
 			t.Errorf("matchSegments(%q, %q) = %t, want %t", test.pattern, test.path, got, test.want)
+		}
+	}
+}
+
+func TestGraphqlMutationFieldsIgnoresCommentsAndStrings(t *testing.T) {
+	cases := map[string][]string{
+		"# mutation {\nmutation { deleteRef(input: {refId: \"x\"}) { clientMutationId } }":               {"deleteRef"},
+		"mutation { updateRef(input: {refId: \"mutation { deleteRef }\"}) { clientMutationId } }":        {"updateRef"},
+		"mutation { createIssue(input: {body: \"\"\"mutation {\n deleteRef\n\"\"\"}) { issue { id } } }": {"createIssue"},
+		"# only a comment mentioning mutation { deleteRef }":                                             nil,
+	}
+	for query, want := range cases {
+		if got := graphqlMutationFields(query); fmt.Sprint(got) != fmt.Sprint(want) {
+			t.Errorf("%q: fields = %v, want %v", query, got, want)
 		}
 	}
 }

--- a/internal/shellprojection/github_operations_test.go
+++ b/internal/shellprojection/github_operations_test.go
@@ -319,3 +319,12 @@ func TestGraphqlMutationFieldsIgnoresCommentsAndStrings(t *testing.T) {
 		}
 	}
 }
+
+func TestGraphqlMutationFieldsHonoursEscapedBlockStringQuotes(t *testing.T) {
+	query := "mutation { createIssue(input: {body: \"\"\"quote \\\"\"\" mutation { deleteRef }\"\"\"}) { issue { id } } }\n" +
+		"mutation { updateRef(input: {}) { clientMutationId } }"
+	want := []string{"createIssue", "updateRef"}
+	if got := graphqlMutationFields(query); fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Errorf("fields = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
Follow-up to #483, addressing the Greptile finding on `graphqlMutationFields`: a `# mutation {` comment or a string argument containing `mutation {` could pose as the operation and steer the brace parser past the real mutation, leaving `deleteRef` and friends catalogued but without their operation fact.

`blankGraphqlNoise` now replaces `#` comments, string literals and block strings with spaces before the mutation keyword and brace scan. Regression test covers a comment before the mutation, a string argument, a block string, and a comment-only document.

`go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)