### PR TITLE
Run the managed daemon in launchd's Standard class

### DIFF
--- a/internal/guard/app/server/cedar.go
+++ b/internal/guard/app/server/cedar.go
@@ -431,10 +431,27 @@ func applyCedarDecision(decision *risk.RiskDecision, mapping cedareval.DecisionM
 // Denies without a rule (enforcement not ready, engine errors, unavailable
 // ask) keep the generic wording.
 func cedarDecisionReason(mapping cedareval.DecisionMapping) string {
-	if mapping.EffectiveExecutionAction == cedareval.EffectiveExecutionActionDeny &&
-		mapping.DerivedCedarAction == cedareval.DerivedCedarActionDeny &&
+	if mapping.EffectiveExecutionAction != cedareval.EffectiveExecutionActionDeny {
+		return "local Cedar policy decision"
+	}
+	if mapping.DerivedCedarAction == cedareval.DerivedCedarActionDeny &&
 		len(mapping.DeterminingPolicyIDs) > 0 {
 		return "Blocked by rule " + strings.Join(mapping.DeterminingPolicyIDs, ", ")
 	}
-	return "local Cedar policy decision"
+	// A deny with no forbid rule to name: the effective reason code already
+	// tells default-deny, an unavailable approval, a not-ready policy and an
+	// evaluation failure apart, so the message should too.
+	switch mapping.EffectiveReasonCode {
+	case cedareval.ReasonAskUnavailable:
+		return "Approval required but unavailable"
+	case cedareval.ReasonEnforcementNotReady:
+		return "Cedar enforcement is not ready"
+	case cedareval.ReasonDefaultDeny:
+		return "No policy permits this action"
+	case cedareval.ReasonEngineError, cedareval.ReasonRequestConversionFailed,
+		cedareval.ReasonInvalidCachedPolicy, cedareval.ReasonStaleCachedPolicy:
+		return "Policy evaluation failed"
+	default:
+		return "local Cedar policy decision"
+	}
 }

--- a/internal/guard/app/server/cedar_test.go
+++ b/internal/guard/app/server/cedar_test.go
@@ -485,14 +485,14 @@ func TestCedarEnforceDenyReasonNamesRule(t *testing.T) {
 	}
 }
 
