### PR TITLE
Prompt submits fail open when the managed daemon is unavailable

### DIFF
--- a/internal/managedobserve/lifecycle.go
+++ b/internal/managedobserve/lifecycle.go
@@ -119,7 +119,9 @@ func (l Lifecycle) Process(ctx context.Context, event hook.Event) hook.Result {
 	switch event.HookName {
 	case hook.HookSessionStart:
 		return l.processWithKickstart(ctx, event, sessionStartWait)
-	case hook.HookPreToolUse:
+	case hook.HookPreToolUse, hook.HookUserPromptSubmit:
+		// Both gate something the person is waiting on, so both get the
+		// decision budget and a kickstart of a dead daemon.
 		return l.processWithKickstart(ctx, event, preToolUseWait)
 	default:
 		return l.processIfAvailable(ctx, event, asyncHookWait)
@@ -185,17 +187,26 @@ func (l Lifecycle) finalize(event hook.Event, result hook.Result) hook.Result {
 	return guardhookruntime.ObserveResult(event, result)
 }
 
+// failsClosedWhenUnavailable names the one hook that must deny without an
+// authoritative decision: PreToolUse gates a tool call, which is what policy
+// judges. A user prompt is not a tool call. Denying it because the daemon was
+// slow blocks the person, not the agent, and protects nothing, since every
+// tool call that follows is still gated. So prompt submits fail open.
+func failsClosedWhenUnavailable(name hook.HookName) bool {
+	return name == hook.HookPreToolUse
+}
+
 // daemonUnavailable is the fail path when the managed daemon cannot be reached.
-// Observe fails open (it never blocks). Enforce fails closed for blocking
-// hooks: enforcement requires an authoritative decision and an unreachable
-// daemon cannot provide one. Non-blocking lifecycle hooks remain informational.
+// Observe fails open (it never blocks). Enforce fails closed for PreToolUse:
+// enforcement requires an authoritative decision and an unreachable daemon
+// cannot provide one. Prompt submits and lifecycle hooks remain informational.
 // Remote fails closed only while the cached policy distribution claims
 // enforcement; otherwise it fails open like observe, so a fresh self-serve
 // install without an enforcing deployment never hard-blocks the agent.
 func (l Lifecycle) daemonUnavailable(event hook.Event) hook.Result {
 	if l.remote() && l.RemoteEnforce != nil && l.RemoteEnforce() {
 		decision := hook.DecisionAllow
-		if event.HookName.CanBlock() {
+		if failsClosedWhenUnavailable(event.HookName) {
 			decision = hook.DecisionDeny
 		}
 		return hook.Result{
@@ -206,7 +217,7 @@ func (l Lifecycle) daemonUnavailable(event hook.Event) hook.Result {
 	}
 	if l.enforcing() {
 		decision := hook.DecisionAllow
-		if event.HookName.CanBlock() {
+		if failsClosedWhenUnavailable(event.HookName) {
 			decision = hook.DecisionDeny
 		}
 		return hook.Result{

--- a/internal/managedobserve/lifecycle_test.go
+++ b/internal/managedobserve/lifecycle_test.go
@@ -334,6 +334,53 @@ func TestLifecycleEnforceUnavailableNonBlockingHookDoesNotDeny(t *testing.T) {
 	}
 }
 
+func TestLifecycleEnforceUnavailablePromptSubmitFailsOpen(t *testing.T) {
+	t.Parallel()
+
+	// A slow or dead daemon must not block the person's prompt: the tool
+	// calls that follow are still gated by PreToolUse.
+	lifecycle := Lifecycle{Mode: "enforce"}
+	result := lifecycle.daemonUnavailable(hook.Event{HookName: hook.HookUserPromptSubmit})
+	if result.Decision != hook.DecisionAllow || result.Mode != "enforce" {
+		t.Fatalf("daemonUnavailable() = %+v, want enforce allow for prompt submit", result)
+	}
+	if result.Reason != "Kontext enforce: managed policy daemon unavailable" {
+		t.Fatalf("reason = %q, want the unavailable reason kept for diagnostics", result.Reason)
+	}
+}
+
+func TestLifecycleRemoteUnavailablePromptSubmitFailsOpenWhileEnforcing(t *testing.T) {
+	t.Parallel()
+
+	lifecycle := Lifecycle{Mode: "remote", RemoteEnforce: func() bool { return true }}
+	result := lifecycle.daemonUnavailable(hook.Event{HookName: hook.HookUserPromptSubmit})
+	if result.Decision != hook.DecisionAllow {
+		t.Fatalf("daemonUnavailable() = %+v, want allow for prompt submit", result)
+	}
+	tool := lifecycle.daemonUnavailable(hook.Event{HookName: hook.HookPreToolUse})
+	if tool.Decision != hook.DecisionDeny {
+		t.Fatalf("daemonUnavailable() = %+v, want deny for pre-tool-use", tool)
+	}
+}
+
+func TestLifecycleEnforcePromptSubmitDeadDaemonAllowsAfterKickstart(t *testing.T) {
+	socketPath := filepath.Join("/tmp", fmt.Sprintf("kontext-managedobserve-prompt-down-%d.sock", time.Now().UnixNano()))
+	kickstarted := false
+	lifecycle := Lifecycle{
+		SocketPath: socketPath,
+		Label:      DefaultLaunchdLabel,
+		Mode:       "enforce",
+		Kickstart:  func(context.Context, string) error { kickstarted = true; return nil },
+	}
+	result := lifecycle.Process(context.Background(), hook.Event{HookName: hook.HookUserPromptSubmit})
+	if !kickstarted {
+		t.Fatal("prompt submit should kickstart a dead daemon like pre-tool-use does")
+	}
+	if result.Decision != hook.DecisionAllow {
+		t.Fatalf("result = %+v, want allow: a prompt is not a tool call", result)
+	}
+}
+
 func TestObserveResultFormatsBlockingPromptSubmit(t *testing.T) {
 	result := guardhookruntime.ObserveResult(hook.Event{HookName: hook.HookUserPromptSubmit}, hook.Result{
 		Decision: hook.DecisionDeny,


### PR DESCRIPTION
## Problem

With a deployment in Enforce, Codex users saw "Kontext enforce: managed policy daemon unavailable" on plain text prompts and the message was blocked. The `UserPromptSubmit` hook ran with a 120 ms budget, no daemon kickstart, and was treated like a tool call on failure: enforce + unreachable daemon = deny. Any daemon hiccup over 120 ms (SQLite `database is locked` bursts, cold pages, a policy refresh against a slow backend) blocked the person, regardless of what the policy said.

## Fix

- A prompt is not a tool call. Only `PreToolUse` fails closed without an authoritative decision; `UserPromptSubmit` fails open with the reason kept for diagnostics. Every tool call that follows is still gated.
- `UserPromptSubmit` now takes the same 250 ms budget and launchd kickstart path as `PreToolUse`.

Tests: enforce and remote-enforce prompt submits allow when the daemon is down; PreToolUse still denies; a dead daemon is kickstarted on prompt submit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)