-func TestCedarEnforceKeepsGenericReasonWithoutRule(t *testing.T) {
+func TestCedarEnforceNamesNotReadyDeny(t *testing.T) {
 	provider := newCedarPolicyProvider(&countingHookPolicy{}, staticCedarSnapshots{snapshot: cedarpolicy.Snapshot{State: cedarpolicy.StateUnauthorized}}, CedarEnforcementStatic)
 	decision, err := provider.DecideHook(context.Background(), cedarHookEvent("Read", map[string]any{}))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if decision.Decision != risk.DecisionDeny || decision.Reason != "local Cedar policy decision" {
-		t.Fatalf("decision = %#v, want generic fail-closed wording", decision)
+	if decision.Decision != risk.DecisionDeny || decision.Reason != "Cedar enforcement is not ready" {
+		t.Fatalf("decision = %#v, want the not-ready deny named", decision)
 	}
 }
 
@@ -928,5 +928,72 @@ func TestCedarCodexNonShellAndEmptyInputs(t *testing.T) {
 	}
 	if mcp.Cedar.ToolID != "github-mcp/get_me" {
 		t.Fatalf("Cedar evidence = %#v, want pinned GitHub tool id", mcp.Cedar)
+	}
+}
+
+func TestCedarDecisionReasonDistinguishesDenyCauses(t *testing.T) {
+	cases := []struct {
+		name    string
+		mapping cedareval.DecisionMapping
+		want    string
+	}{
+		{
+			name: "named forbid",
+			mapping: cedareval.DecisionMapping{
+				EffectiveExecutionAction: cedareval.EffectiveExecutionActionDeny,
+				DerivedCedarAction:       cedareval.DerivedCedarActionDeny,
+				DeterminingPolicyIDs:     []string{"block-force-push"},
+			},
+			want: "Blocked by rule block-force-push",
+		},
+		{
+			name: "default deny",
+			mapping: cedareval.DecisionMapping{
+				EffectiveExecutionAction: cedareval.EffectiveExecutionActionDeny,
+				DerivedCedarAction:       cedareval.DerivedCedarActionDeny,
+				EffectiveReasonCode:      cedareval.ReasonDefaultDeny,
+			},
+			want: "No policy permits this action",
+		},
+		{
+			name: "ask unavailable",
+			mapping: cedareval.DecisionMapping{
+				EffectiveExecutionAction: cedareval.EffectiveExecutionActionDeny,
+				DerivedCedarAction:       cedareval.DerivedCedarActionAsk,
+				EffectiveReasonCode:      cedareval.ReasonAskUnavailable,
+			},
+			want: "Approval required but unavailable",
+		},
+		{
+			name: "not ready",
+			mapping: cedareval.DecisionMapping{
+				EffectiveExecutionAction: cedareval.EffectiveExecutionActionDeny,
+				EffectiveReasonCode:      cedareval.ReasonEnforcementNotReady,
+			},
+			want: "Cedar enforcement is not ready",
+		},
+		{
+			name: "engine error",
+			mapping: cedareval.DecisionMapping{
+				EffectiveExecutionAction: cedareval.EffectiveExecutionActionDeny,
+				EffectiveReasonCode:      cedareval.ReasonEngineError,
+			},
+			want: "Policy evaluation failed",
+		},
+		{
+			name: "allow keeps generic",
+			mapping: cedareval.DecisionMapping{
+				EffectiveExecutionAction: cedareval.EffectiveExecutionActionAllow,
+				EffectiveReasonCode:      cedareval.ReasonPermit,
+			},
+			want: "local Cedar policy decision",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cedarDecisionReason(tc.mapping); got != tc.want {
+				t.Fatalf("cedarDecisionReason = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/guard/store/sqlite/store.go
+++ b/internal/guard/store/sqlite/store.go
@@ -106,9 +106,20 @@ func OpenStore(path string) (*Store, error) {
 		return nil, err
 	}
 	db.SetMaxOpenConns(1)
-	if _, err := db.ExecContext(context.Background(), "pragma busy_timeout = 5000"); err != nil {
-		db.Close()
-		return nil, err
+	// WAL lets the doctor's and the menubar's read-only opens coexist with the
+	// daemon's writes; in the default rollback journal every reader blocks the
+	// writer and the deferred decision records time out on SQLITE_BUSY.
+	// synchronous=NORMAL is the WAL-safe fsync level (durable across crashes,
+	// one fsync per checkpoint instead of per commit).
+	for _, pragma := range []string{
+		"pragma busy_timeout = 5000",
+		"pragma journal_mode = WAL",
+		"pragma synchronous = NORMAL",
+	} {
+		if _, err := db.ExecContext(context.Background(), pragma); err != nil {
+			db.Close()
+			return nil, err
+		}
 	}
 	signer, err := newReceiptSigner(path)
 	if err != nil {

--- a/internal/guard/store/sqlite/store.go
+++ b/internal/guard/store/sqlite/store.go
@@ -309,8 +309,25 @@ func (s *Store) migrate(ctx context.Context) error {
 			return err
 		}
 	}
-	if err := s.backfillAuthorizationActionCursorKeys(ctx); err != nil {
+	// The cursor-key backfill is a one-time migration of rows written before
+	// the column existed; every write since keeps the key in step with
+	// updated_at, so once done no row drifts. Gate it on user_version so it
+	// runs once per database rather than on every OpenStore: the managed
+	// stream flusher reopens the store every 10s, and an ungated full-table
+	// scan there burned CPU that starved the enforce hook's 250ms budget.
+	// ponytail: user_version is this store's single migration counter; a later
+	// backfill bumps it to 2.
+	var cursorBackfillVersion int
+	if err := s.db.QueryRowContext(ctx, "pragma user_version").Scan(&cursorBackfillVersion); err != nil {
 		return err
+	}
+	if cursorBackfillVersion < 1 {
+		if err := s.backfillAuthorizationActionCursorKeys(ctx); err != nil {
+			return err
+		}
+		if _, err := s.db.ExecContext(ctx, "pragma user_version = 1"); err != nil {
+			return err
+		}
 	}
 	if _, err := s.db.ExecContext(ctx, `
 	create index if not exists idx_authorization_actions_session_updated

--- a/internal/guard/store/sqlite/store_test.go
+++ b/internal/guard/store/sqlite/store_test.go
@@ -1891,3 +1891,42 @@ func TestSaveDecisionHonorsPresetEventID(t *testing.T) {
 		t.Fatalf("record.ID = %q, want preset %q", record.ID, preset)
 	}
 }
+
+func TestOpenStoreGatesCursorBackfillOnUserVersion(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/guard.db"
+	store, err := OpenStore(path)
+	if err != nil {
+		t.Fatalf("OpenStore() error = %v", err)
+	}
+	var version int
+	if err := store.db.QueryRowContext(context.Background(), "pragma user_version").Scan(&version); err != nil {
+		t.Fatalf("read user_version: %v", err)
+	}
+	if version != 1 {
+		t.Fatalf("user_version = %d, want 1 after first open runs the one-time backfill", version)
+	}
+	// A row whose cursor key is deliberately wrong: a re-run of the backfill
+	// would rewrite it, so if it survives a reopen the backfill was skipped.
+	actions := insertLifecycleActions(t, store)
+	if _, err := store.db.ExecContext(context.Background(),
+		`update authorization_actions set updated_at_cursor_key = 'sentinel' where id = ?`, actions[0].ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := OpenStore(path)
+	if err != nil {
+		t.Fatalf("reopen error = %v", err)
+	}
+	defer reopened.Close()
+	var key string
+	if err := reopened.db.QueryRowContext(context.Background(),
+		`select updated_at_cursor_key from authorization_actions where id = ?`, actions[0].ID).Scan(&key); err != nil {
+		t.Fatal(err)
+	}
+	if key != "sentinel" {
+		t.Fatalf("cursor key = %q, want the backfill skipped on reopen (user_version already 1)", key)
+	}
+}

--- a/internal/managedobserve/daemon.go
+++ b/internal/managedobserve/daemon.go
@@ -65,6 +65,7 @@ func RunDaemon(ctx context.Context, opts DaemonOptions) error {
 		binaryVersion = "dev"
 	}
 	logAlways(opts.Diagnostic, "managed-observe daemon %s (pid %d) started\n", binaryVersion, os.Getpid())
+	healLaunchAgentPriority(DefaultLabel(), opts.Diagnostic)
 
 	loadedConfig, err := managedconfig.Load()
 	if err != nil {

--- a/internal/managedobserve/launchagent_heal.go
+++ b/internal/managedobserve/launchagent_heal.go
@@ -11,19 +11,27 @@ import (
 	"github.com/kontext-security/kontext/internal/diagnostic"
 )
 
-const backgroundProcessType = "<key>ProcessType</key>\n\t<string>Background</string>"
-const standardProcessType = "<key>ProcessType</key>\n\t<string>Standard</string>"
+// plistFixes are the settings older setups wrote that make the hook see a
+// dead daemon. Background is macOS's throttled QoS: the daemon starves
+// whenever the user does anything, the hook times out and fails closed in
+// enforce. ThrottleInterval 30 makes launchd hold a relaunch for up to 30 s
+// when the daemon restarts twice in a row (doctor --fix after an upgrade),
+// longer than the hook waits; 10 is launchd's floor.
+var plistFixes = [][2]string{
+	{"<key>ProcessType</key>\n\t<string>Background</string>", "<key>ProcessType</key>\n\t<string>Standard</string>"},
+	{"<key>ThrottleInterval</key>\n\t<integer>30</integer>", "<key>ThrottleInterval</key>\n\t<integer>10</integer>"},
+}
 
-// raiseProcessType rewrites a LaunchAgent plist that runs the daemon in
-// launchd's Background class to Standard. Background is macOS's throttled
-// QoS: the daemon starves whenever the user does anything, and the hook,
-// a foreground process with a 250 ms budget, reads that as a dead daemon and
-// fails closed in enforce. Returns false when nothing needed changing.
-func raiseProcessType(plist string) (string, bool) {
-	if !strings.Contains(plist, backgroundProcessType) {
-		return plist, false
+// healPlist applies plistFixes. Returns false when nothing needed changing.
+func healPlist(plist string) (string, bool) {
+	changed := false
+	for _, fix := range plistFixes {
+		if strings.Contains(plist, fix[0]) {
+			plist = strings.Replace(plist, fix[0], fix[1], 1)
+			changed = true
+		}
 	}
-	return strings.Replace(plist, backgroundProcessType, standardProcessType, 1), true
+	return plist, changed
 }
 
 // healLaunchAgentPriority fixes an installed plist from an older setup and
@@ -32,6 +40,11 @@ func raiseProcessType(plist string) (string, bool) {
 // daemon is not ours to rewrite. The reload runs detached because bootout
 // ends this process.
 func healLaunchAgentPriority(label string, log diagnostic.Logger) {
+	// launchd names the service it started; a daemon run by hand or by a test
+	// must not rewrite and reload the user's agent.
+	if os.Getenv("XPC_SERVICE_NAME") != label {
+		return
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return
@@ -41,7 +54,7 @@ func healLaunchAgentPriority(label string, log diagnostic.Logger) {
 	if err != nil {
 		return
 	}
-	next, changed := raiseProcessType(string(raw))
+	next, changed := healPlist(string(raw))
 	if !changed {
 		return
 	}
@@ -57,5 +70,5 @@ func healLaunchAgentPriority(label string, log diagnostic.Logger) {
 		logAlways(log, "launch agent priority: reload: %v\n", err)
 		return
 	}
-	logAlways(log, "launch agent priority: plist ran the daemon in the Background class; rewrote it to Standard and reloading\n")
+	logAlways(log, "launch agent: plist used the Background class or a 30 s relaunch throttle; rewrote it and reloading\n")
 }

--- a/internal/managedobserve/launchagent_heal.go
+++ b/internal/managedobserve/launchagent_heal.go
@@ -1,0 +1,61 @@
+package managedobserve
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/kontext-security/kontext/internal/diagnostic"
+)
+
+const backgroundProcessType = "<key>ProcessType</key>\n\t<string>Background</string>"
+const standardProcessType = "<key>ProcessType</key>\n\t<string>Standard</string>"
+
+// raiseProcessType rewrites a LaunchAgent plist that runs the daemon in
+// launchd's Background class to Standard. Background is macOS's throttled
+// QoS: the daemon starves whenever the user does anything, and the hook,
+// a foreground process with a 250 ms budget, reads that as a dead daemon and
+// fails closed in enforce. Returns false when nothing needed changing.
+func raiseProcessType(plist string) (string, bool) {
+	if !strings.Contains(plist, backgroundProcessType) {
+		return plist, false
+	}
+	return strings.Replace(plist, backgroundProcessType, standardProcessType, 1), true
+}
+
+// healLaunchAgentPriority fixes an installed plist from an older setup and
+// reloads the agent so the running daemon gets the new class. Only the
+// self-serve plist in the user's LaunchAgents is touched; an MDM-managed
+// daemon is not ours to rewrite. The reload runs detached because bootout
+// ends this process.
+func healLaunchAgentPriority(label string, log diagnostic.Logger) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return
+	}
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", label+".plist")
+	raw, err := os.ReadFile(plistPath)
+	if err != nil {
+		return
+	}
+	next, changed := raiseProcessType(string(raw))
+	if !changed {
+		return
+	}
+	if err := os.WriteFile(plistPath, []byte(next), 0o644); err != nil {
+		logAlways(log, "launch agent priority: rewrite %s: %v\n", plistPath, err)
+		return
+	}
+	domain := fmt.Sprintf("gui/%d", os.Getuid())
+	script := fmt.Sprintf("sleep 2; launchctl bootout %s/%s; launchctl bootstrap %s %q", domain, label, domain, plistPath)
+	cmd := exec.Command("/bin/sh", "-c", script)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		logAlways(log, "launch agent priority: reload: %v\n", err)
+		return
+	}
+	logAlways(log, "launch agent priority: plist ran the daemon in the Background class; rewrote it to Standard and reloading\n")
+}

--- a/internal/managedobserve/launchagent_heal.go
+++ b/internal/managedobserve/launchagent_heal.go
@@ -62,9 +62,26 @@ func healLaunchAgentPriority(label string, log diagnostic.Logger) {
 		logAlways(log, "launch agent priority: rewrite %s: %v\n", plistPath, err)
 		return
 	}
+	// bootout tears the job down asynchronously; a bootstrap that lands
+	// during the teardown fails with "Input/output error" and would leave
+	// the job unloaded, beyond the reach of KeepAlive and the hook's
+	// kickstart. So bootstrap retries for a while and reports the outcome on
+	// the daemon's own stdout/stderr, which launchd already points at the log.
 	domain := fmt.Sprintf("gui/%d", os.Getuid())
-	script := fmt.Sprintf("sleep 2; launchctl bootout %s/%s; launchctl bootstrap %s %q", domain, label, domain, plistPath)
+	script := fmt.Sprintf(`sleep 2
+launchctl bootout %[1]s/%[2]s
+for attempt in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+	if launchctl bootstrap %[1]s %[3]q; then
+		echo "launch agent: reloaded after rewrite (bootstrap attempt $attempt)"
+		exit 0
+	fi
+	sleep 1
+done
+echo "launch agent: bootstrap failed after rewrite; the daemon is unloaded, run kontext setup" >&2
+exit 1`, domain, label, plistPath)
 	cmd := exec.Command("/bin/sh", "-c", script)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	if err := cmd.Start(); err != nil {
 		logAlways(log, "launch agent priority: reload: %v\n", err)

--- a/internal/managedobserve/launchagent_heal_test.go
+++ b/internal/managedobserve/launchagent_heal_test.go
@@ -5,16 +5,16 @@ import (
 	"testing"
 )
 
-func TestRaiseProcessType(t *testing.T) {
+func TestHealPlist(t *testing.T) {
 	plist := "<dict>\n\t<key>ThrottleInterval</key>\n\t<integer>30</integer>\n\t<key>ProcessType</key>\n\t<string>Background</string>\n\t<key>StandardOutPath</key>\n</dict>"
-	next, changed := raiseProcessType(plist)
-	if !changed || !strings.Contains(next, "<string>Standard</string>") || strings.Contains(next, "Background") {
-		t.Fatalf("Background plist not raised: %q", next)
+	next, changed := healPlist(plist)
+	if !changed || !strings.Contains(next, "<string>Standard</string>") || !strings.Contains(next, "<integer>10</integer>") || strings.Contains(next, "Background") {
+		t.Fatalf("old plist not healed: %q", next)
 	}
-	if _, changed := raiseProcessType(next); changed {
-		t.Fatal("a Standard plist must be left alone")
+	if _, changed := healPlist(next); changed {
+		t.Fatal("a healed plist must be left alone")
 	}
-	if _, changed := raiseProcessType("<dict></dict>"); changed {
-		t.Fatal("a plist without ProcessType must be left alone")
+	if _, changed := healPlist("<dict></dict>"); changed {
+		t.Fatal("a plist without the old settings must be left alone")
 	}
 }

--- a/internal/managedobserve/launchagent_heal_test.go
+++ b/internal/managedobserve/launchagent_heal_test.go
@@ -1,0 +1,20 @@
+package managedobserve
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRaiseProcessType(t *testing.T) {
+	plist := "<dict>\n\t<key>ThrottleInterval</key>\n\t<integer>30</integer>\n\t<key>ProcessType</key>\n\t<string>Background</string>\n\t<key>StandardOutPath</key>\n</dict>"
+	next, changed := raiseProcessType(plist)
+	if !changed || !strings.Contains(next, "<string>Standard</string>") || strings.Contains(next, "Background") {
+		t.Fatalf("Background plist not raised: %q", next)
+	}
+	if _, changed := raiseProcessType(next); changed {
+		t.Fatal("a Standard plist must be left alone")
+	}
+	if _, changed := raiseProcessType("<dict></dict>"); changed {
+		t.Fatal("a plist without ProcessType must be left alone")
+	}
+}

--- a/internal/managedobserve/lifecycle.go
+++ b/internal/managedobserve/lifecycle.go
@@ -3,11 +3,13 @@ package managedobserve
 import (
 	"context"
 	"errors"
+	"io"
 	"net"
 	"os"
 	"os/exec"
 	"runtime"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/kontext-security/kontext/internal/cedarpolicy"
@@ -24,6 +26,14 @@ const (
 	asyncHookWait    = 120 * time.Millisecond
 	probeTimeout     = 60 * time.Millisecond
 )
+
+// daemonRestartWait bounds how long a gating hook waits for the daemon's
+// socket to come back. A dead or restarting daemon refuses the dial at once,
+// so this only spends time while the daemon is genuinely away (brew upgrade,
+// launchd reload, the plist self-heal), never on a slow one: the decision
+// itself still gets its own budget from the moment the socket accepts. The
+// agents give the hook 20 s, so waiting a few of them beats a false deny.
+var daemonRestartWait = 3 * time.Second
 
 var launchdMu sync.Mutex
 
@@ -129,26 +139,49 @@ func (l Lifecycle) Process(ctx context.Context, event hook.Event) hook.Result {
 }
 
 func (l Lifecycle) processWithKickstart(ctx context.Context, event hook.Event, budget time.Duration) hook.Result {
-	ctx, cancel := context.WithTimeout(ctx, budget)
+	restartCtx, cancel := context.WithTimeout(ctx, daemonRestartWait)
 	defer cancel()
 
-	if !l.probe(ctx) {
-		launchdMu.Lock()
-		if !l.probe(ctx) {
-			if err := l.Kickstart(ctx, l.Label); err != nil {
-				l.Diagnostic.Printf("managed observe kickstart: %v\n", err)
-			}
-		}
-		launchdMu.Unlock()
-	}
-	if l.waitForProbe(ctx) {
-		result, err := l.call(ctx, event)
-		if err != nil {
+	for attempt := 0; ; attempt++ {
+		if !l.reach(restartCtx) {
 			return l.daemonUnavailable(event)
 		}
-		return l.finalize(event, result)
+		callCtx, cancelCall := context.WithTimeout(ctx, budget)
+		result, err := l.call(callCtx, event)
+		cancelCall()
+		if err == nil {
+			return l.finalize(event, result)
+		}
+		// The daemon went away between the probe and its reply, which is what
+		// a restart looks like from here. One more round through reach waits
+		// for the successor. A slow reply is not retried; that would double
+		// the decision budget.
+		if attempt == 0 && connectionLost(err) {
+			continue
+		}
+		return l.daemonUnavailable(event)
 	}
-	return l.daemonUnavailable(event)
+}
+
+// reach makes sure something is listening on the socket, kickstarting launchd
+// when nothing is, and waits for the listener within ctx.
+func (l Lifecycle) reach(ctx context.Context) bool {
+	if l.probe(ctx) {
+		return true
+	}
+	launchdMu.Lock()
+	if !l.probe(ctx) {
+		if err := l.Kickstart(ctx, l.Label); err != nil {
+			l.Diagnostic.Printf("managed observe kickstart: %v\n", err)
+		}
+	}
+	launchdMu.Unlock()
+	return l.waitForProbe(ctx)
+}
+
+func connectionLost(err error) bool {
+	return errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ECONNREFUSED)
 }
 
 func (l Lifecycle) processIfAvailable(ctx context.Context, event hook.Event, budget time.Duration) hook.Result {

--- a/internal/managedobserve/lifecycle_test.go
+++ b/internal/managedobserve/lifecycle_test.go
@@ -141,13 +141,12 @@ func TestLifecycleHealthySocketDoesNotKickstart(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		for i := 0; i < 2; i++ {
-			conn, err := ln.Accept()
-			if err != nil {
-				return
-			}
-			_ = conn.Close()
+		// One probe, then the call: a healthy socket is dialled once.
+		probe, err := ln.Accept()
+		if err != nil {
+			return
 		}
+		_ = probe.Close()
 		conn, err := ln.Accept()
 		if err != nil {
 			return
@@ -198,13 +197,12 @@ func TestLifecycleEnforcePassesDaemonDenyThroughToAgent(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		for i := 0; i < 2; i++ {
-			conn, err := ln.Accept()
-			if err != nil {
-				return
-			}
-			_ = conn.Close()
+		// One probe, then the call: a healthy socket is dialled once.
+		probe, err := ln.Accept()
+		if err != nil {
+			return
 		}
+		_ = probe.Close()
 		conn, err := ln.Accept()
 		if err != nil {
 			return
@@ -499,5 +497,59 @@ func TestLifecycleRemoteUnavailableFailsOpenWithoutEnforceClaim(t *testing.T) {
 				t.Fatalf("daemonUnavailable() = %+v, want observe fail-open", result)
 			}
 		})
+	}
+}
+
+func TestMain(m *testing.M) {
+	// Keep the unavailable-daemon tests fast; the restart wait is exercised
+	// by TestLifecycleWaitsForDaemonRestartBeyondDecisionBudget.
+	daemonRestartWait = 500 * time.Millisecond
+	os.Exit(m.Run())
+}
+
+func TestLifecycleWaitsForDaemonRestartBeyondDecisionBudget(t *testing.T) {
+	socketPath := filepath.Join("/tmp", fmt.Sprintf("kontext-managedobserve-restart-%d.sock", time.Now().UnixNano()))
+	t.Cleanup(func() { _ = os.Remove(socketPath) })
+	done := make(chan struct{})
+	lifecycle := Lifecycle{
+		SocketPath: socketPath,
+		Label:      DefaultLaunchdLabel,
+		Mode:       "enforce",
+		Kickstart: func(context.Context, string) error {
+			go func() {
+				// Longer than the 250 ms decision budget, shorter than the
+				// restart wait: a daemon coming back from a launchd reload.
+				time.Sleep(preToolUseWait + 100*time.Millisecond)
+				ln, err := net.Listen("unix", socketPath)
+				if err != nil {
+					return
+				}
+				defer ln.Close()
+				defer close(done)
+				for {
+					conn, err := ln.Accept()
+					if err != nil {
+						return
+					}
+					var req localruntime.EvaluateRequest
+					if err := localruntime.ReadMessage(conn, &req); err == nil {
+						_ = localruntime.WriteMessage(conn, localruntime.EvaluateResult{Decision: "allow", Allowed: true, Reason: "local Cedar policy decision", Mode: "enforce"})
+						_ = conn.Close()
+						return
+					}
+					_ = conn.Close()
+				}
+			}()
+			return nil
+		},
+	}
+	result := lifecycle.Process(context.Background(), hook.Event{HookName: hook.HookPreToolUse})
+	if result.Decision != hook.DecisionAllow {
+		t.Fatalf("result = %+v, want the restarted daemon's allow, not a fail-closed deny", result)
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("restarted daemon did not receive the request")
 	}
 }

--- a/internal/setup/launchagent.go
+++ b/internal/setup/launchagent.go
@@ -131,7 +131,7 @@ func renderLaunchAgentPlist(binary, logPath string, llm *localLLMAgentConfig) st
 	<key>ThrottleInterval</key>
 	<integer>30</integer>
 	<key>ProcessType</key>
-	<string>Background</string>
+	<string>Standard</string>
 	<key>StandardOutPath</key>
 	<string>` + xmlEscape(logPath) + `</string>
 	<key>StandardErrorPath</key>

--- a/internal/setup/launchagent.go
+++ b/internal/setup/launchagent.go
@@ -129,7 +129,7 @@ func renderLaunchAgentPlist(binary, logPath string, llm *localLLMAgentConfig) st
 	<key>KeepAlive</key>
 	<true/>
 	<key>ThrottleInterval</key>
-	<integer>30</integer>
+	<integer>10</integer>
 	<key>ProcessType</key>
 	<string>Standard</string>
 	<key>StandardOutPath</key>

--- a/internal/setup/launchagent_test.go
+++ b/internal/setup/launchagent_test.go
@@ -30,7 +30,7 @@ func TestRenderLaunchAgentPlistGolden(t *testing.T) {
 	<key>ThrottleInterval</key>
 	<integer>30</integer>
 	<key>ProcessType</key>
-	<string>Background</string>
+	<string>Standard</string>
 	<key>StandardOutPath</key>
 	<string>/Users/x/Library/Logs/Kontext/managed-observe.log</string>
 	<key>StandardErrorPath</key>

--- a/internal/setup/launchagent_test.go
+++ b/internal/setup/launchagent_test.go
@@ -28,7 +28,7 @@ func TestRenderLaunchAgentPlistGolden(t *testing.T) {
 	<key>KeepAlive</key>
 	<true/>
 	<key>ThrottleInterval</key>
-	<integer>30</integer>
+	<integer>10</integer>
 	<key>ProcessType</key>
 	<string>Standard</string>
 	<key>StandardOutPath</key>


### PR DESCRIPTION
Hooks kept denying tool calls with `Kontext enforce: managed policy daemon unavailable` while the daemon was up. #485 only made prompt submits fail open; the denials stayed on `PreToolUse`, the path that blocks the agent.

## How a tool call gets decided

Every tool call goes through the hook. The hook asks the daemon over a local socket "allow or deny?" and gives it 250 ms. No answer means the hook cannot know the policy, and in Enforce "don't know" is a deny. That rule is right. Every problem below is a reason the daemon did not answer in time even though the policy would have said allow.

## Problem 1: we told macOS the daemon was unimportant

The LaunchAgent plist said `ProcessType=Background`. That is macOS's "run this when nothing else needs the CPU" class (PRI 4). A build, a test run or a busy browser tab starved the daemon. It was alive, it just got no CPU inside the 250 ms. Under saturation every call denied and the user was locked out.

Fix: `ProcessType=Standard`. launchd applies the class only at bootstrap, so existing installs self-heal: on start, if launchd started it (`XPC_SERVICE_NAME`), the daemon rewrites its own plist in `~/Library/LaunchAgents` and reloads once. The reload retries the bootstrap for up to 15 s, because a bootstrap that lands while launchd is still tearing the old job down fails and would leave the daemon unloaded; the outcome goes to the daemon log. An MDM-managed daemon is left alone.

| same 40 KB payloads | Background | Standard |
|---|---|---|
| 8×40 KB burst | 640–1,450 ms | max 117 ms |
| 25 calls under CPU saturation | 7 denied, then all | 25/25 allow, max 142 ms |

## Problem 2: the same starvation broke the decision log

The daemon records every decision in SQLite. Starved, and on the default rollback journal, readers (doctor, menubar) and the deferred writer blocked each other: ~380 `SQLITE_BUSY` a day.

Fix: `journal_mode=WAL`, `synchronous=NORMAL`. Readers never block the writer. 0 `SQLITE_BUSY` across all load tests below.

## Problem 3: every daemon restart denied

A brew upgrade or a launchd reload takes the daemon away for 1–3 s. The hook charged that gap against the 250 ms, so each tool call in the window was denied.

Fix: two questions instead of one. "Is anyone listening?" gets up to 3 s; an absent daemon refuses the dial instantly, so this costs nothing when the daemon is merely slow. "What is the decision?" still gets 250 ms, from the moment the socket accepts. A connection that drops mid-call is retried once through the same wait. Agents give the hook 20 s.

| restart under continuous hook traffic | result |
|---|---|
| `bootout`, 2 s gap, `bootstrap` | 40/40 allow, max wait 2.5 s |
| `kickstart -k` | 30/30 allow, max 202 ms |

## Problem 4: launchd's restart brake was 30 s

launchd will not relaunch a process that ran less than `ThrottleInterval`. Ours was 30 s, so a restart shortly after a restart left a 30 s hole.

Fix: 10 s, launchd's floor, covered by the same self-heal. Two restarts within 10 s still leave a hole of up to 10 s; the hook denies after its 3 s wait. That is a crash loop or a manual double restart, not normal operation.

## What stays

The 250 ms budget. With a normally scheduled daemon a 40 KB request answers in ≤ 25 ms. Raising it would only hide the next scheduling bug.

## Found while testing

The first self-heal ran on every daemon start, including inside `go test`, and rewrote and reloaded the developer's real daemon. It now runs only under launchd.

## Problem 5: the flusher rescanned the whole ledger every 10 s

While load-testing the above I found the last source of the same false deny. `OpenStore` runs a cursor-key backfill, a full-table scan, on every open, and the managed-stream flusher reopens the store every 10 s. On a large ledger that scan burned CPU that competed with the enforce hook's 250 ms budget: about 1 in 100 calls crossed the budget and denied.

Fix: the backfill is a one-time migration (every write since keeps the key in step with `updated_at`), so it is gated on `user_version` and runs once per database. On the live daemon the scan dropped from dominating the flush to zero samples.

## Problem 6: an enforce deny did not say why

A blocked call reported the generic "local Cedar policy decision" whether the cause was a default-deny, an unavailable approval, a not-ready policy, or an evaluation failure. The effective reason code already tells them apart, so the message now does too ("No policy permits this action", "Approval required but unavailable", "Cedar enforcement is not ready", "Policy evaluation failed"). A named forbid still reads "Blocked by rule X".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
